### PR TITLE
Support ucontext

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -10,7 +10,6 @@ static inline void ABTD_thread_terminate_thread(ABTI_local *p_local,
 static inline void ABTD_thread_terminate_sched(ABTI_local *p_local,
                                                ABTI_thread *p_thread);
 
-#if defined(ABT_CONFIG_USE_FCONTEXT)
 void ABTD_thread_func_wrapper_thread(void *p_arg)
 {
     ABTD_thread_context *p_fctx = (ABTD_thread_context *)p_arg;
@@ -44,42 +43,6 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTD_thread_terminate_sched(p_local, p_thread);
 }
-#else
-void ABTD_thread_func_wrapper(int func_upper, int func_lower,
-                              int arg_upper, int arg_lower)
-{
-    ABTI_local *p_local = ABTI_local_get_local();
-    void (*thread_func)(void *);
-    void *p_arg;
-    size_t ptr_size, int_size;
-
-    ptr_size = sizeof(void *);
-    int_size = sizeof(int);
-    if (ptr_size == int_size) {
-        thread_func = (void (*)(void *))(uintptr_t)func_lower;
-        p_arg = (void *)(uintptr_t)arg_lower;
-    } else if (ptr_size == int_size * 2) {
-        uintptr_t shift_bits = CHAR_BIT * int_size;
-        uintptr_t mask = ((uintptr_t)1 << shift_bits) - 1;
-        thread_func = (void (*)(void *))(
-                ((uintptr_t)func_upper << shift_bits) |
-                ((uintptr_t)func_lower & mask));
-        p_arg = (void *)(
-                ((uintptr_t)arg_upper << shift_bits) |
-                ((uintptr_t)arg_lower & mask));
-    } else {
-        ABTI_ASSERT(0);
-    }
-
-    thread_func(p_arg);
-
-    /* Now, the ULT has finished its job. Terminate the ULT.
-     * We don't need to use the atomic operation here because the ULT will be
-     * terminated regardless of other requests. */
-    ABTI_thread *p_thread = p_local->p_thread;
-    p_thread->request |= ABTI_THREAD_REQ_TERMINATE;
-}
-#endif
 
 void ABTD_thread_exit(ABTI_local *p_local, ABTI_thread *p_thread)
 {
@@ -98,7 +61,6 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
                                           ABTI_thread *p_thread,
                                           ABT_bool is_sched)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     ABTD_thread_context *p_fctx = &p_thread->ctx;
     ABTD_thread_context *p_link = (ABTD_thread_context *)
         ABTD_atomic_load_ptr((void **)&p_fctx->p_link);
@@ -180,9 +142,6 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
-#else
-#error "Not implemented yet"
-#endif
 }
 
 static inline void ABTD_thread_terminate_thread(ABTI_local *p_local,
@@ -215,7 +174,6 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
      * ULT has finished its execution and calls ABTD_thread_terminate/exit,
      * this function is called by the scheduler.  Therefore, we should not
      * context switch to the joiner ULT and need to always wake it up. */
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     ABTD_thread_context *p_fctx = &p_thread->ctx;
 
     /* acquire load is not needed here. */
@@ -234,43 +192,15 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
             ABTI_thread_set_ready(p_local, p_joiner);
         }
     }
-#else
-#error "Not implemented yet"
-#endif
 }
