### PR TITLE
Support __atomic builtins.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -618,6 +618,7 @@ if test "x$have_atomic_builtin" = "xyes" ; then
               [Define if __atomic builtins are supported])
 fi
 
+
 # --enable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,

--- a/configure.ac
+++ b/configure.ac
@@ -593,21 +593,29 @@ AS_IF([test "x$enable_sched_sleep" = "xyes"],
                  [Define to make the scheduler sleep when its pools are empty])])
 
 
-# check if __atomic_exchange_n() is supported
+# check if __atomic builtins are supported
 AC_TRY_COMPILE(
 [#include <stdint.h>],
-[uint32_t val = 0;
- uint32_t old = __atomic_exchange_n(&val, 2, __ATOMIC_SEQ_CST);],
-[have_atomic_exchange=yes],
-[have_atomic_exchange=no]
+[int *lock = 0, new = 0, old = 0, val = 0, weak;
+ __atomic_test_and_set((char *)lock, __ATOMIC_ACQ_REL);
+ __atomic_clear((volatile char *)lock, __ATOMIC_RELEASE);
+ __atomic_exchange(&val, &new, &old, __ATOMIC_ACQ_REL);
+ old = __atomic_exchange_n(&val, new, __ATOMIC_ACQ_REL);
+ val = __atomic_compare_exchange(&val, &old, &new, weak = 0, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+ val = __atomic_compare_exchange_n(&val, &old, new, weak = 1, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+ __atomic_load(lock, &val, __ATOMIC_ACQUIRE);
+ val = __atomic_load_n(lock, __ATOMIC_ACQUIRE);
+ __atomic_store(lock, &val, __ATOMIC_RELEASE);
+ __atomic_store_n(lock, val, __ATOMIC_RELEASE);
+ __atomic_add_fetch(lock, 1, __ATOMIC_ACQ_REL);
+ __atomic_fetch_add(lock, 1, __ATOMIC_ACQ_REL);
+ __atomic_thread_fence(__ATOMIC_ACQ_REL);],
+[have_atomic_builtin=yes],
+[have_atomic_builtin=no]
 )
-if test "x$have_atomic_exchange" = "xyes" ; then
-    AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_EXCHANGE, 1,
-              [Define if __atomic_exchange_n is supported])
-else
-    # If __atomic_exchange_n is not supported, we have to use the simple mutex
-    # implementation.
-    enable_simple_mutex=yes
+if test "x$have_atomic_builtin" = "xyes" ; then
+    AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_BUILTIN, 1,
+              [Define if __atomic builtins are supported])
 fi
 
 # --enable-simple-mutex

--- a/src/event.c
+++ b/src/event.c
@@ -343,7 +343,8 @@ static void ABTI_event_free_xstream(void *arg)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     int abt_errno, n;
 
-    while (p_xstream->state != ABT_XSTREAM_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)p_xstream->state)
+           != ABT_XSTREAM_STATE_TERMINATED) {
         ABT_thread_yield();
     }
 
@@ -369,7 +370,8 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
 
     for (n = 0; n < num_xstreams; n++) {
         ABTI_xstream *p_xstream = p_xstreams[n+1];
-        while (p_xstream->state != ABT_XSTREAM_STATE_TERMINATED) {
+        while (ABTD_atomic_load_uint32((uint32_t *)p_xstream->state)
+               != ABT_XSTREAM_STATE_TERMINATED) {
             ABT_thread_yield();
         }
 

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -113,7 +113,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        volatile int ext_signal = 0;
+        int32_t ext_signal = 0;
 
         if (lp_ABTI_local != NULL) {
             p_current = ABTI_local_get_thread();
@@ -153,8 +153,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ext_signal) {
-            }
+            while (!ABTD_atomic_load_int32(&ext_signal));
             ABTU_free(p_unit);
         }
     } else {
@@ -258,8 +257,8 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
             ABTI_thread_set_ready(p_thread);
         } else {
             /* When the head is an external thread */
-            volatile int *p_ext_signal = (volatile int *)p_unit->pool;
-            *p_ext_signal = 1;
+            int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+            ABTD_atomic_store_int32(p_ext_signal, 1);
         }
 
         /* Next ULT */

