### PR TITLE
Implement the basic stack dump functionality

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -228,3 +228,37 @@ void ABTD_thread_cancel(ABTI_thread *p_thread)
 #endif
 }
 
+static inline
+void print_bytes(size_t size, void *p_val, FILE *p_os) {
+    size_t i;
+    for (i = 0; i < size; i++) {
+        uint8_t val = ((uint8_t *)p_val)[i];
+        fprintf(p_os, "%02" PRIx8, val);
+    }
+}
+
+void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
+{
+    char *prefix = ABTU_get_indent_str(indent);
+    ABTD_thread_context *p_ctx = &p_thread->ctx;
+#if defined(ABT_CONFIG_USE_FCONTEXT)
+    fprintf(p_os, "%sfctx     : %p\n", prefix, p_ctx->fctx);
+    fprintf(p_os, "%sf_thread : %p\n", prefix, p_ctx->f_thread);
+    fprintf(p_os, "%sp_arg    : %p\n", prefix, p_ctx->p_arg);
+    fprintf(p_os, "%sp_link   : %p\n", prefix, p_ctx->p_link);
+#else
+    /* TODO: print information in more detail. */
+    fprintf(p_os, "%suc_link     : %p\n", prefix, p_ctx->uc_link);
+    fprintf(p_os, "%suc_sigmask  : ", prefix);
+    print_bytes(sizeof(sigset_t), &p_ctx->uc_sigmask, p_os);
+    fprintf(p_os, "\n");
+    fprintf(p_os, "%suc_stack    : ", prefix);
+    print_bytes(sizeof(stack_t), &p_ctx->uc_stack, p_os);
+    fprintf(p_os, "\n");
+    fprintf(p_os, "%suc_mcontext : ", prefix);
+    print_bytes(sizeof(mcontext_t), &p_ctx->uc_mcontext, p_os);
+    fprintf(p_os, "\n");
+#endif
+    fflush(p_os);
+    ABTU_free(prefix);
+}

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -634,6 +634,7 @@ int ABT_info_print_thread(FILE* fp, ABT_thread thread) ABT_API_PUBLIC;
 int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr) ABT_API_PUBLIC;
 int ABT_info_print_task(FILE* fp, ABT_task task) ABT_API_PUBLIC;
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread) ABT_API_PUBLIC;
+int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool) ABT_API_PUBLIC;
 
 #if defined(__cplusplus)
 }

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -633,6 +633,7 @@ int ABT_info_print_pool(FILE* fp, ABT_pool pool) ABT_API_PUBLIC;
 int ABT_info_print_thread(FILE* fp, ABT_thread thread) ABT_API_PUBLIC;
 int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr) ABT_API_PUBLIC;
 int ABT_info_print_task(FILE* fp, ABT_task task) ABT_API_PUBLIC;
+int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread) ABT_API_PUBLIC;
 
 #if defined(__cplusplus)
 }

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -318,6 +318,8 @@ typedef ABT_unit      (*ABT_pool_pop_fn)(ABT_pool);
 typedef ABT_unit      (*ABT_pool_pop_timedwait_fn)(ABT_pool, double);
 typedef int           (*ABT_pool_remove_fn)(ABT_pool, ABT_unit);
 typedef int           (*ABT_pool_free_fn)(ABT_pool);
