### PR TITLE
Fix a potential bug in thread joining.

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -416,7 +416,9 @@ int ABT_thread_join(ABT_thread thread)
          * changes the state first followed by pushing p_thread to the pool.
          * Therefore, we have to check whether p_thread is in the pool, and if
          * not, we need to wait until it is added. */
-        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {}
+        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {
+            ABTD_atomic_mem_barrier();
+        }
 
         /* Increase the number of blocked units.  Be sure to execute
          * ABTI_pool_inc_num_blocked before ABTI_POOL_REMOVE in order not to


### PR DESCRIPTION
A while loop busy in `ABT_thread_join` waits until `u_is_in_pool` returns `ABT_TRUE`, though there is no guarantee that `u_is_in_pool`, which can be given by a user, is aware of memory ordering.

This patch adds a memory barrier to fix this issue.  Note that this path is rarely taken so the additional barrier does not affect performance.