### PR TITLE
remove pool size check from scheduler inner loops

### DIFF
--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -112,14 +112,11 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABT_pool pool = pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            size_t size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                /* Pop one work unit */
-                ABT_unit unit = ABTI_pool_pop(p_pool);
-                if (unit != ABT_UNIT_NULL) {
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            /* Pop one work unit */
+            ABT_unit unit = ABTI_pool_pop(p_pool);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
                 break;
             }
         }

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -95,13 +95,10 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABT_pool pool = p_pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            size_t size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                ABT_unit unit = ABTI_pool_pop(p_pool);
-                if (unit != ABT_UNIT_NULL) {
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            ABT_unit unit = ABTI_pool_pop(p_pool);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
                 break;
             }
         }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -82,27 +82,21 @@ static void sched_run(ABT_sched sched)
         /* Execute one work unit from the scheduler's pool */
         ABT_pool pool = p_pools[0];
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-        size_t size = ABTI_pool_get_size(p_pool);
-        if (size > 0) {
-            unit = ABTI_pool_pop(p_pool);
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                CNT_INC(run_cnt);
-            }
+        unit = ABTI_pool_pop(p_pool);
+        if (unit != ABT_UNIT_NULL) {
+            ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+            CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
             target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
             pool = p_pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
-            size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                unit = ABTI_pool_pop(p_pool);
-                LOG_EVENT_POOL_POP(p_pool, unit);
-                if (unit != ABT_UNIT_NULL) {
-                    ABT_unit_set_associated_pool(unit, pool);
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            unit = ABTI_pool_pop(p_pool);
+            LOG_EVENT_POOL_POP(p_pool, unit);
+            if (unit != ABT_UNIT_NULL) {
+                ABT_unit_set_associated_pool(unit, pool);
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
             }
         }
 


### PR DESCRIPTION
the pop() function itself will return NULL if no work units available