### PR TITLE
Implement a dynamic promotion thread for ARM64.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -607,7 +607,15 @@ AS_IF([test "x$enable_sched_sleep" = "xyes"],
                  [Define to make the scheduler sleep when its pools are empty])])
 
 # --enable-dynamic-promotion
-AS_IF([test "x$enable_dynamic_promotion" = "xyes" -a "x$enable_fcontext" != "xno" -a "x$fctx_arch_bin" = "xx86_64_sysv_elf_gas"],
+case "x$fctx_arch_bin" in
+    xx86_64_sysv_elf_gas|xarm64_aapcs_elf_gas)
+        support_dynamic_promotion="yes"
+    ;;
+    *)
+        support_dynamic_promotion="no"
+    ;;
+esac
+AS_IF([test "x$enable_dynamic_promotion" = "xyes" -a "x$enable_fcontext" != "xno" -a "x$support_dynamic_promotion" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_THREAD_TYPE, ABT_THREAD_TYPE_DYNAMIC_PROMOTION,
                  [Define to use the dynamic promotion technique for ULT])],
       [AC_DEFINE(ABT_CONFIG_THREAD_TYPE, ABT_THREAD_TYPE_FULLY_FLEDGED)])

--- a/src/arch/fcontext/jump_arm64_aapcs_elf_gas.S
+++ b/src/arch/fcontext/jump_arm64_aapcs_elf_gas.S
@@ -117,6 +117,64 @@ jump_fcontext:
 
     ret x4
 .size   jump_fcontext,.-jump_fcontext
+
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+.text
+.globl init_and_call_fcontext
+.type init_and_call_fcontext,@function
+.align 16
+init_and_call_fcontext:
+    # save the current rsp to [sp - 0x08]
+    mov x4, sp
+    stp x30, x4, [x2, -0x10]
+
+    # save callee-saved registers
+    # prepare stack for GP + FPU
+    sub  sp, sp, #0xb0
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    # save d8 - d15
+    stp  d8,  d9,  [sp, #0x00]
+    stp  d10, d11, [sp, #0x10]
+    stp  d12, d13, [sp, #0x20]
+    stp  d14, d15, [sp, #0x30]
+#endif
+
+    # save x19-x30
+    stp  x19, x20, [sp, #0x40]
+    stp  x21, x22, [sp, #0x50]
+    stp  x23, x24, [sp, #0x60]
+    stp  x25, x26, [sp, #0x70]
+    stp  x27, x28, [sp, #0x80]
+    stp  x29, x30, [sp, #0x90]
+
+    # save LR as PC
+    str  x30, [sp, #0xa0]
+
+    # store sp in x3 (= fctx)
+    mov x4, sp
+    str x4, [x3]
+
+    # assign x2 (=p_stack) to sp
+    sub sp, x2, #0x10
+
+    # call x1 (= f_thread). x0 (= p_arg) has been already set
+    # sp is 16-byte aligned (ABI specification)
+    blr x1
+
+    # restore original LR and sp
+    ldp x30, x3, [sp]
+    mov sp, x3
+
+    # - when the thread did not yield, sp is the original one, so ret jumps to
+    #   the original control flow.
+    # - any suspension updates sp to (p_stack - 0x10). so that ret calls
+    #   (p_stack - 0x8), which is a set to a terminator function
+    # sp is 16-byte aligned (ABI specification)
+    ret
+.size init_and_call_fcontext,.-init_and_call_fcontext
+#endif
+
 # Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits
 


### PR DESCRIPTION
This PR implements `init_and_call_fcontext` for `arm64-elf`, which is a key assembly function for dynamic promotion technique (#72).
Now `x86_64-elf` and `arm64-elf` support the dynamic promotion technique.

It passed all the tests on an ARM machine.