### PR TITLE
Fix #60

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -2123,11 +2123,17 @@ int ABTI_thread_set_ready(ABTI_thread *p_thread)
     LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
+    /* p_thread->p_pool is loaded before ABTI_POOL_ADD_THREAD to keep
+     * num_blocked consistent. Otherwise, other threads might pop p_thread
+     * that has been pushed in ABTI_POOL_ADD_THREAD and change p_thread->p_pool
+     * by ABT_unit_set_associated_pool. */
+    ABTI_pool *p_pool = p_thread->p_pool;
+
     /* Add the ULT to its associated pool */
     ABTI_POOL_ADD_THREAD(p_thread, ABTI_xstream_self());
 
     /* Decrease the number of blocked threads */
-    ABTI_pool_dec_num_blocked(p_thread->p_pool);
+    ABTI_pool_dec_num_blocked(p_pool);
 
   fn_exit:
     return abt_errno;


### PR DESCRIPTION
This PR fixes #60. Especially, this bug seems to happen when shared pools are used with `ABT_unit_set_associated_pool`. The bug happens in the following way.
1. A thread `T1` suspends. `ABTI_thread_suspend` is called and atomically increments `num_blocked` of the pool associated with `T1` (`P1`).
2. Another thread (`T2`) tries to resume `T1`. In this case, this thread must decrease `num_blocked` of the pool *originally* associated with `T1` (i.e., `P1`). However, in `ABTI_thread_set_ready`, the pool is dereferenced *after* `T1` is pushed to `P1`.
3. A scheduler (`S1`) can get `T1` from `P1` and change the associated pool of `T1` from `P1` to `P2` by calling `ABT_unit_set_associated_pool`.
4. `T2` will decrement `num_blocked` of `P2`, not `P1` in `ABTI_thread_set_ready`.

The problem is that `T1`’s pool is dereferenced after a push operation. This PR fixes it.