### PR TITLE
WIP: add signal_fn for custom scheduler definition

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -290,6 +290,7 @@ typedef void     (*ABT_sched_run_fn)(ABT_sched);
 typedef int      (*ABT_sched_free_fn)(ABT_sched);
 /* To get a pool ready for receiving a migration */
 typedef ABT_pool (*ABT_sched_get_migr_pool_fn)(ABT_sched);
+typedef void     (*ABT_sched_signal_fn)(ABT_sched);
 
 typedef struct {
     ABT_sched_type type; /* ULT or tasklet */
@@ -299,6 +300,7 @@ typedef struct {
     ABT_sched_run_fn           run;
     ABT_sched_free_fn          free;
     ABT_sched_get_migr_pool_fn get_migr_pool;
+    ABT_sched_signal_fn        signal;
 } ABT_sched_def;
 
 /* Pool Functions */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -267,6 +267,7 @@ struct ABTI_sched {
     ABT_sched_run_fn  run;
     ABT_sched_free_fn free;
     ABT_sched_get_migr_pool_fn get_migr_pool;
+    ABT_sched_signal_fn signal;
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     uint64_t id;                /* ID */
@@ -278,6 +279,10 @@ struct ABTI_pool {
     ABT_bool automatic;      /* To know if automatic data free */
     int32_t num_scheds;      /* Number of associated schedulers */
                              /* NOTE: int32_t to check if still positive */
+    int32_t num_signal_scheds; /* Number of associated schedulers that support
+                                * signalling 
+                                */
+    ABTI_sched** signal_scheds;/* Associated schedulers to signal on push */
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     ABTI_xstream *consumer;  /* Associated consumer ES */
 #endif

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -38,6 +38,8 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     p_pool->access               = def->access;
     p_pool->automatic            = ABT_FALSE;
     p_pool->num_scheds           = 0;
+    p_pool->num_signal_scheds    = 0;
+    p_pool->signal_scheds        = NULL;
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     p_pool->consumer             = NULL;
 #endif


### PR DESCRIPTION
Do not merge; this is a prototype for discussion/evaluation.

This pull request adds a new user-definable function pointer to user defined schedulers called signal().  If a scheduler associated with a pool defines this function, then it will be invoked when new work items are added to the pool.

The purpose of this feature is to allow idle schedulers to be awoken when new work arrives.  It's use is demonstrated in a branch of the abt-snoozer scheduler here: https://xgitlab.cels.anl.gov/sds/abt-snoozer/tree/dev-sched-signal.  The original (see origin/master) version of abt-snoozer defines its own pool that stacks on top of the default pool so that it can intercept the push() function for this purpose, which is a little awkward and exposes us to #26.  

The patch does not yet correctly protect data structures in the modified ABTI_pool_retain() and ABTI_pool_release() functions.

The new variation of abt-snoozer is also incomplete; it could be simplified considerably now that it doesn't have to be organized to link a user defined scheduler and user defined pool via their data pointers.