-
-#if !defined(ABT_CONFIG_USE_FCONTEXT)
-static inline
-void print_bytes(size_t size, void *p_val, FILE *p_os) {
-    size_t i;
-    for (i = 0; i < size; i++) {
-        uint8_t val = ((uint8_t *)p_val)[i];
-        fprintf(p_os, "%02" PRIx8, val);
-    }
-}
-#endif
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
 {
     char *prefix = ABTU_get_indent_str(indent);
     ABTD_thread_context *p_ctx = &p_thread->ctx;
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     fprintf(p_os, "%sfctx     : %p\n", prefix, (void *)p_ctx->fctx);
     fprintf(p_os, "%sp_arg    : %p\n", prefix, p_ctx->p_arg);
     fprintf(p_os, "%sp_link   : %p\n", prefix, (void *)p_ctx->p_link);
-#else
-    /* TODO: print information in more detail. */
-    fprintf(p_os, "%suc_link     : %p\n", prefix, p_ctx->uc_link);
-    fprintf(p_os, "%suc_sigmask  : ", prefix);
-    print_bytes(sizeof(sigset_t), &p_ctx->uc_sigmask, p_os);
-    fprintf(p_os, "\n");
-    fprintf(p_os, "%suc_stack    : ", prefix);
-    print_bytes(sizeof(stack_t), &p_ctx->uc_stack, p_os);
-    fprintf(p_os, "\n");
-    fprintf(p_os, "%suc_mcontext : ", prefix);
-    print_bytes(sizeof(mcontext_t), &p_ctx->uc_mcontext, p_os);
-    fprintf(p_os, "\n");
-#endif
     fflush(p_os);
     ABTU_free(prefix);
 }

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -9,10 +9,10 @@ noinst_HEADERS = \
 	include/abt_config.h \
 	include/abtd.h \
 	include/abtd_atomic.h \
+	include/abtd_context.h \
 	include/abtd_fcontext.h \
 	include/abtd_thread.h \
 	include/abtd_ucontext.h \
-	include/abtd_context.h \
 	include/abti.h \
 	include/abti_barrier.h \
 	include/abti_cond.h \

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -9,6 +9,7 @@ noinst_HEADERS = \
 	include/abt_config.h \
 	include/abtd.h \
 	include/abtd_atomic.h \
+	include/abtd_fcontext.h \
 	include/abtd_thread.h \
 	include/abtd_context.h \
 	include/abti.h \

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -11,6 +11,7 @@ noinst_HEADERS = \
 	include/abtd_atomic.h \
 	include/abtd_fcontext.h \
 	include/abtd_thread.h \
+	include/abtd_ucontext.h \
 	include/abtd_context.h \
 	include/abti.h \
 	include/abti_barrier.h \

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -10,7 +10,7 @@ noinst_HEADERS = \
 	include/abtd.h \
 	include/abtd_atomic.h \
 	include/abtd_thread.h \
-	include/abtd_ucontext.h \
+	include/abtd_context.h \
 	include/abti.h \
 	include/abti_barrier.h \
 	include/abti_cond.h \

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -8,7 +8,7 @@
 
 #define __USE_GNU
 #include <pthread.h>
-#include "abtd_ucontext.h"
+#include "abtd_context.h"
 
 /* Atomic Functions */
 #include "abtd_atomic.h"
@@ -21,7 +21,6 @@ typedef pthread_barrier_t   ABTD_xstream_barrier;
 #else
 typedef void *              ABTD_xstream_barrier;
 #endif
-typedef abt_ucontext_t      ABTD_thread_context;
 
 /* ES Storage Qualifier */
 #define ABTD_XSTREAM_LOCAL  __thread

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -13,15 +13,14 @@
 #include <ucontext.h>
 #endif
 
