### PR TITLE
Tests on a CPU that have few cores

### DIFF
--- a/test/basic/barrier.c
+++ b/test/basic/barrier.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     int ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = 4;
         N = 10;
@@ -58,6 +58,7 @@ int main(int argc, char *argv[])
         N = ATS_get_arg_val(ATS_ARG_N_ULT);
         iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", N * N);

--- a/test/basic/cond_join.c
+++ b/test/basic/cond_join.c
@@ -180,7 +180,9 @@ int main(int argc, char *argv[])
     if (argc > 1) iter = atoi(argv[1]);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+
+    ATS_init(argc, argv, NUM_XSTREAMS);
 
     ATS_printf(1, "# of ES   : %d\n", NUM_XSTREAMS);
     ATS_printf(1, "# of ULT  : %d\n", NUM_THREADS);

--- a/test/basic/cond_signal_in_main.c
+++ b/test/basic/cond_signal_in_main.c
@@ -27,7 +27,9 @@ int main(int argc, char *argv[])
     ABT_xstream xstream;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+
+    ATS_init(argc, argv, 1);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstream);

--- a/test/basic/cond_test.c
+++ b/test/basic/cond_test.c
@@ -119,7 +119,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/cond_timedwait.c
+++ b/test/basic/cond_timedwait.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     ABT_thread_id tid;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -78,6 +78,7 @@ int main(int argc, char *argv[])
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);

--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
     ABT_xstream xstream;
 
     /* init and thread creation */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
 
     ret = ABT_xstream_self(&xstream);
     ATS_ERROR(ret, "ABT_xstream_self");

--- a/test/basic/eventual_test.c
+++ b/test/basic/eventual_test.c
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
     int i, ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -225,6 +225,7 @@ int main(int argc, char *argv[])
         num_threads  = num_tasks * 2;
         num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs        : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES    : %d\n", num_threads + num_tasks);

--- a/test/basic/ext_thread.c
+++ b/test/basic/ext_thread.c
@@ -223,7 +223,8 @@ int main(int argc, char *argv[])
     int ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
 
     /* Create a pthread */
     ret = pthread_create(&pthread, NULL, pthread_test, NULL);

--- a/test/basic/future_create.c
+++ b/test/basic/future_create.c
@@ -62,7 +62,8 @@ int main(int argc, char *argv[])
     total_num_threads = num_threads*num_xstreams;
 
     /* init and thread creation */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ABT_xstream *xstreams =

--- a/test/basic/info_print.c
+++ b/test/basic/info_print.c
@@ -47,12 +47,13 @@ int main(int argc, char *argv[])
     int i, ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ret = ABT_info_print_config(stdout);
     ATS_ERROR(ret, "ABT_info_print_config");

--- a/test/basic/init_finalize.c
+++ b/test/basic/init_finalize.c
@@ -17,7 +17,6 @@ static int num_iter = DEFAULT_NUM_ITER;
 static void *init_test(void *arg)
 {
     int i, ret;
-
     ret = ABT_initialized();
     ATS_ERROR(ret, "ABT_initialized");
 
@@ -45,12 +44,13 @@ int main(int argc, char *argv[])
     assert(initialized == ABT_ERR_UNINITIALIZED);
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc > 2) {
         num_threads = ATS_get_arg_val(ATS_ARG_N_ES);
         num_iter    = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_threads);
+
 
     threads = (pthread_t *)malloc(num_threads * sizeof(pthread_t));
     assert(threads);

--- a/test/basic/mutex.c
+++ b/test/basic/mutex.c
@@ -54,13 +54,13 @@ int main(int argc, char *argv[])
     int num_threads = DEFAULT_NUM_THREADS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
         g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(2, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);

--- a/test/basic/mutex_prio.c
+++ b/test/basic/mutex_prio.c
@@ -64,13 +64,13 @@ int main(int argc, char *argv[])
     int num_threads = DEFAULT_NUM_THREADS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
         g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(2, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);

--- a/test/basic/mutex_recursive.c
+++ b/test/basic/mutex_recursive.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     int num_xstreams, num_threads;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -57,6 +57,7 @@ int main(int argc, char *argv[])
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);

--- a/test/basic/mutex_spinlock.c
+++ b/test/basic/mutex_spinlock.c
@@ -55,13 +55,14 @@ int main(int argc, char *argv[])
     int num_threads = DEFAULT_NUM_THREADS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
         g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
+
 
     ATS_printf(2, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);

--- a/test/basic/mutex_unlock_se.c
+++ b/test/basic/mutex_unlock_se.c
@@ -54,13 +54,13 @@ int main(int argc, char *argv[])
     int num_threads = DEFAULT_NUM_THREADS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
         g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(2, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);

