### PR TITLE
[WIP] add ABT_pool_get_def_basic() function

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -414,6 +414,8 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
                     ABT_pool *newpool) ABT_API_PUBLIC;
 int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
                           ABT_bool automatic, ABT_pool *newpool) ABT_API_PUBLIC;
+int ABT_pool_get_def_basic(ABT_pool_kind kind, ABT_pool_access access, 
+                           ABT_pool_def *p_def) ABT_API_PUBLIC;
 int ABT_pool_free(ABT_pool *pool) ABT_API_PUBLIC;
 int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access) ABT_API_PUBLIC;
 int ABT_pool_get_size(ABT_pool pool, size_t *size) ABT_API_PUBLIC;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -87,6 +87,32 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
 
 /**
  * @ingroup POOL
+ * @brief   Retrieve pool definition for predefined pools
+ *
+ * @param[in]  kind      name of the predefined pool
+ * @param[in]  access    access type of the predefined pool
+ * @param[out] def       definition of default pool
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_pool_get_def_basic(ABT_pool_kind kind, 
+                           ABT_pool_access access, ABT_pool_def *p_def) 
+{
+    int abt_errno = ABT_SUCCESS;
+
+    switch (kind) {
+        case ABT_POOL_FIFO:
+            abt_errno = ABTI_pool_get_fifo_def(access, p_def);
+            break;
+        default:
+            abt_errno = ABT_ERR_INV_POOL_KIND;
+            break;
+    }
+    return abt_errno;
+}
+
+/**
+ * @ingroup POOL
  * @brief   Create a new pool from a predefined type and return its handle
  *          through \c newpool.
  *


### PR DESCRIPTION
- this allows external code to retrieve the pool definition for the
  standard pool implementation in Argobots
- the purpose is to allow custom pools to selectively override/intercept
  functions rather than re-implement entire pool for new functionality

This is a proof of concept, see example of use in this branch of abt-snoozer scheduler/pool implementation (below), it overrides just the init, free, and push functions.

https://xgitlab.cels.anl.gov/sds/abt-snoozer/blob/dev-pool-stack/src/pool.c