### PR TITLE
sched: support ABT_sched_config_automatic.

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -336,6 +336,8 @@ extern ABT_sched_config_var ABT_sched_basic_freq ABT_API_PUBLIC;
   /* To configure the frequency for checking events of the basic scheduler */
 extern ABT_sched_config_var ABT_sched_config_access ABT_API_PUBLIC;
   /* To configure the access type of the pools created automatically */
+extern ABT_sched_config_var ABT_sched_config_automatic ABT_API_PUBLIC;
+  /* To configure whether ths scheduler is freed automatically or not */
 
 /* Scheduler Functions */
 typedef int      (*ABT_sched_init_fn)(ABT_sched, ABT_sched_config);

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -25,6 +25,11 @@ ABT_sched_config_var ABT_sched_config_access = {
     .type = ABT_SCHED_CONFIG_INT
 };
 
+ABT_sched_config_var ABT_sched_config_automatic = {
+    .idx = -3,
+    .type = ABT_SCHED_CONFIG_INT
+};
+
 
 /**
  * @ingroup SCHED_CONFIG
@@ -227,9 +232,9 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
     int access_i = -1;
     int automatic_i = -1;
 
-    void **variables = (void **)ABTU_malloc(num_vars*sizeof(void *));
-    variables[0] = &access_i;
-    variables[1] = &automatic_i;
+    void **variables = (void **)ABTU_malloc(num_vars * sizeof(void *));
+    variables[(ABT_sched_config_access.idx + 2) * (-1)] = &access_i;
+    variables[(ABT_sched_config_automatic.idx + 2) * (-1)] = &automatic_i;
 
     abt_errno = ABTI_sched_config_read(config, 0, num_vars, variables);
     ABTU_free(variables);

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -41,7 +41,10 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     ABTI_sched *p_sched;
 
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
-    abt_errno = ABTI_sched_create(def, num_pools, pools, config, ABT_FALSE,
+    /* TODO: the default value of automatic is different from
+     * ABT_sched_create_basic(). Make it consistent. */
+    const ABT_bool def_automatic = ABT_FALSE;
+    abt_errno = ABTI_sched_create(def, num_pools, pools, config, def_automatic,
                                   &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -637,7 +640,9 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
 
     /* We set the access to the default one */
     access = ABT_POOL_ACCESS_MPSC;
-    automatic = ABT_TRUE;;
+    /* TODO: the default value is different from ABT_sched_create().
+     * Make it consistent. */
+    automatic = ABT_TRUE;
     /* We read the config and set the configured parameters */
     abt_errno = ABTI_sched_config_read_global(config, &access, &automatic);
     ABTI_CHECK_ERROR(abt_errno);


### PR DESCRIPTION
Add `ABT_sched_config_automatic` that did not exist though it was mentioned in the comment.
```
  *     - ABT_sched_config_automatic: to automatically free the scheduler when
  *     unused (ABT_TRUE by default)
```
Now users can overwrite `automatic` of `ABT_sched` by passing `ABT_sched_config`.
This PR addresses #59.