### PR TITLE
Avoid underestimation of pool size

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -525,6 +525,10 @@ int ABT_thread_join(ABT_thread thread)
          * not, we need to wait until it is added. */
         while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {}
 
+        /* Increase the number of blocked units.  Be sure to execute
+         * ABTI_pool_inc_num_blocked before ABTI_POOL_REMOVE in order not to
+         * underestimate the number of units in a pool. */
+        ABTI_pool_inc_num_blocked(p_self->p_pool);
         /* Remove the target ULT from the pool */
         ABTI_POOL_REMOVE(p_thread->p_pool, p_thread->unit, p_xstream);
 
@@ -537,7 +541,6 @@ int ABT_thread_join(ABT_thread thread)
 
         /* Make the current ULT BLOCKED */
         p_self->state = ABT_THREAD_STATE_BLOCKED;
-        ABTI_pool_inc_num_blocked(p_self->p_pool);
 
         LOG_EVENT("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
                   ABTI_thread_get_id(p_self), p_self->p_last_xstream->rank,


### PR DESCRIPTION
This commit is to avoid the underestimation of the pool size on
joining, which affects the scheduling behavior.

Specifically, ABTI_sched_has_to_stop() returns TRUE (i.e., stops a
scheduler) when ABTI_sched_get_effective_size() is 0.
https://github.com/pmodels/argobots/blob/master/src/sched/sched.c#L460
Because ABTI_sched_get_effective_size() calculates the effective
size by adding blocked_num and the current pool size, blocked_num
must be increased "before" extracting a unit from a pool.
https://github.com/pmodels/argobots/blob/master/src/sched/sched.c#L659

Previously, this problem might cause the following case:
1. A pool is shared by multiple schedulers.
2. One scheduler picks up a thread in a pool on joining.
3. Though the true effective size of this pool is not zero, the
otherd think this pool is empty and finishes its schedulers.
Note this fix might overestimate of the effective pool size.

This commit does not explain what is effective_size, but this behavior
should be natural in the current implementation.