+typedef int           (*ABT_pool_print_all_fn)(ABT_pool, void *arg,
+                                               void (*)(void*, ABT_unit));
 
 typedef struct {
     ABT_pool_access access; /* Access type */
@@ -339,6 +341,7 @@ typedef struct {
     ABT_pool_pop_timedwait_fn p_pop_timedwait;
     ABT_pool_remove_fn   p_remove;
     ABT_pool_free_fn     p_free;
+    ABT_pool_print_all_fn p_print_all;
 } ABT_pool_def;
 
 
@@ -426,6 +429,8 @@ int ABT_pool_pop(ABT_pool pool, ABT_unit *unit) ABT_API_PUBLIC;
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *unit, double abstime_secs) ABT_API_PUBLIC;
 int ABT_pool_remove(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
 int ABT_pool_push(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
+int ABT_pool_print_all(ABT_pool pool, void *arg,
+                       void (*print_fn)(void *arg, ABT_unit)) ABT_API_PUBLIC;
 int ABT_pool_set_data(ABT_pool pool, void *data) ABT_API_PUBLIC;
 int ABT_pool_get_data(ABT_pool pool, void **data) ABT_API_PUBLIC;
 int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched) ABT_API_PUBLIC;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -334,14 +334,14 @@ typedef struct {
     ABT_unit_free_fn               u_free;
 
     /* Functions to manage the pool */
-    ABT_pool_init_fn     p_init;
-    ABT_pool_get_size_fn p_get_size;
-    ABT_pool_push_fn     p_push;
-    ABT_pool_pop_fn      p_pop;
+    ABT_pool_init_fn          p_init;
+    ABT_pool_get_size_fn      p_get_size;
+    ABT_pool_push_fn          p_push;
+    ABT_pool_pop_fn           p_pop;
     ABT_pool_pop_timedwait_fn p_pop_timedwait;
-    ABT_pool_remove_fn   p_remove;
-    ABT_pool_free_fn     p_free;
-    ABT_pool_print_all_fn p_print_all;
+    ABT_pool_remove_fn        p_remove;
+    ABT_pool_free_fn          p_free;
+    ABT_pool_print_all_fn     p_print_all;
 } ABT_pool_def;
 
 

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -25,4 +25,6 @@ typedef ucontext_t  abt_ucontext_t;
 
 #endif
 
+void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
+
 #endif /* ABTD_UCONTEXT_H_INCLUDED */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -567,6 +567,7 @@ int   ABTI_thread_set_blocked(ABTI_thread *p_thread);
 void  ABTI_thread_suspend(ABTI_thread *p_thread);
 int   ABTI_thread_set_ready(ABTI_thread *p_thread);
 void  ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
+int   ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
 void  ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
 void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -314,6 +314,7 @@ struct ABTI_pool {
     ABT_pool_pop_timedwait_fn      p_pop_timedwait;
     ABT_pool_remove_fn             p_remove;
     ABT_pool_free_fn               p_free;
+    ABT_pool_print_all_fn          p_print_all;
 };
 
 struct ABTI_unit {

--- a/src/info.c
+++ b/src/info.c
@@ -359,3 +359,80 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
+
+struct ABTI_info_print_unit_arg_t {
+    FILE *fp;
+    ABT_pool pool;
+};
+
+static void ABTI_info_print_unit(void *arg, ABT_unit unit)
+{
+    /* This function may not have any side effect on unit because it is passed
+     * to p_print_all. */
+    struct ABTI_info_print_unit_arg_t *p_arg;
+    p_arg = (struct ABTI_info_print_unit_arg_t *)arg;
+    FILE *fp = p_arg->fp;
+    ABT_pool pool = p_arg->pool;
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABT_unit_type type = p_pool->u_get_type(unit);
+
+    if (type == ABT_UNIT_TYPE_THREAD) {
+        fprintf(fp, "=== ULT (%p) ===\n", (void *)unit);
+        ABT_thread thread = p_pool->u_get_thread(unit);
+        ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+        ABT_thread_id thread_id = ABTI_thread_get_id(p_thread);
+        fprintf(fp, "id        : %" PRIu64 "\n"
+                    "ctx       : %p\n",
+                    (uint64_t)thread_id,
+                    &p_thread->ctx);
+        ABTD_thread_print_context(p_thread, fp, 2);
+        fprintf(fp, "stack     : %p\n"
+                    "stacksize : %" PRIu64 "\n",
+                    p_thread->attr.p_stack,
+                    (uint64_t)p_thread->attr.stacksize);
+        int abt_errno = ABT_info_print_thread_stack(fp, thread);
+        if (abt_errno != ABT_SUCCESS)
+            fprintf(fp, "Failed to print stack.\n");
+    } else if (type == ABT_UNIT_TYPE_TASK) {
+        fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);
+    } else {
+        fprintf(fp, "=== unknown (%p) ===\n", (void *)unit);
+    }
+}
+
+/**
+ * @ingroup INFO
+ * @brief   Dump stack information of all the threads in the target pool.
+ *
+ * \c ABT_info_print_thread_stacks_in_pool() dumps call stacks of all threads
+ * stored in \c pool.  This function returns \c ABT_ERR_POOL if \c pool does not
+ * support \c p_print_all.
+ *
+ * @param[in] fp    output stream
+ * @param[in] pool  handle to the target pool
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+
+    if (!p_pool->p_print_all) {
+        abt_errno = ABT_ERR_POOL;
+        goto fn_fail;
+    }
+    fprintf(fp, "== pool (%p) ==\n", p_pool);
+    struct ABTI_info_print_unit_arg_t arg;
+    arg.fp = fp;
+    arg.pool = pool;
+    p_pool->p_print_all(pool, &arg, ABTI_info_print_unit);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}

--- a/src/info.c
+++ b/src/info.c
@@ -332,3 +332,30 @@ int ABT_info_print_task(FILE* fp, ABT_task task)
     goto fn_exit;
 }
 
+/**
+ * @ingroup INFO
+ * @brief   Dump the stack of the target thread to the output stream.
+ *
+ * \c ABT_info_print_thread_stack() dumps the call stack of \c thread
+ * to the given output stream \c fp.
+ *
+ * @param[in] fp      output stream
+ * @param[in] thread  handle to the target thread
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+
+    abt_errno = ABTI_thread_print_stack(p_thread, fp);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}


### PR DESCRIPTION
This PR adds a basic stack dump functionality.
- `ABT_info_print_thread_stack` prints a stack of a given thread.
- `ABT_info_print_thread_stack_in_pool` prints stack information of threads in a given pool.

This commit is a prerequisite for #68.
