### PR TITLE
Remove unused thread variables

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -564,10 +564,6 @@ int   ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
 void  ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
 void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);
-void  ABTI_thread_put_req_arg(ABTI_thread *p_thread,
-                              ABTI_thread_req_arg *p_req_arg);
-ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
-                                             uint32_t req);
 #endif
 void  ABTI_thread_retain(ABTI_thread *p_thread);
 void  ABTI_thread_release(ABTI_thread *p_thread);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -336,18 +336,22 @@ struct ABTI_thread {
     ABTI_pool *p_pool;              /* Associated pool */
     uint32_t refcount;              /* Reference count */
     ABTI_thread_type type;          /* Type */
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_req_arg *p_req_arg; /* Request argument */
     ABTI_spinlock lock;             /* Spinlock */
+#endif
     ABTI_ktable *p_keytable;        /* ULT-specific data */
     ABTI_thread_attr attr;          /* Attributes */
     ABT_thread_id id;               /* ID */
 };
 
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
 struct ABTI_thread_req_arg {
     uint32_t request;
     void *p_arg;
     ABTI_thread_req_arg *next;
 };
+#endif
 
 struct ABTI_thread_list {
     ABTI_thread_entry *head;

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -366,25 +366,6 @@ void ABTI_thread_unset_request(ABTI_thread *p_thread, uint32_t req)
     ABTD_atomic_fetch_and_uint32(&p_thread->request, ~req);
 }
 
-#ifdef ABT_CONFIG_DISABLE_MIGRATION
-static inline
-void  ABTI_thread_put_req_arg(ABTI_thread *p_thread,
-                              ABTI_thread_req_arg *p_req_arg)
-{
-    ABTI_ASSERT(p_thread->p_req_arg == NULL);
-    p_thread->p_req_arg = p_req_arg;
-}
-
-static inline
-ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
-                                             uint32_t req)
-{
-    ABTI_thread_req_arg *p_result = p_thread->p_req_arg;
-    p_thread->p_req_arg = NULL;
-    return p_result;
-}
-#endif /* ABT_CONFIG_DISABLE_MIGRATION */
-
 static inline
 void ABTI_thread_yield(ABTI_local **pp_local, ABTI_thread *p_thread)
 {

--- a/src/thread.c
+++ b/src/thread.c
@@ -1508,12 +1508,16 @@ int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
     p_newthread->p_pool         = p_pool;
     p_newthread->refcount       = refcount;
     p_newthread->type           = thread_type;
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
     p_newthread->p_req_arg      = NULL;
+#endif
     p_newthread->p_keytable     = NULL;
     p_newthread->id             = ABTI_THREAD_INIT_ID;
 
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* Create a spinlock */
     ABTI_spinlock_create(&p_newthread->lock);
+#endif
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     ABT_thread_id thread_id = ABTI_thread_get_id(p_newthread);
@@ -1759,8 +1763,10 @@ void ABTI_thread_free_internal(ABTI_thread *p_thread)
         ABTI_ktable_free(p_thread->p_keytable);
     }
 
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* Free the spinlock */
     ABTI_spinlock_free(&p_thread->lock);
+#endif
 }
 
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread)
@@ -1949,7 +1955,9 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
         "%spool    : %p\n"
         "%srefcount: %u\n"
         "%srequest : 0x%x\n"
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
         "%sreq_arg : %p\n"
+#endif
         "%skeytable: %p\n"
         "%sattr    : %s\n",
         prefix, (void *)p_thread,
@@ -1963,7 +1971,9 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
         prefix, (void *)p_thread->p_pool,
         prefix, p_thread->refcount,
         prefix, p_thread->request,
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
         prefix, (void *)p_thread->p_req_arg,
+#endif
         prefix, (void *)p_thread->p_keytable,
         prefix, attr
     );


### PR DESCRIPTION
This PR removes unused variables when `ABT_CONFIG_DISABLE_MIGRATION` is enabled, which removes a few initialization operations in `ABT_thread_create` and its friends.

PR  #65 is prerequisite.



