### PR TITLE
Introduce opaque pointers.

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -190,37 +190,88 @@ enum ABT_event_kind {
 #define ABT_XSTREAM_ANY_RANK    -1
 
 /* Data Types */
-typedef void *                 ABT_xstream;         /* Execution Stream */
-typedef enum ABT_xstream_state ABT_xstream_state;   /* ES state */
-typedef void *                 ABT_xstream_barrier; /* ES barrier */
-typedef void *                 ABT_sched;           /* Scheduler */
-typedef void *                 ABT_sched_config;    /* Sched-specific config */
-typedef enum ABT_sched_predef  ABT_sched_predef;    /* Predefined scheduler */
-typedef enum ABT_sched_state   ABT_sched_state;     /* Scheduler state */
-typedef enum ABT_sched_type    ABT_sched_type;      /* Scheduler type */
-typedef void *                 ABT_pool;            /* Pool */
-typedef void *                 ABT_pool_config;     /* Specific pool config */
-typedef enum ABT_pool_kind     ABT_pool_kind;       /* Pool kind */
-typedef enum ABT_pool_access   ABT_pool_access;     /* Pool access mode */
-typedef void *                 ABT_unit;            /* Unit */
-typedef enum ABT_unit_type     ABT_unit_type;       /* Unit type */
-typedef void *                 ABT_thread;          /* User-Level Thread (ULT) */
-typedef void *                 ABT_thread_attr;     /* ULT attribute */
-typedef enum ABT_thread_state  ABT_thread_state;    /* ULT state */
-typedef uint64_t               ABT_thread_id;       /* ULT id */
-typedef void *                 ABT_task;            /* Tasklet */
-typedef enum ABT_task_state    ABT_task_state;      /* Tasklet state */
-typedef void *                 ABT_key;             /* WU-specific data key */
-typedef void *                 ABT_mutex;           /* Mutex */
-typedef void *                 ABT_mutex_attr;      /* Mutex attribute */
-typedef void *                 ABT_cond;            /* Condition variable */
-typedef void *                 ABT_rwlock;          /* Readers writer lock */
-typedef void *                 ABT_eventual;        /* Eventual */
-typedef void *                 ABT_future;          /* Future */
-typedef void *                 ABT_barrier;         /* Barrier */
-typedef void *                 ABT_timer;           /* Timer */
-typedef int                    ABT_bool;            /* Boolean type */
-typedef enum ABT_event_kind    ABT_event_kind;      /* Event kind */
+struct ABT_xstream_opaque;
+struct ABT_xstream_barrier_opaque;
+struct ABT_sched_opaque;
+struct ABT_sched_config_opaque;
+struct ABT_pool_opaque;
+struct ABT_pool_config_opaque;
+struct ABT_unit_opaque;
+struct ABT_thread_opaque;
+struct ABT_thread_attr_opaque;
+struct ABT_task_opaque;
+struct ABT_key_opaque;
+struct ABT_mutex_opaque;
+struct ABT_mutex_attr_opaque;
+struct ABT_cond_opaque;
+struct ABT_rwlock_opaque;
+struct ABT_eventual_opaque;
+struct ABT_future_opaque;
+struct ABT_barrier_opaque;
+struct ABT_timer_opaque;
+
+/* Execution Stream */
+typedef struct ABT_xstream_opaque *         ABT_xstream;
+/* ES state */
+typedef enum ABT_xstream_state              ABT_xstream_state;
+/* ES barrier */
+typedef struct ABT_xstream_barrier_opaque * ABT_xstream_barrier;
+/* Scheduler */
+typedef struct ABT_sched_opaque *           ABT_sched;
+/* Sched-specific config */
+typedef struct ABT_sched_config_opaque *    ABT_sched_config;
+/* Predefined scheduler */
+typedef enum ABT_sched_predef               ABT_sched_predef;
+/* Scheduler state */
+typedef enum ABT_sched_state                ABT_sched_state;
+/* Scheduler type */
+typedef enum ABT_sched_type                 ABT_sched_type;
+/* Pool */
+typedef struct ABT_pool_opaque *            ABT_pool;
+/* Specific pool config */
+typedef struct ABT_pool_config_opaque *     ABT_pool_config;
+/* Pool kind */
+typedef enum ABT_pool_kind                  ABT_pool_kind;
+/* Pool access mode */
+typedef enum ABT_pool_access                ABT_pool_access;
+/* Unit */
+typedef struct ABT_unit_opaque *            ABT_unit;
+/* Unit type */
+typedef enum ABT_unit_type                  ABT_unit_type;
+/* User-Level Thread (ULT) */
+typedef struct ABT_thread_opaque *          ABT_thread;
+/* ULT attribute */
+typedef struct ABT_thread_attr_opaque *     ABT_thread_attr;
+/* ULT state */
+typedef enum ABT_thread_state               ABT_thread_state;
+/* Tasklet state */
+typedef enum ABT_task_state                 ABT_task_state;
+/* ULT id */
+typedef uint64_t                            ABT_thread_id;
+/* Tasklet */
+typedef struct ABT_task_opaque *            ABT_task;
+/* WU-specific data key */
+typedef struct ABT_key_opaque *             ABT_key;
+/* Mutex */
+typedef struct ABT_mutex_opaque *           ABT_mutex;
+/* Mutex attribute */
+typedef struct ABT_mutex_attr_opaque *      ABT_mutex_attr;
+/* Condition variable */
+typedef struct ABT_cond_opaque *            ABT_cond;
+/* Readers writer lock */
+typedef struct ABT_rwlock_opaque *          ABT_rwlock;
+/* Eventual */
+typedef struct ABT_eventual_opaque *        ABT_eventual;
+/* Future */
+typedef struct ABT_future_opaque *          ABT_future;
+/* Barrier */
+typedef struct ABT_barrier_opaque *         ABT_barrier;
+/* Timer */
+typedef struct ABT_timer_opaque *           ABT_timer;
+/* Boolean type */
+typedef int                                 ABT_bool;
+/* Event kind */
+typedef enum ABT_event_kind                 ABT_event_kind;
 
 
 /* Null Object Handles */

--- a/src/info.c
+++ b/src/info.c
@@ -357,7 +357,7 @@ int ABTI_info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool)
     fprintf(fp, "== pool (%p) ==\n", (void *)p_pool);
     struct ABTI_info_print_unit_arg_t arg;
     arg.fp = fp;
