### PR TITLE
Unify ABT(I)_thread_create_xxx

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -79,6 +79,9 @@ int ABT_init(int argc, char **argv)
     /* Create the primary ULT, i.e., the main thread */
     ABTI_thread *p_main_thread;
     abt_errno = ABTI_thread_create_main(p_newxstream, &p_main_thread);
+    /* Set as if p_newxstream is currently running the main thread. */
+    p_main_thread->state = ABT_THREAD_STATE_RUNNING;
+    p_main_thread->p_last_xstream = p_newxstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
     ABTI_local_set_thread(p_main_thread);

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -138,7 +138,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
 }
 
 static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
+ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
 {
     /* Basic idea: allocate a memory for stack and use the first some memory as
      * ABTI_stack_header and ABTI_thread. So, the effective stack area is
@@ -153,7 +153,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
 
     /* Get the stack size */
     def_stacksize = ABTI_global_get_thread_stacksize();
-    if (attr == ABT_THREAD_ATTR_NULL) {
+    if (p_attr == NULL) {
         stacksize = def_stacksize;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
@@ -164,8 +164,6 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
 #endif
 
     } else {
-        ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
-
         if (p_attr->stacktype == ABTI_STACK_TYPE_USER ||
             p_attr->stacktype == ABTI_STACK_TYPE_MAIN) {
             /* Since the stack is given by the user, we create ABTI_thread and
@@ -222,12 +220,11 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
     p_stack  = p_sh->p_stack;
 
     /* Set attributes */
-    if (attr == ABT_THREAD_ATTR_NULL) {
+    if (p_attr == NULL) {
         ABTI_thread_attr *p_myattr = &p_thread->attr;
         ABTI_thread_attr_init(p_myattr, p_stack, actual_stacksize,
                               ABTI_STACK_TYPE_MEMPOOL, ABT_TRUE);
     } else {
-        ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
         ABTI_thread_attr_copy(&p_thread->attr, p_attr);
         p_thread->attr.stacksize = actual_stacksize;
         p_thread->attr.p_stack = p_stack;

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -166,14 +166,17 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
     } else {
         ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
 
-        if (p_attr->stacktype == ABTI_STACK_TYPE_USER) {
+        if (p_attr->stacktype == ABTI_STACK_TYPE_USER ||
+            p_attr->stacktype == ABTI_STACK_TYPE_MAIN) {
             /* Since the stack is given by the user, we create ABTI_thread and
              * ABTI_stack_header explicitly with a single ABTU_malloc call. */
             p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));
             ABTI_thread_attr_copy(&p_thread->attr, p_attr);
 
-            ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack,
-                                         p_attr->stacksize);
+            if (p_attr->stacktype != ABTI_STACK_TYPE_MAIN) {
+                ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack,
+                                             p_attr->stacksize);
+            }
             return p_thread;
         }
 
@@ -231,19 +234,6 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
     }
 
     ABTI_VALGRIND_REGISTER_STACK(p_thread->attr.p_stack, actual_stacksize);
-    return p_thread;
-}
-
-static inline
-ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
-{
-    ABTI_thread *p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));
-
-    /* Set attributes */
-    /* TODO: Need to set the actual stack address and size for the main ULT */
-    ABTI_thread_attr *p_attr = &p_thread->attr;
-    ABTI_thread_attr_init(p_attr, NULL, 0, ABTI_STACK_TYPE_MAIN, ABT_FALSE);
-
     return p_thread;
 }
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -166,8 +166,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr)
     } else {
         ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
 
-        if (p_attr->p_stack != NULL) {
-            ABTI_ASSERT(p_attr->stacktype == ABTI_STACK_TYPE_USER);
+        if (p_attr->stacktype == ABTI_STACK_TYPE_USER) {
             /* Since the stack is given by the user, we create ABTI_thread and
              * ABTI_stack_header explicitly with a single ABTU_malloc call. */
             p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));

--- a/src/stream.c
+++ b/src/stream.c
@@ -299,6 +299,7 @@ int ABTI_xstream_start(ABTI_xstream *p_xstream)
         ABTI_sched *p_sched = p_xstream->p_main_sched;
         abt_errno = ABTI_thread_create_main_sched(p_xstream, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
+        p_sched->p_thread->p_last_xstream = p_xstream;
 
     } else {
         /* Start the main scheduler on a different ES */
@@ -350,6 +351,7 @@ int ABTI_xstream_start_primary(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
     ABTI_sched *p_sched = p_xstream->p_main_sched;
     abt_errno = ABTI_thread_create_main_sched(p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
+    p_sched->p_thread->p_last_xstream = p_xstream;
 
     /* Start the scheduler by context switching to it */
     LOG_EVENT("[U%" PRIu64 ":E%d] yield\n",
@@ -1879,6 +1881,7 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     ABTI_sched *p_sched = p_xstream->p_main_sched;
     abt_errno = ABTI_thread_create_main_sched(p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
+    p_sched->p_thread->p_last_xstream = p_xstream;
 
     /* Set the sched ULT as the current ULT */
     ABTI_local_set_thread(p_sched->p_thread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -1701,9 +1701,9 @@ int ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread)
                                            &p_newthread->ctx);
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_newthread->state           = ABT_THREAD_STATE_RUNNING;
+    p_newthread->state           = ABT_THREAD_STATE_READY;
     p_newthread->request         = 0;
-    p_newthread->p_last_xstream  = p_xstream;
+    p_newthread->p_last_xstream  = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     p_newthread->is_sched        = NULL;
 #endif
@@ -1723,7 +1723,7 @@ int ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread)
 
     LOG_EVENT("[U%" PRIu64 ":E%d] main ULT created\n",
               ABTI_thread_get_id(p_newthread),
-              p_newthread->p_last_xstream->rank);
+              p_xstream->rank);
 
     /* Although this main ULT is running now, we add this main ULT to the pool
      * so that the scheduler can schedule the main ULT when the main ULT is
@@ -1782,7 +1782,7 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 
     p_newthread->state          = ABT_THREAD_STATE_READY;
     p_newthread->request        = 0;
-    p_newthread->p_last_xstream = p_xstream;
+    p_newthread->p_last_xstream = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     p_newthread->is_sched       = p_sched;
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -1782,7 +1782,8 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
         /* Create a ULT object and its stack */
         ABTI_thread_attr attr;
-        ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(), ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
+        ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
+                              ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
         ABTI_thread *p_main_thread = ABTI_global_get_main();
         abt_errno = ABTI_thread_create(NULL, ABTI_xstream_schedule,
                                        (void *)p_xstream, &attr,
@@ -1835,7 +1836,8 @@ int ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
     }
 
     /* Allocate a ULT object and its stack */
-    ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(), ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
+    ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
+                          ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
     abt_errno = ABTI_thread_create(p_pool, p_sched->run,
                                    (void *)ABTI_sched_get_handle(p_sched),
                                    &attr, ABTI_THREAD_TYPE_USER, p_sched, 1,

--- a/src/thread.c
+++ b/src/thread.c
@@ -1621,7 +1621,7 @@ int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
     ABT_thread h_newthread;
 
     /* Allocate a ULT object and its stack, then create a thread context. */
-    p_newthread = ABTI_mem_alloc_thread(ABTI_thread_attr_get_handle(p_attr));
+    p_newthread = ABTI_mem_alloc_thread(p_attr);
     abt_errno = ABTD_thread_context_create(NULL, thread_func, arg,
                                            p_newthread->attr.stacksize,
                                            p_newthread->attr.p_stack,


### PR DESCRIPTION
`ABT_thread_create`, `ABTI_thread_create_sched`, `ABTI_thread_create_main`, and `ABTI_thread_create_main_sched` share most part of implementations, but they are individually coded, which significantly degrades maintainability.

This PR creates a new internal function `ABTI_thread_create` and makes all the `ABT(I)_thread_create_xxx` functions call `ABTI_thread_create`.

This does not affect the performance of `ABT_thread_create` if `ABTI_thread_create` is properly unrolled.

This PR is a prerequisite for #72.