### PR TITLE
#19 Cache line size can be statically obtained on configuration.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,13 @@ AC_ARG_ENABLE([sched-sleep],
 AC_ARG_ENABLE([simple-mutex],
     AS_HELP_STRING([--enable-simple-mutex], [use a simple mutex implementation]))
 
+# --enable-static-cacheline-size
+AC_ARG_ENABLE([static-cacheline-size],
+[  --enable-static-cacheline-size@<:@=OPTS@:>@ embed cache line size at compile-time.
+        auto                - automatically get size. Use 128 if detection fails
+        <value>             - assume [value] bytes (e.g., <value> = 64)
+],,[enable_static_cacheline_size=auto])
+
 # --with-lts
 AC_ARG_WITH([lts],
     AS_HELP_STRING([--with-lts=PATH],
@@ -607,6 +614,30 @@ fi
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,
                  [Define to use a simple mutex implementation])])
+
+
+# --enable-static-cacheline-size
+static_cacheline_size=0
+default_static_cacheline_size=128
+if test "x$enable_static_cacheline_size" = "xauto" ; then
+  # For Linux
+  static_cacheline_size=`cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size | grep -Po '^(\d+)$'`
+  if test "x$static_cacheline_size" = "x" ; then
+    # For Mac
+    static_cacheline_size=`sysctl -a | grep hw.cachelinesize | grep -Po '(\d+)$' | grep -Po '^(\d+)$'`
+    if test "x$static_cacheline_size" = "x" ; then
+      static_cacheline_size=$default_static_cacheline_size
+    fi
+  fi
+else
+  static_cacheline_size=`echo $enable_static_cacheline_size | grep -Po '^(\d+)$'`
+  if test "x$static_cacheline_size" = "x" ; then
+    static_cacheline_size=$default_static_cacheline_size
+  fi
+fi
+
+AC_DEFINE_UNQUOTED(ABT_CONFIG_STATIC_CACHELINE_SIZE, [$static_cacheline_size],
+                   [Define to use static cache-line size])
 
 
 # --with-lts

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -13,7 +13,6 @@
 #define ABTD_SCHED_EVENT_FREQ           50
 #define ABTD_SCHED_SLEEP_NSEC           100
 
-#define ABTD_CACHE_LINE_SIZE            64
 #define ABTD_OS_PAGE_SIZE               (4*1024)
 #define ABTD_HUGE_PAGE_SIZE             (2*1024*1024)
 #define ABTD_MEM_PAGE_SIZE              (2*1024*1024)
@@ -148,15 +147,6 @@ void ABTD_env_init(ABTI_global *p_global)
         ABTI_ASSERT(p_global->mutex_max_wakeups >= 1);
     } else {
         p_global->mutex_max_wakeups = 1;
-    }
-
-    /* Cache line size */
-    env = getenv("ABT_CACHE_LINE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_CACHE_LINE_SIZE");
-    if (env != NULL) {
-        p_global->cache_line_size = (uint32_t)atol(env);
-    } else {
-        p_global->cache_line_size = ABTD_CACHE_LINE_SIZE;
     }
 
     /* OS page size */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -169,8 +169,6 @@ struct ABTI_global {
 
     uint32_t mutex_max_handovers;      /* Default max. # of local handovers */
     uint32_t mutex_max_wakeups;        /* Default max. # of wakeups */
-
-    uint32_t cache_line_size;          /* Cache line size */
     uint32_t os_page_size;             /* OS page size */
     uint32_t huge_page_size;           /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
@@ -178,8 +176,6 @@ struct ABTI_global {
     uint32_t mem_sp_size;              /* Stack page size */
     uint32_t mem_max_stacks;           /* Max. # of stacks kept in each ES */
     int mem_lp_alloc;                  /* How to allocate large pages */
-    uint32_t mem_sh_size;              /* Stack header (including ABTI_thread
-                                          ABTI_stack_header) size */
     ABTI_stack_header *p_mem_stack;    /* List of ULT stack */
     ABTI_page_header *p_mem_task;      /* List of task block pages */
     ABTI_sp_header *p_mem_sph;         /* List of stack pages */

--- a/src/info.c
+++ b/src/info.c
@@ -31,7 +31,7 @@ int ABT_info_print_config(FILE *fp)
 
     fprintf(fp, "Argobots Configuration:\n");
     fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
-    fprintf(fp, " - cache line size: %u\n", p_global->cache_line_size);
+    fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
     fprintf(fp, " - OS page size: %u\n", p_global->os_page_size);
     fprintf(fp, " - huge page size: %u\n", p_global->huge_page_size);
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -56,14 +56,6 @@ void ABTI_mem_init(ABTI_global *p_global)
     p_global->p_mem_task = NULL;
     p_global->p_mem_sph = NULL;
 
-    /* Calculate the header size that should be a multiple of cache line size */
-    size_t header_size = sizeof(ABTI_thread) + sizeof(ABTI_stack_header);
-    uint32_t rem = header_size % p_global->cache_line_size;
-    if (rem > 0) {
-        header_size += (p_global->cache_line_size - rem);
-    }
-    p_global->mem_sh_size = header_size;
-
     g_sp_id = 0;
 }
 
@@ -428,7 +420,7 @@ ABTI_page_header *ABTI_mem_alloc_page(ABTI_local *p_local, size_t blk_size)
     ABTI_page_header *p_ph;
     ABTI_blk_header *p_cur;
     ABTI_global *p_global = gp_ABTI_global;
-    uint32_t clsize = p_global->cache_line_size;
+    const uint32_t clsize = ABT_CONFIG_STATIC_CACHELINE_SIZE;
     size_t pgsize = p_global->mem_page_size;
     ABT_bool is_mmapped;
 
@@ -612,7 +604,7 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
     uint32_t num_stacks;
     int i;
 
-    uint32_t header_size = gp_ABTI_global->mem_sh_size;
+    uint32_t header_size = ABTI_MEM_SH_SIZE;
     uint32_t sp_size = gp_ABTI_global->mem_sp_size;
     size_t actual_stacksize = stacksize - header_size;
     void *p_stack = NULL;


### PR DESCRIPTION
Solve #19  It improves performance by embedding the constant.

Specifically, users can specify one of the following:
- auto: use the automatic cache line size detection. It uses 64 if all attempts fail.
- specific value (e.g., “64”): use that value.
- otherwise (default): use an environmental variable, or use 64 if it is not set.

Internally, the following command is used for Linux:
``cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size | grep -Po '^(\d+)$'``
I checked it on the following environments:
- Red Hat 7.4 + POWER8 ... OK
- Red Hat 7.4 + Intel Xeon ... OK
- Red Hat 7.4 + Intel Xeon Phi (KNL) ... OK
- Ubuntu 16.04 + Intel Xeon ... OK
- VMWare Ubuntu 16.04 + Intel Core i7 ... OK
- openSUSE 42.2 Arm64 (ARM Cortex 8) ... NG
Note I could not find any command working for the last environment.

For Mac, the following is used.
``sysctl -a | grep hw.cachelinesize | grep -Po '(\d+)$' | grep -Po '^(\d+)$'``
It worked on Intel Mac.