### PR TITLE
abtu: always use aligned malloc.

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -800,14 +800,18 @@ int ABT_event_add_callback(ABT_event_kind event,
             max_num = gp_einfo->max_stop_xstream_fn;
             if (cur_num == max_num) {
                 /* We need to allocate more space */
+                size_t cur_size;
                 max_num = max_num * 2;
                 gp_einfo->max_stop_xstream_fn = max_num;
+                cur_size = cur_num * 2 * sizeof(ABT_event_cb_fn);
                 new_size = max_num * 2 * sizeof(ABT_event_cb_fn);
                 gp_einfo->stop_xstream_fn = (ABT_event_cb_fn *)
-                    ABTU_realloc(gp_einfo->stop_xstream_fn, new_size);
+                    ABTU_realloc(gp_einfo->stop_xstream_fn, cur_size, new_size);
+                cur_size = cur_num * 2 * sizeof(void *);
                 new_size = max_num * 2 * sizeof(void *);
                 gp_einfo->stop_xstream_arg = (void **)
-                    ABTU_realloc(gp_einfo->stop_xstream_arg, new_size);
+                    ABTU_realloc(gp_einfo->stop_xstream_arg, cur_size,
+                                 new_size);
             }
             ABTI_ASSERT(cur_num < max_num);
 
@@ -838,14 +842,17 @@ int ABT_event_add_callback(ABT_event_kind event,
             max_num = gp_einfo->max_add_xstream_fn;
             if (cur_num == max_num) {
                 /* We need to allocate more space */
+                size_t cur_size;
                 max_num = max_num * 2;
                 gp_einfo->max_add_xstream_fn = max_num;
+                cur_size = cur_num * 2 * sizeof(ABT_event_cb_fn);
                 new_size = max_num * 2 * sizeof(ABT_event_cb_fn);
                 gp_einfo->add_xstream_fn = (ABT_event_cb_fn *)
-                    ABTU_realloc(gp_einfo->add_xstream_fn, new_size);
+                    ABTU_realloc(gp_einfo->add_xstream_fn, cur_size, new_size);
+                cur_size = cur_num * 2 * sizeof(void *);
                 new_size = max_num * 2 * sizeof(void *);
                 gp_einfo->add_xstream_arg = (void **)
-                    ABTU_realloc(gp_einfo->add_xstream_arg, new_size);
+                    ABTU_realloc(gp_einfo->add_xstream_arg, cur_size, new_size);
             }
             ABTI_ASSERT(cur_num < max_num);
 

--- a/src/global.c
+++ b/src/global.c
@@ -264,7 +264,7 @@ int ABT_initialized(void)
  */
 void ABTI_global_update_max_xstreams(int new_size)
 {
-    int i;
+    int i, cur_size;
 
     if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams) return;
 
@@ -290,10 +290,12 @@ void ABTI_global_update_max_xstreams(int new_size)
         max_xstreams_warning_once = 1;
     }
 
-    new_size = (new_size > 0) ? new_size : gp_ABTI_global->max_xstreams * 2;
+    cur_size = gp_ABTI_global->max_xstreams;
+    new_size = (new_size > 0) ? new_size : cur_size * 2;
     gp_ABTI_global->max_xstreams = new_size;
     gp_ABTI_global->p_xstreams = (ABTI_xstream **)ABTU_realloc(
-            gp_ABTI_global->p_xstreams, new_size * sizeof(ABTI_xstream *));
+            gp_ABTI_global->p_xstreams, cur_size * sizeof(ABTI_xstream *),
+            new_size * sizeof(ABTI_xstream *));
 
     for (i = gp_ABTI_global->num_xstreams; i < new_size; i++) {
         gp_ABTI_global->p_xstreams[i] = NULL;

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -8,12 +8,6 @@
 
 /* Memory allocation */
 
-#if defined(ABT_CONFIG_USE_ALIGNED_ALLOC)
-#define ABTU_CA_MALLOC(s)   ABTU_memalign(ABT_CONFIG_STATIC_CACHELINE_SIZE, s)
-#else
-#define ABTU_CA_MALLOC(s)   ABTU_malloc(s)
-#endif /* defined(ABT_CONFIG_USE_ALIGNED_ALLOC) */
-
 /* Header size should be a multiple of cache line size. It is constant. */
 #define ABTI_MEM_SH_SIZE (((sizeof(ABTI_thread) + sizeof(ABTI_stack_header) \
                             + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) \
@@ -113,7 +107,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
     actual_stacksize = stacksize - sizeof(ABTI_thread);
 
     /* Allocate a stack */
-    p_blk = (char *)ABTU_CA_MALLOC(stacksize);
+    p_blk = (char *)ABTU_malloc(stacksize);
 
     /* Allocate ABTI_thread, ABTI_stack_header, and the actual stack area in
      * the allocated stack memory */
