### PR TITLE
Improve maintainability by splitting context switching functions

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -149,9 +149,7 @@ static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
     } else {
 #endif
         p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-        ABTI_LOG_SET_SCHED((p_sched->p_ctx == p_link)
-                           ? ABTI_xstream_get_top_sched(p_thread->p_last_xstream)
-                           : NULL);
+        ABTI_LOG_SET_SCHED(ABTI_xstream_get_top_sched(p_thread->p_last_xstream));
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -145,11 +145,9 @@ static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
         /* If p_thread is a scheduler ULT, we have to context switch to
          * the parent scheduler. */
         p_sched = ABTI_xstream_get_parent_sched(p_thread->p_last_xstream);
-        ABTI_LOG_SET_SCHED(p_sched);
     } else {
 #endif
         p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-        ABTI_LOG_SET_SCHED(ABTI_xstream_get_top_sched(p_thread->p_last_xstream));
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif

--- a/src/global.c
+++ b/src/global.c
@@ -157,7 +157,6 @@ int ABT_finalize(void)
 
         /* Switch to the top scheduler */
         ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-        ABTI_LOG_SET_SCHED(p_sched);
         ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
 
         /* Back to the original thread */

--- a/src/global.c
+++ b/src/global.c
@@ -158,7 +158,7 @@ int ABT_finalize(void)
         /* Switch to the top scheduler */
         ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
         ABTI_LOG_SET_SCHED(p_sched);
-        ABTD_thread_context_switch(&p_thread->ctx, p_sched->p_ctx);
+        ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
 
         /* Back to the original thread */
         LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -44,8 +44,7 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
        Note that the parameter, p_stack, points to the bottom of stack. */
     p_stacktop = (void *)(((char *)p_stack) + stacksize);
 
-    p_newctx->fctx = make_fcontext(p_stacktop, stacksize,
-                                   f_wrapper);
+    p_newctx->fctx = make_fcontext(p_stacktop, stacksize, f_wrapper);
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
     p_newctx->p_link = p_link;
@@ -85,8 +84,8 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
         ABTI_ASSERT(0);
     }
 
