### PR TITLE
implement ABT_SCHED_BASIC_WAIT

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -147,7 +147,8 @@ enum ABT_sched_predef {
     ABT_SCHED_DEFAULT,   /* Default scheduler */
     ABT_SCHED_BASIC,     /* Basic scheduler */
     ABT_SCHED_PRIO,      /* Priority scheduler */
-    ABT_SCHED_RANDWS     /* Random work-stealing scheduler */
+    ABT_SCHED_RANDWS,    /* Random work-stealing scheduler */
+    ABT_SCHED_BASIC_WAIT /* Basic scheduler with ability to wait for units */
 };
 
 enum ABT_sched_type {

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -314,6 +314,7 @@ typedef size_t        (*ABT_pool_get_size_fn)(ABT_pool);
 typedef void          (*ABT_pool_push_fn)(ABT_pool, ABT_unit);
 typedef ABT_unit      (*ABT_pool_pop_fn)(ABT_pool);
 typedef ABT_unit      (*ABT_pool_pop_wait_fn)(ABT_pool);
+typedef ABT_unit      (*ABT_pool_pop_timedwait_fn)(ABT_pool, const struct timespec*);
 typedef int           (*ABT_pool_remove_fn)(ABT_pool, ABT_unit);
 typedef int           (*ABT_pool_free_fn)(ABT_pool);
 
@@ -335,6 +336,7 @@ typedef struct {
     ABT_pool_push_fn     p_push;
     ABT_pool_pop_fn      p_pop;
     ABT_pool_pop_wait_fn p_pop_wait;
+    ABT_pool_pop_timedwait_fn p_pop_timedwait;
     ABT_pool_remove_fn   p_remove;
     ABT_pool_free_fn     p_free;
 } ABT_pool_def;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -313,6 +313,7 @@ typedef int           (*ABT_pool_init_fn)(ABT_pool, ABT_pool_config);
 typedef size_t        (*ABT_pool_get_size_fn)(ABT_pool);
 typedef void          (*ABT_pool_push_fn)(ABT_pool, ABT_unit);
 typedef ABT_unit      (*ABT_pool_pop_fn)(ABT_pool);
+typedef ABT_unit      (*ABT_pool_pop_wait_fn)(ABT_pool);
 typedef int           (*ABT_pool_remove_fn)(ABT_pool, ABT_unit);
 typedef int           (*ABT_pool_free_fn)(ABT_pool);
 
@@ -333,6 +334,7 @@ typedef struct {
     ABT_pool_get_size_fn p_get_size;
     ABT_pool_push_fn     p_push;
     ABT_pool_pop_fn      p_pop;
+    ABT_pool_pop_wait_fn p_pop_wait;
     ABT_pool_remove_fn   p_remove;
     ABT_pool_free_fn     p_free;
 } ABT_pool_def;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -156,7 +156,8 @@ enum ABT_sched_type {
 };
 
 enum ABT_pool_kind {
-    ABT_POOL_FIFO
+    ABT_POOL_FIFO,       /* FIFO pool */
+    ABT_POOL_FIFO_WAIT   /* FIFO pool with ability to wait for units */
 };
 
 enum ABT_pool_access {

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -300,6 +300,7 @@ struct ABTI_pool {
     ABT_pool_push_fn               p_push;
     ABT_pool_pop_fn                p_pop;
     ABT_pool_pop_wait_fn           p_pop_wait;
+    ABT_pool_pop_timedwait_fn      p_pop_timedwait;
     ABT_pool_remove_fn             p_remove;
     ABT_pool_free_fn               p_free;
 };

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -538,6 +538,7 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
 
 /* Pool */
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def);
+int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def);
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
 int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_xstream *p_xstream);
 #endif

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -299,6 +299,7 @@ struct ABTI_pool {
     ABT_pool_get_size_fn           p_get_size;
     ABT_pool_push_fn               p_push;
     ABT_pool_pop_fn                p_pop;
+    ABT_pool_pop_wait_fn           p_pop_wait;
     ABT_pool_remove_fn             p_remove;
     ABT_pool_free_fn               p_free;
 };

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -516,6 +516,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
 
 /* Scheduler */
 ABT_sched_def *ABTI_sched_get_basic_def(void);
