### PR TITLE
Fix the undefined is_sched error

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -18,7 +18,9 @@ void ABTD_thread_func_wrapper_thread(void *p_arg)
 
     /* NOTE: ctx is located in the beginning of ABTI_thread */
     ABTI_thread *p_thread = (ABTI_thread *)p_fctx;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(p_thread->is_sched == NULL);
+#endif
 
     ABTD_thread_terminate_thread(p_thread);
 }
@@ -32,7 +34,9 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
 
     /* NOTE: ctx is located in the beginning of ABTI_thread */
     ABTI_thread *p_thread = (ABTI_thread *)p_fctx;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(p_thread->is_sched != NULL);
+#endif
 
     ABTD_thread_terminate_sched(p_thread);
 }

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -143,7 +143,9 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
                                                           ABTI_thread *p_new,
                                                           ABT_bool is_finish)
 {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
+#endif
     ABTI_local_set_thread(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old is discarded. */
@@ -168,7 +170,9 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
                                                          ABTI_sched *p_new,
                                                          ABT_bool is_finish)
 {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched);
+#endif
     ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old is discarded. */
@@ -190,7 +194,9 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                                                          ABTI_thread *p_new,
                                                          ABT_bool is_finish)
 {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->is_sched);
+#endif
     ABTI_LOG_SET_SCHED(NULL);
     ABTI_local_set_thread(p_new);
     ABTI_local_set_task(NULL); /* A tasklet scheduler can invoke ULT. */


### PR DESCRIPTION
Similar to #79, but it only happens with `--enable-debug=yes`; when the stackable scheduler feature is disabled, compilation error happens (`is_sched` is undefined). This PR fixes this issue by adding `#ifdef`.