### PR TITLE
Add ABTU_memcpy and ABTU_memset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -714,6 +714,22 @@ AC_CHECK_LIB(pthread, pthread_join)
 # check pthread_barrier
 AC_CHECK_FUNCS(pthread_barrier_init)
 
+# check builtin functions
+AC_TRY_COMPILE(
+[#include <string.h>], [__builtin_memcpy(NULL, NULL, 1);],
+[have_builtin_memcpy=yes], [have_builtin_memcpy=no]
+)
+AS_IF([test "x$have_builtin_memcpy" = "xyes"],
+      [AC_DEFINE(ABT_CONFIG_HAVE___BUILTIN_MEMCPY, 1,
+                 [Define to 1 if you have the `__builtin_memcpy' function.])])
+AC_TRY_COMPILE(
+[#include <string.h>], [__builtin_memset(NULL, 0, 1);],
+[have_builtin_memset=yes], [have_builtin_memset=no]
+)
+AS_IF([test "x$have_builtin_memset" = "xyes"],
+      [AC_DEFINE(ABT_CONFIG_HAVE___BUILTIN_MEMSET, 1,
+                 [Define to 1 if you have the `__builtin_memset' function.])])
+
 # check timer functions
 AC_CHECK_FUNCS(clock_gettime mach_absolute_time gettimeofday)
 if test "$ac_cv_func_clock_gettime" = "yes" ; then

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -237,7 +237,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     ABTI_spinlock_acquire(&p_eventual->lock);
 
     p_eventual->ready = ABT_TRUE;
-    if (p_eventual->value) memcpy(p_eventual->value, value, nbytes);
+    if (p_eventual->value) ABTU_memcpy(p_eventual->value, value, nbytes);
 
     if (p_eventual->p_head == NULL) {
         ABTI_spinlock_release(&p_eventual->lock);

--- a/src/include/abti_mutex_attr.h
+++ b/src/include/abti_mutex_attr.h
@@ -41,7 +41,7 @@ ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
 }
 
 #define ABTI_mutex_attr_copy(p_dest,p_src)              \
-    memcpy(p_dest, p_src, sizeof(ABTI_mutex_attr))
+    ABTU_memcpy(p_dest, p_src, sizeof(ABTI_mutex_attr))
 
 #endif /* MUTEX_ATTR_H_INCLUDED */
 

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -82,7 +82,7 @@ ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
     }
 
 #define ABTI_thread_attr_copy(p_dest,p_src)             \
-    memcpy(p_dest, p_src, sizeof(ABTI_thread_attr))
+    ABTU_memcpy(p_dest, p_src, sizeof(ABTI_thread_attr))
 
 
 #endif /* THREAD_ATTR_H_INCLUDED */

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include "abt_config.h"
 
 /* Utility Functions */
 #define ABTU_malloc(a)          malloc((size_t)(a))
@@ -24,6 +25,18 @@ void *ABTU_memalign(size_t alignment, size_t size)
     assert(ret == 0);
     return p_ptr;
 }
+
+#ifdef ABT_CONFIG_HAVE___BUILTIN_MEMCPY
+#define ABTU_memcpy(d,s,n)      __builtin_memcpy(d,s,n)
+#else
+#define ABTU_memcpy(d,s,n)      memcpy(d,s,n)
+#endif
+
+#ifdef ABT_CONFIG_HAVE___BUILTIN_MEMSET
+#define ABTU_memset(p,v,n)      __builtin_memset(p,v,n)
+#else
+#define ABTU_memset(p,v,n)      memset(p,v,n)
+#endif
 
 #define ABTU_strcpy(d,s)        strcpy(d,s)
 #define ABTU_strncpy(d,s,n)     strncpy(d,s,n)

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -89,11 +89,11 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
             buffer = ABTU_realloc(buffer, buffer_size);
         }
         /* Copy the parameter index */
-        memcpy(buffer+offset, (void *)&param, sizeof(param));
+        ABTU_memcpy(buffer+offset, (void *)&param, sizeof(param));
         offset += sizeof(param);
 
         /* Copy the size of the argument */
-        memcpy(buffer+offset, (void *)&size, sizeof(size));
+        ABTU_memcpy(buffer+offset, (void *)&size, sizeof(size));
         offset += sizeof(size);
 
         /* Copy the argument */
@@ -119,13 +119,13 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 goto fn_fail;
         }
 
-        memcpy(buffer+offset, ptr, size);
+        ABTU_memcpy(buffer+offset, ptr, size);
         offset += size;
     }
     va_end(varg_list);
 
     if (num_params) {
-        memcpy(buffer, (int *)&num_params, sizeof(num_params));
+        ABTU_memcpy(buffer, (int *)&num_params, sizeof(num_params));
     } else {
         ABTU_free(buffer);
         buffer = NULL;
@@ -261,7 +261,7 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
     char *buffer = (char *)p_config;
 
     /* Number of parameters in buffer */
-    memcpy(&num_params, buffer, sizeof(num_params));
+    ABTU_memcpy(&num_params, buffer, sizeof(num_params));
     offset += sizeof(num_params);
 
     /* Copy the data from buffer to the right variables */
@@ -272,10 +272,10 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
         size_t size;
 
         /* Get the variable index of the next parameter */
-        memcpy(&var_idx, buffer+offset, sizeof(var_idx));
+        ABTU_memcpy(&var_idx, buffer+offset, sizeof(var_idx));
         offset += sizeof(var_idx);
         /* Get the size of the next parameter */
-        memcpy(&size, buffer+offset, sizeof(size));
+        ABTU_memcpy(&size, buffer+offset, sizeof(size));
         offset += sizeof(size);
         /* Get the next argument */
         /* We save it only if
@@ -286,12 +286,12 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
             if (var_idx < 0) {
                 var_idx = (var_idx+2)*-1;
                 if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                ABTU_memcpy(variables[var_idx], buffer+offset, size);
             }
         } else {
             if (var_idx >= 0) {
                 if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                ABTU_memcpy(variables[var_idx], buffer+offset, size);
             }
         }
         offset += size;

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -28,7 +28,7 @@ ABTI_thread_htable *ABTI_thread_htable_create(uint32_t num_rows)
     p_htable->num_elems = 0;
     p_htable->num_rows = num_rows;
     p_htable->queue = (ABTI_thread_queue *)ABTU_memalign(64, q_size);
-    memset(p_htable->queue, 0, q_size);
+    ABTU_memset(p_htable->queue, 0, q_size);
     p_htable->h_list = NULL;
     p_htable->l_list = NULL;
 
@@ -63,8 +63,9 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
         new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
         p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
                 p_htable->queue, new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[p_htable->num_rows], 0,
-               (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
+        ABTU_memset(&p_htable->queue[p_htable->num_rows], 0,
+                    (new_size - p_htable->num_rows)
+                    * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 
@@ -122,8 +123,9 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
         new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
         p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
                 p_htable->queue, new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[p_htable->num_rows], 0,
-               (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
+        ABTU_memset(&p_htable->queue[p_htable->num_rows], 0,
+                    (new_size - p_htable->num_rows)
+                    * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -91,7 +91,7 @@ int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
     ABTI_CHECK_ERROR(abt_errno);
     p_newtimer = ABTI_timer_get_ptr(h_newtimer);
 
-    memcpy(p_newtimer, p_timer, sizeof(ABTI_timer));
+    ABTU_memcpy(p_newtimer, p_timer, sizeof(ABTI_timer));
 
     *newtimer = h_newtimer;
 

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -14,7 +14,7 @@ char *ABTU_get_indent_str(int indent)
 {
     char *space;
     space = (char *)ABTU_malloc(sizeof(char) * (indent + 1));
-    if (indent > 0) memset(space, ' ', indent);
+    if (indent > 0) ABTU_memset(space, ' ', indent);
     space[indent] = '\0';
     return space;
 }


### PR DESCRIPTION
This PR adds `ABTU_memcpy` and `ABTU_memset`, which are replaced with GCC `__builtin` functions
if available. ` __builtin` functions can save function calling overheads (and be inlined), so they
perform better especially when the target memory size is small.