+ABT_sched_def *ABTI_sched_get_basic_wait_def(void);
 ABT_sched_def *ABTI_sched_get_prio_def(void);
 ABT_sched_def *ABTI_sched_get_randws_def(void);
 int ABTI_sched_free(ABTI_sched *p_sched);

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -211,6 +211,17 @@ int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_consumer)
 #endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
 static inline
+ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool, const struct timespec *abstime)
+{
+    ABT_unit unit;
+
+    unit = p_pool->p_pop_timedwait(ABTI_pool_get_handle(p_pool), abstime);
+    LOG_EVENT_POOL_POP(p_pool, unit);
+
+    return unit;
+}
+
+static inline
 ABT_unit ABTI_pool_pop_wait(ABTI_pool *p_pool)
 {
     ABT_unit unit;

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -211,6 +211,17 @@ int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_consumer)
 #endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
 static inline
+ABT_unit ABTI_pool_pop_wait(ABTI_pool *p_pool)
+{
+    ABT_unit unit;
+
+    unit = p_pool->p_pop_wait(ABTI_pool_get_handle(p_pool));
+    LOG_EVENT_POOL_POP(p_pool, unit);
+
+    return unit;
+}
+
+static inline
 ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
 {
     ABT_unit unit;

--- a/src/pool/Makefile.mk
+++ b/src/pool/Makefile.mk
@@ -5,5 +5,6 @@
 
 abt_sources += \
 	pool/fifo.c \
+	pool/fifo_wait.c \
 	pool/pool.c
 

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -26,25 +26,6 @@ static ABT_unit unit_create_from_thread(ABT_thread thread);
 static ABT_unit unit_create_from_task(ABT_task task);
 static void unit_free(ABT_unit *unit);
 
-
-/* FIXME: do we need this? */
-ABT_pool_def ABTI_pool_fifo = {
-    .access               = ABT_POOL_ACCESS_MPSC,
-    .p_init               = pool_init,
-    .p_free               = pool_free,
-    .p_get_size           = pool_get_size,
-    .p_push               = pool_push_shared,
-    .p_pop                = pool_pop_shared,
-    .p_remove             = pool_remove_shared,
-    .u_get_type           = unit_get_type,
-    .u_get_thread         = unit_get_thread,
-    .u_get_task           = unit_get_task,
-    .u_is_in_pool         = unit_is_in_pool,
-    .u_create_from_thread = unit_create_from_thread,
-    .u_create_from_task   = unit_create_from_task,
-    .u_free               = unit_free,
-};
-
 struct data {
     ABTI_spinlock mutex;
     size_t num_units;
@@ -57,7 +38,6 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 {
     return (data_t *)p_data;
 }
-
 
 /* Obtain the FIFO pool definition according to the access type */
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -15,6 +15,7 @@ static void     pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
 static ABT_unit pool_pop_wait(ABT_pool pool);
+static ABT_unit pool_pop_timedwait(ABT_pool pool, const struct timespec *abstime);
 static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
 static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
 
@@ -73,6 +74,7 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     p_def->p_free               = pool_free;
     p_def->p_get_size           = pool_get_size;
     p_def->p_pop_wait           = pool_pop_wait;
+    p_def->p_pop_timedwait      = pool_pop_timedwait;
     p_def->u_get_type           = unit_get_type;
     p_def->u_get_thread         = unit_get_thread;
     p_def->u_get_task           = unit_get_task;
@@ -199,6 +201,12 @@ static void pool_push_private(ABT_pool pool, ABT_unit unit)
 static ABT_unit pool_pop_wait(ABT_pool pool)
 {
     HANDLE_ERROR("ABT_POOL_FIFO does not support pop_wait operation");
+    ABTI_ASSERT(0);
+}
+
+static ABT_unit pool_pop_timedwait(ABT_pool pool, const struct timespec *abstime)
+{
+    HANDLE_ERROR("ABT_POOL_FIFO does not support pop_timedwait operation");
     ABTI_ASSERT(0);
 }
 

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -14,6 +14,7 @@ static void     pool_push_shared(ABT_pool pool, ABT_unit unit);
 static void     pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
+static ABT_unit pool_pop_wait(ABT_pool pool);
 static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
 static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
 
@@ -71,6 +72,7 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     p_def->p_init               = pool_init;
     p_def->p_free               = pool_free;
     p_def->p_get_size           = pool_get_size;
+    p_def->p_pop_wait           = pool_pop_wait;
     p_def->u_get_type           = unit_get_type;
     p_def->u_get_thread         = unit_get_thread;
     p_def->u_get_task           = unit_get_task;
@@ -192,6 +194,12 @@ static void pool_push_private(ABT_pool pool, ABT_unit unit)
     p_data->num_units++;
 
     p_unit->pool = pool;
+}
+
+static ABT_unit pool_pop_wait(ABT_pool pool)
+{
+    HANDLE_ERROR("ABT_POOL_FIFO does not support pop_wait operation");
+    ABTI_ASSERT(0);
 }
 
 static ABT_unit pool_pop_shared(ABT_pool pool)

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -1,0 +1,342 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+/* FIFO_WAIT pool implementation */
+
+static int      pool_init(ABT_pool pool, ABT_pool_config config);
+static int      pool_free(ABT_pool pool);
+static size_t   pool_get_size(ABT_pool pool);
+static void     pool_push(ABT_pool pool, ABT_unit unit);
+static ABT_unit pool_pop(ABT_pool pool);
+static ABT_unit pool_pop_wait(ABT_pool pool);
+static ABT_unit pool_pop_timedwait(ABT_pool pool, const struct timespec *abstime);
+static int      pool_remove(ABT_pool pool, ABT_unit unit);
+
+typedef ABTI_unit unit_t;
+static ABT_unit_type unit_get_type(ABT_unit unit);
+static ABT_thread unit_get_thread(ABT_unit unit);
+static ABT_task unit_get_task(ABT_unit unit);
+static ABT_bool unit_is_in_pool(ABT_unit unit);
+static ABT_unit unit_create_from_thread(ABT_thread thread);
+static ABT_unit unit_create_from_task(ABT_task task);
+static void unit_free(ABT_unit *unit);
+
+struct data {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    size_t num_units;
+    unit_t *p_head;
+    unit_t *p_tail;
+};
+typedef struct data data_t;
+
+static inline data_t *pool_get_data_ptr(void *p_data)
+{
+    return (data_t *)p_data;
+}
+
+int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def)
+{
+    p_def->access               = access;
+    p_def->p_init               = pool_init;
+    p_def->p_free               = pool_free;
+    p_def->p_get_size           = pool_get_size;
+    p_def->p_push               = pool_push;
+    p_def->p_pop                = pool_pop;
+    p_def->p_pop_wait           = pool_pop_wait;
+    p_def->p_pop_timedwait      = pool_pop_timedwait;
+    p_def->p_remove             = pool_remove;
+    p_def->u_get_type           = unit_get_type;
+    p_def->u_get_thread         = unit_get_thread;
+    p_def->u_get_task           = unit_get_task;
+    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->u_create_from_thread = unit_create_from_thread;
+    p_def->u_create_from_task   = unit_create_from_task;
+    p_def->u_free               = unit_free;
+
+    return ABT_SUCCESS;
+}
+
+
+/* Pool functions */
+
+int pool_init(ABT_pool pool, ABT_pool_config config)
+{
+    ABTI_UNUSED(config);
+    int abt_errno = ABT_SUCCESS;
+
+    data_t *p_data = (data_t *)ABTU_malloc(sizeof(data_t));
+    
+    pthread_mutex_init(&p_data->mutex, NULL);
+    pthread_cond_init(&p_data->cond, NULL);
+
+    p_data->num_units = 0;
+    p_data->p_head = NULL;
+    p_data->p_tail = NULL;
+
+    ABT_pool_set_data(pool, p_data);
+
+    return abt_errno;
+}
+
+static int pool_free(ABT_pool pool)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+
+    pthread_mutex_destroy(&p_data->mutex);
+    pthread_cond_destroy(&p_data->cond);
+    ABTU_free(p_data);
+
+    return abt_errno;
+}
+
+static size_t pool_get_size(ABT_pool pool)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    return p_data->num_units;
+}
+
+static void pool_push(ABT_pool pool, ABT_unit unit)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    unit_t *p_unit = (unit_t *)unit;
+
+    pthread_mutex_lock(&p_data->mutex);
+    if (p_data->num_units == 0) {
+        p_unit->p_prev = p_unit;
+        p_unit->p_next = p_unit;
+        p_data->p_head = p_unit;
+        p_data->p_tail = p_unit;
+    } else {
+        unit_t *p_head = p_data->p_head;
+        unit_t *p_tail = p_data->p_tail;
+        p_tail->p_next = p_unit;
+        p_head->p_prev = p_unit;
+        p_unit->p_prev = p_tail;
+        p_unit->p_next = p_head;
+        p_data->p_tail = p_unit;
+    }
+    p_data->num_units++;
+
+    p_unit->pool = pool;
+    pthread_cond_signal(&p_data->cond);
+    pthread_mutex_unlock(&p_data->mutex);
+}
+
+static ABT_unit pool_pop_wait(ABT_pool pool)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    unit_t *p_unit = NULL;
+    ABT_unit h_unit = ABT_UNIT_NULL;
+
+    pthread_mutex_lock(&p_data->mutex);
+    while(!p_data->num_units)
+        pthread_cond_wait(&p_data->cond, &p_data->mutex);
+
+    p_unit = p_data->p_head;
+    if (p_data->num_units == 1) {
+        p_data->p_head = NULL;
+        p_data->p_tail = NULL;
+    } else {
+        p_unit->p_prev->p_next = p_unit->p_next;
+        p_unit->p_next->p_prev = p_unit->p_prev;
+        p_data->p_head = p_unit->p_next;
+    }
+    p_data->num_units--;
+
+    p_unit->p_prev = NULL;
+    p_unit->p_next = NULL;
+    p_unit->pool = ABT_POOL_NULL;
+
+    h_unit = (ABT_unit)p_unit;
+
+    pthread_mutex_unlock(&p_data->mutex);
+
+    return h_unit;
+}
+
+static ABT_unit pool_pop_timedwait(ABT_pool pool, const struct timespec *abstime)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    unit_t *p_unit = NULL;
+    ABT_unit h_unit = ABT_UNIT_NULL;
+
+    pthread_mutex_lock(&p_data->mutex);
+
+    if(!p_data->num_units)
+        pthread_cond_timedwait(&p_data->cond, &p_data->mutex, abstime);
+    
+    if (p_data->num_units > 0) {
+        p_unit = p_data->p_head;
+        if (p_data->num_units == 1) {
+            p_data->p_head = NULL;
+            p_data->p_tail = NULL;
+        } else {
+            p_unit->p_prev->p_next = p_unit->p_next;
+            p_unit->p_next->p_prev = p_unit->p_prev;
+            p_data->p_head = p_unit->p_next;
+        }
+        p_data->num_units--;
+
+        p_unit->p_prev = NULL;
+        p_unit->p_next = NULL;
+        p_unit->pool = ABT_POOL_NULL;
+
+        h_unit = (ABT_unit)p_unit;
+    }
+    pthread_mutex_unlock(&p_data->mutex);
+
+    return h_unit;
+}
+
+static ABT_unit pool_pop(ABT_pool pool)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    unit_t *p_unit = NULL;
+    ABT_unit h_unit = ABT_UNIT_NULL;
+
+    pthread_mutex_lock(&p_data->mutex);
+    if (p_data->num_units > 0) {
+        p_unit = p_data->p_head;
+        if (p_data->num_units == 1) {
+            p_data->p_head = NULL;
+            p_data->p_tail = NULL;
+        } else {
+            p_unit->p_prev->p_next = p_unit->p_next;
+            p_unit->p_next->p_prev = p_unit->p_prev;
+            p_data->p_head = p_unit->p_next;
+        }
+        p_data->num_units--;
+
+        p_unit->p_prev = NULL;
+        p_unit->p_next = NULL;
+        p_unit->pool = ABT_POOL_NULL;
+
+        h_unit = (ABT_unit)p_unit;
+    }
+    pthread_mutex_unlock(&p_data->mutex);
+
+    return h_unit;
+}
+
+static int pool_remove(ABT_pool pool, ABT_unit unit)
+{
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    void *data = ABTI_pool_get_data(p_pool);
+    data_t *p_data = pool_get_data_ptr(data);
+    unit_t *p_unit = (unit_t *)unit;
+
+    ABTI_CHECK_TRUE_RET(p_data->num_units != 0, ABT_ERR_POOL);
+    ABTI_CHECK_TRUE_RET(p_unit->pool != ABT_POOL_NULL, ABT_ERR_POOL);
+    ABTI_CHECK_TRUE_MSG_RET(p_unit->pool == pool, ABT_ERR_POOL, "Not my pool");
+
+    pthread_mutex_lock(&p_data->mutex);
+    if (p_data->num_units == 1) {
+        p_data->p_head = NULL;
+        p_data->p_tail = NULL;
+    } else {
+        p_unit->p_prev->p_next = p_unit->p_next;
+        p_unit->p_next->p_prev = p_unit->p_prev;
+        if (p_unit == p_data->p_head) {
+            p_data->p_head = p_unit->p_next;
+        } else if (p_unit == p_data->p_tail) {
+            p_data->p_tail = p_unit->p_prev;
+        }
+    }
+    p_data->num_units--;
+
+    p_unit->pool = ABT_POOL_NULL;
+    pthread_mutex_unlock(&p_data->mutex);
+
+    p_unit->p_prev = NULL;
+    p_unit->p_next = NULL;
+
+    return ABT_SUCCESS;
+}
+
+/* Unit functions */
+
+static ABT_unit_type unit_get_type(ABT_unit unit)
+{
+   unit_t *p_unit = (unit_t *)unit;
+   return p_unit->type;
+}
+
+static ABT_thread unit_get_thread(ABT_unit unit)
+{
+    ABT_thread h_thread;
+    unit_t *p_unit = (unit_t *)unit;
+    if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
+        h_thread = p_unit->thread;
+    } else {
+        h_thread = ABT_THREAD_NULL;
+    }
+    return h_thread;
+}
+
+static ABT_task unit_get_task(ABT_unit unit)
+{
+    ABT_task h_task;
+    unit_t *p_unit = (unit_t *)unit;
+    if (p_unit->type == ABT_UNIT_TYPE_TASK) {
+        h_task = p_unit->task;
+    } else {
+        h_task = ABT_TASK_NULL;
+    }
+    return h_task;
+}
+
+static ABT_bool unit_is_in_pool(ABT_unit unit)
+{
+    unit_t *p_unit = (unit_t *)unit;
+    return (p_unit->pool != ABT_POOL_NULL) ? ABT_TRUE : ABT_FALSE;
+}
+
+static ABT_unit unit_create_from_thread(ABT_thread thread)
+{
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    unit_t *p_unit = &p_thread->unit_def;
+    p_unit->p_prev = NULL;
+    p_unit->p_next = NULL;
+    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->thread = thread;
+    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+
+    return (ABT_unit)p_unit;
+}
+
+static ABT_unit unit_create_from_task(ABT_task task)
+{
+    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    unit_t *p_unit = &p_task->unit_def;
+    p_unit->p_prev = NULL;
+    p_unit->p_next = NULL;
+    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->task   = task;
+    p_unit->type   = ABT_UNIT_TYPE_TASK;
+
+    return (ABT_unit)p_unit;
+}
+
+static void unit_free(ABT_unit *unit)
+{
+    *unit = ABT_UNIT_NULL;
+}
+

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -109,6 +109,9 @@ int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
         case ABT_POOL_FIFO:
             abt_errno = ABTI_pool_get_fifo_def(access, &def);
             break;
