### PR TITLE
Inline fpu check

### DIFF
--- a/src/arch/fcontext/jump_arm64_aapcs_elf_gas.S
+++ b/src/arch/fcontext/jump_arm64_aapcs_elf_gas.S
@@ -51,6 +51,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .cpu    generic+fp+simd
 .text
 .align  2
@@ -60,23 +62,14 @@ jump_fcontext:
     # prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 
-# Because gcc may save integer registers in fp registers across a
-# function call we cannot skip saving the fp registers.
-#
-# Do not reinstate this test unless you fully understand what you
-# are doing.
-#
-#    # test if fpu env should be preserved
-#    cmp  w3, #0
-#    b.eq  1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     # save d8 - d15
     stp  d8,  d9,  [sp, #0x00]
     stp  d10, d11, [sp, #0x10]
     stp  d12, d13, [sp, #0x20]
     stp  d14, d15, [sp, #0x30]
+#endif
 
-1:
     # save x19-x30
     stp  x19, x20, [sp, #0x40]
     stp  x21, x22, [sp, #0x50]
@@ -96,17 +89,14 @@ jump_fcontext:
     # restore RSP (pointing to context-data) from A2 (x1)
     mov  sp, x1
 
-#    # test if fpu env should be preserved
-#    cmp  w3, #0
-#    b.eq  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     # load d8 - d15
     ldp  d8,  d9,  [sp, #0x00]
     ldp  d10, d11, [sp, #0x10]
     ldp  d12, d13, [sp, #0x20]
     ldp  d14, d15, [sp, #0x30]
+#endif
 
-2:
     # load x19-x30
     ldp  x19, x20, [sp, #0x40]
     ldp  x21, x22, [sp, #0x50]

--- a/src/arch/fcontext/jump_arm64_aapcs_macho_gas.S
+++ b/src/arch/fcontext/jump_arm64_aapcs_macho_gas.S
@@ -45,6 +45,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _jump_fcontext
 .balign 16
@@ -52,18 +54,12 @@ _jump_fcontext:
     ; prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-    ; test if fpu env should be preserved
-    cmp  w3, #0
-    b.eq  1f
-
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__)) && ABTD_FCONTEXT_PRESERVE_FPU
     ; save d8 - d15
     stp  d8,  d9,  [sp, #0x00]
     stp  d10, d11, [sp, #0x10]
     stp  d12, d13, [sp, #0x20]
     stp  d14, d15, [sp, #0x30]
-
-1:
 #endif
 
     ; save x19-x30
@@ -85,18 +81,12 @@ _jump_fcontext:
     ; restore RSP (pointing to context-data) from A2 (x1)
     mov  sp, x1
 
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
-    ; test if fpu env should be preserved
-    cmp  w3, #0
-    b.eq  2f
-
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__)) && ABTD_FCONTEXT_PRESERVE_FPU
     ; load d8 - d15
     ldp  d8,  d9,  [sp, #0x00]
     ldp  d10, d11, [sp, #0x10]
     ldp  d12, d13, [sp, #0x20]
     ldp  d14, d15, [sp, #0x30]
-
-2:
 #endif
 
     ; load x19-x30

--- a/src/arch/fcontext/jump_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_elf_gas.S
@@ -17,6 +17,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl jump_fcontext
 .align 2
@@ -33,16 +35,13 @@ jump_fcontext:
     /* prepare stack for FPU */
     leal  -0x8(%esp), %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* save MMX control- and status-word */
     stmxcsr  (%esp)
     /* save x87 control-word */
     fnstcw  0x4(%esp)
+#endif
 
-1:
     /* first arg of jump_fcontext() == context jumping from */
     movl  0x1c(%esp), %eax
 
@@ -58,15 +57,13 @@ jump_fcontext:
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%esp)
     /* restore x87 control-word */
     fldcw  0x4(%esp)
-2:
+#endif
+
     /* prepare stack for FPU */
     leal  0x8(%esp), %esp
 

--- a/src/arch/fcontext/jump_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_macho_gas.S
@@ -17,6 +17,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _jump_fcontext
 .align 2
@@ -32,16 +34,13 @@ _jump_fcontext:
     /* prepare stack for FPU */
     leal  -0x8(%esp), %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* save MMX control- and status-word */
     stmxcsr  (%esp)
     /* save x87 control-word */
     fnstcw  0x4(%esp)
+#endif
 
-1:
     /* first arg of jump_fcontext() == context jumping from */
     movl  0x1c(%esp), %eax
 
@@ -57,15 +56,13 @@ _jump_fcontext:
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%esp)
     /* restore x87 control-word */
     fldcw  0x4(%esp)
-2:
+#endif
+
     /* prepare stack for FPU */
     leal  0x8(%esp), %esp
 

--- a/src/arch/fcontext/jump_ppc32_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_ppc32_sysv_elf_gas.S
@@ -66,6 +66,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl jump_fcontext
 .align 2
@@ -103,10 +105,7 @@ jump_fcontext:
     # save LR as PC
     stw  %r0, 236(%r1)
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  %f14, 0(%r1)  # save F14
     stfd  %f15, 8(%r1)  # save F15
     stfd  %f16, 16(%r1)  # save F16
@@ -127,18 +126,15 @@ jump_fcontext:
     stfd  %f31, 136(%r1)  # save F31
     mffs  %f0  # load FPSCR
     stfd  %f0, 144(%r1)  # save FPSCR
+#endif
 
-1:
     # store RSP (pointing to context-data) in R3
     stw  %r1, 0(%r3)
 
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  %f14, 0(%r1)  # restore F14
     lfd  %f15, 8(%r1)  # restore F15
     lfd  %f16, 16(%r1)  # restore F16
@@ -159,8 +155,8 @@ jump_fcontext:
     lfd  %f31, 136(%r1)  # restore F31
     lfd  %f0,  144(%r1)  # load FPSCR
     mtfsf  0xff, %f0  # restore FPSCR
+#endif
 
-2:
     lwz  %r13, 152(%r1)  # restore R13
     lwz  %r14, 156(%r1)  # restore R14
     lwz  %r15, 160(%r1)  # restore R15

--- a/src/arch/fcontext/jump_ppc32_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_ppc32_sysv_macho_gas.S
@@ -66,6 +66,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _jump_fcontext
 .align 2
@@ -102,10 +104,7 @@ _jump_fcontext:
     ; save LR as PC
     stw  r0, 236(r1)
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l1 
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  f14, 0(r1)  ; save F14
     stfd  f15, 8(r1)  ; save F15
     stfd  f16, 16(r1)  ; save F16
@@ -126,18 +125,15 @@ _jump_fcontext:
     stfd  f31, 136(r1)  ; save F31
     mffs  f0  ; load FPSCR
     stfd  f0, 144(r1)  ; save FPSCR
+#endif
 
-l1:
     ; store RSP (pointing to context-data) in R3
     stw  r1, 0(r3)
 
     ; restore RSP (pointing to context-data) from R4
     mr  r1, r4
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l2
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  f14, 0(r1)  ; restore F14
     lfd  f15, 8(r1)  ; restore F15
     lfd  f16, 16(r1)  ; restore F16
@@ -158,8 +154,8 @@ l1:
     lfd  f31, 136(r1)  ; restore F31
     lfd  f0,  144(r1)  ; load FPSCR
     mtfsf  0xff, f0  ; restore FPSCR
+#endif
 
-l2:
     lwz  r13, 152(r1)  ; restore R13
     lwz  r14, 156(r1)  ; restore R14
     lwz  r15, 160(r1)  ; restore R15

--- a/src/arch/fcontext/jump_ppc64_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_ppc64_sysv_elf_gas.S
@@ -88,6 +88,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .globl jump_fcontext
 #if _CALL_ELF == 2
 	.text
@@ -151,10 +153,7 @@ jump_fcontext:
     # save LR as PC
     std  %r0, 320(%r1)
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  %f14, 0(%r1)  # save F14
     stfd  %f15, 8(%r1)  # save F15
     stfd  %f16, 16(%r1)  # save F16
@@ -175,18 +174,15 @@ jump_fcontext:
     stfd  %f31, 136(%r1)  # save F31
     mffs  %f0  # load FPSCR
     stfd  %f0, 144(%r1)  # save FPSCR
+#endif
 
-1:
     # store RSP (pointing to context-data) in R3
     std  %r1, 0(%r3)
 
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  %f14, 0(%r1)  # restore F14
     lfd  %f15, 8(%r1)  # restore F15
     lfd  %f16, 16(%r1)  # restore F16
@@ -207,8 +203,8 @@ jump_fcontext:
     lfd  %f31, 136(%r1)  # restore F31
     lfd  %f0,  144(%r1)  # load FPSCR
     mtfsf  0xff, %f0  # restore FPSCR
+#endif
 
-2:
 #if _CALL_ELF != 2
     ld  %r2,  152(%r1)  # restore TOC
 #endif

--- a/src/arch/fcontext/jump_ppc64_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_ppc64_sysv_macho_gas.S
@@ -88,6 +88,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .align 2
 .globl jump_fcontext
@@ -125,10 +127,7 @@ _jump_fcontext:
     ; save LR as PC
     std  r0, 320(r1)
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l1
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  f14, 0(r1)  ; save F14
     stfd  f15, 8(r1)  ; save F15
     stfd  f16, 16(r1)  ; save F16
@@ -149,18 +148,15 @@ _jump_fcontext:
     stfd  f31, 136(r1)  ; save F31
     mffs  f0  ; load FPSCR
     stfd  f0, 144(r1)  ; save FPSCR
+#endif
 
-l1:
     ; store RSP (pointing to context-data) in R3
     stw  r1, 0(r3)
 
     ; restore RSP (pointing to context-data) from R4
     mr  r1, r4
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l2
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  f14, 0(r1)  ; restore F14
     lfd  f15, 8(r1)  ; restore F15
     lfd  f16, 16(r1)  ; restore F16
@@ -181,8 +177,8 @@ l1:
     lfd  f31, 136(r1)  ; restore F31
     lfd  f0,  144(r1)  ; load FPSCR
     mtfsf  0xff, f0  ; restore FPSCR
+#endif
 
-2:
     ld  r13, 152(r1)  ; restore R13
     ld  r14, 160(r1)  ; restore R14
     ld  r15, 168(r1)  ; restore R15

--- a/src/arch/fcontext/jump_x86_64_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_x86_64_sysv_elf_gas.S
@@ -31,6 +31,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl jump_fcontext
 .type jump_fcontext,@function
@@ -46,32 +48,26 @@ jump_fcontext:
     /* prepare stack for FPU */
     leaq  -0x8(%rsp), %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* save MMX control- and status-word */
     stmxcsr  (%rsp)
     /* save x87 control-word */
     fnstcw   0x4(%rsp)
+#endif
 
-1:
     /* store RSP (pointing to context-data) in RDI */
     movq  %rsp, (%rdi)
 
     /* restore RSP (pointing to context-data) from RSI */
     movq  %rsi, %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%rsp)
     /* restore x87 control-word */
     fldcw  0x4(%rsp)
+#endif
 
-2:
     /* prepare stack for FPU */
     leaq  0x8(%rsp), %rsp
 

--- a/src/arch/fcontext/jump_x86_64_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_x86_64_sysv_macho_gas.S
@@ -31,6 +31,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _jump_fcontext
 .align 8
@@ -45,32 +47,26 @@ _jump_fcontext:
     /* prepare stack for FPU */
     leaq  -0x8(%rsp), %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* save MMX control- and status-word */
     stmxcsr  (%rsp)
     /* save x87 control-word */
     fnstcw   0x4(%rsp)
+#endif
 
-1:
     /* store RSP (pointing to context-data) in RDI */
     movq  %rsp, (%rdi)
 
     /* restore RSP (pointing to context-data) from RSI */
     movq  %rsi, %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%rsp)
     /* restore x87 control-word */
     fldcw  0x4(%rsp)
+#endif
 
-2:
     /* prepare stack for FPU */
     leaq  0x8(%rsp), %rsp
 

--- a/src/arch/fcontext/take_arm64_aapcs_elf_gas.S
+++ b/src/arch/fcontext/take_arm64_aapcs_elf_gas.S
@@ -51,6 +51,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .cpu    generic+fp+simd
 .text
 .align  2
@@ -60,17 +62,14 @@ take_fcontext:
     # restore RSP (pointing to context-data) from A2 (x1)
     mov  sp, x1
 
-#    # test if fpu env should be preserved
-#    cmp  w3, #0
-#    b.eq  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     # load d8 - d15
     ldp  d8,  d9,  [sp, #0x00]
     ldp  d10, d11, [sp, #0x10]
     ldp  d12, d13, [sp, #0x20]
     ldp  d14, d15, [sp, #0x30]
+#endif
 
-2:
     # load x19-x30
     ldp  x19, x20, [sp, #0x40]
     ldp  x21, x22, [sp, #0x50]

--- a/src/arch/fcontext/take_arm64_aapcs_macho_gas.S
+++ b/src/arch/fcontext/take_arm64_aapcs_macho_gas.S
@@ -45,6 +45,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _take_fcontext
 .balign 16
@@ -52,17 +54,13 @@ _take_fcontext:
     ; restore RSP (pointing to context-data) from A2 (x1)
     mov  sp, x1
 
-    ; test if fpu env should be preserved
-    ; cmp  w3, #0
-    ; b.eq  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     ; load d8 - d15
     ldp  d8,  d9,  [sp, #0x00]
     ldp  d10, d11, [sp, #0x10]
     ldp  d12, d13, [sp, #0x20]
     ldp  d14, d15, [sp, #0x30]
-
-2:
+#endif
 
     ; load x19-x30
     ldp  x19, x20, [sp, #0x40]

--- a/src/arch/fcontext/take_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_elf_gas.S
@@ -17,6 +17,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl take_fcontext
 .align 2
@@ -34,15 +36,13 @@ take_fcontext:
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%esp)
     /* restore x87 control-word */
     fldcw  0x4(%esp)
-2:
+#endif
+
     /* prepare stack for FPU */
     leal  0x8(%esp), %esp
 

--- a/src/arch/fcontext/take_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_macho_gas.S
@@ -17,6 +17,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _take_fcontext
 .align 2
@@ -33,15 +35,13 @@ _take_fcontext:
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp
 
-    /* test for flag preserve_fpu */
-    test  %ecx, %ecx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%esp)
     /* restore x87 control-word */
     fldcw  0x4(%esp)
-2:
+#endif
+
     /* prepare stack for FPU */
     leal  0x8(%esp), %esp
 

--- a/src/arch/fcontext/take_ppc32_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_ppc32_sysv_elf_gas.S
@@ -66,6 +66,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl take_fcontext
 .align 2
@@ -103,10 +105,7 @@ take_fcontext:
     # save LR as PC
     stw  %r0, 236(%r1)
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  %f14, 0(%r1)  # save F14
     stfd  %f15, 8(%r1)  # save F15
     stfd  %f16, 16(%r1)  # save F16
@@ -127,18 +126,15 @@ take_fcontext:
     stfd  %f31, 136(%r1)  # save F31
     mffs  %f0  # load FPSCR
     stfd  %f0, 144(%r1)  # save FPSCR
+#endif
 
-1:
     # store RSP (pointing to context-data) in R3
     stw  %r1, 0(%r3)
 
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  %f14, 0(%r1)  # restore F14
     lfd  %f15, 8(%r1)  # restore F15
     lfd  %f16, 16(%r1)  # restore F16
@@ -159,8 +155,8 @@ take_fcontext:
     lfd  %f31, 136(%r1)  # restore F31
     lfd  %f0,  144(%r1)  # load FPSCR
     mtfsf  0xff, %f0  # restore FPSCR
+#endif
 
-2:
     lwz  %r13, 152(%r1)  # restore R13
     lwz  %r14, 156(%r1)  # restore R14
     lwz  %r15, 160(%r1)  # restore R15

--- a/src/arch/fcontext/take_ppc32_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_ppc32_sysv_macho_gas.S
@@ -66,6 +66,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _take_fcontext
 .align 2
@@ -102,10 +104,7 @@ _take_fcontext:
     ; save LR as PC
     stw  r0, 236(r1)
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l1 
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  f14, 0(r1)  ; save F14
     stfd  f15, 8(r1)  ; save F15
     stfd  f16, 16(r1)  ; save F16
@@ -126,18 +125,15 @@ _take_fcontext:
     stfd  f31, 136(r1)  ; save F31
     mffs  f0  ; load FPSCR
     stfd  f0, 144(r1)  ; save FPSCR
+#endif
 
-l1:
     ; store RSP (pointing to context-data) in R3
     stw  r1, 0(r3)
 
     ; restore RSP (pointing to context-data) from R4
     mr  r1, r4
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l2
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  f14, 0(r1)  ; restore F14
     lfd  f15, 8(r1)  ; restore F15
     lfd  f16, 16(r1)  ; restore F16
@@ -158,8 +154,8 @@ l1:
     lfd  f31, 136(r1)  ; restore F31
     lfd  f0,  144(r1)  ; load FPSCR
     mtfsf  0xff, f0  ; restore FPSCR
+#endif
 
-l2:
     lwz  r13, 152(r1)  ; restore R13
     lwz  r14, 156(r1)  ; restore R14
     lwz  r15, 160(r1)  ; restore R15

--- a/src/arch/fcontext/take_ppc64_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_ppc64_sysv_elf_gas.S
@@ -88,6 +88,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .globl take_fcontext
 #if _CALL_ELF == 2
 	.text
@@ -151,10 +153,7 @@ take_fcontext:
     # save LR as PC
     std  %r0, 320(%r1)
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 1f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  %f14, 0(%r1)  # save F14
     stfd  %f15, 8(%r1)  # save F15
     stfd  %f16, 16(%r1)  # save F16
@@ -175,18 +174,15 @@ take_fcontext:
     stfd  %f31, 136(%r1)  # save F31
     mffs  %f0  # load FPSCR
     stfd  %f0, 144(%r1)  # save FPSCR
+#endif
 
-1:
     # store RSP (pointing to context-data) in R3
     std  %r1, 0(%r3)
 
     # restore RSP (pointing to context-data) from R4
     mr  %r1, %r4
 
-    # test if fpu env should be preserved
-    cmpwi  cr7, %r6, 0
-    beq  cr7, 2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  %f14, 0(%r1)  # restore F14
     lfd  %f15, 8(%r1)  # restore F15
     lfd  %f16, 16(%r1)  # restore F16
@@ -207,8 +203,8 @@ take_fcontext:
     lfd  %f31, 136(%r1)  # restore F31
     lfd  %f0,  144(%r1)  # load FPSCR
     mtfsf  0xff, %f0  # restore FPSCR
+#endif
 
-2:
 #if _CALL_ELF != 2
     ld  %r2,  152(%r1)  # restore TOC
 #endif

--- a/src/arch/fcontext/take_ppc64_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_ppc64_sysv_macho_gas.S
@@ -88,6 +88,8 @@
  *                                                     *
  *******************************************************/
 
+#include "abt_config.h"
+
 .text
 .align 2
 .globl take_fcontext
@@ -125,10 +127,7 @@ _take_fcontext:
     ; save LR as PC
     std  r0, 320(r1)
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l1
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     stfd  f14, 0(r1)  ; save F14
     stfd  f15, 8(r1)  ; save F15
     stfd  f16, 16(r1)  ; save F16
@@ -149,18 +148,15 @@ _take_fcontext:
     stfd  f31, 136(r1)  ; save F31
     mffs  f0  ; load FPSCR
     stfd  f0, 144(r1)  ; save FPSCR
+#endif
 
-l1:
     ; store RSP (pointing to context-data) in R3
     stw  r1, 0(r3)
 
     ; restore RSP (pointing to context-data) from R4
     mr  r1, r4
 
-    ; test if fpu env should be preserved
-    cmpwi  cr7, r6, 0
-    beq  cr7, l2
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     lfd  f14, 0(r1)  ; restore F14
     lfd  f15, 8(r1)  ; restore F15
     lfd  f16, 16(r1)  ; restore F16
@@ -181,8 +177,8 @@ l1:
     lfd  f31, 136(r1)  ; restore F31
     lfd  f0,  144(r1)  ; load FPSCR
     mtfsf  0xff, f0  ; restore FPSCR
+#endif
 
-2:
     ld  r13, 152(r1)  ; restore R13
     ld  r14, 160(r1)  ; restore R14
     ld  r15, 168(r1)  ; restore R15

--- a/src/arch/fcontext/take_x86_64_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_x86_64_sysv_elf_gas.S
@@ -31,6 +31,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl take_fcontext
 .type take_fcontext,@function
@@ -39,16 +41,13 @@ take_fcontext:
     /* restore RSP (pointing to context-data) from RSI */
     movq  %rsi, %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%rsp)
     /* restore x87 control-word */
     fldcw  0x4(%rsp)
+#endif
 
-2:
     /* prepare stack for FPU */
     leaq  0x8(%rsp), %rsp
 

--- a/src/arch/fcontext/take_x86_64_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_x86_64_sysv_macho_gas.S
@@ -31,6 +31,8 @@
  *                                                                                      *
  ****************************************************************************************/
 
+#include "abt_config.h"
+
 .text
 .globl _take_fcontext
 .align 8
@@ -38,16 +40,13 @@ _take_fcontext:
     /* restore RSP (pointing to context-data) from RSI */
     movq  %rsi, %rsp
 
-    /* test for flag preserve_fpu */
-    cmp  $0, %rcx
-    je  2f
-
+#if ABTD_FCONTEXT_PRESERVE_FPU
     /* restore MMX control- and status-word */
     ldmxcsr  (%rsp)
     /* restore x87 control-word */
     fldcw  0x4(%rsp)
+#endif
 
-2:
     /* prepare stack for FPU */
     leaq  0x8(%rsp), %rsp
 

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -16,10 +16,8 @@
 void ABTD_thread_func_wrapper(void *p_arg);
 fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func)(void *))
                          ABT_API_PRIVATE;
-void *jump_fcontext(fcontext_t *old, fcontext_t new, void *arg,
-                    int preserve_fpu) ABT_API_PRIVATE;
-void *take_fcontext(fcontext_t *old, fcontext_t new, void *arg,
-                    int preserve_fpu) ABT_API_PRIVATE;
+void *jump_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
+void *take_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
 #else
 void ABTD_thread_func_wrapper(int func_upper, int func_lower,
                               int arg_upper, int arg_lower);
@@ -103,8 +101,7 @@ void ABTD_thread_context_switch(ABTD_thread_context *p_old,
                                 ABTD_thread_context *p_new)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
-    jump_fcontext(&p_old->fctx, p_new->fctx, p_new,
-                  ABTD_FCONTEXT_PRESERVE_FPU);
+    jump_fcontext(&p_old->fctx, p_new->fctx, p_new);
 
 #else
     int ret = swapcontext(p_old, p_new);
@@ -117,8 +114,7 @@ void ABTD_thread_finish_context(ABTD_thread_context *p_old,
                                 ABTD_thread_context *p_new)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
-    take_fcontext(&p_old->fctx, p_new->fctx, p_new,
-                  ABTD_FCONTEXT_PRESERVE_FPU);
+    take_fcontext(&p_old->fctx, p_new->fctx, p_new);
 #else
     int ret = swapcontext(p_old, p_new);
     ABTI_ASSERT(ret == 0);


### PR DESCRIPTION
This PR improves performance.

Embed FPU preservation check into assembly code to reduce instructions.

Previously, `preserve_fpu` flag was passed to `jump_fcontext` and `take_fcontext` functions and checked in the assembly functions. `preserve_fpu` is compile-time constant, but `xxx_fcontext` functions cannot be inlined because they are written in assembly, which incurs a runtime overhead.

Now the macro (`#if ABTD_FCONTEXT_PRESERVE_FPU`) is embedded into the assembly code, so there is no runtime overhead. This optimization reduces at least 6 instructions (including 3 branches) per fork-join operation.