### PR TITLE
Add likely and unlikely

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -736,6 +736,15 @@ if test -z "$timer_type" ; then
 fi
 AC_MSG_NOTICE([Timer type selected is $timer_type])
 
+# check __builtin_expect
+AC_TRY_COMPILE(
+[], [int cond = 0; if (__builtin_expect(cond, 1)) cond = 2;],
+[have_builtin_expect=yes], [have_builtin_expect=no]
+)
+AS_IF([test "x$have_builtin_expect" = "xyes"],
+      [AC_DEFINE(ABT_CONFIG_HAVE___BUILTIN_EXPECT, 1,
+                 [Define to 1 if you have the `__builtin_expect' function.])])
+
 # check math library
 AC_CHECK_LIB([m], [log10])
 

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -9,6 +9,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include "abt_config.h"
+
+/* Utility feature */
+#ifdef ABT_CONFIG_HAVE___BUILTIN_EXPECT
+#define ABTU_likely(cond)       __builtin_expect(!!(cond), 1)
+#define ABTU_unlikely(cond)     __builtin_expect(!!(cond), 0)
+#else
+#define ABTU_likely(cond)       (cond)
+#define ABTU_unlikely(cond)     (cond)
+#endif
 
 /* Utility Functions */
 #define ABTU_malloc(a)          malloc((size_t)(a))


### PR DESCRIPTION
This PR adds `ABTU_likely` and `ABTU_unlikely` functions, which give hints to the compiler with branch prediction information. Those features are currently not used. They will be added in future.
