### PR TITLE
configure: enable simple mutex by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,9 +195,10 @@ AC_ARG_ENABLE([dynamic-promotion],
                    [use the dynamic promotion threading technique that performs
                     better if a ULT does not yield.]))
 
-# --enable-simple-mutex
+# --disable-simple-mutex
 AC_ARG_ENABLE([simple-mutex],
-    AS_HELP_STRING([--enable-simple-mutex], [use a simple mutex implementation]))
+    AS_HELP_STRING([--disable-simple-mutex], [use an experimental mutex implementation]),,
+    [enable_simple_mutex=yes])
 
 # --enable-static-cacheline-size
 AC_ARG_ENABLE([static-cacheline-size],
@@ -631,7 +632,7 @@ if test "x$have_atomic_builtin" = "xyes" ; then
 fi
 
 
-# --enable-simple-mutex
+# --disable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,
                  [Define to use a simple mutex implementation])])


### PR DESCRIPTION
Currently, Argobots uses an advanced mutex implementation using a hand-off mechanism by default.  However, this mutex algorithm has algorithmic issues.

1. it potentially causes SEGV (#14, #41)
2. it forces users to set the maximum number of execution streams before initialization (#34)

A quick hack does not work for these issues. We need to completely improve the current mutex implementation. It is the right way to fix these issues, but it requires longer time than I expect.

For stability, this PR disables the current experimental mutex implementation and uses the stable simple mutex algorithm, which does not have any reported issues.

Note that this change might negatively affect the mutex performance; one can enable the previous mutex by setting `--disable-simple-mutex`.