-typedef void *  fcontext_t;
-
 typedef struct ABTD_thread_context {
-    fcontext_t             fctx;    /* actual context */
-    void (*f_thread)(void *);       /* ULT function */
-    void *                 p_arg;   /* ULT function argument */
+    void *                 p_ctx;        /* actual context of fcontext, or a
+                                          * pointer to uctx */
+    void (*f_thread)(void *);            /* ULT function */
+    void *                 p_arg;        /* ULT function argument */
     struct ABTD_thread_context *p_link;  /* pointer to scheduler context */
 #ifndef ABT_CONFIG_USE_FCONTEXT
-    ucontext_t             uctx;         /* ucontext entity pointed by fctx */
+    ucontext_t             uctx;         /* ucontext entity pointed by p_ctx */
     void (*f_uctx_thread)(void *);       /* root function called by ucontext */
     void *                 p_uctx_arg;   /* argument for root function */
 #endif

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -3,20 +3,20 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef ABTD_UCONTEXT_H_INCLUDED
-#define ABTD_UCONTEXT_H_INCLUDED
+#ifndef ABTD_CONTEXT_H_INCLUDED
+#define ABTD_CONTEXT_H_INCLUDED
 
 #include "abt_config.h"
 
 typedef void *  fcontext_t;
 
-typedef struct abt_ucontext_t {
+typedef struct ABTD_thread_context {
     fcontext_t             fctx;    /* actual context */
     void (*f_thread)(void *);       /* ULT function */
     void *                 p_arg;   /* ULT function argument */
-    struct abt_ucontext_t *p_link;  /* pointer to scheduler context */
-} abt_ucontext_t;
+    struct ABTD_thread_context *p_link;  /* pointer to scheduler context */
+} ABTD_thread_context;
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
 
-#endif /* ABTD_UCONTEXT_H_INCLUDED */
+#endif /* ABTD_CONTEXT_H_INCLUDED */

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -8,6 +8,11 @@
 
 #include "abt_config.h"
 
+#ifndef ABT_CONFIG_USE_FCONTEXT
+#define _XOPEN_SOURCE
+#include <ucontext.h>
+#endif
+
 typedef void *  fcontext_t;
 
 typedef struct ABTD_thread_context {
@@ -15,6 +20,11 @@ typedef struct ABTD_thread_context {
     void (*f_thread)(void *);       /* ULT function */
     void *                 p_arg;   /* ULT function argument */
     struct ABTD_thread_context *p_link;  /* pointer to scheduler context */
+#ifndef ABT_CONFIG_USE_FCONTEXT
+    ucontext_t             uctx;         /* ucontext entity pointed by fctx */
+    void (*f_uctx_thread)(void *);       /* root function called by ucontext */
+    void *                 p_uctx_arg;   /* argument for root function */
+#endif
 } ABTD_thread_context;
 
 static void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp,
@@ -32,6 +42,10 @@ static void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx,
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
 
+#ifdef ABT_CONFIG_USE_FCONTEXT
 #include "abtd_fcontext.h"
+#else
+#include "abtd_ucontext.h"
+#endif
 
 #endif /* ABTD_CONTEXT_H_INCLUDED */

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -17,6 +17,21 @@ typedef struct ABTD_thread_context {
     struct ABTD_thread_context *p_link;  /* pointer to scheduler context */
 } ABTD_thread_context;
 
+static void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp,
+                                     size_t size, void (*thread_func)(void *));
+static void ABTD_thread_context_jump(ABTD_thread_context *p_old,
+                                     ABTD_thread_context *p_new, void *arg);
+static void ABTD_thread_context_take(ABTD_thread_context *p_old,
+                                     ABTD_thread_context *p_new, void *arg);
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+static void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx,
+                                              void *sp,
+                                              void (*thread_func)(void *),
+                                              void *arg);
+#endif
+
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
+
+#include "abtd_fcontext.h"
 
 #endif /* ABTD_CONTEXT_H_INCLUDED */

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -6,6 +6,8 @@
 #ifndef ABTD_FCONTEXT_H_INCLUDED
 #define ABTD_FCONTEXT_H_INCLUDED
 
+typedef void *fcontext_t;
+
 #if defined(ABT_C_HAVE_VISIBILITY)
 #define ABT_API_PRIVATE     __attribute__((visibility ("hidden")))
 #else