--- a/test/basic/pool_access.c
+++ b/test/basic/pool_access.c
@@ -226,7 +226,8 @@ int main(int argc, char *argv[])
     int *ret_push_from_another_pool[5];
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 5);
 
     /* ABT_POOL_ACCESS_PRIV */
     ret_add_to_another_ES[0] = error;

--- a/test/basic/rwlock_reader_incl.c
+++ b/test/basic/rwlock_reader_incl.c
@@ -114,7 +114,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, targ.num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/rwlock_reader_writer_excl.c
+++ b/test/basic/rwlock_reader_writer_excl.c
@@ -141,7 +141,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, targ.num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/rwlock_writer_excl.c
+++ b/test/basic/rwlock_writer_excl.c
@@ -134,7 +134,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, targ.num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/sched_basic.c
+++ b/test/basic/sched_basic.c
@@ -38,7 +38,8 @@ int main(int argc, char *argv[])
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create schedulers */
     ABT_sched_config config;

--- a/test/basic/sched_config.c
+++ b/test/basic/sched_config.c
@@ -31,7 +31,8 @@ int main(int argc, char *argv[])
     double b2;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
 
     ABT_sched_config_create(&config1, param_a, a, ABT_sched_config_var_end);
     a2 = 0; b2 = 0.0;

--- a/test/basic/sched_prio.c
+++ b/test/basic/sched_prio.c
@@ -30,6 +30,8 @@ typedef struct {
     ABT_xstream *xstreams;
 } g_data_t;
 
+const int num_scheds = sizeof(accesses) / sizeof(accesses[0]) + 1;
+
 static g_data_t g_data;
 
 
@@ -48,7 +50,8 @@ int main(int argc, char *argv[])
     assert(num_units >= 0);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_scheds);
 
     /* Create schedulers and ESs */
     init_global_data();
@@ -74,8 +77,6 @@ int main(int argc, char *argv[])
 
 static void init_global_data(void)
 {
-    int num_scheds = sizeof(accesses)/sizeof(accesses[0])+1;
-
     g_data.num_scheds = num_scheds;
     g_data.num_pools = (int *)calloc(num_scheds, sizeof(int));
     g_data.pools = (ABT_pool **)calloc(num_scheds, sizeof(ABT_pool *));

--- a/test/basic/sched_randws.c
+++ b/test/basic/sched_randws.c
@@ -103,12 +103,13 @@ int main(int argc, char *argv[])
     int i, k, ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
+
     ATS_printf(1, "# of ESs    : %d\n"
                        "# of ULTs/ES: %d\n",
                        num_xstreams, num_threads);

--- a/test/basic/sched_set_main.c
+++ b/test/basic/sched_set_main.c
@@ -86,12 +86,13 @@ int main(int argc, char *argv[])
     ABT_thread *threads;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
+
     ATS_printf(1, "num_xstreams=%d num_threads=%d\n",
                     num_xstreams, num_threads);
 

--- a/test/basic/sched_stack.c
+++ b/test/basic/sched_stack.c
@@ -40,7 +40,8 @@ int main(int argc, char *argv[])
     ABT_sched mainsched, subsched1, subsched2;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
 
     /* Creation of the main pool/sched */
     ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,

--- a/test/basic/sched_user_ws.c
+++ b/test/basic/sched_user_ws.c
@@ -271,12 +271,13 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
+
     ATS_printf(1, "num_xstreams=%d num_threads=%d\n", num_xstreams,
                     num_threads);
 

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -152,7 +152,8 @@ int main(int argc, char *argv[])
     assert(ret == ABT_ERR_UNINITIALIZED && flag == ABT_FALSE);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 2);
 
     /* Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/task_create.c
+++ b/test/basic/task_create.c
@@ -58,7 +58,8 @@ int main(int argc, char *argv[])
     args = (task_arg_t *)malloc(sizeof(task_arg_t) * num_tasks);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/task_create_on_xstream.c
+++ b/test/basic/task_create_on_xstream.c
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
     args = (task_arg_t *)malloc(sizeof(task_arg_t) * num_tasks);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
     int i, ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_tasks  = DEFAULT_NUM_TASKS;
@@ -120,6 +120,7 @@ int main(int argc, char *argv[])
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_tasks  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs        : %d\n", num_xstreams);
     ATS_printf(1, "# of tasklets/ES: %d\n", num_tasks);

--- a/test/basic/task_revive.c
+++ b/test/basic/task_revive.c
@@ -110,12 +110,12 @@ int main(int argc, char *argv[])
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs        : %d\n", num_xstreams);
     ATS_printf(1, "# of tasklets/ES: %d\n", num_tasks);

--- a/test/basic/thread_attr.c
+++ b/test/basic/thread_attr.c
@@ -50,7 +50,8 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_create.c
+++ b/test/basic/thread_create.c
@@ -35,7 +35,8 @@ int main(int argc, char *argv[])
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_create2.c
+++ b/test/basic/thread_create2.c
@@ -60,7 +60,8 @@ int main(int argc, char *argv[])
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_create_on_xstream.c
+++ b/test/basic/thread_create_on_xstream.c
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
     int i, ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -127,6 +127,7 @@ int main(int argc, char *argv[])
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);

--- a/test/basic/thread_id.c
+++ b/test/basic/thread_id.c
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_migrate.c
+++ b/test/basic/thread_migrate.c
@@ -52,7 +52,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_revive.c
+++ b/test/basic/thread_revive.c
@@ -111,12 +111,13 @@ int main(int argc, char *argv[])
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
+    ATS_init(argc, argv, num_xstreams);
+
 
     ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);

--- a/test/basic/thread_self_suspend_resume.c
+++ b/test/basic/thread_self_suspend_resume.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     int ret;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -109,6 +109,7 @@ int main(int argc, char *argv[])
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
         num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);

--- a/test/basic/thread_task.c
+++ b/test/basic/thread_task.c
@@ -175,7 +175,8 @@ int main(int argc, char *argv[])
     task_args = (task_arg_t *)malloc(sizeof(task_arg_t) * num_tasks);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_task_arg.c
+++ b/test/basic/thread_task_arg.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     void *ret_arg;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
         num_threads  = DEFAULT_NUM_THREADS;
@@ -71,6 +71,7 @@ int main(int argc, char *argv[])
         num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
         num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs     : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES : %d\n", num_threads);

--- a/test/basic/thread_task_num.c
+++ b/test/basic/thread_task_num.c
@@ -41,7 +41,8 @@ int main(int argc, char *argv[])
     int err = 0;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
 
     /* Get the SELF Execution Stream */
     ret = ABT_xstream_self(&xstream);