@@ -169,7 +163,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
             stacktype == ABTI_STACK_TYPE_MAIN) {
             /* Since the stack is given by the user, we create ABTI_thread and
              * ABTI_stack_header explicitly with a single ABTU_malloc call. */
-            p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));
+            p_thread = (ABTI_thread *)ABTU_malloc(sizeof(ABTI_thread));
             ABTI_thread_attr_copy(&p_thread->attr, p_attr);
 
             if (p_attr->stacktype != ABTI_STACK_TYPE_MAIN) {
@@ -274,7 +268,7 @@ ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     if (p_local == NULL) {
         /* For external threads */
-        char *p_blk = (char *)ABTU_CA_MALLOC(blk_size);
+        char *p_blk = (char *)ABTU_malloc(blk_size);
         ABTI_blk_header *p_blk_header = (ABTI_blk_header *)p_blk;
         p_blk_header->p_ph = NULL;
         p_task = (ABTI_task *)(p_blk + sizeof(ABTI_blk_header));
@@ -376,7 +370,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
     actual_stacksize = stacksize - sizeof(ABTI_thread);
 
     /* Allocate ABTI_thread and a stack */
-    p_blk = (char *)ABTU_CA_MALLOC(stacksize);
+    p_blk = (char *)ABTU_malloc(stacksize);
     p_thread = (ABTI_thread *)p_blk;
     p_stack = (void *)(p_blk + sizeof(ABTI_thread));
 
@@ -405,7 +399,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
     if (p_attr->p_stack == NULL) {
         ABTI_ASSERT(p_attr->userstack == ABT_FALSE);
 
-        char *p_blk = (char *)ABTU_CA_MALLOC(p_attr->stacksize);
+        char *p_blk = (char *)ABTU_malloc(p_attr->stacksize);
         p_thread = (ABTI_thread *)p_blk;
 
         ABTI_thread_attr_copy(&p_thread->attr, p_attr);
@@ -416,7 +410,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
         /* Since the stack is given by the user, we create ABTI_thread
          * explicitly instead of using a part of stack because the stack
          * will be freed by the user. */
-        p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));
+        p_thread = (ABTI_thread *)ABTU_malloc(sizeof(ABTI_thread));
         ABTI_thread_attr_copy(&p_thread->attr, p_attr);
     }
 
