### PR TITLE
Fix spin lock (#42)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -603,6 +603,23 @@ else
     enable_simple_mutex=yes
 fi
 
+
+# check if __atomic_test_and_set() and __atomic_clear() are supported
+AC_TRY_COMPILE(
+[#include <stdint.h>],
+[int *lock = 0, val;
+ __atomic_test_and_set((char *)lock, __ATOMIC_ACQ_REL);
+ __atomic_clear((volatile char *)lock, __ATOMIC_RELEASE);
+ val = __atomic_load_n(lock, __ATOMIC_ACQUIRE);],
+[have_atomic_lock=yes],
+[have_atomic_lock=no]
+)
+if test "x$have_atomic_lock" = "xyes" ; then
+    AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_LOCK, 1,
+              [Define if __atomic_test_and_set and _clear are supported])
+fi
+
+
 # --enable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -175,6 +175,49 @@ uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
     return __sync_fetch_and_xor(ptr, v);
 }
 
+#ifdef ABT_CONFIG_HAVE_ATOMIC_LOCK
+
+static inline
+int ABTD_atomic_is_locked_uint32(uint32_t *lock)
+{
+    return __atomic_load_n((char *)lock, __ATOMIC_ACQUIRE);
+}
+
+static inline
+uint32_t ABTD_atomic_lock_uint32(uint32_t *lock)
+{
+    return __atomic_test_and_set((char *)lock, __ATOMIC_ACQ_REL);
+}
+
+static inline
+void ABTD_atomic_unlock_uint32(uint32_t *lock)
+{
+    __atomic_clear((char *)lock, __ATOMIC_RELEASE);
+}
+
+#else
+
+static inline
+int ABTD_atomic_is_locked_uint32(uint32_t *lock)
+{
+    __sync_synchronize();
+    return (*(uint32_t *)lock) == 1;
+}
+
+static inline
+uint32_t ABTD_atomic_lock_uint32(uint32_t *lock)
+{
+    return __sync_lock_test_and_set(lock, 1);
+}
+
+static inline
+void ABTD_atomic_unlock_uint32(uint32_t *lock)
+{
+    __sync_lock_release(lock);
+}
+
+#endif
+
 #ifdef ABT_CONFIG_HAVE_ATOMIC_EXCHANGE
 static inline
 int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -22,16 +22,16 @@ static inline void ABTI_spinlock_free(ABTI_spinlock *p_lock)
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (ABTD_atomic_cas_uint32(&p_lock->val, 0, 1) != 0) {
-        while (*(volatile uint32_t *)(&p_lock->val) != 0) {
+    while (ABTD_atomic_lock_uint32(&p_lock->val)) {
+        while (ABTD_atomic_is_locked_uint32(&p_lock->val)) {
+            ;
         }
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    *(volatile uint32_t *)&p_lock->val = 0;
-    ABTD_atomic_mem_barrier();
+    ABTD_atomic_unlock_uint32(&p_lock->val);
 }
 
 #endif /* SPINLOCK_H_INCLUDED */


### PR DESCRIPTION
This PR is an improvement version of #38 and #42.

The previous spinlock issues mem_barrier "after" releasing locks.

It means that, any memory accesses before membarrier can be reordered, so some memory writes might happen (although it is compiler dependent) after releasing a lock.  Other threads can take that lock and read this memory.

To address this issue, this commit uses GCC built-ins.

As shown in https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html, __atomic_test_and_set() and __atomic_clear() are for spin lock implementation, which usually shows better performance because of compiler help.  In addition, they have clear semantics.

For old GCC, __sync built-ins are supported as well.
https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html
However, as written in the first page, new code should always use __atomic rather than __sync.  In this implementation, Argobots uses __sync builtins only when __atomic is not supported.