+        case ABT_POOL_FIFO_WAIT:
+            abt_errno = ABTI_pool_get_fifo_wait_def(access, &def);
+            break;
         default:
             abt_errno = ABT_ERR_INV_POOL_KIND;
             break;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -60,6 +60,8 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     p_pool->p_get_size           = def->p_get_size;
     p_pool->p_push               = def->p_push;
     p_pool->p_pop                = def->p_pop;
+    p_pool->p_pop_wait           = def->p_pop_wait;
+    p_pool->p_pop_timedwait      = def->p_pop_timedwait;
     p_pool->p_remove             = def->p_remove;
     p_pool->p_free               = def->p_free;
     p_pool->id                   = ABTI_pool_get_new_id();

--- a/src/sched/Makefile.mk
+++ b/src/sched/Makefile.mk
@@ -5,6 +5,7 @@
 
 abt_sources += \
 	sched/basic.c \
+	sched/basic_wait.c \
 	sched/config.c \
 	sched/prio.c \
 	sched/sched.c \

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -112,14 +112,11 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABT_pool pool = pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            size_t size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                /* Pop one work unit */
-                ABT_unit unit = ABTI_pool_pop(p_pool);
-                if (unit != ABT_UNIT_NULL) {
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            /* Pop one work unit */
+            ABT_unit unit = ABTI_pool_pop(p_pool);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
                 break;
             }
         }

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -1,0 +1,204 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+/** @defgroup SCHED_BASIC_WAIT Basic waiting scheduler
+ * This group is for the basic waiting scheudler.
+ */
+
+static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static void sched_run(ABT_sched sched);
+static int  sched_free(ABT_sched);
+static void sched_sort_pools(int num_pools, ABT_pool *pools);
+
+static ABT_sched_def sched_basic_wait_def = {
+    .type = ABT_SCHED_TYPE_TASK,
+    .init = sched_init,
+    .run = sched_run,
+    .free = sched_free,
+    .get_migr_pool = NULL,
+};
+
+typedef struct {
+    uint32_t event_freq;
+    int num_pools;
+    ABT_pool *pools;
+} sched_data;
+
+ABT_sched_config_var ABT_sched_basic_wait_freq = {
+    .idx = 0,
+    .type = ABT_SCHED_CONFIG_INT
+};
+
+ABT_sched_def *ABTI_sched_get_basic_wait_def(void)
+{
+    return &sched_basic_wait_def;
+}
+
+static inline sched_data *sched_data_get_ptr(void *data)
+{
+    return (sched_data *)data;
+}
+
+static int sched_init(ABT_sched sched, ABT_sched_config config)
+{
+    int abt_errno = ABT_SUCCESS;
+    int num_pools;
+
+    /* Default settings */
+    sched_data *p_data = (sched_data *)ABTU_malloc(sizeof(sched_data));
+    p_data->event_freq = ABTI_global_get_sched_event_freq();
+
+    /* Set the variables from the config */
+    ABT_sched_config_read(config, 1, &p_data->event_freq);
+
+    /* Save the list of pools */
+    ABT_sched_get_num_pools(sched, &num_pools);
+    p_data->num_pools = num_pools;
+    p_data->pools = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
+    abt_errno = ABT_sched_get_pools(sched, num_pools, 0, p_data->pools);
+    ABTI_CHECK_ERROR(abt_errno);
+
+    /* Sort pools according to their access mode so the scheduler can execute
+       work units from the private pools. */
+    if (num_pools > 1) {
+        sched_sort_pools(num_pools, p_data->pools);
+    }
+
+    abt_errno = ABT_sched_set_data(sched, (void *)p_data);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_WITH_CODE("basic_wait: sched_init", abt_errno);
+    goto fn_exit;
+}
+
+static void sched_run(ABT_sched sched)
+{
+    uint32_t work_count = 0;
+    void *data;
+    sched_data *p_data;
+    uint32_t event_freq;
+    int num_pools;
+    ABT_pool *pools;
+    int i;
+    int run_cnt_nowait;
+
+    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+
+    ABT_sched_get_data(sched, &data);
+    p_data = sched_data_get_ptr(data);
+    event_freq = p_data->event_freq;
+    num_pools  = p_data->num_pools;
+    pools      = p_data->pools;
+
+    while (1) {
+        run_cnt_nowait = 0;
+
+        /* Execute one work unit from the scheduler's pool */
+        for (i = 0; i < num_pools; i++) {
+            ABT_pool pool = pools[i];
+            ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+            /* Pop one work unit */
+            ABT_unit unit = ABTI_pool_pop(p_pool);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                run_cnt_nowait++;
+                break;
+            }
+        }
+
+        /* Block briefly on pop_timedwait() if we didn't find work to do in
+         * main loop above.
+         */
+        if(!run_cnt_nowait) {
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += 1e8;
+            if(ts.tv_nsec > 1e9) {
+                ts.tv_nsec -= 1e9;
+                ts.tv_sec++;
+            }
+            ABT_unit unit = ABTI_pool_pop_timedwait(
+                ABTI_pool_get_ptr(pools[0]), &ts);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, 
+                    ABTI_pool_get_ptr(pools[0]));
+                break;
+            }
+        }
+
+        /* If run_cnt_nowait is zero, that means that no units were
+         * found in first pass through pools and we must have called 
+         * pop_timedwait above. We should check events regardless of 
+         * work_count in that case for them to be processed in a timely
+         * manner
+         */
+        if (!run_cnt_nowait || (++work_count >= event_freq)) {
+            ABTI_xstream_check_events(p_xstream, sched);
+            ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+            if (stop == ABT_TRUE)
+                break;
+            work_count = 0;
+        }
+    }
+}
+
+static int sched_free(ABT_sched sched)
+{
+    int abt_errno = ABT_SUCCESS;
+
+    void *data;
+
+    ABT_sched_get_data(sched, &data);
+    sched_data *p_data = sched_data_get_ptr(data);
+    ABTU_free(p_data->pools);
+    ABTU_free(p_data);
+    return abt_errno;
+}
+
+static int pool_get_access_num(ABT_pool *p_pool)
+{
+    ABT_pool_access access;
+    int num = 0;
+
+    ABT_pool_get_access(*p_pool, &access);
+    switch (access) {
+        case ABT_POOL_ACCESS_PRIV: num = 0; break;
+        case ABT_POOL_ACCESS_SPSC:
+        case ABT_POOL_ACCESS_MPSC: num = 1; break;
+        case ABT_POOL_ACCESS_SPMC:
+        case ABT_POOL_ACCESS_MPMC: num = 2; break;
+        default: ABTI_ASSERT(0); break;
+    }
+
+    return num;
+}
+
+static int sched_cmp_pools(const void *p1, const void *p2)
+{
+    int p1_access, p2_access;
+
+    p1_access = pool_get_access_num((ABT_pool *)p1);
+    p2_access = pool_get_access_num((ABT_pool *)p2);
+
+    if (p1_access > p2_access) {
+        return 1;
+    } else if (p1_access < p2_access) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+static void sched_sort_pools(int num_pools, ABT_pool *pools)
+{
+    qsort(pools, num_pools, sizeof(ABT_pool), sched_cmp_pools);
+}
+

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -95,13 +95,10 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABT_pool pool = p_pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            size_t size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                ABT_unit unit = ABTI_pool_pop(p_pool);
-                if (unit != ABT_UNIT_NULL) {
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            ABT_unit unit = ABTI_pool_pop(p_pool);
+            if (unit != ABT_UNIT_NULL) {
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
                 break;
             }
         }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -82,27 +82,21 @@ static void sched_run(ABT_sched sched)
         /* Execute one work unit from the scheduler's pool */
         ABT_pool pool = p_pools[0];
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-        size_t size = ABTI_pool_get_size(p_pool);
-        if (size > 0) {
-            unit = ABTI_pool_pop(p_pool);
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                CNT_INC(run_cnt);
-            }
+        unit = ABTI_pool_pop(p_pool);
+        if (unit != ABT_UNIT_NULL) {
+            ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+            CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
             target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
             pool = p_pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
-            size = ABTI_pool_get_size(p_pool);
-            if (size > 0) {
-                unit = ABTI_pool_pop(p_pool);
-                LOG_EVENT_POOL_POP(p_pool, unit);
-                if (unit != ABT_UNIT_NULL) {
-                    ABT_unit_set_associated_pool(unit, pool);
-                    ABTI_xstream_run_unit(p_xstream, unit, p_pool);
-                    CNT_INC(run_cnt);
-                }
+            unit = ABTI_pool_pop(p_pool);
+            LOG_EVENT_POOL_POP(p_pool, unit);
+            if (unit != ABT_UNIT_NULL) {
+                ABT_unit_set_associated_pool(unit, pool);
+                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                CNT_INC(run_cnt);
             }
         }
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -138,6 +138,7 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
 {
     int abt_errno = ABT_SUCCESS;
     ABT_pool_access access;
+    ABT_pool_kind kind = ABT_POOL_FIFO;
     ABT_bool automatic;
     int p;
 
@@ -172,6 +173,12 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                                              ABT_SCHED_CONFIG_NULL,
                                              newsched);
                 break;
+            case ABT_SCHED_BASIC_WAIT:
+                abt_errno = ABT_sched_create(ABTI_sched_get_basic_wait_def(),
+                                             num_pools, pool_list,
+                                             ABT_SCHED_CONFIG_NULL,
+                                             newsched);
+                break;
             case ABT_SCHED_PRIO:
                 abt_errno = ABT_sched_create(ABTI_sched_get_prio_def(),
                                              num_pools, pool_list,
@@ -200,6 +207,11 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
             case ABT_SCHED_BASIC:
                 num_pools = 1;
                 break;
+            case ABT_SCHED_BASIC_WAIT:
+                /* FIFO_WAIT is default pool for use with BASIC_WAIT sched */
+                kind = ABT_POOL_FIFO_WAIT;
+                num_pools = 1;
+                break;
             case ABT_SCHED_PRIO:
                 num_pools = ABTI_SCHED_NUM_PRIO;
                 break;
@@ -217,7 +229,7 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
         ABT_pool pool_list[ABTI_SCHED_NUM_PRIO];
         int p;
         for (p = 0; p < num_pools; p++) {
-            abt_errno = ABT_pool_create_basic(ABT_POOL_FIFO, access, ABT_TRUE,
+            abt_errno = ABT_pool_create_basic(kind, access, ABT_TRUE,
                                               pool_list+p);
             ABTI_CHECK_ERROR(abt_errno);
         }
@@ -227,6 +239,11 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
             case ABT_SCHED_DEFAULT:
             case ABT_SCHED_BASIC:
                 abt_errno = ABT_sched_create(ABTI_sched_get_basic_def(),
+                                             num_pools, pool_list,
+                                             config, newsched);
+                break;
+            case ABT_SCHED_BASIC_WAIT:
+                abt_errno = ABT_sched_create(ABTI_sched_get_basic_wait_def(),
                                              num_pools, pool_list,
                                              config, newsched);
                 break;
@@ -816,6 +833,8 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     kind = p_sched->kind;
     if (kind == ABTI_sched_get_kind(ABTI_sched_get_basic_def())) {
         kind_str = "BASIC";
+    } else if (kind == ABTI_sched_get_kind(ABTI_sched_get_basic_wait_def())) {
+        kind_str = "BASIC_WAIT";
     } else if (kind == ABTI_sched_get_kind(ABTI_sched_get_prio_def())) {
         kind_str = "PRIO";
     } else {

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -28,6 +28,7 @@ TESTS = \
 	thread_task_arg \
 	thread_task_num \
 	sched_basic \
+	sched_basic_wait \
 	sched_prio \
 	sched_randws \
 	sched_set_main \
@@ -93,6 +94,7 @@ thread_task_SOURCES = thread_task.c
 thread_task_arg_SOURCES = thread_task_arg.c
 thread_task_num_SOURCES = thread_task_num.c
 sched_basic_SOURCES = sched_basic.c
+sched_basic_wait_SOURCES = sched_basic_wait.c
 sched_prio_SOURCES = sched_prio.c
 sched_randws_SOURCES = sched_randws.c
 sched_set_main_SOURCES = sched_set_main.c
@@ -146,6 +148,7 @@ testing:
 	./thread_task_arg
 	./thread_task_num
 	./sched_basic
+	./sched_basic_wait
 	./sched_prio
 	./sched_randws
 	./sched_set_main

--- a/test/basic/sched_basic_wait.c
+++ b/test/basic/sched_basic_wait.c
@@ -1,0 +1,99 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS    4
+#define DEFAULT_NUM_THREADS     4
+
+void thread_func(void *arg)
+{
+    size_t my_id = (size_t)arg;
+    ATS_printf(1, "[TH%lu]: Hello, world!\n", my_id);
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j;
+    int ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1) num_xstreams = atoi(argv[1]);
+    assert(num_xstreams >= 0);
+    if (argc > 2) num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    ABT_xstream *xstreams;
+    xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+
+    ABT_sched *scheds;
+    scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * num_xstreams);
+
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
+
+    /* Create schedulers */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_sched_create_basic(ABT_SCHED_BASIC_WAIT, 0, NULL,
+                                     ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create_basic");
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    ret = ABT_xstream_set_main_sched(xstreams[0], scheds[0]);
+    ATS_ERROR(ret, "ABT_xstream_set_main_sched");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(scheds[i], &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create ULTs */
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            size_t tid = i * num_threads + j + 1;
+            ret = ABT_thread_create(pools[i],
+                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
+                    NULL);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(pools);
+    free(scheds);
+    free(xstreams);
+
+    return ret;
+}
+


### PR DESCRIPTION
This adds a new predefined scheduler type called ABT_SCHED_BASIC_WAIT that will block when idle if used in conjunction with ABT_POOL_FIFO_WAIT.

Includes test program and minor change to sched_create_basic() to make it use pool of type POOL_FIFO_WAIT by default with SCHED_BASIC_WAIT if the caller does not specify an explicit pool to use.

This is the revised version of PR #46.  This PR includes generic improvements from PR #47 and PR #48 .

Corresponding branch of margo that uses this capability can be found at https://xgitlab.cels.anl.gov/sds/margo/tree/dev-fifo-wait