### PR TITLE
Set up Travis CI for style check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: c
+
+os: linux
+
+dist: bionic
+
+addons:
+  apt:
+    packages: indent
+
+script:
+  - maint/hook/pre-commit

--- a/maint/hook/pre-commit
+++ b/maint/hook/pre-commit
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=$(git merge-base --fork-point master)
+else
+    # Initial commit: diff against an git hash-object -t tree /dev/nullempty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if test $(git diff --cached --name-only --diff-filter=A -z $against |
+         LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+    cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+EOF
+    exit 1
+fi
+
+MIRROR=/tmp/${USER}/argobots-tmp-mirror
+TMP_FILENAME=/tmp/${USER}/argobots-tmp-file
+
+# Checkout a copy of the current index into MIRROR
+git checkout-index --prefix=$MIRROR/ -af
+
+# Remove files from MIRROR which are no longer present in the index
+git diff-index --cached --name-only --diff-filter=D -z $against | \
+    (cd $MIRROR && xargs -0 rm -f --)
+
+# This will check the previous commit again when not amending a commit, but that
+# should be ok if the patches are correct.
+filestring=`git diff --cached --name-only --diff-filter=ACM $against`
+
+# Everything else happens in the temporary build tree
+pushd $MIRROR > /dev/null
+
+ret=0
+
+# This won't work if we ever have a file with a space in the name
+for file in $filestring
+do
+    if [[ ($file == *.c || $file == *.h || $file == *.c.in || $file == *.h.in)
+          && !($file == *abt.h.in) ]]; then
+        cp ${file} ${TMP_FILENAME}
+        maint/code-cleanup.sh ${file}
+        git --no-pager diff ${TMP_FILENAME} ${file}
+        if [ $? != 0 ] ; then
+            ret=1
+        fi
+    fi
+done
+
+rm -rf ${MIRROR} ${TMP_FILENAME}
+
+if [ $ret != 0 ] ; then
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    echo -e "${RED}== CODE CLEANUP SCRIPT FAILED ==${NC}"
+    exit $ret
+fi


### PR DESCRIPTION
As done by many other projects (including MPICH), Argobots should check the coding style automatically. This PR sets up scripts for Travis CI, which checks trailing white spaces. Note that the original `maint/hook/pre-commit` is that of MPICH (https://github.com/pmodels/mpich/blob/master/maint/hooks/pre-commit).

Specifically, `.travis.yml` executes `maint/hook/pre-commit`, which performs style check by running `maint/code-cleanup.sh`.

The current version of `code-cleanup.sh` is outdated; the future PR should update it.
