### PR TITLE
Valgrind Support

### DIFF
--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -133,6 +133,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
     ABTI_thread_attr_init(p_myattr, p_stack, actual_stacksize, ABT_TRUE);
 
     *p_stacksize = actual_stacksize;
+    ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, *p_stacksize);
     return p_thread;
 }
 
@@ -179,6 +180,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
             ABTI_thread_attr_copy(&p_thread->attr, p_attr);
 
             *p_stacksize = p_attr->stacksize;
+            ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, *p_stacksize);
             return p_thread;
         }
 
@@ -198,6 +200,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
             p_thread->attr.p_stack = (void *)(p_blk + header_size);
 
             *p_stacksize = actual_stacksize;
+            ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, *p_stacksize);
             return p_thread;
         }
     }
@@ -247,6 +250,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
     }
 
     *p_stacksize = actual_stacksize;
+    ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, *p_stacksize);
     return p_thread;
 }
 
@@ -278,6 +282,7 @@ void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
     ABTI_local *p_local;
     ABTI_stack_header *p_sh;
+    ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
 
     p_sh = (ABTI_stack_header *)((char *)p_thread + sizeof(ABTI_thread));
 
@@ -414,6 +419,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
     ABTI_thread_attr_init(p_myattr, p_stack, actual_stacksize, ABT_TRUE);
 
     *p_stacksize = actual_stacksize;
+    ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, *p_stacksize);
     return p_thread;
 }
 
@@ -469,6 +475,7 @@ ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
 static inline
 void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
+    ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
     ABTU_free(p_thread);
 }
 

--- a/src/include/abti_valgrind.h
+++ b/src/include/abti_valgrind.h
@@ -6,12 +6,23 @@
 #ifndef ABTI_VALGRIND_H_INCLUDED
 #define ABTI_VALGRIND_H_INCLUDED
 
+/* Valgrind support */
 #ifdef HAVE_VALGRIND_SUPPORT
+
 #include <valgrind/valgrind.h>
-#define ABTI_VALGRIND_STACK_REGISTER(p,s)             \
-    VALGRIND_STACK_REGISTER(p, ((char *)p)+s)
+
+void ABTI_valgrind_register_stack(const void *p_stack, size_t size);
+void ABTI_valgrind_unregister_stack(const void *p_stack);
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size) \
+            ABTI_valgrind_register_stack  (p_stack, size)
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack) \
+            ABTI_valgrind_unregister_stack(p_stack)
+
 #else
-#define ABTI_VALGRIND_STACK_REGISTER(p,s)
-#endif
+
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)   do { } while(0)
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)       do { } while(0)
+
+#endif /* HAVE_VALGRIND_SUPPORT */
 
 #endif /* ABTI_VALGRIND_H_INCLUDED */

--- a/src/mem/Makefile.mk
+++ b/src/mem/Makefile.mk
@@ -4,5 +4,6 @@
 #
 
 abt_sources += \