-    arg.pool = ABTI_pool_get_handle(pool);
+    arg.pool = pool;
     p_pool->p_print_all(pool, &arg, ABTI_info_print_unit);
 
   fn_exit:

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -457,8 +457,8 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
              * a pool with another associated pool, and set the right value if
              * it is okay  */
             for (p = 0; p < p_sched->num_pools; p++) {
-                abt_errno = ABTI_pool_set_consumer(p_sched->pools[p],
-                                                   p_pool->consumer);
+                abt_errno = ABTI_pool_set_consumer(
+                    ABTI_pool_get_ptr(p_sched->pools[p]), p_pool->consumer);
                 ABTI_CHECK_ERROR(abt_errno);
             }
             break;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -841,10 +841,10 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
         if (p_sched->num_pools == 0)
             p_pool = NULL;
         else
-            p_pool = p_sched->pools[0];
+            p_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
     }
     else
-        p_pool = p_sched->get_migr_pool(sched);
+        p_pool = ABTI_pool_get_ptr(p_sched->get_migr_pool(sched));
 
     /* Check the pool */
     if (ABTI_pool_accept_migration(p_pool, source_pool) == ABT_TRUE) {

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -103,7 +103,7 @@ int ABT_xstream_barrier_create(uint32_t num_waiters, ABT_xstream_barrier *newbar
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_xstream_barrier_free(ABT_barrier *barrier)
+int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
     int abt_errno = ABT_SUCCESS;

--- a/src/task.c
+++ b/src/task.c
@@ -81,15 +81,17 @@ int ABTI_task_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     void *arg = (void *)ABTI_sched_get_handle(p_sched);
     /* If p_sched is reused, ABTI_task_revive() can be used. */
     if (p_sched->p_task) {
-        abt_errno = ABTI_task_revive(p_local, p_pool, p_sched->run, arg,
+        abt_errno = ABTI_task_revive(p_local, p_pool,
+                                     (void (*)(void *))p_sched->run, arg,
                                      p_sched->p_task);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
     }
 
     /* Allocate a task object */
-    abt_errno = ABTI_task_create(p_local, p_pool, p_sched->run, arg, p_sched, 1,
-                                 &p_newtask);
+    abt_errno = ABTI_task_create(p_local, p_pool,
+                                 (void (*)(void *))p_sched->run, arg, p_sched,
+                                 1, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:

--- a/src/thread.c
+++ b/src/thread.c
@@ -345,7 +345,7 @@ int ABT_thread_free_many(int num, ABT_thread *thread_list)
     int i;
 
     for (i = 0; i < num; i++) {
-        ABTI_thread *p_thread = ABTI_thread_get_ptr(&thread_list[i]);
+        ABTI_thread *p_thread = ABTI_thread_get_ptr(thread_list[i]);
         ABTI_thread_free(p_local, p_thread);
     }
     return ABT_SUCCESS;
@@ -1720,7 +1720,8 @@ int ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     /* If p_sched is reused, ABTI_thread_revive() can be used. */
     if (p_sched->p_thread) {
         ABT_sched h_sched = ABTI_sched_get_handle(p_sched);
-        abt_errno = ABTI_thread_revive(p_local, p_pool, p_sched->run,
+        abt_errno = ABTI_thread_revive(p_local, p_pool,
+                                       (void (*)(void *))p_sched->run,
                                        (void *)h_sched, p_sched->p_thread);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
@@ -1729,9 +1730,9 @@ int ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Allocate a ULT object and its stack */
     ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                           ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
-    abt_errno = ABTI_thread_create_internal(p_local, p_pool, p_sched->run,
-        (void *)ABTI_sched_get_handle(p_sched), &attr, ABTI_THREAD_TYPE_USER,
-        p_sched, 1, NULL, ABT_TRUE, &p_newthread);
+    abt_errno = ABTI_thread_create_internal(p_local, p_pool,
+        (void (*)(void *))p_sched->run, (void *)ABTI_sched_get_handle(p_sched),
+        &attr, ABTI_THREAD_TYPE_USER, p_sched, 1, NULL, ABT_TRUE, &p_newthread);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -80,7 +80,7 @@ static void task_create(void *arg)
     int my_id = (int)(intptr_t)arg;
     ABT_thread my_thread;
     ABT_pool my_pool;
-    ABT_thread *tasks;
+    ABT_task *tasks;
 
     ret = ABT_thread_self(&my_thread);
     ATS_ERROR(ret, "ABT_thread_self");


### PR DESCRIPTION
This PR makes opaque types unique, and fixes several problems revealed by this.
The definition is changed as follows:
```
// Previous
typedef void *ABT_thread;
// New
struct ABT_thread_opaque;
typedef struct ABT_thread_opaque *ABT_thread;
```
This technique is very common. See https://en.wikipedia.org/wiki/Opaque_pointer for details.
This improvement revealed several problems (see the second commit).

For users, this change is beneficial in the following situation:
```
// ABT_thread_join(ABT_thread thread);
// ABT_thread_free(ABT_thread *thread);
ABT_thread thread = [...];
ABT_thread_join(&thread); // ERROR, but no warning previously
ABT_thread_free(&thread); // OK
```
It is because any pointer type (i.e., `&thread` = `void **`) can be converted to  `void *`.
After the improvement,  the type of `&thread` becomes `struct ABT_thread_opaque **`, which is different from `struct ABT_thread_opaque *`. The compiler therefore warns at the line of `ABT_thread_join`.

