### PR TITLE
Add missing error string in ABT_error_get_str

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -49,6 +49,7 @@ int ABT_error_get_str(int err, char *str, size_t *len)
         "ABT_ERR_INV_TASK",
         "ABT_ERR_INV_KEY",
         "ABT_ERR_INV_MUTEX",
+        "ABT_ERR_INV_MUTEX_ATTR",
         "ABT_ERR_INV_COND",
         "ABT_ERR_INV_RWLOCK",
         "ABT_ERR_INV_EVENTUAL",


### PR DESCRIPTION
Add missing error string for `ABT_ERR_INV_MUTEX_ATTR` to  the lookup
table for error strings.

This fixes a bug that lead to:
 * segmentation fault when `ABT_error_str` is called with `err==ABT_ERR_FEATURE_NA`
 * incorrect error strings for `err>ABT_ERR_INV_MUTEX`
