### PR TITLE
Fix compilation error when stackable scheduler is disabled.

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -74,11 +74,15 @@ void ABTD_thread_func_wrapper(int func_upper, int func_lower,
 
 void ABTD_thread_exit(ABTI_thread *p_thread)
 {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_thread->is_sched) {
         ABTD_thread_terminate_sched(p_thread);
     } else {
+#endif
         ABTD_thread_terminate_thread(p_thread);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
+#endif
 }
 
 static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
@@ -104,12 +108,16 @@ static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
              * type ULT would be a joiner (=suspend), no scheduler is available
              * when a running ULT needs suspension. Hence, it always jumps to a
              * non-scheduler-type ULT. */
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             if (is_sched) {
                 ABTI_thread_finish_context_sched_to_thread(p_thread->is_sched,
                                                            p_joiner);
             } else {
+#endif
                 ABTI_thread_finish_context_thread_to_thread(p_thread, p_joiner);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             }
+#endif
             return;
         } else {
             /* If the current ULT's associated ES is different from p_joiner's,
@@ -151,11 +159,15 @@ static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (is_sched) {
         ABTI_thread_finish_context_sched_to_sched(p_thread->is_sched, p_sched);
     } else {
+#endif
         ABTI_thread_finish_context_thread_to_sched(p_thread, p_sched);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
+#endif
 #else
 #error "Not implemented yet"
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -235,15 +235,19 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
 
     /* Create a ULT context */
     stacksize = p_thread->attr.stacksize;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_thread->is_sched) {
         abt_errno = ABTD_thread_context_create_sched(NULL, thread_func, arg,
                                            stacksize, p_thread->attr.p_stack,
                                            &p_thread->ctx);
     } else {
+#endif
         abt_errno = ABTD_thread_context_create_thread(NULL, thread_func, arg,
                                            stacksize, p_thread->attr.p_stack,
                                            &p_thread->ctx);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
+#endif
     ABTI_CHECK_ERROR(abt_errno);
 
     p_thread->state          = ABT_THREAD_STATE_READY;


### PR DESCRIPTION
Thread code uses `is_sched`. However, this variable is only declared when the
stackable scheduler is enabled. When this feature is disabled, compile-time
errors occur.

This PR fixes this issue by adding `#ifdef` macros.