--- a/test/basic/thread_yield.c
+++ b/test/basic/thread_yield.c
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/thread_yield_to.c
+++ b/test/basic/thread_yield_to.c
@@ -100,7 +100,8 @@ int main(int argc, char *argv[])
     }
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);

--- a/test/basic/timer.c
+++ b/test/basic/timer.c
@@ -83,7 +83,8 @@ int main(int argc, char *argv[])
 
     /* Initialize */
     t_init = ABT_get_wtime();
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
     t_init = (ABT_get_wtime() - t_init);
 
     ABT_timer_start(timer);

--- a/test/basic/xstream_affinity.c
+++ b/test/basic/xstream_affinity.c
@@ -108,11 +108,11 @@ int main(int argc, char *argv[])
     int cpuid = -1;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs: %d\n", num_xstreams);
 

--- a/test/basic/xstream_barrier.c
+++ b/test/basic/xstream_barrier.c
@@ -40,12 +40,12 @@ int main(int argc, char *argv[])
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
         num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs       : %d\n", num_xstreams);
     ATS_printf(1, "# of iterations: %d\n", num_iter);

--- a/test/basic/xstream_create.c
+++ b/test/basic/xstream_create.c
@@ -18,11 +18,11 @@ int main(int argc, char *argv[])
     int ret, tmp;
 
     /* Initialize */
-    ATS_init(argc, argv);
-
+    ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs: %d\n", num_xstreams);
 

--- a/test/basic/xstream_rank.c
+++ b/test/basic/xstream_rank.c
@@ -18,10 +18,11 @@ int main(int argc, char *argv[])
     int rank;
 
     /* Initialize */
-    ATS_init(argc, argv);
+    ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
     }
+    ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs: %d\n", num_xstreams);
 

--- a/test/benchmark/init_finalize.c
+++ b/test/benchmark/init_finalize.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 
     /* measure init/finalize time (cold) */
     ABT_timer_start(timer);
-    ABT_init(argc, argv);
+    ATS_init(argc, argv, 2);
     ABT_finalize();
     ABT_timer_stop_and_read(timer, &t_timers[T_INIT_FINALIZE_COLD]);
     t_timers[T_INIT_FINALIZE_COLD] -= t_overhead;

--- a/test/benchmark/sync_ops.c
+++ b/test/benchmark/sync_ops.c
@@ -146,8 +146,14 @@ int main(int argc, char *argv[])
     double t_time;
     int i;
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* create a timer */
     ABT_timer_create(&timer);
@@ -155,11 +161,6 @@ int main(int argc, char *argv[])
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
     for (i = 0; i < T_LAST; i++) t_timers[i] = 0.0;
-
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/task_fork_join.c
+++ b/test/benchmark/task_fork_join.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
 
-    ABT_init(argc, argv);
+    ATS_init(argc, argv, ness);
 
     /* output beginning */
     print_header("#Tasks", 0);

