### PR TITLE
eventual: added a nonblocking test API

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -566,6 +566,7 @@ int ABT_rwlock_unlock(ABT_rwlock rwlock) ABT_API_PUBLIC;
 int ABT_eventual_create(int nbytes, ABT_eventual *neweventual) ABT_API_PUBLIC;
 int ABT_eventual_free(ABT_eventual *eventual) ABT_API_PUBLIC;
 int ABT_eventual_wait(ABT_eventual eventual, void **value) ABT_API_PUBLIC;
+int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready) ABT_API_PUBLIC;
 int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes) ABT_API_PUBLIC;
 int ABT_eventual_reset(ABT_eventual eventual) ABT_API_PUBLIC;
 

--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -28,9 +28,14 @@ void fn1(void *args)
 void fn2(void *args)
 {
     ATS_UNUSED(args);
-    int i = 0;
+    int i = 0, is_ready = 0;
     void *data = malloc(EVENTUAL_SIZE);
     ATS_printf(1, "Thread 2 iteration %d waiting from eventual\n", i);
+    ABT_eventual_test(myeventual,&data, &is_ready);
+    while (!is_ready) {
+       ABT_thread_yield();
+       ABT_eventual_test(myeventual,&data, &is_ready);
+    }
     ABT_eventual_wait(myeventual,&data);
     ATS_printf(1, "Thread 2 continue iteration %d returning from "
             "eventual\n", i);


### PR DESCRIPTION
A thread might want to overlap waiting on an eventual with other activities. The
current eventual interface only allow a blocking wait operation. This patch
extends the eventual interface with a nonblocking routine; ABT_eventual_test.