### PR TITLE
Simplify ABT_thread_xxx_many functions.

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -66,46 +66,6 @@ static inline void ABTD_thread_terminate(ABTI_thread *p_thread)
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     ABTD_thread_context *p_fctx = &p_thread->ctx;
 
-    /* Now, the ULT has finished its job. Terminate the ULT. */
-    if (p_thread->request & ABTI_THREAD_REQ_JOIN_MANY) {
-        /* ABT_thread_join_many case */
-        p_thread->state = ABT_THREAD_STATE_TERMINATED;
-
-        ABTI_thread_req_arg *p_req_arg;
-        ABTI_thread_join_arg *p_jarg;
-        p_req_arg = ABTI_thread_get_req_arg(p_thread, ABTI_THREAD_REQ_JOIN_MANY);
-        p_jarg = (ABTI_thread_join_arg *)p_req_arg->p_arg;
-
-        p_jarg->counter++;
-        if (p_jarg->counter < p_jarg->num_threads) {
-            int i;
-            ABTI_thread *p_next;
-            for (i = p_jarg->counter; i < p_jarg->num_threads; i++) {
-                p_next = ABTI_thread_get_ptr(p_jarg->p_threads[i]);
-                if (p_next->state != ABT_THREAD_STATE_TERMINATED) {
-                    ABTI_xstream *p_xstream = p_thread->p_last_xstream;
-                    ABTI_POOL_REMOVE(p_next->p_pool, p_next->unit, p_xstream);
-                    ABTI_thread_put_req_arg(p_next, p_req_arg);
-                    /* FIXME: we may need ABTI_thread_set_request */
-                    p_next->request |= ABTI_THREAD_REQ_JOIN_MANY;
-                    p_next->p_last_xstream = p_xstream;
-                    p_next->state = ABT_THREAD_STATE_RUNNING;
-                    ABTI_local_set_thread(p_next);
-                    ABTD_thread_finish_context(p_fctx, &p_next->ctx);
-                    return;
-                } else {
-                    p_jarg->counter++;
-                }
-            }
-        } else {
-            /* Switch back to the caller ULT of join_many */
-            ABTI_thread *p_caller = p_jarg->p_caller;
-            ABTI_local_set_thread(p_caller);
-            ABTD_thread_finish_context(p_fctx, &p_caller->ctx);
-            return;
-        }
-    }
-
     if (p_fctx->p_link) {
         /* If p_link is set, it means that other ULT has called the join. */
         ABTI_thread *p_joiner = (ABTI_thread *)p_fctx->p_link;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -39,7 +39,6 @@
 #define ABTI_THREAD_REQ_BLOCK       (1 << 5)
 #define ABTI_THREAD_REQ_ORPHAN      (1 << 6)
 #define ABTI_THREAD_REQ_NOPUSH      (1 << 7)
-#define ABTI_THREAD_REQ_JOIN_MANY   (1 << 8)
 #define ABTI_THREAD_REQ_STOP        \
     (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_TERMINATE)
 #define ABTI_THREAD_REQ_NON_YIELD   \
@@ -100,7 +99,6 @@ typedef struct ABTI_thread_attr     ABTI_thread_attr;
 typedef struct ABTI_thread          ABTI_thread;
 typedef enum ABTI_thread_type       ABTI_thread_type;
 typedef struct ABTI_thread_req_arg  ABTI_thread_req_arg;
-typedef struct ABTI_thread_join_arg ABTI_thread_join_arg;
 typedef struct ABTI_thread_list     ABTI_thread_list;
 typedef struct ABTI_thread_entry    ABTI_thread_entry;
 typedef struct ABTI_thread_htable   ABTI_thread_htable;
@@ -350,13 +348,6 @@ struct ABTI_thread_req_arg {
     uint32_t request;
     void *p_arg;
     ABTI_thread_req_arg *next;
-};
-
-struct ABTI_thread_join_arg {
-    int num_threads;
-    int counter;
-    ABT_thread *p_threads;
-    ABTI_thread *p_caller;
 };
 
 struct ABTI_thread_list {


### PR DESCRIPTION
Remove restrictions of `ABT_thread_create_many`, `ABT_thread_join_many`, and `ABT_thread_free_many` by removing an experimental join_many feature.

These functions create, join and free many threads, but the current implementation only works under very limited circumstances. This was a note of `ABT_thread_join_many`.

```
NOTE: The current implementation is very experimental. It works only for the
case where all ULTs in thread_list are mapped to the same ES as that of the
caller. They do not need to be in the same pool, but pools associated with
target ULTs should be exclusively associated with the caller's ES.
```

They also have an interoperability issue; threads created by `ABT_thread_create` cannot be joined by `ABT_thread_join_many` and vice versa.

This commit still keeps the functions but removes all the restrictions by abolishing the join many optimization. The current implementation is not mature, but there is plenty of room for performance improvement; not only reducing function calling overheads, but also function inlining, efficient joining (in a more general way), and aggregated pool operation (e.g., `push_many`).

This commit does not have any compatibility issue.