--- a/src/futures.c
+++ b/src/futures.c
@@ -138,7 +138,7 @@ int ABT_future_wait(ABT_future future)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        volatile int ext_signal = 0;
+        int32_t ext_signal = 0;
 
         if (lp_ABTI_local != NULL) {
             p_current = ABTI_local_get_thread();
@@ -178,8 +178,7 @@ int ABT_future_wait(ABT_future future)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ext_signal) {
-            }
+            while (!ABTD_atomic_load_int32(&ext_signal));
             ABTU_free(p_unit);
         }
     } else {
@@ -276,8 +275,8 @@ int ABT_future_set(ABT_future future, void *value)
                 ABTI_thread_set_ready(p_thread);
             } else {
                 /* When the head is an external thread */
-                volatile int *p_ext_signal = (volatile int *)p_unit->pool;
-                *p_ext_signal = 1;
+                int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+                ABTD_atomic_store_int32(p_ext_signal, 1);
             }
 
             /* Next ULT */

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -10,6 +10,9 @@
 #include <pthread.h>
 #include "abtd_ucontext.h"
 
+/* Atomic Functions */
+#include "abtd_atomic.h"
+
 /* Data Types */
 typedef pthread_t           ABTD_xstream_context;
 typedef pthread_mutex_t     ABTD_xstream_mutex;
@@ -48,9 +51,6 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
 #include "abtd_thread.h"
 void ABTD_thread_exit(ABTI_thread *p_thread);
 void ABTD_thread_cancel(ABTI_thread *p_thread);
-
-/* Atomic Functions */
-#include "abtd_atomic.h"
 
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
 #include <time.h>

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -9,51 +9,301 @@
 #include <stdint.h>
 
 static inline
-int32_t ABTD_atomic_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
+                                   int weak)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    int32_t tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
     return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
 }
 
 static inline
-uint32_t ABTD_atomic_cas_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
+uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
+                                     uint32_t newv, int weak)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    uint32_t tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
     return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
 }
 
 static inline
-int64_t ABTD_atomic_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
+                                   int weak)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    int64_t tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
     return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
 }
 
 static inline
-uint64_t ABTD_atomic_cas_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
+uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
+                                     uint64_t newv, int weak)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    uint64_t tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
     return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    void *tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
+    return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
+                                int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv,
+                                 int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
+                                int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv,
+                                 int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
+static inline
+int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+{
+   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
+}
+
+static inline
+uint32_t ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
+                                         uint32_t newv)
+{
+   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
+}
+
+static inline
+int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+{
+   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
+}
+
+static inline
+uint64_t ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
+                                         uint64_t newv)
+{
+   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
+}
+
+static inline
+void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+{
+   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
+}
+
+static inline
+int32_t ABTD_atomic_val_cas_strong_int32(int32_t *ptr, int32_t oldv,
+                                         int32_t newv)
+{
+   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
+}
+
+static inline
+uint32_t ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
+                                           uint32_t newv)
+{
+   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
+}
+
+static inline
+int64_t ABTD_atomic_val_cas_strong_int64(int64_t *ptr, int64_t oldv,
+                                         int64_t newv)
+{
+   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
+}
+
+static inline
+uint64_t ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
+                                           uint64_t newv)
+{
+   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
+}
+
+static inline
+void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+{
+   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
+}
+
+static inline
+int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+{
+   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
+}
+
+static inline
+int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
+                                     uint32_t newv)
+{
+   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
+}
+
+static inline
+int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+{
+   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
+}
+
+static inline
+int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
+                                     uint64_t newv)
+{
+   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
+}
+
+static inline
+int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+{
+   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
+}
+
+static inline
+int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+{
+   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
+}
+
+static inline
+int ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
+                                       uint32_t newv)
+{
+   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
+}
+
+static inline
+int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+{
+   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
+}
+
+static inline
+int ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
+                                       uint64_t newv)
+{
+   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
+}
+
+static inline
+int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+{
+   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
 }
 
 static inline
 int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_add(ptr, v);
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_add(ptr, v);
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_add(ptr, v);
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_add(ptr, v);
+#endif
 }
 
 static inline