-    makecontext(p_newctx, (void (*)())f_wrapper,
-                4, func_upper, func_lower, arg_upper, arg_lower);
+    makecontext(p_newctx, (void (*)())f_wrapper, 4, func_upper, func_lower,
+                arg_upper, arg_lower);
 
   fn_exit:
     return abt_errno;

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -59,6 +59,7 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
                                                          ABT_bool is_finish)
 {
     ABTI_ASSERT(!p_old->is_sched);
+    ABTI_LOG_SET_SCHED(p_new);
     if (is_finish) {
         ABTD_thread_finish_context(&p_old->ctx, p_new->p_ctx);
     } else {
@@ -72,6 +73,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                                                          ABT_bool is_finish)
 {
     ABTI_ASSERT(!p_new->is_sched);
+    ABTI_LOG_SET_SCHED(NULL);
     if (is_finish) {
         ABTD_thread_finish_context(p_old->p_ctx, &p_new->ctx);
     } else {
@@ -84,6 +86,7 @@ void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
                                                         ABTI_sched *p_new,
                                                         ABT_bool is_finish)
 {
+    ABTI_LOG_SET_SCHED(p_new);
     if (is_finish) {
         ABTD_thread_finish_context(p_old->p_ctx, p_new->p_ctx);
     } else {
@@ -195,7 +198,6 @@ void ABTI_thread_yield(ABTI_thread *p_thread)
 
     /* Switch to the top scheduler */
     p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-    ABTI_LOG_SET_SCHED(p_sched);
     ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
 
     /* Back to the original thread */

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -46,6 +46,7 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
                                                           ABT_bool is_finish)
 {
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
+    ABTI_local_set_thread(p_new);
     if (is_finish) {
         ABTD_thread_finish_context(&p_old->ctx, &p_new->ctx);
     } else {
@@ -74,6 +75,8 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
 {
     ABTI_ASSERT(!p_new->is_sched);
     ABTI_LOG_SET_SCHED(NULL);
+    ABTI_local_set_thread(p_new);
+    ABTI_local_set_task(NULL); /* A tasklet scheduler can invoke ULT. */
     if (is_finish) {
         ABTD_thread_finish_context(p_old->p_ctx, &p_new->ctx);
     } else {

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -548,7 +548,7 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
     ABTI_pool_dec_num_blocked(p_next->p_pool);
     ABTI_local_set_thread(p_next);
     p_next->state = ABT_THREAD_STATE_RUNNING;
-    ABTD_thread_context_switch(&p_thread->ctx, &p_next->ctx);
+    ABTI_thread_context_switch_thread_to_thread(p_thread, p_next);
 #endif
 
     return abt_errno;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -546,7 +546,6 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
     /* yield_to the next ULT */
     while (ABTD_atomic_load_uint32(&p_next->request) & ABTI_THREAD_REQ_BLOCK);
     ABTI_pool_dec_num_blocked(p_next->p_pool);
-    ABTI_local_set_thread(p_next);
     p_next->state = ABT_THREAD_STATE_RUNNING;
     ABTI_thread_context_switch_thread_to_thread(p_thread, p_next);
 #endif

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -513,7 +513,7 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream)
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
                 ABTI_sched *p_par_sched;
                 p_par_sched = ABTI_xstream_get_parent_sched(p_xstream);
-                ABTD_thread_context_switch(p_sched->p_ctx, p_par_sched->p_ctx);
+                ABTI_thread_context_switch_sched_to_sched(p_sched, p_par_sched);
             }
         }
     }

--- a/src/thread.c
+++ b/src/thread.c
@@ -438,7 +438,6 @@ int ABT_thread_join(ABT_thread thread)
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch the context */
-        ABTI_local_set_thread(p_thread);
         ABTI_thread_context_switch_thread_to_thread(p_self, p_thread);
 
     } else if ((p_self->p_pool != p_thread->p_pool) &&
@@ -474,13 +473,12 @@ int ABT_thread_join(ABT_thread thread)
      * ES as p_self's ES and the control has come from the target ULT.
      * Otherwise, the target ULT had been migrated to a different ES, p_self
      * has been resumed by p_self's scheduler.  In the latter case, we don't
-     * need to change p_self's state and the local ULT information. */
+     * need to change p_self's state. */
     if (p_self->state == ABT_THREAD_STATE_BLOCKED) {
         p_self->state = ABT_THREAD_STATE_RUNNING;
         ABTI_pool_dec_num_blocked(p_self->p_pool);
         LOG_EVENT("[U%" PRIu64 ":E%d] resume after join\n",
                   ABTI_thread_get_id(p_self), p_self->p_last_xstream->rank);
-        ABTI_local_set_thread(p_self);
         return abt_errno;
     }
 
@@ -901,7 +899,6 @@ int ABT_thread_yield_to(ABT_thread thread)
     p_tar_thread->p_last_xstream = p_xstream;
 
     /* Switch the context */
-    ABTI_local_set_thread(p_tar_thread);
     p_tar_thread->state = ABT_THREAD_STATE_RUNNING;
     ABTI_thread_context_switch_thread_to_thread(p_cur_thread, p_tar_thread);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1970,7 +1970,6 @@ void ABTI_thread_suspend(ABTI_thread *p_thread)
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_xstream);
     LOG_EVENT("[U%" PRIu64 ":E%d] suspended\n",
               ABTI_thread_get_id(p_thread), p_xstream->rank);
-    ABTI_LOG_SET_SCHED(p_sched);
     ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
 
     /* The suspended ULT resumes its execution from here. */

--- a/src/thread.c
+++ b/src/thread.c
@@ -1626,15 +1626,17 @@ int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
     /* Allocate a ULT object and its stack, then create a thread context. */
     p_newthread = ABTI_mem_alloc_thread(p_attr);
     if (p_sched == NULL) {
+        size_t stack_size = p_newthread->attr.stacksize;
+        void *p_stack = p_newthread->attr.p_stack;
         abt_errno = ABTD_thread_context_create_thread(NULL, thread_func, arg,
-                                           p_newthread->attr.stacksize,
-                                           p_newthread->attr.p_stack,
-                                           &p_newthread->ctx);
+                                                      stack_size, p_stack,
+                                                      &p_newthread->ctx);
     } else {
+        size_t stack_size = p_newthread->attr.stacksize;
+        void *p_stack = p_newthread->attr.p_stack;
         abt_errno = ABTD_thread_context_create_sched(NULL, thread_func, arg,
-                                           p_newthread->attr.stacksize,
-                                           p_newthread->attr.p_stack,
-                                           &p_newthread->ctx);
+                                                     stack_size, p_stack,
+                                                     &p_newthread->ctx);
     }
     ABTI_CHECK_ERROR(abt_errno);
 

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -246,7 +246,6 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
         LOG_EVENT("switch -> U%" PRIu64 "\n", ABTI_thread_get_id(p_target));
 
         /* Context-switch to p_target */
-        ABTI_local_set_thread(p_target);
         p_target->state = ABT_THREAD_STATE_RUNNING;
         ABTI_thread_context_switch_thread_to_thread(p_thread, p_target);
         return ABT_TRUE;

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -248,7 +248,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
         /* Context-switch to p_target */
         ABTI_local_set_thread(p_target);
         p_target->state = ABT_THREAD_STATE_RUNNING;
-        ABTD_thread_context_switch(&p_thread->ctx, &p_target->ctx);
+        ABTI_thread_context_switch_thread_to_thread(p_thread, p_target);
         return ABT_TRUE;
     } else {
         return ABT_FALSE;


### PR DESCRIPTION
Argobots has many implicit rules before calling `ABT_thread_context_switch` and `ABT_thread_finish context`;  `ABTI_LOG_SET_SCHED`, `ABTI_local_set_thread` and `ABTI_local_set_task` must be called properly before these functions.

This behavior is difficult to follow and very error-prone. To address this issue, this PR hides them from most code by splitting context switching functions;
- `ABT_thread_[context_switch/finish_context]_thread_to_thread`
- `ABT_thread_[context_switch/finish_context]_thread_to_sched`
- `ABT_thread_[context_switch/finish_context]_sched_to_thread`
- `ABT_thread_[context_switch/finish_context]_sched_to_sched`

This PR requires #76 in advance.