@@ -429,7 +423,7 @@ ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
 {
     ABTI_thread *p_thread;
 
-    p_thread = (ABTI_thread *)ABTU_CA_MALLOC(sizeof(ABTI_thread));
+    p_thread = (ABTI_thread *)ABTU_malloc(sizeof(ABTI_thread));
 
     /* Set attributes */
     /* TODO: Need to set the actual stack address and size for the main ULT */
@@ -449,7 +443,7 @@ void ABTI_mem_free_thread(ABTI_thread *p_thread)
 static inline
 ABTI_task *ABTI_mem_alloc_task(void)
 {
-    return (ABTI_task *)ABTU_CA_MALLOC(sizeof(ABTI_task));
+    return (ABTI_task *)ABTU_malloc(sizeof(ABTI_task));
 }
 
 static inline

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -113,11 +113,13 @@ static inline
 void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
     if (p_xstream->num_scheds == p_xstream->max_scheds) {
-        int max_size = p_xstream->max_scheds+10;
+        int cur_size = p_xstream->max_scheds;
+        int new_size = cur_size + 10;
         void *temp;
-        temp = ABTU_realloc(p_xstream->scheds, max_size*sizeof(ABTI_sched *));
+        temp = ABTU_realloc(p_xstream->scheds, cur_size * sizeof(ABTI_sched *),
+                            new_size * sizeof(ABTI_sched *));
         p_xstream->scheds = (ABTI_sched **)temp;
-        p_xstream->max_scheds = max_size;
+        p_xstream->max_scheds = new_size;
     }
 
     p_xstream->scheds[p_xstream->num_scheds++] = p_sched;

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -41,6 +41,11 @@ void ABTU_free(void *ptr)
 static inline
 void *ABTU_malloc(size_t size)
 {
+    /* Round up to the smallest multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE
+     * which is greater than or equal to size in order to avoid any
+     * false-sharing. */
+    size = (size + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)
+           & (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
     return ABTU_memalign(ABT_CONFIG_STATIC_CACHELINE_SIZE, size);
 }
 

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -21,10 +21,29 @@
 #endif
 
 /* Utility Functions */
-#define ABTU_malloc(a)          malloc((size_t)(a))
-#define ABTU_calloc(a,b)        calloc((size_t)(a),(size_t)b)
-#define ABTU_free(a)            free((void *)(a))
-#define ABTU_realloc(a,b)       realloc((void *)(a),(size_t)(b))
+static inline
+void *ABTU_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+static inline
+void *ABTU_calloc(size_t num, size_t size)
+{
+    return calloc(num, size);
+}
+
+static inline
+void ABTU_free(void *ptr)
+{
+    free(ptr);
+}
+
+static inline
+void *ABTU_realloc(void *ptr, size_t size)
+{
+    return realloc(ptr, size);
+}
 
 static inline
 void *ABTU_memalign(size_t alignment, size_t size)

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -21,6 +21,7 @@
 #endif
 
 /* Utility Functions */
+
 static inline
 void *ABTU_malloc(size_t size)
 {
@@ -40,9 +41,10 @@ void ABTU_free(void *ptr)
 }
 
 static inline
-void *ABTU_realloc(void *ptr, size_t size)
+void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 {
-    return realloc(ptr, size);
+    (void)old_size;
+    return realloc(ptr, new_size);
 }
 
 static inline

--- a/src/info.c
+++ b/src/info.c
@@ -401,6 +401,7 @@ void ABTI_info_add_pool_set(ABT_pool pool, struct ABTI_info_pool_set_t *p_set)
     if (p_set->num == p_set->len) {
         size_t new_len = p_set->len * 2;
         p_set->pools = (ABT_pool *)ABTU_realloc(p_set->pools,
+                                                sizeof(ABT_pool) * p_set->len,
                                                 sizeof(ABT_pool) * new_len);
         p_set->len = new_len;
     }

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -85,8 +85,9 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
 
         size_t size = ABTI_sched_config_type_size(type);
         if (offset+sizeof(param)+sizeof(type)+size > buffer_size) {
+            size_t cur_buffer_size = buffer_size;
             buffer_size += alloc_size;
-            buffer = ABTU_realloc(buffer, buffer_size);
+            buffer = ABTU_realloc(buffer, cur_buffer_size, buffer_size);
         }
         /* Copy the parameter index */
         memcpy(buffer+offset, (void *)&param, sizeof(param));

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -60,12 +60,14 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
     if (idx >= p_htable->num_rows) {
         ABTI_ASSERT(0);
         /* Increase the hash table */
-        uint32_t new_size;
-        new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
+        uint32_t cur_size, new_size;
+        cur_size = p_htable->num_rows;
+        new_size = (idx / cur_size + 1) * cur_size;
         p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[p_htable->num_rows], 0,
-               (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
+                p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
+                new_size * sizeof(ABTI_thread_queue));
+        memset(&p_htable->queue[cur_size], 0, (new_size - cur_size)
+                                              * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 
@@ -119,12 +121,14 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
     if (idx >= p_htable->num_rows) {
         ABTI_ASSERT(0);
         /* Increase the hash table */
-        uint32_t new_size;
-        new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
+        uint32_t cur_size, new_size;
+        cur_size = p_htable->num_rows;
+        new_size = (idx / cur_size + 1) * cur_size;
         p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[p_htable->num_rows], 0,
-               (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
+                p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
+                new_size * sizeof(ABTI_thread_queue));
+        memset(&p_htable->queue[cur_size], 0, (new_size - cur_size)
+                                              * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 


### PR DESCRIPTION
Currently, some Argobots codes use `malloc`, `calloc` and `realloc` via `ABTU_malloc` etc in order to allocate data. Since these functions are not aware of cache line alignment. this allocation sometimes causes cache line conflict.

For example,
```
void case1() { // Conflict between Argobots objects
  ABT_mutex mutex1, mutex2;
  ABT_mutex_create(&mutex1); // It internally calls ABTU_calloc, which is mapped to calloc
  ABT_mutex_create(&mutex2); // It internally calls ABTU_calloc, which is mapped to calloc
  // mutex1 and mutex2 can share the same cache lines.
}
void case2() { // Conflict between an Argobot object and user data
  ABT_mutex mutex;
  ABT_mutex_create(&mutex); // It internally calls ABTU_calloc, which is mapped to calloc
  int *user_data = (int *)malloc(sizeof(int) * 16);
  // mutex and user_data can share the same cache line.
}
```
See the implementation of `ABT_mutex_create` for details (See https://github.com/pmodels/argobots/blob/master/src/mutex.c#L36). Note that it actually happened in the past.

To avoid any potential cache line conflict, all the allocation in Argobots should be aligned and the size should be a multiple of the cache line size. This PR improves `ABTU_malloc`, `ABTU_calloc`, and `ABTU_realloc` to return aligned address by rounding up the size to a multiple of cache line size.

Minor changes:
- Since aligned `realloc` is not available, callers need to specify the old size as well (i.e., `ABTU_realloc` takes `old_size`.)
- Replace `ABTU_CA_MALLOC` (cache-aligned malloc) by `ABTU_malloc`.