@@ -67,8 +317,8 @@ double ABTD_atomic_fetch_add_double(double *ptr, double v)
     do {
         oldv.d_val = *ptr;
         newv.d_val = oldv.d_val + v;
-    } while (ABTD_atomic_cas_uint64((uint64_t *)ptr, oldv.u_val, newv.u_val)
-             != oldv.u_val);
+    } while (!ABTD_atomic_bool_cas_weak_uint64((uint64_t *)ptr, oldv.u_val,
+                                               newv.u_val));
 
     return oldv.d_val;
 }
@@ -76,25 +326,41 @@ double ABTD_atomic_fetch_add_double(double *ptr, double v)
 static inline
 int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_sub(ptr, v);
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_sub(ptr, v);
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_sub(ptr, v);
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_sub(ptr, v);
+#endif
 }
 
 static inline
@@ -106,105 +372,362 @@ double ABTD_atomic_fetch_sub_double(double *ptr, double v)
 static inline
 int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_and(ptr, v);
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_and(ptr, v);
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_and(ptr, v);
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_and(ptr, v);
+#endif
 }
 
 static inline
 int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_or(ptr, v);
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_or(ptr, v);
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_or(ptr, v);
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_or(ptr, v);
+#endif
 }
 
 static inline
 int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_xor(ptr, v);
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_xor(ptr, v);
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_xor(ptr, v);
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+#else
     return __sync_fetch_and_xor(ptr, v);
+#endif
 }
 
