### PR TITLE
Fix ABTD_atomic_pause.

### DIFF
--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -739,7 +739,9 @@ void ABTD_compiler_barrier(void)
 static inline
 void ABTD_atomic_pause(void)
 {
+#ifdef __x86_64__
     __asm__ __volatile__ ( "pause" ::: "memory" );
+#endif
 }
 
 #endif /* ABTD_ATOMIC_H_INCLUDED */


### PR DESCRIPTION
Non x86-64 machines fail to compile Argobots, because `ABTD_atomic_pause()` uses an x86/64 specific instruction, `pause`.
This commit removes it when non x86-64 machines are used.

This change passes a quick test on an ARM 64 machine.