### PR TITLE
Fix for nested calls to Argobots runtime

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1673,6 +1673,18 @@ int ABTI_xstream_set_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     ABTI_pool *p_tar_pool = NULL;
     int p;
 
+    /* Pool effective size check is required to make nested ABT calls work, and to avoid replacing the main scheduler of the ES. 
+     * This will return an error which should be handled in user code */
+    /* TODO: permit to change the scheduler even when having work units in pools */
+    if (p_xstream->p_main_sched) {
+	/* We only allow to change the main scheduler when the current main
+	 * * *          * scheduler of p_xstream has no work unit in its associated pools. */
+	if (ABTI_sched_get_effective_size(p_xstream->p_main_sched) > 0) {
+	    abt_errno = ABT_ERR_XSTREAM;
+	    goto fn_fail;
+	}
+    }
+
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     /* We check that from the pool set of the scheduler we do not find a pool
      * with another associated pool, and set the right value if it is okay  */


### PR DESCRIPTION
Currently, when making nested calls to the Argobots runtime, the program hangs. The issue is that effective pool size check is missing in `ABTI_xstream_set_main_sched` which replaces the scheduler of the primary execution stream. They is a possibility of having pending ULTs in the scheduler's pool which are lost and not executed at all. 

This issue happens only when a ULT running on the primary execution stream calls `ABT_xstream_set_main_sched_basic`. Effective pool size check is present in `ABT_xstream_set_main_sched`, which in turn calls `ABTI_xstream_set_main_sched`, but not all code paths for setting the main scheduler have this check.