--- a/test/benchmark/task_ops.c
+++ b/test/benchmark/task_ops.c
@@ -175,8 +175,14 @@ int main(int argc, char *argv[])
     uint64_t t_min[T_LAST];
     uint64_t t_max[T_LAST];
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     for (i = 0; i < T_LAST; i++) {
         t_avg[i] = 0;
@@ -187,10 +193,6 @@ int main(int argc, char *argv[])
         t_all[i] = 0;
     }
 
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/task_ops_all.c
+++ b/test/benchmark/task_ops_all.c
@@ -75,17 +75,19 @@ int main(int argc, char *argv[])
     size_t i, t;
     uint64_t t_start;
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     for (i = 0; i < T_LAST; i++) {
         t_times[i] = 0;
     }
 
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/thread_fork_join.c
+++ b/test/benchmark/thread_fork_join.c
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
 
-    ABT_init(argc, argv);
+    ATS_init(argc, argv, ness);
 
     /* output beginning */
     print_header("#ULTs", 1);

--- a/test/benchmark/thread_many_ops.c
+++ b/test/benchmark/thread_many_ops.c
@@ -246,8 +246,14 @@ int main(int argc, char *argv[])
     uint64_t t_min[T_LAST];
     uint64_t t_max[T_LAST];
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     for (i = 0; i < T_LAST; i++) {
         t_avg[i] = 0;
@@ -257,11 +263,6 @@ int main(int argc, char *argv[])
     for (i = 0; i < T_ALL_LAST; i++) {
         t_all[i] = 0;
     }
-
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/thread_ops.c
+++ b/test/benchmark/thread_ops.c
@@ -391,8 +391,14 @@ int main(int argc, char *argv[])
     uint64_t t_min[T_LAST];
     uint64_t t_max[T_LAST];
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     for (i = 0; i < T_LAST; i++) {
         t_avg[i] = 0;
@@ -402,11 +408,6 @@ int main(int argc, char *argv[])
     for (i = 0; i < T_ALL_LAST; i++) {
         t_all[i] = 0;
     }
-
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/thread_ops_all.c
+++ b/test/benchmark/thread_ops_all.c
@@ -292,17 +292,18 @@ int main(int argc, char *argv[])
     size_t i, t;
     uint64_t t_start;
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     for (i = 0; i < T_LAST; i++) {
         t_times[i] = 0;
     }
-
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/benchmark/xstream_ops.c
+++ b/test/benchmark/xstream_ops.c
@@ -42,8 +42,12 @@ int main(int argc, char *argv[])
     int num_xstreams, iter;
     double t_overhead;
 
+    /* read command-line arguments */
+    ATS_read_args(argc, argv);
+    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     /* initialize */
-    ATS_init(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
 
     /* create a timer */
     ABT_timer_create(&timer);
@@ -52,9 +56,6 @@ int main(int argc, char *argv[])
     ABT_timer_get_overhead(&t_overhead);
     for (i = 0; i < T_LAST; i++) t_times[i] = 0.0;
 
-    /* read command-line arguments */
-    num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));

--- a/test/util/abttest.c
+++ b/test/util/abttest.c
@@ -18,13 +18,15 @@ static int g_num_errs = 0;
 #define NUM_ARG_KINDS   4
 static int g_arg_val[NUM_ARG_KINDS];
 
-void ATS_init(int argc, char **argv)
+void ATS_init(int argc, char **argv, int num_xstreams)
 {
     int ret;
     char *envval;
 
-    /* Read the command arguments */
-    ATS_read_args(argc, argv);
+    /* ABT_MAX_NUM_XSTREAMS determines the size of internal ES array */
+    char snprintf_buffer[128];
+    sprintf(snprintf_buffer, "ABT_MAX_NUM_XSTREAMS=%d", num_xstreams);
+    putenv(snprintf_buffer);
 
     /* Initialize Argobots */
     ret = ABT_init(argc, argv);

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -33,11 +33,11 @@
  *   This is used by ATS_error(). If not set, ATS_VERBOSE is the
  *   same as 0.
  *
- * @param[in] argc  the number of arguments
- * @param[in] argv  argument vector
+ * @param[in] argc         the number of arguments
+ * @param[in] argv         argument vector
+ * @param[in] num_xstreams the number of xstreams used in a prgoram
  */
-void ATS_init(int argc, char **argv);
-
+void ATS_init(int argc, char **argv, int num_xstreams);
 
 /**
  * @ingroup TESTUTIL


### PR DESCRIPTION
This PR addresses #34 

The test sometimes failed on machines that have few (<4) cores,
because some tests creates more execution streams than CPU cores.

To solve this issue, all benchmarks specify the max number of
execution streams at the beginning.  The environmental variable
(=ABT_MAX_NUM_XSTREAMS) is set before ABT_init() so that Argobots
can use that value.
Note ABT_MAX_NUM_XSTREAMS is originally employed by Argobots.