### PR TITLE
Separate ABTI_global->lock

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -64,7 +64,7 @@ int ABT_init(int argc, char **argv)
     gp_ABTI_global->num_xstreams = 0;
 
     /* Create a spinlock */
-    ABTI_spinlock_create(&gp_ABTI_global->lock);
+    ABTI_spinlock_create(&gp_ABTI_global->xstreams_lock);
 
     /* Init the ES local data */
     abt_errno = ABTI_local_init();
@@ -183,7 +183,7 @@ int ABT_finalize(void)
     ABTI_mem_finalize(gp_ABTI_global);
 
     /* Free the spinlock */
-    ABTI_spinlock_free(&gp_ABTI_global->lock);
+    ABTI_spinlock_free(&gp_ABTI_global->xstreams_lock);
 
     /* Free the ABTI_global structure */
     ABTU_free(gp_ABTI_global);
@@ -228,7 +228,7 @@ void ABTI_global_update_max_xstreams(int new_size)
 
     if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams) return;
 
-    ABTI_spinlock_acquire(&gp_ABTI_global->lock);
+    ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
 
     new_size = (new_size > 0) ? new_size : gp_ABTI_global->max_xstreams * 2;
     gp_ABTI_global->max_xstreams = new_size;
@@ -239,6 +239,6 @@ void ABTI_global_update_max_xstreams(int new_size)
         gp_ABTI_global->p_xstreams[i] = NULL;
     }
 
-    ABTI_spinlock_release(&gp_ABTI_global->lock);
+    ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -154,7 +154,9 @@ struct ABTI_global {
     int max_xstreams;           /* Max. size of p_xstreams */
     int num_xstreams;           /* Current # of ESs */
     ABTI_xstream **p_xstreams;  /* ES array */
-    ABTI_spinlock lock;         /* Spinlock */
+    ABTI_spinlock xstreams_lock; /* Spinlock protecting p_xstreams. Any write
+                                  * to p_xstreams and p_xstreams[*] requires a
+                                  * lock. Dereference does not require a lock.*/
 
     int num_cores;              /* Number of CPU cores */
     ABT_bool set_affinity;      /* Whether CPU affinity is used */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -151,9 +151,9 @@ struct ABTI_mutex {
 };
 
 struct ABTI_global {
-    int max_xstreams;           /* Max. size of p_xstreams */
-    int num_xstreams;           /* Current # of ESs */
-    ABTI_xstream **p_xstreams;  /* ES array */
+    int max_xstreams;            /* Max. size of p_xstreams */
+    int num_xstreams;            /* Current # of ESs */
+    ABTI_xstream **p_xstreams;   /* ES array */
     ABTI_spinlock xstreams_lock; /* Spinlock protecting p_xstreams. Any write
                                   * to p_xstreams and p_xstreams[*] requires a
                                   * lock. Dereference does not require a lock.*/

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -172,6 +172,7 @@ struct ABTI_global {
     uint32_t os_page_size;             /* OS page size */
     uint32_t huge_page_size;           /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
+    ABTI_spinlock mem_task_lock;       /* Spinlock protecting p_mem_task */
     uint32_t mem_page_size;            /* Page size for memory allocation */
     uint32_t mem_sp_size;              /* Stack page size */
     uint32_t mem_max_stacks;           /* Max. # of stacks kept in each ES */

--- a/src/info.c
+++ b/src/info.c
@@ -135,7 +135,7 @@ int ABT_info_print_all_xstreams(FILE *fp)
     ABTI_global *p_global = gp_ABTI_global;
     int i;
 
-    ABTI_spinlock_acquire(&p_global->lock);
+    ABTI_spinlock_acquire(&p_global->xstreams_lock);
 
     fprintf(fp, "# of created ESs: %d\n", p_global->num_xstreams);
     for (i = 0; i < p_global->num_xstreams; i++) {
@@ -145,7 +145,7 @@ int ABT_info_print_all_xstreams(FILE *fp)
         }
     }
 
-    ABTI_spinlock_release(&p_global->lock);
+    ABTI_spinlock_release(&p_global->xstreams_lock);
 
     fflush(fp);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1903,7 +1903,7 @@ static void ABTI_xstream_set_new_rank(ABTI_xstream *p_xstream)
             ABTI_global_update_max_xstreams(0);
         }
 
-        ABTI_spinlock_acquire(&gp_ABTI_global->lock);
+        ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
         for (i = 0; i < gp_ABTI_global->max_xstreams; i++) {
             if (gp_ABTI_global->p_xstreams[i] == NULL) {
                 /* Add this ES to the global ES array */
@@ -1914,7 +1914,7 @@ static void ABTI_xstream_set_new_rank(ABTI_xstream *p_xstream)
                 break;
             }
         }
-        ABTI_spinlock_release(&gp_ABTI_global->lock);
+        ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
     }
 
     /* Set the rank */
@@ -1929,7 +1929,7 @@ static ABT_bool ABTI_xstream_take_rank(ABTI_xstream *p_xstream, int rank)
         ABTI_global_update_max_xstreams(rank + 1);
     }
 
-    ABTI_spinlock_acquire(&gp_ABTI_global->lock);
+    ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
     if (gp_ABTI_global->p_xstreams[rank] == NULL) {
         /* Add this ES to the global ES array */
         gp_ABTI_global->p_xstreams[rank] = p_xstream;
@@ -1938,7 +1938,7 @@ static ABT_bool ABTI_xstream_take_rank(ABTI_xstream *p_xstream, int rank)
     } else {
         ret = ABT_FALSE;
     }
-    ABTI_spinlock_release(&gp_ABTI_global->lock);
+    ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 
     if (ret == ABT_TRUE) {
 
@@ -1952,9 +1952,9 @@ static ABT_bool ABTI_xstream_take_rank(ABTI_xstream *p_xstream, int rank)
 static void ABTI_xstream_return_rank(ABTI_xstream *p_xstream)
 {
     /* Remove this xstream from the global ES array */
-    ABTI_spinlock_acquire(&gp_ABTI_global->lock);
+    ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
     gp_ABTI_global->p_xstreams[p_xstream->rank] = NULL;
     gp_ABTI_global->num_xstreams--;
-    ABTI_spinlock_release(&gp_ABTI_global->lock);
+    ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
 


### PR DESCRIPTION
Originally, `p_xstreams` and task pages (`p_mem_task`) are managed by the same lock (`ABTI_global->lock`), though there is no conflict between them. To address this issue, this PR
1. adds a new lock, `ABTI_global->mem_task_lock` for the task page management, and
2. renames `ABTI_global->lock` to `ABTI_global->xstreams_lock` to clarity what it protects.
