### PR TITLE
[WIP] #14 Fix an assert problem of mutex

### DIFF
--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -51,6 +51,20 @@
         ptr[0] = 0;                                     \
     } while (0)
 
+/* Do not change the values of the constants. */
+
+/* Mutex is unlocked. Anyone not taking a lock tries to change it with CAS. */
+#define ABTI_MUTEX_UNLOCKED                   0
+/* Mutex is locked. Since no threads are waiting, no need to wake them up.
+ * When the lock has this value, the value might be rewritten by threads that
+ * want to wait for this mutex with CAS. */
+#define ABTI_MUTEX_LOCKED_NO_WAITING_THREADS  1
+/* Mutex is locked. No threads wait for this mutex by adding themselves to
+ * htable. This state is only updated by the owner of lock. */
+#define ABTI_MUTEX_LOCKED_NEVER_WAIT          2
+/* Mutex is locked and has waiting threads. This state is only updated by the
+ * owner of lock. */
+#define ABTI_MUTEX_LOCKED_WAITING_THREADS     3
 
 static inline
 ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
@@ -123,7 +137,8 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     ABT_self_get_type(&type);
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
-        while (ABTD_atomic_cas_uint32(&p_mutex->val, 0, 1) != 0) {
+        while (ABTD_atomic_cas_uint32(&p_mutex->val, ABTI_MUTEX_UNLOCKED,
+               ABTI_MUTEX_LOCKED_NO_WAITING_THREADS) != ABTI_MUTEX_UNLOCKED) {
             ABT_thread_yield();
         }
         LOG_EVENT("%p: lock - acquired\n", p_mutex);
@@ -139,36 +154,54 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     ABT_self_get_type(&type);
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
-        int c;
-        if ((c = ABTD_atomic_cas_uint32(&p_mutex->val, 0, 1)) != 0) {
-            if (c != 2) {
-                c = ABTD_atomic_exchange_uint32(&p_mutex->val, 2);
+        int c = ABTD_atomic_cas_uint32(&p_mutex->val, ABTI_MUTEX_UNLOCKED,
+                                       ABTI_MUTEX_LOCKED_NO_WAITING_THREADS);
+        while (c != ABTI_MUTEX_UNLOCKED) {
+            if (c == ABTI_MUTEX_LOCKED_NO_WAITING_THREADS) {
+                /* If p_mutex->val is ABTI_MUTEX_LOCKED_NO_WAITING_THREADS,
+                 * update it to ABTI_MUTEX_LOCKED_WAITING_THREADS since
+                 * this thread becomes waiting. */
+                c = ABTD_atomic_cas_uint32(&p_mutex->val,
+                        ABTI_MUTEX_LOCKED_NO_WAITING_THREADS,
+                        ABTI_MUTEX_LOCKED_WAITING_THREADS);
             }
-            while (c != 0) {
-                ABTI_mutex_wait(p_mutex, 2);
-                /* If the mutex has been handed over to the current ULT from
-                 * other ULT on the same ES, we don't need to change the mutex
-                 * state. */
-                if (p_mutex->p_handover) {
-                    ABTI_thread *p_self = ABTI_local_get_thread();
-                    if (p_self == p_mutex->p_handover) {
-                        p_mutex->p_handover = NULL;
-                        p_mutex->val = 2;
-
-                        /* Push the previous ULT to its pool */
-                        ABTI_thread *p_giver = p_mutex->p_giver;
-                        p_giver->state = ABT_THREAD_STATE_READY;
-                        ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
-                                       p_self->p_last_xstream);
-                        /* When handover succeeds, p_mutex->val is still locked,
-                         * and owned by this thread. */
-                        break;
-                    }
-                }
-
-                c = ABTD_atomic_exchange_uint32(&p_mutex->val, 2);
+            /* It waits for p_mutex using p_htable only if p_mutex->val
+             * is ABTI_MUTEX_LOCKED_WAITING_THREADS. Otherwise, no one might
+             * wake me up. */
+            ABTI_mutex_wait(p_mutex, ABTI_MUTEX_LOCKED_WAITING_THREADS);
+            /* If the mutex has been handed over to the current ULT from
+             * other ULT on the same ES, we don't need to change the mutex
+             * state. */
+            ABTI_thread *p_self = ABTI_local_get_thread();
+            if (p_self == p_mutex->p_handover) {
+                /* If it is handed over, p_mutex is still locked,
+                 * but p_mutex->p_htable->mutex is unlocked. */
+                p_mutex->p_handover = NULL;
+                ABTI_ASSERT(p_mutex->val == ABTI_MUTEX_LOCKED_NEVER_WAIT);
+                /* Update p_mutex->val to ABTI_MUTEX_LOCKED_WAITING_THREADS
+                 * because, though this thread is not waiting now, other threads
+                 * might be still waiting. We do not need atomic operations
+                 * since ABTI_MUTEX_LOCKED_NEVER_WAIT state is only modified
+                 * by the owner of the lock. */
+                p_mutex->val = ABTI_MUTEX_LOCKED_WAITING_THREADS;
+                /* Push the previous ULT to its pool */
+                ABTI_thread *p_giver = p_mutex->p_giver;
+                p_giver->state = ABT_THREAD_STATE_READY;
+                ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
+                               p_self->p_last_xstream);
+                /* When handover succeeds, p_mutex->val is still locked,
+                 * and owned by this thread. */
+                break;
             }
+            /* If p_mutex->val is unlocked, take the lock. This time, it is
+             * updated to ABTI_MUTEX_LOCKED_WAITING_THREADS because the thread
+             * that woke up this thread might not have woken up all the sleeping
+             * threads (because of max_wakeups, for instance.)
+             */
+            c = ABTD_atomic_cas_uint32(&p_mutex->val, ABTI_MUTEX_UNLOCKED,
+                                       ABTI_MUTEX_LOCKED_WAITING_THREADS);
         }
+        /* This thread successfully gets a lock. */
         LOG_EVENT("%p: lock - acquired\n", p_mutex);
     } else {
         ABTI_mutex_spinlock(p_mutex);
@@ -186,7 +219,8 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
 static inline
 int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
 {
-    if (ABTD_atomic_cas_uint32(&p_mutex->val, 0, 1) != 0) {
+    if (ABTD_atomic_cas_uint32(&p_mutex->val, ABTI_MUTEX_UNLOCKED,
+        ABTI_MUTEX_LOCKED_NO_WAITING_THREADS) != ABTI_MUTEX_UNLOCKED) {
         return ABT_ERR_MUTEX_LOCKED;
     }
     return ABT_SUCCESS;
@@ -197,10 +231,16 @@ void ABTI_mutex_unlock(ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTD_atomic_mem_barrier();
-    *(volatile uint32_t *)&p_mutex->val = 0;
+    *(volatile uint32_t *)&p_mutex->val = ABTI_MUTEX_UNLOCKED;
     LOG_EVENT("%p: unlock w/o wake\n", p_mutex);
 #else
-    if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1) != 1) {
+    /* Here's a trick to unlock p_mutex->val if p_mutex is
+     * ABTI_MUTEX_LOCKED_NO_WAITING_THREADS (=1). If it's not, p_mutex->lock
+     * is not released. Note ABTI_MUTEX_LOCKED_NO_WAITING_THREADS is 1. */
+    if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1)
+        != ABTI_MUTEX_LOCKED_NO_WAITING_THREADS) {
+        /* p_mutex->val was ABTI_MUTEX_LOCKED_WAITING_THREADS (=3),
+         * so p_mutex->val becomes ABTI_MUTEX_LOCKED_NEVER_WAIT. */
         LOG_EVENT("%p: unlock with wake\n", p_mutex);
         ABTI_mutex_wake_de(p_mutex);
         /* p_mutex is unlocked after waking up threads. */

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -429,7 +429,7 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     return ABT_ERR_FEATURE_NA;
 #else
     int abt_errno = ABT_SUCCESS;
-    
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 


### PR DESCRIPTION
This PR addresses #14.

Previously, `p_mutex->p_htable` is not protected by `p_mutex->val` (in other words, `p_mutex` itself.)
#14 reports the following problem:
1. in `ABTI_mutex_unlock`, `p_mutex->p_htable` is used after releasing `p_mutex`. 
2. Another thread takes `p_mutex`, unlock it, and release p_mutex and `p_mutex->p_htable`, though `p_mutex->p_htable` is still used in 1.

To solve this problem, `p_mutex->p_htable` should be protected by `p_mutex`. This PR does so, and solves issues incurred by this change. 