### PR TITLE
Fix spin lock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -603,6 +603,22 @@ else
     enable_simple_mutex=yes
 fi
 
+
+# check if __atomic_test_and_set() and __atomic_clear() are supported
+AC_TRY_COMPILE(
+[#include <stdint.h>],
+[int *lock = 0;
+ __atomic_test_and_set((char *)lock, __ATOMIC_ACQ_REL);
+ __atomic_clear((volatile char *)lock, __ATOMIC_RELEASE);],
+[have_atomic_lock=yes],
+[have_atomic_lock=no]
+)
+if test "x$have_atomic_lock" = "xyes" ; then
+    AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_LOCK, 1,
+              [Define if __atomic_test_and_set and _clear are supported])
+fi
+
+
 # --enable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -175,6 +175,48 @@ uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
     return __sync_fetch_and_xor(ptr, v);
 }
 
+#ifdef ABT_CONFIG_HAVE_ATOMIC_LOCK
+
+static inline
+int ABTD_atomic_is_locked_uint32(uint32_t *lock)
+{
+    return (*(volatile char *)lock) == 1;
+}
+
+static inline
+uint32_t ABTD_atomic_lock_uint32(uint32_t *lock)
+{
+    return __atomic_test_and_set((char *)lock, __ATOMIC_ACQ_REL);
+}
+
+static inline
+void ABTD_atomic_unlock_uint32(uint32_t *lock)
+{
+    __atomic_clear((volatile char *)lock, __ATOMIC_RELEASE);
+}
+
+#else
+
+static inline
+int ABTD_atomic_is_locked_uint32(uint32_t *lock)
+{
+    return (*(uint32_t *)lock) == 1;
+}
+
+static inline
+uint32_t ABTD_atomic_lock_uint32(uint32_t *lock)
+{
+    return __sync_lock_test_and_set(lock, 1);
+}
+
+static inline
+void ABTD_atomic_unlock_uint32(uint32_t *lock)
+{
+    __sync_lock_release(lock);
+}
+
+#endif
+
 #ifdef ABT_CONFIG_HAVE_ATOMIC_EXCHANGE
 static inline
 int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -30,8 +30,8 @@ static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    *(volatile uint32_t *)&p_lock->val = 0;
     ABTD_atomic_mem_barrier();
+    *(volatile uint32_t *)&p_lock->val = 0;
 }
 
 #endif /* SPINLOCK_H_INCLUDED */

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -22,16 +22,16 @@ static inline void ABTI_spinlock_free(ABTI_spinlock *p_lock)
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (ABTD_atomic_cas_uint32(&p_lock->val, 0, 1) != 0) {
-        while (*(volatile uint32_t *)(&p_lock->val) != 0) {
+    while (ABTD_atomic_lock_uint32(&p_lock->val)) {
+        while (ABTD_atomic_is_locked_uint32(&p_lock->val)) {
+            ABTD_compiler_barrier();
         }
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    ABTD_atomic_mem_barrier();
-    *(volatile uint32_t *)&p_lock->val = 0;
+    ABTD_atomic_unlock_uint32(&p_lock->val);
 }
 
 #endif /* SPINLOCK_H_INCLUDED */


### PR DESCRIPTION
It fixes a potential bug of spin lock (No corresponding issue)

This bug (see the first commit log) is fixed in the first commit, while the second commit is for performance improvement.
The second commit uses __atomic built-ins that usually perform better than the naive (manual) spin lock implementation because of compiler supports. In addition, we do not need to pay attention to the location of memory barriers in ``ABTI_spinlock_releas.e`` 