@@ -25,21 +27,21 @@ static inline
 void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
                               void (*thread_func)(void *))
 {
-    p_ctx->fctx = make_fcontext(sp, size, thread_func);
+    p_ctx->p_ctx = make_fcontext(sp, size, thread_func);
 }
 
 static inline
 void ABTD_thread_context_jump(ABTD_thread_context *p_old,
                               ABTD_thread_context *p_new, void *arg)
 {
-    jump_fcontext(&p_old->fctx, p_new->fctx, arg);
+    jump_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
 }
 
 static inline
 void ABTD_thread_context_take(ABTD_thread_context *p_old,
                               ABTD_thread_context *p_new, void *arg)
 {
-    take_fcontext(&p_old->fctx, p_new->fctx, arg);
+    take_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -47,7 +49,7 @@ static inline
 void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx, void *sp,
                                        void (*thread_func)(void *), void *arg)
 {
-    init_and_call_fcontext(arg, thread_func, sp, &p_ctx->fctx);
+    init_and_call_fcontext(arg, thread_func, sp, &p_ctx->p_ctx);
 }
 #endif
 

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -1,0 +1,54 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTD_FCONTEXT_H_INCLUDED
+#define ABTD_FCONTEXT_H_INCLUDED
+
+#if defined(ABT_C_HAVE_VISIBILITY)
+#define ABT_API_PRIVATE     __attribute__((visibility ("hidden")))
+#else
+#define ABT_API_PRIVATE
+#endif
+
+fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func)(void *))
+                         ABT_API_PRIVATE;
+void *jump_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
+void *take_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+void init_and_call_fcontext(void *p_arg, void (*f_thread)(void *),
+                            void *p_stacktop, fcontext_t *old);
+#endif
+
+static inline
+void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
+                              void (*thread_func)(void *))
+{
+    p_ctx->fctx = make_fcontext(sp, size, thread_func);
+}
+
+static inline
+void ABTD_thread_context_jump(ABTD_thread_context *p_old,
+                              ABTD_thread_context *p_new, void *arg)
+{
+    jump_fcontext(&p_old->fctx, p_new->fctx, arg);
+}
+
+static inline
+void ABTD_thread_context_take(ABTD_thread_context *p_old,
+                              ABTD_thread_context *p_new, void *arg)
+{
+    take_fcontext(&p_old->fctx, p_new->fctx, arg);
+}
+
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+static inline
+void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx, void *sp,
+                                       void (*thread_func)(void *), void *arg)
+{
+    init_and_call_fcontext(arg, thread_func, sp, &p_ctx->fctx);
+}
+#endif
+
+#endif /* ABTD_FCONTEXT_H_INCLUDED */

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -12,7 +12,6 @@
 #define ABT_API_PRIVATE
 #endif
 
-#if defined(ABT_CONFIG_USE_FCONTEXT)
 void ABTD_thread_func_wrapper_thread(void *p_arg);
 void ABTD_thread_func_wrapper_sched(void *p_arg);
 fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func)(void *))
@@ -24,12 +23,6 @@ void init_and_call_fcontext(void *p_arg, void (*f_thread)(void *),
                             void *p_stacktop, fcontext_t *old);
 void ABTD_thread_terminate_thread_no_arg();
 #endif
-#else
-void ABTD_thread_func_wrapper(int func_upper, int func_lower,
-                              int arg_upper, int arg_lower);
-#define ABTD_thread_func_wrapper_thread ABTD_thread_func_wrapper
-#define ABTD_thread_func_wrapper_sched  ABTD_thread_func_wrapper
-#endif
 
 static inline
 int ABTDI_thread_context_create(ABTD_thread_context *p_link,
@@ -39,7 +32,6 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
                                ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     void *p_stacktop;
 
     /* fcontext uses the top address of stack.
@@ -52,49 +44,6 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     p_newctx->p_link = p_link;
 
     return abt_errno;
-
-#else
-    int func_upper, func_lower;
-    int arg_upper, arg_lower;
-    size_t ptr_size, int_size;
-
-    /* If stack is NULL, we don't need to make a new context */
-    if (p_stack == NULL) goto fn_exit;
-
-    abt_errno = getcontext(p_newctx);
-    ABTI_CHECK_TRUE(!abt_errno, ABT_ERR_THREAD);
-
-    p_newctx->uc_link = p_link;
-    p_newctx->uc_stack.ss_sp = p_stack;
-    p_newctx->uc_stack.ss_size = stacksize;
-
-    ptr_size = sizeof(void *);
-    int_size = sizeof(int);
-    if (ptr_size == int_size) {
-        func_upper = 0;
-        func_lower = (int)(uintptr_t)f_thread;
-        arg_upper = 0;
-        arg_lower = (int)(uintptr_t)p_arg;
-    } else if (ptr_size == int_size * 2) {
-        uintptr_t shift_bits = CHAR_BIT * int_size;
-        func_upper = (int)((uintptr_t)f_thread >> shift_bits);
-        func_lower = (int)(uintptr_t)f_thread;
-        arg_upper = (int)((uintptr_t)p_arg >> shift_bits);
-        arg_lower = (int)(uintptr_t)p_arg;
-    } else {
-        ABTI_ASSERT(0);
-    }
-
-    makecontext(p_newctx, (void (*)())f_wrapper, 4, func_upper, func_lower,
-                arg_upper, arg_lower);
-
-  fn_exit:
-    return abt_errno;
-
-  fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-#endif
 }
 
 static inline