-#ifdef ABT_CONFIG_HAVE_ATOMIC_EXCHANGE
+static inline
+uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
+{
+    /* return 0 if this test_and_set succeeds to set a value. */
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_test_and_set(ptr, __ATOMIC_ACQUIRE);
+#else
+    return __sync_lock_test_and_set(ptr, 1);
+#endif
+}
+
+static inline
+void ABTD_atomic_clear_uint8(uint8_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_clear(ptr, __ATOMIC_RELEASE);
+#else
+    __sync_lock_release(ptr);
+#endif
+}
+
+static inline
+uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    uint8_t val = *(volatile uint8_t *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+int32_t ABTD_atomic_load_int32(int32_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    int32_t val = *(volatile int32_t *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    uint32_t val = *(volatile uint32_t *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+int64_t ABTD_atomic_load_int64(int64_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    int64_t val = *(volatile int64_t *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
+{
+    /* return 0 if this test_and_set succeeds to set a value. */
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    uint64_t val = *(volatile uint64_t *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+void *ABTD_atomic_load_ptr(void **ptr)
+{
+    /* return 0 if this test_and_set succeeds to set a value. */
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    void *val = *(void * volatile *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
+static inline
+void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(volatile int32_t *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
+static inline
+void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(volatile uint32_t *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
+static inline
+void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(volatile int64_t *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
+static inline
+void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(volatile uint64_t *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
+static inline
+void ABTD_atomic_store_ptr(void **ptr, void *val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(void * volatile *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
 static inline
 int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 {
-    return __atomic_exchange_n(ptr, v, __ATOMIC_SEQ_CST);
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    int32_t val;
+    do {
+        val = ABTD_atomic_load_int32(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_int32(ptr, val, v));
+    return val;
+#endif
 }
 
 static inline
 uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 {
-    return __atomic_exchange_n(ptr, v, __ATOMIC_SEQ_CST);
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    uint32_t val;
+    do {
+        val = ABTD_atomic_load_uint32(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_uint32(ptr, val, v));
+    return val;
+#endif
 }
 
 static inline
 int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 {
-    return __atomic_exchange_n(ptr, v, __ATOMIC_SEQ_CST);
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    int64_t val;
+    do {
+        val = ABTD_atomic_load_int64(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_int64(ptr, val, v));
+    return val;
+#endif
 }
 
 static inline
 uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 {
-    return __atomic_exchange_n(ptr, v, __ATOMIC_SEQ_CST);
-}
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    uint64_t val;
+    do {
+        val = ABTD_atomic_load_uint64(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_uint64(ptr, val, v));
+    return val;
 #endif
+}
+
+static inline
+void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    void *val;
+    do {
+        val = ABTD_atomic_load_ptr(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, val, v));
+    return val;
+#endif
+}
 
 static inline
 void ABTD_atomic_mem_barrier(void)
 {
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_thread_fence(__ATOMIC_ACQ_REL);
+#else
     __sync_synchronize();
+#endif
 }
 
 static inline

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -126,7 +126,7 @@ void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
                                      ABTD_thread_context *p_link)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
-    p_ctx->p_link = p_link;
+    ABTD_atomic_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
 
 #else
 #ifdef __GLIBC__

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -71,7 +71,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
     ABTI_thread *p_thread;
     ABTI_unit *p_unit;
     ABT_unit_type type;
-    volatile int ext_signal = 0;
+    int32_t ext_signal = 0;
 
     if (lp_ABTI_local != NULL) {
         p_thread = ABTI_local_get_thread();
@@ -136,8 +136,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 
         /* External thread is waiting here polling ext_signal. */
         /* FIXME: need a better implementation */
-        while (!ext_signal) {
-        }
+        while (!ABTD_atomic_load_int32(&ext_signal));
         ABTU_free(p_unit);
     }
 
@@ -176,8 +175,8 @@ void ABTI_cond_broadcast(ABTI_cond *p_cond)
             ABTI_thread_set_ready(p_thread);
         } else {
             /* When the head is an external thread */
-            volatile int *p_ext_signal = (volatile int *)p_unit->pool;
-            *p_ext_signal = 1;
+            int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+            ABTD_atomic_store_int32(p_ext_signal, 1);
         }
 
         /* Next ULT */

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -8,10 +8,10 @@
 
 /* Inlined functions for Mutex */
 
-#define ABTI_PTR_SPINLOCK(ptr)                          \
+#define ABTI_PTR_SPINLOCK(ptr)                             \
     while (!ABTD_atomic_bool_cas_weak_uint32(ptr, 0, 1)) { \
-        while (*(volatile uint32_t *)(ptr) != 0) {      \
-        }                                               \
+        while (*(volatile uint32_t *)(ptr) != 0) {         \
+        }                                                  \
     }
 
 #define ABTI_PTR_UNLOCK(ptr)                            \
@@ -19,36 +19,36 @@
         *(volatile uint32_t *)(ptr) = 0;                \
     } while (0)
 
-#define ABTI_PTR_SPINLOCK_HIGH(ptr)                                 \
-{                                                                   \
-    uint64_t old_v = (uint64_t)1 << 32;                             \
-    uint64_t new_v = ((uint64_t)1 << 32) | 1;                       \
-    ptr[1] = 1;                                                     \
-    uint64_t *v_ptr = (uint64_t *)ptr;                              \
+#define ABTI_PTR_SPINLOCK_HIGH(ptr)                                  \
+{                                                                    \
+    uint64_t old_v = (uint64_t)1 << 32;                              \
+    uint64_t new_v = ((uint64_t)1 << 32) | 1;                        \
+    ptr[1] = 1;                                                      \
+    uint64_t *v_ptr = (uint64_t *)ptr;                               \
     while (!ABTD_atomic_bool_cas_weak_uint64(v_ptr, old_v, new_v)) { \
-        while (*(volatile uint32_t *)(&ptr[0]) != 0 ) {             \
-        }                                                           \
-        ptr[1] = 1;                                                 \
-    }                                                               \
+        while (*(volatile uint32_t *)(&ptr[0]) != 0 ) {              \
+        }                                                            \
+        ptr[1] = 1;                                                  \
+    }                                                                \
 }
 
-#define ABTI_PTR_UNLOCK_HIGH(ptr)                       \
-    do {                                                \
-        *(volatile uint64_t *)(ptr) = 0;                \
+#define ABTI_PTR_UNLOCK_HIGH(ptr)                             \
+    do {                                                      \
+        *(volatile uint64_t *)(ptr) = 0;                      \
     } while (0)
 
-#define ABTI_PTR_SPINLOCK_LOW(ptr)                      \
-{                                                       \
-    uint64_t *v_ptr = (uint64_t *)ptr;                  \
+#define ABTI_PTR_SPINLOCK_LOW(ptr)                            \
+{                                                             \
+    uint64_t *v_ptr = (uint64_t *)ptr;                        \
     while (!ABTD_atomic_bool_cas_weak_uint64(v_ptr, 0, 1)) {  \
-        while (*(volatile uint32_t *)(&ptr[0]) != 0) {  \
-        }                                               \
-    }                                                   \
+        while (*(volatile uint32_t *)(&ptr[0]) != 0) {        \
+        }                                                     \
+    }                                                         \
 }
 
-#define ABTI_PTR_UNLOCK_LOW(ptr)                        \
-    do {                                                \
-        ptr[0] = 0;                                     \
+#define ABTI_PTR_UNLOCK_LOW(ptr)                              \
+    do {                                                      \
+        ptr[0] = 0;                                           \
     } while (0)
 
 

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -7,7 +7,7 @@
 #define SPINLOCK_H_INCLUDED
 
 struct ABTI_spinlock {
-    uint32_t val;
+    uint8_t val;
 };
 
 static inline void ABTI_spinlock_create(ABTI_spinlock *p_lock)
@@ -22,16 +22,14 @@ static inline void ABTI_spinlock_free(ABTI_spinlock *p_lock)
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (!ABTD_atomic_bool_cas_weak_uint32(&p_lock->val, 0, 1)) {
-        while (*(volatile uint32_t *)(&p_lock->val) != 0) {
-        }
+    while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_lock->val)) {
+        while (ABTD_atomic_load_uint8((uint8_t *)&p_lock->val) != 0);
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    *(volatile uint32_t *)&p_lock->val = 0;
-    ABTD_atomic_mem_barrier();
+    ABTD_atomic_clear_uint8((uint8_t *)&p_lock->val);
 }
 
 #endif /* SPINLOCK_H_INCLUDED */

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -22,7 +22,7 @@ static inline void ABTI_spinlock_free(ABTI_spinlock *p_lock)
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (ABTD_atomic_cas_uint32(&p_lock->val, 0, 1) != 0) {
+    while (!ABTD_atomic_bool_cas_weak_uint32(&p_lock->val, 0, 1)) {
         while (*(volatile uint32_t *)(&p_lock->val) != 0) {
         }
     }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -130,12 +130,14 @@ void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
     ABTI_EVENT_INC_UNIT_CNT(p_thread->p_last_xstream, ABT_UNIT_TYPE_THREAD);
     if (p_thread->refcount == 0) {
-        p_thread->state = ABT_THREAD_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+                                 ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-        p_thread->state = ABT_THREAD_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+                                 ABT_THREAD_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_thread->is_sched);
 #endif
     } else {
@@ -143,7 +145,8 @@ void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        p_thread->state = ABT_THREAD_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+                                 ABT_THREAD_STATE_TERMINATED);
     }
 }
 
@@ -154,12 +157,14 @@ void ABTI_xstream_terminate_task(ABTI_task *p_task)
               ABTI_task_get_id(p_task), p_task->p_xstream->rank);
     ABTI_EVENT_INC_UNIT_CNT(p_task->p_xstream, ABT_UNIT_TYPE_TASK);
     if (p_task->refcount == 0) {
-        p_task->state = ABT_TASK_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+                                 ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
-        p_task->state = ABT_TASK_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+                                 ABT_TASK_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_task->is_sched);
 #endif
     } else {
@@ -167,7 +172,8 @@ void ABTI_xstream_terminate_task(ABTI_task *p_task)
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        p_task->state = ABT_TASK_STATE_TERMINATED;
+        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+                                 ABT_TASK_STATE_TERMINATED);
     }
 }
 

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -461,6 +461,7 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
     uint32_t num_remote_free = p_ph->num_remote_free;
     void **ptr;
     void *old;
+
     ABTD_atomic_fetch_sub_uint32(&p_ph->num_remote_free, num_remote_free);
     p_ph->num_empty_blks += num_remote_free;
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -181,7 +181,7 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
     ABT_self_get_type(&type);
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock_low - try\n", p_mutex);
-        while (ABTD_atomic_cas_uint32(&p_mutex->val, 0, 1) != 0) {
+        while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
             ABT_thread_yield();
         }
         LOG_EVENT("%p: lock_low - acquired\n", p_mutex);
@@ -215,7 +215,7 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
             }
         }
 
-        if ((c = ABTD_atomic_cas_uint32(&p_mutex->val, 0, 1)) != 0) {
+        if ((c = ABTD_atomic_val_cas_strong_uint32(&p_mutex->val, 0, 1)) != 0) {
             if (c != 2) {
                 c = ABTD_atomic_exchange_uint32(&p_mutex->val, 2);
             }

--- a/src/task.c
+++ b/src/task.c
@@ -880,8 +880,8 @@ void ABTI_task_release(ABTI_task *p_task)
 {
     uint32_t refcount;
     while ((refcount = p_task->refcount) > 0) {
-        if (ABTD_atomic_cas_uint32(&p_task->refcount, refcount,
-            refcount - 1) == refcount) {
+        if (ABTD_atomic_bool_cas_weak_uint32(&p_task->refcount, refcount,
+                                             refcount - 1)) {
             break;
         }
     }

--- a/src/task.c
+++ b/src/task.c
@@ -302,7 +302,8 @@ int ABT_task_free(ABT_task *task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* Wait until the task terminates */
-    while (p_task->state != ABT_TASK_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
+           != ABT_TASK_STATE_TERMINATED) {
         ABT_thread_yield();
     }
 
@@ -340,7 +341,8 @@ int ABT_task_join(ABT_task task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* TODO: better implementation */
-    while (p_task->state != ABT_TASK_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
+           != ABT_TASK_STATE_TERMINATED) {
         ABT_thread_yield();
     }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -509,8 +509,8 @@ int ABT_thread_join(ABT_thread thread)
     }
 
   yield_based:
-    while (*(volatile ABT_thread_state *)(&p_thread->state) !=
-           ABT_THREAD_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state)
+           != ABT_THREAD_STATE_TERMINATED) {
         ABT_thread_yield();
     }
 
@@ -2001,8 +2001,8 @@ int ABTI_thread_set_ready(ABTI_thread *p_thread)
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
      * request. Otherwise, the ULT can be pushed to a pool here and be
      * scheduled by another scheduler if it is pushed to a shared pool. */
-    while (*(volatile uint32_t *)(&p_thread->request) & ABTI_THREAD_REQ_BLOCK) {
-    }
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->request)
+           & ABTI_THREAD_REQ_BLOCK);
 
     LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);

--- a/src/thread.c
+++ b/src/thread.c
@@ -2205,8 +2205,8 @@ void ABTI_thread_release(ABTI_thread *p_thread)
 {
     uint32_t refcount;
     while ((refcount = p_thread->refcount) > 0) {
-        if (ABTD_atomic_cas_uint32(&p_thread->refcount, refcount,
-            refcount - 1) == refcount) {
+        if (ABTD_atomic_bool_cas_weak_uint32(&p_thread->refcount, refcount,
+                                             refcount - 1)) {
             break;
         }
     }


### PR DESCRIPTION
This commit fully supports GCC's `__atomic` builtins providing precise memory semantics.

This commit does not only fix incorrect spinlocks (#38, #42, #44), but also gives correct implementations
for synchronization of `state`, `request`, `ext_signal` and so on which are previously accessed by multiple threads without any synchronization.

See commit logs for details.