-	mem/malloc.c
+	mem/malloc.c \
+	mem/valgrind.c
 

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -1,0 +1,95 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+#ifdef HAVE_VALGRIND_SUPPORT
+
+/*
+ * These routines register and unregister stacks of threads so that Valgrind can
+ * handle them.  This implementation uses a very naive linear list to keep track
+ * of stacks and valgrind_id.  Its performance is bad compared to, for example,
+ * hash tables, but performance is less important when Valgrind is used.
+ */
+
+typedef size_t ABTI_valgrind_id;
+
+typedef struct ABTI_valgrind_id_list_t {
+    const void *p_stack;
+    ABTI_valgrind_id valgrind_id;
+    struct ABTI_valgrind_id_list_t *p_next;
+} ABTI_valgrind_id_list;
+
+/* The list is protected by a global lock. */
+uint32_t g_valgrind_id_list_lock = 0;
+ABTI_valgrind_id_list *gp_valgrind_id_list_head = NULL;
+ABTI_valgrind_id_list *gp_valgrind_id_list_tail = NULL;
+
+#include <valgrind/valgrind.h>
+
+void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
+    if (p_stack == 0)
+        return;
+
+    const void *p_start = (char *)(p_stack);
+    const void *p_end   = (char *)(p_stack) + size;
+
+    ABTI_PTR_SPINLOCK(&g_valgrind_id_list_lock);
+    ABTI_valgrind_id valgrind_id = VALGRIND_STACK_REGISTER(p_start, p_end);
+    ABTI_valgrind_id_list *p_valgrind_id_list =
+                 (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
+    p_valgrind_id_list->p_stack = p_stack;
+    p_valgrind_id_list->valgrind_id = valgrind_id;
+    p_valgrind_id_list->p_next = 0;
+    if (!gp_valgrind_id_list_head) {
+        gp_valgrind_id_list_head = p_valgrind_id_list;
+        gp_valgrind_id_list_tail = p_valgrind_id_list;
+    } else {
+        gp_valgrind_id_list_tail->p_next = p_valgrind_id_list;
+        gp_valgrind_id_list_tail = p_valgrind_id_list;
+    }
+    LOG_DEBUG("valgrind : register stack %p (id = %d)\n",
+              p_stack, (int) valgrind_id);
+    ABTI_PTR_UNLOCK(&g_valgrind_id_list_lock);
+}
+
+void ABTI_valgrind_unregister_stack(const void *p_stack) {
+    if (p_stack == 0)
+        return;
+
+    ABTI_PTR_SPINLOCK(&g_valgrind_id_list_lock);
+    if (gp_valgrind_id_list_head->p_stack == p_stack) {
+        VALGRIND_STACK_DEREGISTER(gp_valgrind_id_list_head->valgrind_id);
+        ABTI_valgrind_id_list *p_next = gp_valgrind_id_list_head->p_next;
+        free(gp_valgrind_id_list_head);
+        gp_valgrind_id_list_head = p_next;
+        if (!p_next)
+            gp_valgrind_id_list_tail = NULL;
+    } else {
+        /* Do linear search to find the corresponding valgrind_id. */
+        ABTI_valgrind_id_list *p_prev    = gp_valgrind_id_list_head;
+        ABTI_valgrind_id_list *p_current = gp_valgrind_id_list_head->p_next;
+        ABT_bool deregister_flag = ABT_FALSE;
+        while (p_current) {
+            if (p_current->p_stack == p_stack) {
+                LOG_DEBUG("valgrind : deregister stack %p (id = %d)\n",
+                          p_stack, (int) p_current->valgrind_id);
+                VALGRIND_STACK_DEREGISTER(p_current->valgrind_id);
+                p_prev->p_next = p_current->p_next;
+                if (!p_prev->p_next)
+                    gp_valgrind_id_list_tail = p_prev;
+                free(p_current);
+                deregister_flag = ABT_TRUE;
+                break;
+            }
+            p_prev    = p_current;
+            p_current = p_current->p_next;
+        }
+        ABTI_ASSERT(deregister_flag);
+    }
+    ABTI_PTR_UNLOCK(&g_valgrind_id_list_lock);
+}
+
+#endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -1874,8 +1874,6 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
         /* Create a ULT object and its stack */
         size_t stacksize = ABTI_global_get_sched_stacksize();
         p_newthread = ABTI_mem_alloc_thread_with_stacksize(&stacksize);
-        ABTI_VALGRIND_STACK_REGISTER(p_newthread->attr.p_stack, stacksize);
-
         /* When the main scheduler is terminated, the control will jump to the
          * primary ULT. */
         ABTI_thread *p_main_thread = ABTI_global_get_main();


### PR DESCRIPTION
This problem has been mentioned in #10.

This PR is to support Valgrind.

When`` --enable-valgrind`` is given and compiled with debuging flags,
Argobots registers all stacks allocated from heaps to Valgrind so
that Valgrind can correctly handle stacks used by threads. It is
completely ignored and thus does not affect performance when
Valgrind is disabled (by default), or compiled with debugging flags.