@@ -123,7 +72,6 @@ static inline
 int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
-#if defined(ABT_CONFIG_USE_FCONTEXT)
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* fctx is used to check whether the context requires dynamic promotion is
      * necessary or not, so this value must not be NULL. */
@@ -135,7 +83,6 @@ int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
     p_newctx->p_arg = NULL;
     p_newctx->p_link = NULL;
     return abt_errno;
-#endif
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -145,15 +92,11 @@ int ABTD_thread_context_init(ABTD_thread_context *p_link,
                              ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     p_newctx->fctx = NULL;
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
     p_newctx->p_link = p_link;
     return abt_errno;
-#else
-#error "Not implemented yet"
-#endif
 }
 
 static inline
@@ -165,16 +108,12 @@ int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
      * ABTD_thread_context_create; this function fully creates the context
      * so that the thread can be run by jump_fcontext. */
     int abt_errno = ABT_SUCCESS;
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     /* fcontext uses the top address of stack.
        Note that the parameter, p_stack, points to the bottom of stack. */
     void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     p_newctx->fctx = make_fcontext(p_stacktop, stacksize,
                                    ABTD_thread_func_wrapper_thread);
     return abt_errno;
-#else
-#error "Not implemented yet"
-#endif
 }
 #endif
 
@@ -185,25 +124,14 @@ static inline
 void ABTD_thread_context_switch(ABTD_thread_context *p_old,
                                 ABTD_thread_context *p_new)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     jump_fcontext(&p_old->fctx, p_new->fctx, p_new);
-
-#else
-    int ret = swapcontext(p_old, p_new);
-    ABTI_ASSERT(ret == 0);
-#endif
 }
 
 static inline
 void ABTD_thread_finish_context(ABTD_thread_context *p_old,
                                 ABTD_thread_context *p_new)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     take_fcontext(&p_old->fctx, p_new->fctx, p_new);
-#else
-    int ret = swapcontext(p_old, p_new);
-    ABTI_ASSERT(ret == 0);
-#endif
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -245,48 +173,19 @@ static inline
 void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
                                      ABTD_thread_context *p_link)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     ABTD_atomic_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
-
-#else
-#ifdef __GLIBC__
-    /* FIXME: this will work only with glibc. */
-    unsigned long int *sp;
-    unsigned long int idx_uc_link = 1;
-
-    /* Calulate the position where uc_link is saved. */
-    sp = (unsigned long int *)
-         ((uintptr_t)p_ctx->uc_stack.ss_sp + p_ctx->uc_stack.ss_size);
-    sp -= 1;
-    sp = (unsigned long int *)((((uintptr_t)sp) & -16L) - 8);
-
-    /* The value in stack must be the same as that in the thread context. */
-    ABTI_ASSERT(sp[idx_uc_link] == (unsigned long int)p_ctx->uc_link);
-    sp[idx_uc_link] = (unsigned long int)p_link;
-#endif
-
-    p_ctx->uc_link = p_link;
-#endif
 }
 
 static inline
 void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx, void *arg)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     p_ctx->p_arg = arg;
-#else
-#error "Not implemented yet"
-#endif
 }
 
 static inline
 void *ABTD_thread_context_get_arg(ABTD_thread_context *p_ctx)
 {
-#if defined(ABT_CONFIG_USE_FCONTEXT)
     return p_ctx->p_arg;
-#else
-#error "Not implemented yet"
-#endif
 }
 
 #endif /* ABTD_THREAD_H_INCLUDED */

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -28,7 +28,7 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     int abt_errno = ABT_SUCCESS;
     void *p_stacktop;
 
-    /* fcontext uses the top address of stack.
+    /* ABTD_thread_context_make uses the top address of stack.
        Note that the parameter, p_stack, points to the bottom of stack. */
     p_stacktop = (void *)(((char *)p_stack) + stacksize);
 
@@ -67,11 +67,11 @@ int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-    /* fctx is used to check whether the context requires dynamic promotion is
+    /* p_ctx is used to check whether the context requires dynamic promotion is
      * necessary or not, so this value must not be NULL. */
-    p_newctx->fctx = (void *)((intptr_t)0x1);
+    p_newctx->p_ctx = (void *)((intptr_t)0x1);
 #else
-    p_newctx->fctx = NULL;
+    p_newctx->p_ctx = NULL;
 #endif
     p_newctx->f_thread = NULL;
     p_newctx->p_arg = NULL;
@@ -86,7 +86,7 @@ int ABTD_thread_context_init(ABTD_thread_context *p_link,
                              ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
-    p_newctx->fctx = NULL;
+    p_newctx->p_ctx = NULL;
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
     p_newctx->p_link = p_link;
@@ -100,9 +100,9 @@ int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
     /* This function *arms* the dynamic promotion thread (initialized by
      * ABTD_thread_context_init) as if it were created by
      * ABTD_thread_context_create; this function fully creates the context
-     * so that the thread can be run by jump_fcontext. */
+     * so that the thread can be run by ABTD_thread_context_jump. */
     int abt_errno = ABT_SUCCESS;
-    /* fcontext uses the top address of stack.
+    /* ABTD_thread_context_make uses the top address of stack.
        Note that the parameter, p_stack, points to the bottom of stack. */
     void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     ABTD_thread_context_make(p_newctx, p_stacktop, stacksize,
@@ -142,7 +142,7 @@ ABT_bool ABTD_thread_context_is_dynamic_promoted(ABTD_thread_context *p_ctx)
 {
     /* Check if the ULT has been dynamically promoted; internally, it checks if
      * the context is NULL. */
-    return p_ctx->fctx ? ABT_TRUE : ABT_FALSE;
+    return p_ctx->p_ctx ? ABT_TRUE : ABT_FALSE;
 }
 
 static inline

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -8,7 +8,6 @@
 
 #include "abt_config.h"
 
-#if defined(ABT_CONFIG_USE_FCONTEXT)
 typedef void *  fcontext_t;
 
 typedef struct abt_ucontext_t {
@@ -17,13 +16,6 @@ typedef struct abt_ucontext_t {
     void *                 p_arg;   /* ULT function argument */
     struct abt_ucontext_t *p_link;  /* pointer to scheduler context */
 } abt_ucontext_t;
-
-#else
-#define _XOPEN_SOURCE
-#include <ucontext.h>
-typedef ucontext_t  abt_ucontext_t;
-
-#endif
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
 

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -1,0 +1,73 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTD_UCONTEXT_H_INCLUDED
+#define ABTD_UCONTEXT_H_INCLUDED
+
+static void ABTD_ucontext_wrapper(int arg1, int arg2)
+{
+    ABTD_thread_context *p_self;
+    if (sizeof(void *) == 8) {
+        p_self = (ABTD_thread_context *)(((uintptr_t)((uint32_t)arg1) << 32) |
+                                         ((uintptr_t)((uint32_t)arg2)));
+    } else if (sizeof(void *) == 4) {
+        p_self = (ABTD_thread_context *)((uintptr_t)arg1);
+    } else {
+        ABTI_ASSERT(0);
+    }
+    p_self->f_uctx_thread(p_self->p_uctx_arg);
+    /* ABTD_thread_context_jump or take must be called at the end of
+     * f_uctx_thread, */
+    ABTI_ASSERT(0);
+}
+
+static inline
+void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
+                              void (*thread_func)(void *))
+{
+    getcontext(&p_ctx->uctx);
+    p_ctx->fctx = &p_ctx->uctx;
+
+    /* uc_link is not used. */
+    p_ctx->uctx.uc_link = NULL;
+    p_ctx->uctx.uc_stack.ss_sp = (void *)(((char *)sp) - size);
+    p_ctx->uctx.uc_stack.ss_size = size;
+    p_ctx->f_uctx_thread = thread_func;
+
+    if (sizeof(void *) == 8) {
+        int arg_upper = (int)(((uintptr_t)p_ctx) >> 32);
+        int arg_lower = (int)(((uintptr_t)p_ctx) >> 0);
+        makecontext(&p_ctx->uctx, (void (*)())ABTD_ucontext_wrapper, 2,
+                    arg_upper, arg_lower);
+    } else if (sizeof(void *) == 4) {
+        int arg = (int)((uintptr_t)p_ctx);
+        makecontext(&p_ctx->uctx, (void (*)())ABTD_ucontext_wrapper, 1, arg);
+    } else {
+        ABTI_ASSERT(0);
+    }
+}
+
+static inline
+void ABTD_thread_context_jump(ABTD_thread_context *p_old,
+                              ABTD_thread_context *p_new, void *arg)
+{
+    p_new->p_uctx_arg = arg;
+    swapcontext(&p_old->uctx, &p_new->uctx);
+}
+
+static inline
+void ABTD_thread_context_take(ABTD_thread_context *p_old,
+                              ABTD_thread_context *p_new, void *arg)
+{
+    p_new->p_uctx_arg = arg;
+    setcontext(&p_new->uctx);
+    /* Unreachable. */
+}
+
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+#error "ABTD_thread_context_make_and_call is not implemented."
+#endif
+
+#endif /* ABTD_UCONTEXT_H_INCLUDED */

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -28,7 +28,7 @@ void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
                               void (*thread_func)(void *))
 {
     getcontext(&p_ctx->uctx);
-    p_ctx->fctx = &p_ctx->uctx;
+    p_ctx->p_ctx = &p_ctx->uctx;
 
     /* uc_link is not used. */
     p_ctx->uctx.uc_link = NULL;

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -222,9 +222,9 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
             ABTI_ASSERT(p_prev == p_new);
             /* See ABTDI_thread_terminate for details.
              * TODO: avoid making a copy of the code. */
-            ABTD_thread_context *p_fctx = &p_prev->ctx;
+            ABTD_thread_context *p_ctx = &p_prev->ctx;
             ABTD_thread_context *p_link = (ABTD_thread_context *)
-                ABTD_atomic_load_ptr((void **)&p_fctx->p_link);
+                ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
                  * join. */
@@ -246,7 +246,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
                      */
                     do {
                         p_link = (ABTD_thread_context *)
-                            ABTD_atomic_load_ptr((void **)&p_fctx->p_link);
+                            ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
                     } while (!p_link);
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -220,7 +220,6 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
         ABTI_thread *p_prev = p_local->p_thread;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
-#if defined(ABT_CONFIG_USE_FCONTEXT)
             /* See ABTDI_thread_terminate for details.
              * TODO: avoid making a copy of the code. */
             ABTD_thread_context *p_fctx = &p_prev->ctx;
@@ -252,9 +251,6 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }
             }
-#else
-#error "Not implemented yet"
-#endif
         }
         return;
     }


### PR DESCRIPTION
This PR provides (or revives) `ucontext` support, which is a fallback method when `fcontext` is unavailable.  The previous `ucontext` support was incomplete: compilation fails by `#error`. Though `fcontext` supports many platforms, this PR can widen the support architectures.

The first two commits remove the current incomplete and dirty `ucontext` implementation, and the third commit creates thin wrappers for `fcontext`, and the fourth commit implements their `ucontext` version. The last commit is clean-up.

This PR is related to #11, #18, and #81, all of which as a result encountered the unsupported `ucontext` error.

