### PR TITLE
Update the cleanup script: GNU indent version

### DIFF
--- a/examples/dynamic-es/common.h
+++ b/examples/dynamic-es/common.h
@@ -11,4 +11,3 @@
 #define RECV_BUF_LEN    20
 
 #endif /* COMMON_H */
-

--- a/examples/dynamic-es/dyn_app.c
+++ b/examples/dynamic-es/dyn_app.c
@@ -104,7 +104,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, my_pool);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool tar_pool = pools[target];
             ABT_pool_get_size(tar_pool, &size);
             if (size > 0) {
@@ -121,7 +122,8 @@ static void sched_run(ABT_sched sched)
 
             ABT_bool stop;
             ABT_sched_has_to_stop(sched, &stop);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABT_xstream_check_events(sched);
         }
@@ -176,7 +178,8 @@ int main(int argc, char *argv[])
 
     abt_disconnect();
 
-    printf("Done.\n"); fflush(stdout);
+    printf("Done.\n");
+    fflush(stdout);
 
     return EXIT_SUCCESS;
 }
@@ -196,12 +199,13 @@ static void abt_connect(char *host_str, char *port_str)
 
     server = gethostbyname(host_str);
     if (server == NULL) {
-        fprintf(stderr,"ERROR: no such host (%s)\n", host_str);
+        fprintf(stderr, "ERROR: no such host (%s)\n", host_str);
         exit(0);
     }
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) handle_error("ERROR: socket");
+    if (sockfd < 0)
+        handle_error("ERROR: socket");
 
     bzero((char *)&serv_addr, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
@@ -225,7 +229,8 @@ static void abt_disconnect(void)
 {
     static int called = 0;
 
-    if (called || !abt_alive) return;
+    if (called || !abt_alive)
+        return;
     called = 1;
 
     close(abt_pfd.fd);
@@ -239,10 +244,12 @@ static void abt_check_events(int idx)
     int n, ret;
     char recv_buf[RECV_BUF_LEN];
 
-    if (!abt_alive) return;
+    if (!abt_alive)
+        return;
 
     ret = ABT_mutex_trylock(g_mutex);
-    if (ret == ABT_ERR_MUTEX_LOCKED) return;
+    if (ret == ABT_ERR_MUTEX_LOCKED)
+        return;
     assert(ret == ABT_SUCCESS);
 
     ret = poll(&abt_pfd, 1, 1);
@@ -252,14 +259,23 @@ static void abt_check_events(int idx)
         if (abt_pfd.revents & POLLIN) {
             bzero(recv_buf, RECV_BUF_LEN);
             n = read(abt_pfd.fd, recv_buf, RECV_BUF_LEN);
-            if (n < 0) handle_error("ERROR: read");
+            if (n < 0)
+                handle_error("ERROR: read");
 
             printf("\nES%d: received request '%c'\n", idx, recv_buf[0]);
             switch (recv_buf[0]) {
-                case 'd': decrease_xstream(); break;
-                case 'i': increase_xstream(); break;
-                case 'n': send_num_xstream(); break;
-                case 'q': abt_disconnect(); break;
+                case 'd':
+                    decrease_xstream();
+                    break;
+                case 'i':
+                    increase_xstream();
+                    break;
+                case 'n':
+                    send_num_xstream();
+                    break;
+                case 'q':
+                    abt_disconnect();
+                    break;
                 default:
                     printf("Unknown commend: %s\n", recv_buf);
                     break;
@@ -321,7 +337,8 @@ static void thread_join_xstream(void *arg)
     g_signal[idx] = 1;
     while (1) {
         ABT_xstream_get_state(g_xstreams[idx], &state);
-        if (state == ABT_XSTREAM_STATE_TERMINATED) break;
+        if (state == ABT_XSTREAM_STATE_TERMINATED)
+            break;
         ABT_thread_yield();
     }
     ABT_xstream_free(&g_xstreams[idx]);
@@ -436,8 +453,7 @@ static void thread_add_sched(void *arg)
     /* Create a scheduler */
     ABT_sched_config_create(&config,
                             cv_event_freq, 10,
-                            cv_idx, idx,
-                            ABT_sched_config_var_end);
+                            cv_idx, idx, ABT_sched_config_var_end);
     my_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * max_xstreams);
     for (i = 0; i < max_xstreams; i++) {
         my_pools[i] = g_pools[(idx + i) % max_xstreams];
@@ -559,4 +575,3 @@ static void thread_hello(void *arg)
     msg = (cur_rank == old_rank) ? "" : " (stolen)";
     test_printf("[U%lu:E%d] Goodbye, world!%s\n", id, cur_rank, msg);
 }
-

--- a/examples/dynamic-es/dyn_event.c
+++ b/examples/dynamic-es/dyn_event.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "dyn_event.h"
 
-static int g_max_xstreams;          /* maximum # of ESs */
-static int g_num_xstreams;          /* current # of ESs */
-double g_timeout = 2.0;             /* timeout value in secs. */
+static int g_max_xstreams;      /* maximum # of ESs */
+static int g_num_xstreams;      /* current # of ESs */
+double g_timeout = 2.0;         /* timeout value in secs. */
 
 ABT_xstream *g_xstreams = NULL;
 
@@ -96,4 +96,3 @@ static void run_app(void)
 
     rt1_finalize();
 }
-

--- a/examples/dynamic-es/dyn_event.h
+++ b/examples/dynamic-es/dyn_event.h
@@ -11,4 +11,3 @@ void rt1_finalize(void);
 void rt1_launcher(void *arg);
 
 #endif /* DYN_EVENT_H */
-

--- a/examples/dynamic-es/dyn_event_rt1.c
+++ b/examples/dynamic-es/dyn_event_rt1.c
@@ -53,7 +53,8 @@ void rt1_init(int max_xstreams, ABT_xstream *xstreams)
     rt1_data = (rt1_data_t *)calloc(1, sizeof(rt1_data_t));
     rt1_data->max_xstreams = max_xstreams;
     rt1_data->num_xstreams = max_xstreams;
-    rt1_data->xstreams = (ABT_xstream *)malloc(max_xstreams*sizeof(ABT_xstream));
+    rt1_data->xstreams =
+        (ABT_xstream *)malloc(max_xstreams * sizeof(ABT_xstream));
     for (i = 0; i < max_xstreams; i++) {
         rt1_data->xstreams[i] = xstreams[i];
     }
@@ -73,8 +74,7 @@ void rt1_init(int max_xstreams, ABT_xstream *xstreams)
                            &rt1_data->stop_cb_id);
     ABT_event_add_callback(ABT_EVENT_ADD_XSTREAM,
                            rt1_ask_add_xstream, rt1_data,
-                           rt1_act_add_xstream, rt1_data,
-                           &rt1_data->add_cb_id);
+                           rt1_act_add_xstream, rt1_data, &rt1_data->add_cb_id);
 
     /* application data */
     env = getenv("APP_NUM_COMPS");
@@ -154,8 +154,7 @@ void rt1_launcher(void *arg)
     /* Create a scheduler */
     ABT_sched_config_create(&config,
                             cv_event_freq, 10,
-                            cv_idx, idx,
-                            ABT_sched_config_var_end);
+                            cv_idx, idx, ABT_sched_config_var_end);
     ABT_sched_create(&sched_def, 1, &rt1_data->pool, config, &sched);
 
     /* Push the scheduler to the current pool */
@@ -200,7 +199,8 @@ static void rt1_app(int eid)
     ABT_thread_self(&cur_thread);
     ABT_thread_get_last_pool(cur_thread, &cur_pool);
 
-    if (eid == 0) ABT_event_prof_start();
+    if (eid == 0)
+        ABT_event_prof_start();
 
     num_comps = rt1_data->num_comps;
     for (i = 0; i < num_comps * 2; i += 2) {
@@ -208,8 +208,7 @@ static void rt1_app(int eid)
                           (void *)(intptr_t)(eid * num_comps * 2 + i),
                           ABT_THREAD_ATTR_NULL, NULL);
         ABT_task_create(rt1_data->pool, rt1_app_compute,
-                        (void *)(intptr_t)(eid * num_comps * 2 + i + 1),
-                        NULL);
+                        (void *)(intptr_t)(eid * num_comps * 2 + i + 1), NULL);
     }
 
     do {
@@ -218,7 +217,8 @@ static void rt1_app(int eid)
         /* If the size of cur_pool is zero, it means the stacked scheduler has
          * been terminated because of the shrinking event. */
         ABT_pool_get_total_size(cur_pool, &size);
-        if (size == 0) break;
+        if (size == 0)
+            break;
 
         ABT_pool_get_total_size(rt1_data->pool, &size);
     } while (size > 0);
@@ -443,7 +443,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, my_pool);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool_pop(pools[target], &unit);
             if (unit != ABT_UNIT_NULL) {
                 ABT_xstream_run_unit(unit, pools[target]);
@@ -473,4 +474,3 @@ static int sched_free(ABT_sched sched)
 
     return ABT_SUCCESS;
 }
-

--- a/examples/dynamic-es/dyn_server.c
+++ b/examples/dynamic-es/dyn_server.c
@@ -42,14 +42,16 @@ int main(int argc, char *argv[])
     printf("Port: %d\n", port);
 
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0) handle_error("ERROR: socket");
+    if (sockfd < 0)
+        handle_error("ERROR: socket");
 
     bzero((char *)&my_addr, sizeof(my_addr));
     my_addr.sin_family = AF_INET;
     my_addr.sin_addr.s_addr = INADDR_ANY;
     my_addr.sin_port = htons(port);
     ret = bind(sockfd, (struct sockaddr *)&my_addr, sizeof(my_addr));
-    if (ret < 0) handle_error("ERROR: bind");
+    if (ret < 0)
+        handle_error("ERROR: bind");
 
     while (!quit) {
         printf("Waiting for connection...\n");
@@ -57,7 +59,8 @@ int main(int argc, char *argv[])
         listen(sockfd, 5);
         addrlen = sizeof(abt_addr);
         abt_pfd.fd = accept(sockfd, (struct sockaddr *)&abt_addr, &addrlen);
-        if (abt_pfd.fd < 0) handle_error("ERROR: accept");
+        if (abt_pfd.fd < 0)
+            handle_error("ERROR: accept");
         abt_pfd.events = POLLIN | POLLHUP;
         abt_alive = 1;
 
@@ -114,7 +117,8 @@ int main(int argc, char *argv[])
                 } else if (ret != 0) {
                     if (abt_pfd.revents & POLLIN) {
                         n = read(abt_pfd.fd, recv_buf, RECV_BUF_LEN);
-                        if (n < 0) handle_error("ERROR: read");
+                        if (n < 0)
+                            handle_error("ERROR: read");
 
                         printf("Response: %s\n\n", recv_buf);
                     }
@@ -146,4 +150,3 @@ static void handle_error(const char *msg)
     perror(msg);
     exit(EXIT_FAILURE);
 }
-

--- a/examples/fibonacci_future.c
+++ b/examples/fibonacci_future.c
@@ -28,11 +28,11 @@ typedef struct {
 /* Callback function passed to future */
 void callback(void **args)
 {
-	int n1, n2;
+    int n1, n2;
 
-	n1 = *(int *)args[1];
-	n2 = *(int *)args[2];
-	*(int *)args[0] = n1 + n2;
+    n1 = *(int *)args[1];
+    n2 = *(int *)args[2];
+    *(int *)args[0] = n1 + n2;
 }
 
 /* Function to compute Fibonacci numbers */
@@ -77,7 +77,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {

--- a/examples/fibonacci_task.c
+++ b/examples/fibonacci_task.c
@@ -110,7 +110,8 @@ void aggregate_fibonacci(void *arguments)
         ABT_mutex_lock(parent->mutex);
         parent->result += result;
         flag = parent->flag;
-        if (!flag) parent->flag = 1;
+        if (!flag)
+            parent->flag = 1;
         ABT_mutex_unlock(parent->mutex);
         if (flag) {
             /* creating an aggregate task */
@@ -162,7 +163,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {

--- a/examples/fibonacci_thread_task.c
+++ b/examples/fibonacci_thread_task.c
@@ -95,7 +95,8 @@ void fibonacci_task(void *arguments)
         while (flag && parent != NULL) {
             ABT_mutex_lock(parent->mutex);
             parent->result += result;
-            if (result == parent->result) flag = 0;
+            if (result == parent->result)
+                flag = 0;
             ABT_mutex_unlock(parent->mutex);
             result = parent->result;
             temp = parent->parent;
@@ -135,7 +136,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {
@@ -191,7 +193,8 @@ int main(int argc, char *argv[])
     /* creating thread */
     args_thread.n = n - 1;
     args_thread.eventual = ABT_EVENTUAL_NULL;
-    ABT_thread_create(g_pool, fibonacci_thread, &args_thread, ABT_THREAD_ATTR_NULL, &thread);
+    ABT_thread_create(g_pool, fibonacci_thread, &args_thread,
+                      ABT_THREAD_ATTR_NULL, &thread);
 
     /* creating task */
     args_task = (task_args *)malloc(sizeof(task_args));

--- a/examples/hello_world.c
+++ b/examples/hello_world.c
@@ -28,8 +28,8 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     size_t i;
 
     ABT_init(argc, argv);

--- a/examples/hello_world_thread.c
+++ b/examples/hello_world_thread.c
@@ -18,8 +18,8 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);

--- a/examples/sched_and_pool_user.c
+++ b/examples/sched_and_pool_user.c
@@ -19,9 +19,9 @@ static void thread_hello(void *arg);
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     ABT_pool_def pool_def;
     int i;
 
@@ -114,7 +114,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, pools[0]);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool_pop(pools[target], &unit);
             if (unit != ABT_UNIT_NULL) {
                 ABT_xstream_run_unit(unit, pools[target]);
@@ -124,7 +125,8 @@ static void sched_run(ABT_sched sched)
         if (++work_count >= p_data->event_freq) {
             work_count = 0;
             ABT_sched_has_to_stop(sched, &stop);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             ABT_xstream_check_events(sched);
         }
     }
@@ -231,8 +233,8 @@ static void thread_hello(void *arg)
     printf("  [U%d:E%d] Goodbye, world!%s\n", tid, cur_rank, msg);
 }
 
-/* FIFO pool implementation 
- * 
+/* FIFO pool implementation
+ *
  * Based on src/pool/fifo.c, but modified to avoid the use of internal data
  * structures.
  */
@@ -245,7 +247,7 @@ struct example_unit {
     ABT_pool pool;
     union {
         ABT_thread thread;
-        ABT_task   task;
+        ABT_task task;
     };
     ABT_unit_type type;
 };
@@ -257,15 +259,15 @@ struct example_pool_data {
     struct example_unit *p_tail;
 };
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push_shared(ABT_pool pool, ABT_unit unit);
-static void     pool_push_private(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push_shared(ABT_pool pool, ABT_unit unit);
+static void pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
-static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
-static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
+static int pool_remove_shared(ABT_pool pool, ABT_unit unit);
+static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 
 typedef struct example_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -293,8 +295,8 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
     /* FIXME: need better implementation, e.g., lock-free one */
     switch (access) {
         case ABT_POOL_ACCESS_PRIV:
-            p_def->p_push   = pool_push_private;
-            p_def->p_pop    = pool_pop_private;
+            p_def->p_push = pool_push_private;
+            p_def->p_pop = pool_pop_private;
             p_def->p_remove = pool_remove_private;
             break;
 
@@ -302,8 +304,8 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
         case ABT_POOL_ACCESS_MPSC:
         case ABT_POOL_ACCESS_SPMC:
         case ABT_POOL_ACCESS_MPMC:
-            p_def->p_push   = pool_push_shared;
-            p_def->p_pop    = pool_pop_shared;
+            p_def->p_push = pool_push_shared;
+            p_def->p_pop = pool_pop_shared;
             p_def->p_remove = pool_remove_shared;
             break;
 
@@ -312,17 +314,17 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
     }
 
     /* Common definitions regardless of the access type */
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
     return abt_errno;
 }
@@ -336,7 +338,8 @@ int pool_init(ABT_pool pool, ABT_pool_config config)
     ABT_pool_access access;
 
     data_t *p_data = (data_t *)malloc(sizeof(data_t));
-    if (!p_data) return ABT_ERR_MEM;
+    if (!p_data)
+        return ABT_ERR_MEM;
 
     ABT_pool_get_access(pool, &access);
 
@@ -497,8 +500,10 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(data);
     unit_t *p_unit = (unit_t *)unit;
 
-    if (p_data->num_units == 0) return ABT_ERR_POOL;
-    if (p_unit->pool == ABT_POOL_NULL) return ABT_ERR_POOL;
+    if (p_data->num_units == 0)
+        return ABT_ERR_POOL;
+    if (p_unit->pool == ABT_POOL_NULL)
+        return ABT_ERR_POOL;
 
     if (p_unit->pool != pool) {
         return ABT_ERR_INV_POOL;
@@ -535,8 +540,10 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(data);
     unit_t *p_unit = (unit_t *)unit;
 
-    if (p_data->num_units == 0) return ABT_ERR_POOL;
-    if (p_unit->pool == ABT_POOL_NULL) return ABT_ERR_POOL;
+    if (p_data->num_units == 0)
+        return ABT_ERR_POOL;
+    if (p_unit->pool == ABT_POOL_NULL)
+        return ABT_ERR_POOL;
 
     if (p_unit->pool != pool) {
         return ABT_ERR_INV_POOL;
@@ -568,8 +575,8 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -605,13 +612,14 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     unit_t *p_unit = malloc(sizeof(unit_t));
-    if (!p_unit) return ABT_UNIT_NULL;
+    if (!p_unit)
+        return ABT_UNIT_NULL;
 
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -619,13 +627,14 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 static ABT_unit unit_create_from_task(ABT_task task)
 {
     unit_t *p_unit = malloc(sizeof(unit_t));
-    if (!p_unit) return ABT_UNIT_NULL;
+    if (!p_unit)
+        return ABT_UNIT_NULL;
 
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->pool = ABT_POOL_NULL;
+    p_unit->task = task;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }
@@ -635,4 +644,3 @@ static void unit_free(ABT_unit *unit)
     free(*unit);
     *unit = ABT_UNIT_NULL;
 }
-

--- a/examples/sched_predef.c
+++ b/examples/sched_predef.c
@@ -19,9 +19,9 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    int         num_pools[NUM_XSTREAMS];
-    ABT_pool   *pools[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    int num_pools[NUM_XSTREAMS];
+    ABT_pool *pools[NUM_XSTREAMS];
     int i, k;
 
     ABT_init(argc, argv);

--- a/examples/sched_shared_pool.c
+++ b/examples/sched_shared_pool.c
@@ -20,9 +20,9 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    shared_pool;
-    ABT_thread  threads[NUM_THREADS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool shared_pool;
+    ABT_thread threads[NUM_THREADS];
     int i;
 
     ABT_init(argc, argv);
@@ -65,4 +65,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-

--- a/examples/sched_stack.c
+++ b/examples/sched_stack.c
@@ -47,8 +47,8 @@ void add_sched(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);

--- a/examples/sched_user.c
+++ b/examples/sched_user.c
@@ -18,9 +18,9 @@ static void thread_hello(void *arg);
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);
@@ -112,7 +112,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, pools[0]);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool_pop(pools[target], &unit);
             if (unit != ABT_UNIT_NULL) {
                 ABT_xstream_run_unit(unit, pools[target]);
@@ -122,7 +123,8 @@ static void sched_run(ABT_sched sched)
         if (++work_count >= p_data->event_freq) {
             work_count = 0;
             ABT_sched_has_to_stop(sched, &stop);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             ABT_xstream_check_events(sched);
         }
     }
@@ -228,4 +230,3 @@ static void thread_hello(void *arg)
     msg = (cur_rank == old_rank) ? "" : " (stolen)";
     printf("  [U%d:E%d] Goodbye, world!%s\n", tid, cur_rank, msg);
 }
-

--- a/examples/stencil_task.c
+++ b/examples/stencil_task.c
@@ -50,10 +50,11 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[x*totalSize+y] = (values[left(x,y)]+values[right(x,y)]
-                                     +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[x * totalSize + y] =
+                (values[left(x, y)] + values[right(x, y)]
+                 + values[up(x, y)] + values[down(x, y)]) / 4.0;
         }
     }
 }
@@ -65,17 +66,17 @@ static void update(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_task *tasks = malloc(nBlocks*nBlocks*sizeof(ABT_task));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_task *tasks = malloc(nBlocks * nBlocks * sizeof(ABT_task));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int taskIdx, argsIdx;
 
     int s = 0;
@@ -84,11 +85,11 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         taskIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = taskIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_task_create(pools[s], compute, (void *)&args[argsIdx],
                                       &tasks[taskIdx]);
                 HANDLE_ERROR(ret, "ABT_task_create");
@@ -97,16 +98,16 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_task_free(&tasks[t]);
         }
 
         taskIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = taskIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_task_create(pools[s], update, (void *)&args[argsIdx],
                                       &tasks[taskIdx]);
                 HANDLE_ERROR(ret, "ABT_task_create");
@@ -115,7 +116,7 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_task_free(&tasks[t]);
         }
     }
@@ -128,19 +129,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -155,15 +156,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -179,26 +180,26 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
     run();
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -227,4 +228,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/examples/stencil_thread.c
+++ b/examples/stencil_thread.c
@@ -50,10 +50,11 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[x*totalSize+y] = (values[left(x,y)]+values[right(x,y)]
-                                     +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[x * totalSize + y] =
+                (values[left(x, y)] + values[right(x, y)]
+                 + values[up(x, y)] + values[down(x, y)]) / 4.0;
         }
     }
 }
@@ -65,17 +66,17 @@ static void update(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_thread *threads = malloc(nBlocks*nBlocks*sizeof(ABT_thread));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_thread *threads = malloc(nBlocks * nBlocks * sizeof(ABT_thread));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int threadIdx, argsIdx;
 
     int s = 0;
@@ -84,11 +85,11 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_thread_create(pools[s], compute,
                                         (void *)&args[argsIdx],
                                         ABT_THREAD_ATTR_NULL,
@@ -99,16 +100,16 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_thread_free(&threads[t]);
         }
 
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_thread_create(pools[s], update,
                                         (void *)&args[argsIdx],
                                         ABT_THREAD_ATTR_NULL,
@@ -119,7 +120,7 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++)
+        for (t = 0; t < nBlocks * nBlocks; t++)
             ABT_thread_free(&threads[t]);
     }
 
@@ -131,19 +132,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -158,15 +159,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -182,26 +183,26 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
     run();
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -230,4 +231,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/examples/stencil_thread_cond.c
+++ b/examples/stencil_thread_cond.c
@@ -53,10 +53,11 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[here(x,y)] = (values[left(x,y)]+values[right(x,y)]
-                                 +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[here(x, y)] = (values[left(x, y)] + values[right(x, y)]
+                                   + values[up(x, y)] +
+                                   values[down(x, y)]) / 4.0;
         }
     }
 
@@ -64,8 +65,8 @@ static void compute(void *args)
     /* Left neighbour */
     x = firstX;
     if (x > 1) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = left(x,y)*4;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = left(x, y) * 4;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -74,10 +75,10 @@ static void compute(void *args)
     }
 
     /* Right neighbour */
-    x = firstX+blockSize-1;
+    x = firstX + blockSize - 1;
     if (x < ncells) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = right(x,y)*4+1;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = right(x, y) * 4 + 1;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -88,8 +89,8 @@ static void compute(void *args)
     /* Up neighbour */
     y = firstY;
     if (y > 1) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = up(x,y)*4+2;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = up(x, y) * 4 + 2;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -98,10 +99,10 @@ static void compute(void *args)
     }
 
     /* Down neighbour */
-    y = firstY+blockSize-1;
+    y = firstY + blockSize - 1;
     if (y < ncells) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = down(x,y)*4+3;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = down(x, y) * 4 + 3;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -113,8 +114,8 @@ static void compute(void *args)
     /* From left neighbour */
     x = firstX;
     if (x > 1) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = here(x,y)*4+1;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = here(x, y) * 4 + 1;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -124,10 +125,10 @@ static void compute(void *args)
     }
 
     /* From right neighbour */
-    x = firstX+blockSize-1;
+    x = firstX + blockSize - 1;
     if (x < ncells) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = here(x,y)*4;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = here(x, y) * 4;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -139,8 +140,8 @@ static void compute(void *args)
     /* From up neighbour */
     y = firstY;
     if (y > 1) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = here(x,y)*4+3;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = here(x, y) * 4 + 3;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -150,10 +151,10 @@ static void compute(void *args)
     }
 
     /* From down neighbour */
-    y = firstY+blockSize-1;
+    y = firstY + blockSize - 1;
     if (y < ncells) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = here(x,y)*4+2;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = here(x, y) * 4 + 2;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -162,17 +163,17 @@ static void compute(void *args)
         }
     }
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_thread *threads = malloc(nBlocks*nBlocks*sizeof(ABT_thread));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_thread *threads = malloc(nBlocks * nBlocks * sizeof(ABT_thread));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int threadIdx, argsIdx;
 
     int s = 0;
@@ -181,11 +182,11 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_thread_create(pools[s], compute,
                                         (void *)&args[argsIdx],
                                         ABT_THREAD_ATTR_NULL,
@@ -196,12 +197,12 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_thread_free(&threads[t]);
         }
 
         /* Reset the ready array */
-        memset(ready, 0, 4*(ncells+2)*(ncells+2)*sizeof(int));
+        memset(ready, 0, 4 * (ncells + 2) * (ncells + 2) * sizeof(int));
     }
 
     free(threads);
@@ -212,19 +213,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -239,15 +240,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -263,21 +264,24 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
-    ready = (int *)calloc(4*(ncells+2)*(ncells+2), sizeof(int));
-    ready_cond = (ABT_cond *)malloc(4*(ncells+2)*(ncells+2)*sizeof(ABT_cond));
-    ready_mutex = (ABT_mutex *)malloc(4*(ncells+2)*(ncells+2)*sizeof(ABT_mutex));
-    for (x = 1; x < ncells+1; x++) {
-        for (y = 1; y < ncells+1; y++) {
+    ready = (int *)calloc(4 * (ncells + 2) * (ncells + 2), sizeof(int));
+    ready_cond =
+        (ABT_cond *)malloc(4 * (ncells + 2) * (ncells + 2) * sizeof(ABT_cond));
+    ready_mutex =
+        (ABT_mutex *)malloc(4 * (ncells + 2) * (ncells + 2) *
+                            sizeof(ABT_mutex));
+    for (x = 1; x < ncells + 1; x++) {
+        for (y = 1; y < ncells + 1; y++) {
             for (i = 0; i < 4; i++) {
-                ABT_cond_create(&ready_cond[here(x,y)*4+i]);
-                ABT_mutex_create(&ready_mutex[here(x,y)*4+i]);
+                ABT_cond_create(&ready_cond[here(x, y) * 4 + i]);
+                ABT_mutex_create(&ready_mutex[here(x, y) * 4 + i]);
             }
         }
     }
@@ -286,15 +290,15 @@ int main(int argc, char *argv[])
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -319,11 +323,11 @@ int main(int argc, char *argv[])
     free(results);
     free(values);
 
-    for (x = 1; x < ncells+1; x++) {
-        for (y = 1; y < ncells+1; y++) {
+    for (x = 1; x < ncells + 1; x++) {
+        for (y = 1; y < ncells + 1; y++) {
             for (i = 0; i < 4; i++) {
-                ABT_cond_free(&ready_cond[here(x,y)*4+i]);
-                ABT_mutex_free(&ready_mutex[here(x,y)*4+i]);
+                ABT_cond_free(&ready_cond[here(x, y) * 4 + i]);
+                ABT_mutex_free(&ready_mutex[here(x, y) * 4 + i]);
             }
         }
     }
@@ -336,4 +340,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/maint/code-cleanup.sh
+++ b/maint/code-cleanup.sh
@@ -10,19 +10,48 @@ indent_code()
 {
     file=$1
 
-    $indent --k-and-r-style --line-length80 --else-endif-column1 --start-left-side-of-comments \
-	--break-after-boolean-operator --dont-cuddle-else --dont-format-comments \
-	--comment-indentation1 --indent-level4 --no-tabs --no-space-after-casts \
-    -T ABT_stream -T ABT_stream_state -T ABT_thread -T ABT_thread_state \
-    -T ABT_task -T ABT_task_state -T ABT_mutex -T ABT_condition \
-    -T ABT_scheduler -T ABT_unit_type -T ABT_unit -T ABT_pool \
-    -T ABT_scheduler_funcs \
-    -T ABTI_stream -T ABTI_stream_type -T ABTI_thread -T ABTI_thread_type \
-    -T ABTI_task -T ABTI_mutex -T ABTI_condition -T ABTI_scheduler \
-    -T ABTI_scheduler_type -T ABTI_unit -T ABTI_pool \
-    -T ABTI_stream_pool -T ABTI_task_pool -T ABTI_global -T ABTI_local \
-	${file}
-    rm -f ${file}~
+    if [[ "$file" == *"abt.h.in" ]]; then
+        return
+    fi
+    $indent --k-and-r-style --line-length80 --else-endif-column1 \
+            --start-left-side-of-comments --break-after-boolean-operator \
+            --dont-format-comments --case-indentation4 \
+            --comment-indentation1 --indent-level4 --no-tabs \
+            --no-space-after-casts --dont-format-comments \
+            -T ABT_xstream -T ABT_xstream_state -T ABT_xstream_barrier \
+            -T ABT_sched -T ABT_sched_config -T ABT_sched_predef \
+            -T ABT_sched_def -T ABT_sched_state -T ABT_sched_type \
+            -T ABT_pool -T ABT_pool_config -T ABT_pool_kind \
+            -T ABT_pool_access -T ABT_pool_def -T ABT_unit -T ABT_unit_type \
+            -T ABT_thread -T ABT_thread_attr -T ABT_thread_state \
+            -T ABT_thread_id -T ABT_task -T ABT_task_state -T ABT_key \
+            -T ABT_mutex -T ABT_mutex_attr -T ABT_cond -T ABT_rwlock \
+            -T ABT_eventual -T ABT_future -T ABT_barrier -T ABT_timer \
+            -T ABT_bool -T ABT_event_kind -T ABTI_global -T ABTI_local \
+            -T ABTI_contn -T ABTI_elem -T ABTI_xstream -T ABTI_xstream_type \
+            -T ABTI_xstream_contn -T ABTI_sched -T ABTI_sched_config \
+            -T ABTI_sched_used -T ABTI_sched_id -T ABTI_sched_kind \
+            -T ABTI_pool -T ABTI_unit -T ABTI_thread_attr -T ABTI_thread \
+            -T ABTI_thread_type -T ABTI_stack_type -T ABTI_thread_req_arg \
+            -T ABTI_thread_list -T ABTI_thread_entry -T ABTI_thread_htable \
+            -T ABTI_thread_queue -T ABTI_task -T ABTI_key -T ABTI_ktelem \
+            -T ABTI_ktable -T ABTI_mutex_attr -T ABTI_mutex -T ABTI_cond \
+            -T ABTI_rwlock -T ABTI_eventual -T ABTI_future -T ABTI_barrier \
+            -T ABTI_timer -T ABTI_stack_header -T ABTI_page_header \
+            -T ABTI_sp_header -T ABTI_event_info -T ABTI_blk_header \
+            -T ABTI_valgrind_id_list -T ABTI_log -T ABTI_spinlock \
+            -T ABTI_xstream_barrier -T ABTD_time -T ABTD_xstream_context \
+            -T ABTD_xstream_mutex -T ABTD_thread_context \
+            -T ABTD_xstream_barrier -T ucontext_t -T fcontext_t -T intptr_t \
+            -T uintptr_t -T size_t -T rt1_data_t -T pthread_t -T data_t \
+            -T unit_t -T sched_data_t -T cpu_set_t -T int8_t -T uint8_t \
+            -T int16_t -T uint16_t -T int32_t -T uint32_t -T int64_t \
+            -T uint64_t -T arg_t -T barrier_t -T launch_t -T seq_state_t \
+            -T thread_arg_t -T task_arg_t -T unit_arg_t -T test_arg_t \
+            -T time_t -T FILE -T sched_data -T thread_args -T task_args \
+            -T exp_task_args -T agg_task_args -T thread_func_list \
+            ${file}
+    rm -rf ${file}~
     cp ${file} /tmp/${USER}.__tmp__ && \
 	cat ${file} | sed -e 's/ *$//g' -e 's/( */(/g' -e 's/ *)/)/g' \
 	-e 's/if(/if (/g' -e 's/while(/while (/g' -e 's/do{/do {/g' -e 's/}while/} while/g' > \

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -12,10 +12,9 @@
 #include <sys/cpuset.h>
 #include <pthread_np.h>
 
-typedef cpuset_t  cpu_set_t;
+typedef cpuset_t cpu_set_t;
 
-static inline
-int ABTD_CPU_COUNT(cpu_set_t *p_cpuset)
+static inline int ABTD_CPU_COUNT(cpu_set_t *p_cpuset)
 {
     int i, num_cpus = 0;
     for (i = 0; i < CPU_SETSIZE; i++) {
@@ -48,8 +47,9 @@ static inline cpu_set_t ABTD_affinity_get_cpuset_for_rank(int rank)
         int num_threads_per_socket = num_cores / 2;
         int rem = rank % 2;
         int socket_id = rank / num_threads_per_socket;
-        int target = (rank - num_threads_per_socket * socket_id - rem + socket_id)
-                   + num_threads_per_socket * rem;
+        int target =
+            (rank - num_threads_per_socket * socket_id - rem + socket_id)
+            + num_threads_per_socket * rem;
         return g_cpusets[target % num_cores];
 
     } else if (g_affinity_type == ABTI_ES_AFFINITY_KNC) {
@@ -109,7 +109,8 @@ void ABTD_affinity_init(void)
 
     /* affinity type */
     char *env = getenv("ABT_AFFINITY_TYPE");
-    if (env == NULL) env = getenv("ABT_ENV_AFFINITY_TYPE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_AFFINITY_TYPE");
     if (env != NULL) {
         if (strcmp(env, "chameleon") == 0) {
             g_affinity_type = ABTI_ES_AFFINITY_CHAMELEON;
@@ -226,4 +227,3 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
     return ABT_ERR_FEATURE_NA;
 #endif
 }
-

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -30,7 +30,8 @@ void ABTD_env_init(ABTI_global *p_global)
     /* By default, we use the CPU affinity */
     p_global->set_affinity = ABT_TRUE;
     env = getenv("ABT_SET_AFFINITY");
-    if (env == NULL) env = getenv("ABT_ENV_SET_AFFINITY");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SET_AFFINITY");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -40,7 +41,6 @@ void ABTD_env_init(ABTI_global *p_global)
     if (p_global->set_affinity == ABT_TRUE) {
         ABTD_affinity_init();
     }
-
 #ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
     /* If the debug log printing is set in configure, logging is turned on by
      * default. */
@@ -52,7 +52,8 @@ void ABTD_env_init(ABTI_global *p_global)
     p_global->use_debug = ABT_FALSE;
 #endif
     env = getenv("ABT_USE_LOG");
-    if (env == NULL) env = getenv("ABT_ENV_USE_LOG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_USE_LOG");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -62,7 +63,8 @@ void ABTD_env_init(ABTI_global *p_global)
         }
     }
     env = getenv("ABT_USE_DEBUG");
-    if (env == NULL) env = getenv("ABT_ENV_USE_DEBUG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_USE_DEBUG");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -74,7 +76,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Maximum size of the internal ES array */
     env = getenv("ABT_MAX_NUM_XSTREAMS");
-    if (env == NULL) env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
     if (env != NULL) {
         p_global->max_xstreams = atoi(env);
     } else {
@@ -83,7 +86,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default key table size */
     env = getenv("ABT_KEY_TABLE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_KEY_TABLE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_KEY_TABLE_SIZE");
     if (env != NULL) {
         p_global->key_table_size = (int)atoi(env);
     } else {
@@ -92,7 +96,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default stack size for ULT */
     env = getenv("ABT_THREAD_STACKSIZE");
-    if (env == NULL) env = getenv("ABT_ENV_THREAD_STACKSIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_THREAD_STACKSIZE");
     if (env != NULL) {
         p_global->thread_stacksize = (size_t)atol(env);
         ABTI_ASSERT(p_global->thread_stacksize >= 512);
@@ -102,7 +107,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default stack size for scheduler */
     env = getenv("ABT_SCHED_STACKSIZE");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_STACKSIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_STACKSIZE");
     if (env != NULL) {
         p_global->sched_stacksize = (size_t)atol(env);
         ABTI_ASSERT(p_global->sched_stacksize >= 512);
@@ -112,7 +118,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default frequency for event checking by the scheduler */
     env = getenv("ABT_SCHED_EVENT_FREQ");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_EVENT_FREQ");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_EVENT_FREQ");
     if (env != NULL) {
         p_global->sched_event_freq = (uint32_t)atol(env);
         ABTI_ASSERT(p_global->sched_event_freq >= 1);
@@ -122,7 +129,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default nanoseconds for scheduler sleep */
     env = getenv("ABT_SCHED_SLEEP_NSEC");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_SLEEP_NSEC");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_SLEEP_NSEC");
     if (env != NULL) {
         p_global->sched_sleep_nsec = atol(env);
         ABTI_ASSERT(p_global->sched_sleep_nsec >= 0);
@@ -132,7 +140,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Mutex attributes */
     env = getenv("ABT_MUTEX_MAX_HANDOVERS");
-    if (env == NULL) env = getenv("ABT_ENV_MUTEX_MAX_HANDOVERS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MUTEX_MAX_HANDOVERS");
     if (env != NULL) {
         p_global->mutex_max_handovers = (uint32_t)atoi(env);
         ABTI_ASSERT(p_global->mutex_max_handovers >= 1);
@@ -141,7 +150,8 @@ void ABTD_env_init(ABTI_global *p_global)
     }
 
     env = getenv("ABT_MUTEX_MAX_WAKEUPS");
-    if (env == NULL) env = getenv("ABT_ENV_MUTEX_MAX_WAKEUPS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MUTEX_MAX_WAKEUPS");
     if (env != NULL) {
         p_global->mutex_max_wakeups = (uint32_t)atoi(env);
         ABTI_ASSERT(p_global->mutex_max_wakeups >= 1);
@@ -151,7 +161,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* OS page size */
     env = getenv("ABT_OS_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_OS_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_OS_PAGE_SIZE");
     if (env != NULL) {
         p_global->os_page_size = (uint32_t)atol(env);
     } else {
@@ -160,7 +171,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Huge page size */
     env = getenv("ABT_HUGE_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
     if (env != NULL) {
         p_global->huge_page_size = (uint32_t)atol(env);
     } else {
@@ -170,7 +182,8 @@ void ABTD_env_init(ABTI_global *p_global)
 #ifdef ABT_CONFIG_USE_MEM_POOL
     /* Page size for memory allocation */
     env = getenv("ABT_MEM_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_PAGE_SIZE");
     if (env != NULL) {
         p_global->mem_page_size = (uint32_t)atol(env);
     } else {
@@ -179,7 +192,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Stack page size for memory allocation */
     env = getenv("ABT_MEM_STACK_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_STACK_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_STACK_PAGE_SIZE");
     if (env != NULL) {
         p_global->mem_sp_size = (size_t)atol(env);
     } else {
@@ -188,7 +202,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Maximum number of stacks that each ES can keep during execution */
     env = getenv("ABT_MEM_MAX_NUM_STACKS");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_MAX_NUM_STACKS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_MAX_NUM_STACKS");
     if (env != NULL) {
         p_global->mem_max_stacks = (uint32_t)atol(env);
     } else {
@@ -199,7 +214,8 @@ void ABTD_env_init(ABTI_global *p_global)
      * pages and then to fall back to allocate regular pages using mmap() when
      * huge pages are run out of. */
     env = getenv("ABT_MEM_LP_ALLOC");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_LP_ALLOC");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_LP_ALLOC");
 #if defined(HAVE_MAP_ANONYMOUS) || defined(HAVE_MAP_ANON)
     int lp_alloc = ABTI_MEM_LP_MMAP_HP_RP;
 #else
@@ -232,19 +248,22 @@ void ABTD_env_init(ABTI_global *p_global)
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
     /* Hostname for power management daemon */
     env = getenv("ABT_POWER_EVENT_HOSTNAME");
-    if (env == NULL) env = getenv("ABT_ENV_POWER_EVENT_HOSTNAME");
+    if (env == NULL)
+        env = getenv("ABT_ENV_POWER_EVENT_HOSTNAME");
     p_global->pm_host = (env != NULL) ? env : "localhost";
 
     /* Port number for power management daemon */
     env = getenv("ABT_POWER_EVENT_PORT");
-    if (env == NULL) env = getenv("ABT_ENV_POWER_EVENT_PORT");
+    if (env == NULL)
+        env = getenv("ABT_ENV_POWER_EVENT_PORT");
     p_global->pm_port = (env != NULL) ? atoi(env) : 60439;
 #endif
 
 #ifdef ABT_CONFIG_PUBLISH_INFO
     /* Do we need to publish exec. information? */
     env = getenv("ABT_PUBLISH_INFO");
-    if (env == NULL) env = getenv("ABT_ENV_PUBLISH_INFO");
+    if (env == NULL)
+        env = getenv("ABT_ENV_PUBLISH_INFO");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -258,18 +277,21 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Filename for exec. information publishing */
     env = getenv("ABT_PUBLISH_FILENAME");
-    if (env == NULL) env = getenv("ABT_ENV_PUBLISH_FILENAME");
+    if (env == NULL)
+        env = getenv("ABT_ENV_PUBLISH_FILENAME");
     p_global->pub_filename = env ? env : ABT_CONFIG_DEFAULT_PUB_FILENAME;
 
     /* Time interval for exec. information publishing */
     env = getenv("ABT_PUBLISH_INTERVAL");
-    if (env == NULL) env = getenv("ABT_ENV_PUBLISH_INTERVAL");
+    if (env == NULL)
+        env = getenv("ABT_ENV_PUBLISH_INTERVAL");
     p_global->pub_interval = env ? atof(env) : 1.0;
 #endif
 
     /* Whether to print the configuration on ABT_init() */
     env = getenv("ABT_PRINT_CONFIG");
-    if (env == NULL) env = getenv("ABT_ENV_PRINT_CONFIG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_PRINT_CONFIG");
     if (env != NULL) {
         if (strcmp(env, "1") == 0 || strcasecmp(env, "yes") == 0 ||
             strcasecmp(env, "y") == 0) {
@@ -284,4 +306,3 @@ void ABTD_env_init(ABTI_global *p_global)
     /* Init timer */
     ABTD_time_init();
 }
-

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -5,7 +5,7 @@
 
 #include "abti.h"
 
-int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
+int ABTD_xstream_context_create(void *(*f_xstream) (void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
@@ -48,4 +48,3 @@ int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx)
     *p_ctx = pthread_self();
     return abt_errno;
 }
-

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -12,7 +12,7 @@ static inline void ABTD_thread_terminate_sched(ABTI_thread *p_thread);
 void ABTD_thread_func_wrapper_thread(void *p_arg)
 {
     ABTD_thread_context *p_fctx = (ABTD_thread_context *)p_arg;
-    void (*thread_func)(void *) = p_fctx->f_thread;
+    void (*thread_func) (void *) = p_fctx->f_thread;
 
     thread_func(p_fctx->p_arg);
 
@@ -28,7 +28,7 @@ void ABTD_thread_func_wrapper_thread(void *p_arg)
 void ABTD_thread_func_wrapper_sched(void *p_arg)
 {
     ABTD_thread_context *p_fctx = (ABTD_thread_context *)p_arg;
-    void (*thread_func)(void *) = p_fctx->f_thread;
+    void (*thread_func) (void *) = p_fctx->f_thread;
 
     thread_func(p_fctx->p_arg);
 
@@ -44,7 +44,7 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
 void ABTD_thread_func_wrapper(int func_upper, int func_lower,
                               int arg_upper, int arg_lower)
 {
-    void (*thread_func)(void *);
+    void (*thread_func) (void *);
     void *p_arg;
     size_t ptr_size, int_size;
 
@@ -56,12 +56,10 @@ void ABTD_thread_func_wrapper(int func_upper, int func_lower,
     } else if (ptr_size == int_size * 2) {
         uintptr_t shift_bits = CHAR_BIT * int_size;
         uintptr_t mask = ((uintptr_t)1 << shift_bits) - 1;
-        thread_func = (void (*)(void *))(
-                ((uintptr_t)func_upper << shift_bits) |
-                ((uintptr_t)func_lower & mask));
-        p_arg = (void *)(
-                ((uintptr_t)arg_upper << shift_bits) |
-                ((uintptr_t)arg_lower & mask));
+        thread_func = (void (*)(void *))(((uintptr_t)func_upper << shift_bits) |
+                                         ((uintptr_t)func_lower & mask));
+        p_arg = (void *)(((uintptr_t)arg_upper << shift_bits) |
+                         ((uintptr_t)arg_lower & mask));
     } else {
         ABTI_ASSERT(0);
     }
@@ -136,7 +134,8 @@ static inline void ABTDI_thread_terminate(ABTI_thread *p_thread,
         }
     } else {
         uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+                                                   ABTI_THREAD_REQ_JOIN |
+                                                   ABTI_THREAD_REQ_TERMINATE);
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
@@ -214,7 +213,8 @@ void ABTD_thread_cancel(ABTI_thread *p_thread)
         ABTI_thread_set_ready(p_joiner);
     } else {
         uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+                                                   ABTI_THREAD_REQ_JOIN |
+                                                   ABTI_THREAD_REQ_TERMINATE);
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
@@ -228,8 +228,8 @@ void ABTD_thread_cancel(ABTI_thread *p_thread)
 #endif
 }
 
-static inline
-void print_bytes(size_t size, void *p_val, FILE *p_os) {
+static inline void print_bytes(size_t size, void *p_val, FILE *p_os)
+{
     size_t i;
     for (i = 0; i < size; i++) {
         uint8_t val = ((uint8_t *)p_val)[i];

--- a/src/arch/abtd_time.c
+++ b/src/arch/abtd_time.c
@@ -41,7 +41,8 @@ double ABTD_time_read_sec(ABTD_time *p_time)
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
     secs = ((double)p_time->tv_sec) + 1.0e-9 * ((double)p_time->tv_nsec);
 #elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
-    if (g_time_mult == 0.0) ABTD_time_init();
+    if (g_time_mult == 0.0)
+        ABTD_time_init();
     secs = *p_time * g_time_mult;
 #elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
     secs = ((double)p_time->tv_sec) + 1.0e-6 * ((double)p_time->tv_usec);
@@ -49,4 +50,3 @@ double ABTD_time_read_sec(ABTD_time *p_time)
 
     return secs;
 }
-

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -251,4 +251,3 @@ int ABT_barrier_get_num_waiters(ABT_barrier barrier, uint32_t *num_waiters)
     HANDLE_ERROR_WITH_CODE("ABT_barrier_get_num_waiters", abt_errno);
     goto fn_exit;
 }
-

--- a/src/cond.c
+++ b/src/cond.c
@@ -111,16 +111,14 @@ int ABT_cond_wait(ABT_cond cond, ABT_mutex mutex)
 }
 
 
-static inline
-double convert_timespec_to_sec(const struct timespec *p_ts)
+static inline double convert_timespec_to_sec(const struct timespec *p_ts)
 {
     double secs;
     secs = ((double)p_ts->tv_sec) + 1.0e-9 * ((double)p_ts->tv_nsec);
     return secs;
 }
 
-static inline
-double get_cur_time(void)
+static inline double get_cur_time(void)
 {
 #if defined(HAVE_CLOCK_GETTIME)
     struct timespec ts;
@@ -136,16 +134,16 @@ double get_cur_time(void)
 #endif
 }
 
-static inline
-void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
+static inline void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
 {
-    if (p_unit->p_next == NULL) return;
+    if (p_unit->p_next == NULL)
+        return;
 
     ABTI_spinlock_acquire(&p_cond->lock);
 
     if (p_unit->p_next == NULL) {
         ABTI_spinlock_release(&p_cond->lock);
-        return ;
+        return;
     }
 
     /* If p_unit is still in the queue, we have to remove it. */
@@ -356,4 +354,3 @@ int ABT_cond_broadcast(ABT_cond cond)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/container/contn.c
+++ b/src/container/contn.c
@@ -29,22 +29,25 @@ int ABTI_contn_free(ABTI_contn **pp_contn)
         ABTI_elem *p_elem = ABTI_contn_pop(p_contn);
 
         switch (ABTI_elem_get_type(p_elem)) {
-            case ABT_UNIT_TYPE_THREAD: {
-                ABTI_thread *p_thread = ABTI_elem_get_thread(p_elem);
-                ABTI_thread_free(p_thread);
-                break;
-            }
-            case ABT_UNIT_TYPE_TASK: {
-                ABTI_task *p_task = ABTI_elem_get_task(p_elem);
-                ABTI_task_free(p_task);
-                break;
-            }
-            case ABT_UNIT_TYPE_XSTREAM: {
-                ABTI_xstream *p_xstream = ABTI_elem_get_xstream(p_elem);
-                abt_errno = ABTI_xstream_free(p_xstream);
-                ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_free");
-                break;
-            }
+            case ABT_UNIT_TYPE_THREAD:
+                {
+                    ABTI_thread *p_thread = ABTI_elem_get_thread(p_elem);
+                    ABTI_thread_free(p_thread);
+                    break;
+                }
+            case ABT_UNIT_TYPE_TASK:
+                {
+                    ABTI_task *p_task = ABTI_elem_get_task(p_elem);
+                    ABTI_task_free(p_task);
+                    break;
+                }
+            case ABT_UNIT_TYPE_XSTREAM:
+                {
+                    ABTI_xstream *p_xstream = ABTI_elem_get_xstream(p_elem);
+                    abt_errno = ABTI_xstream_free(p_xstream);
+                    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_free");
+                    break;
+                }
             default:
                 HANDLE_ERROR("Unknown elem type");
                 break;
@@ -116,9 +119,11 @@ ABTI_elem *ABTI_contn_pop(ABTI_contn *p_contn)
 
 void ABTI_contn_remove(ABTI_contn *p_contn, ABTI_elem *p_elem)
 {
-    if (p_elem->p_contn == NULL) return;
+    if (p_elem->p_contn == NULL)
+        return;
 
-    if (p_contn->num_elems == 0) return;
+    if (p_contn->num_elems == 0)
+        return;
 
     if (p_elem->p_contn != p_contn) {
         HANDLE_ERROR("Not my contn");
@@ -142,7 +147,8 @@ void ABTI_contn_remove(ABTI_contn *p_contn, ABTI_elem *p_elem)
     p_elem->p_next = NULL;
 }
 
-void ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent, ABT_bool detail)
+void ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent,
+                      ABT_bool detail)
 {
     size_t i;
     char *prefix = ABTU_get_indent_str(indent);
@@ -153,21 +159,19 @@ void ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent, ABT_bool deta
     }
 
     fprintf(p_os,
-        "%s== CONTN (%p) ==\n"
-        "%snum_elems: %zu\n"
-        "%shead     : %p\n"
-        "%stail     : %p\n",
-        prefix, p_contn,
-        prefix, p_contn->num_elems,
-        prefix, p_contn->p_head,
-        prefix, p_contn->p_tail
-    );
+            "%s== CONTN (%p) ==\n"
+            "%snum_elems: %zu\n"
+            "%shead     : %p\n"
+            "%stail     : %p\n",
+            prefix, p_contn, prefix, p_contn->num_elems, prefix,
+            p_contn->p_head, prefix, p_contn->p_tail);
 
     if (p_contn->num_elems > 0) {
         fprintf(p_os, "%sCONTN (%p) elements:\n", prefix, p_contn);
         ABTI_elem *p_current = p_contn->p_head;
         for (i = 0; i < p_contn->num_elems; i++) {
-            if (i != 0) fprintf(p_os, "%s  -->\n", prefix);
+            if (i != 0)
+                fprintf(p_os, "%s  -->\n", prefix);
             ABTI_elem_print(p_current, p_os, indent + ABTI_INDENT, detail);
         }
     }
@@ -176,4 +180,3 @@ void ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent, ABT_bool deta
     fflush(p_os);
     ABTU_free(prefix);
 }
-

--- a/src/container/elem.c
+++ b/src/container/elem.c
@@ -51,10 +51,10 @@ ABTI_elem *ABTI_elem_create_from_xstream(ABTI_xstream *p_xstream)
 
     p_elem = (ABTI_elem *)ABTU_malloc(sizeof(ABTI_elem));
     p_elem->p_contn = NULL;
-    p_elem->type    = ABT_UNIT_TYPE_XSTREAM;
-    p_elem->p_obj   = (void *)p_xstream;
-    p_elem->p_prev  = NULL;
-    p_elem->p_next  = NULL;
+    p_elem->type = ABT_UNIT_TYPE_XSTREAM;
+    p_elem->p_obj = (void *)p_xstream;
+    p_elem->p_prev = NULL;
+    p_elem->p_next = NULL;
 
     return p_elem;
 }
@@ -65,10 +65,10 @@ ABTI_elem *ABTI_elem_create_from_thread(ABTI_thread *p_thread)
 
     p_elem = (ABTI_elem *)ABTU_malloc(sizeof(ABTI_elem));
     p_elem->p_contn = NULL;
-    p_elem->type    = ABT_UNIT_TYPE_THREAD;
-    p_elem->p_obj   = (void *)p_thread;
-    p_elem->p_prev  = NULL;
-    p_elem->p_next  = NULL;
+    p_elem->type = ABT_UNIT_TYPE_THREAD;
+    p_elem->p_obj = (void *)p_thread;
+    p_elem->p_prev = NULL;
+    p_elem->p_next = NULL;
 
     return p_elem;
 }
@@ -79,10 +79,10 @@ ABTI_elem *ABTI_elem_create_from_task(ABTI_task *p_task)
 
     p_elem = (ABTI_elem *)ABTU_malloc(sizeof(ABTI_elem));
     p_elem->p_contn = NULL;
-    p_elem->type    = ABT_UNIT_TYPE_TASK;
-    p_elem->p_obj   = (void *)p_task;
-    p_elem->p_prev  = NULL;
-    p_elem->p_next  = NULL;
+    p_elem->type = ABT_UNIT_TYPE_TASK;
+    p_elem->p_obj = (void *)p_task;
+    p_elem->p_prev = NULL;
+    p_elem->p_next = NULL;
 
     return p_elem;
 }
@@ -104,47 +104,51 @@ void ABTI_elem_print(ABTI_elem *p_elem, FILE *p_os, int indent, ABT_bool detail)
 
     char *type;
     switch (p_elem->type) {
-        case ABT_UNIT_TYPE_THREAD : type = "ULT"; break;
-        case ABT_UNIT_TYPE_TASK   : type = "TASKLET"; break;
-        case ABT_UNIT_TYPE_XSTREAM: type = "ES"; break;
-        default:                    type = "UNKNOWN"; break;
+        case ABT_UNIT_TYPE_THREAD:
+            type = "ULT";
+            break;
+        case ABT_UNIT_TYPE_TASK:
+            type = "TASKLET";
+            break;
+        case ABT_UNIT_TYPE_XSTREAM:
+            type = "ES";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
 
     fprintf(p_os,
-        "%s== ELEM (%p) ==\n"
-        "%scontn: %p\n"
-        "%stype : %s\n"
-        "%sobj  : %p\n"
-        "%sprev : %p\n"
-        "%snext : %p\n",
-        prefix, p_elem,
-        prefix, p_elem->p_contn,
-        prefix, type,
-        prefix, p_elem->p_obj,
-        prefix, p_elem->p_prev,
-        prefix, p_elem->p_next
-    );
+            "%s== ELEM (%p) ==\n"
+            "%scontn: %p\n"
+            "%stype : %s\n"
+            "%sobj  : %p\n"
+            "%sprev : %p\n"
+            "%snext : %p\n",
+            prefix, p_elem, prefix, p_elem->p_contn, prefix, type, prefix,
+            p_elem->p_obj, prefix, p_elem->p_prev, prefix, p_elem->p_next);
 
     if (detail == ABT_TRUE) {
         switch (p_elem->type) {
-            case ABT_UNIT_TYPE_THREAD: {
-                ABTI_thread *p_thread = (ABTI_thread *)p_elem->p_obj;
-                ABTI_thread_print(p_thread, p_os, indent + ABTI_INDENT);
-                break;
-            }
-
-            case ABT_UNIT_TYPE_TASK: {
-                ABTI_task *p_task = (ABTI_task *)p_elem->p_obj;
-                ABTI_task_print(p_task, p_os, indent + ABTI_INDENT);
-                break;
-            }
-
-            case ABT_UNIT_TYPE_XSTREAM: {
-                ABTI_xstream *p_xstream = (ABTI_xstream *)p_elem->p_obj;
-                ABTI_xstream_print(p_xstream, p_os, indent + ABTI_INDENT,
-                                   ABT_TRUE);
-                break;
-            }
+            case ABT_UNIT_TYPE_THREAD:
+                {
+                    ABTI_thread *p_thread = (ABTI_thread *)p_elem->p_obj;
+                    ABTI_thread_print(p_thread, p_os, indent + ABTI_INDENT);
+                    break;
+                }
+            case ABT_UNIT_TYPE_TASK:
+                {
+                    ABTI_task *p_task = (ABTI_task *)p_elem->p_obj;
+                    ABTI_task_print(p_task, p_os, indent + ABTI_INDENT);
+                    break;
+                }
+            case ABT_UNIT_TYPE_XSTREAM:
+                {
+                    ABTI_xstream *p_xstream = (ABTI_xstream *)p_elem->p_obj;
+                    ABTI_xstream_print(p_xstream, p_os, indent + ABTI_INDENT,
+                                       ABT_TRUE);
+                    break;
+                }
 
             default:
                 break;
@@ -155,4 +159,3 @@ void ABTI_elem_print(ABTI_elem *p_elem, FILE *p_os, int indent, ABT_bool detail)
     fflush(p_os);
     ABTU_free(prefix);
 }
-

--- a/src/error.c
+++ b/src/error.c
@@ -86,8 +86,10 @@ int ABT_error_get_str(int err, char *str, size_t *len)
     int abt_errno = ABT_SUCCESS;
     ABTI_CHECK_TRUE(err >= ABT_SUCCESS && err <= ABT_ERR_FEATURE_NA,
                     ABT_ERR_OTHER);
-    if (str) ABTU_strcpy(str, err_str[err]);
-    if (len) *len = strlen(err_str[err]);
+    if (str)
+        ABTU_strcpy(str, err_str[err]);
+    if (len)
+        *len = strlen(err_str[err]);
 
   fn_exit:
     return abt_errno;
@@ -96,4 +98,3 @@ int ABT_error_get_str(int err, char *str, size_t *len)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/event.c
+++ b/src/event.c
@@ -63,7 +63,7 @@ typedef enum {
 } ABTI_pub_type;
 #endif
 
-typedef struct ABTI_event_info  ABTI_event_info;
+typedef struct ABTI_event_info ABTI_event_info;
 
 struct ABTI_event_info {
     ABTI_mutex mutex;
@@ -137,7 +137,8 @@ void ABTI_event_init(void)
     gethostname(gp_einfo->hostname, 100);
 
     env = getenv("ABT_USE_EVENT_DEBUG");
-    if (env == NULL) env = getenv("ABT_ENV_USE_EVENT_DEBUG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_USE_EVENT_DEBUG");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -182,12 +183,12 @@ void ABTI_event_init(void)
             }
 
             gp_einfo->topic_info = (BEACON_topic_info_t *)
-                              ABTU_malloc(sizeof(BEACON_topic_info_t));
+                ABTU_malloc(sizeof(BEACON_topic_info_t));
             ABTU_strcpy(gp_einfo->topic_info->topic_name, "NODE_POWER");
             sprintf(gp_einfo->topic_info->severity, "INFO");
 
             gp_einfo->eprop = (BEACON_topic_properties_t *)
-                              ABTU_malloc(sizeof(BEACON_topic_properties_t));
+                ABTU_malloc(sizeof(BEACON_topic_properties_t));
             ABTU_strcpy(gp_einfo->eprop->topic_scope, "global");
 #else /* HAVE_BEACON_H */
             fprintf(stderr, "BEACON is unavailable. stdout is used instead.\n");
@@ -211,16 +212,19 @@ void ABTI_event_init(void)
         }
 
         gp_einfo->max_xstream_rank = gp_ABTI_global->max_xstreams * 2;
-        gp_einfo->num_threads = (uint32_t *)ABTU_calloc(
-                gp_einfo->max_xstream_rank, sizeof(uint32_t));
-        gp_einfo->num_tasks = (uint32_t *)ABTU_calloc(
-                gp_einfo->max_xstream_rank, sizeof(uint32_t));
-        gp_einfo->idle_time = (double *)ABTU_calloc(
-                gp_einfo->max_xstream_rank, sizeof(double));
-        gp_einfo->old_num_units = (uint32_t *)ABTU_calloc(
-                gp_einfo->max_xstream_rank, sizeof(uint32_t));
-        gp_einfo->old_timestamp = (double *)ABTU_calloc(
-                gp_einfo->max_xstream_rank, sizeof(double));
+        gp_einfo->num_threads =
+            (uint32_t *)ABTU_calloc(gp_einfo->max_xstream_rank,
+                                    sizeof(uint32_t));
+        gp_einfo->num_tasks =
+            (uint32_t *)ABTU_calloc(gp_einfo->max_xstream_rank,
+                                    sizeof(uint32_t));
+        gp_einfo->idle_time =
+            (double *)ABTU_calloc(gp_einfo->max_xstream_rank, sizeof(double));
+        gp_einfo->old_num_units =
+            (uint32_t *)ABTU_calloc(gp_einfo->max_xstream_rank,
+                                    sizeof(uint32_t));
+        gp_einfo->old_timestamp =
+            (double *)ABTU_calloc(gp_einfo->max_xstream_rank, sizeof(double));
         gp_einfo->timestamp = ABT_get_wtime();
 
         int ret = RAPLREADER_INIT(&gp_einfo->rr);
@@ -315,7 +319,8 @@ void ABTI_event_connect_power(char *p_host, int port)
 
 void ABTI_event_disconnect_power(void)
 {
-    if (gp_ABTI_global->pm_connected == ABT_FALSE) return;
+    if (gp_ABTI_global->pm_connected == ABT_FALSE)
+        return;
 
     close(gp_einfo->pfd.fd);
     gp_ABTI_global->pm_connected = ABT_FALSE;
@@ -369,7 +374,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
     int abt_errno, n;
 
     for (n = 0; n < num_xstreams; n++) {
-        ABTI_xstream *p_xstream = p_xstreams[n+1];
+        ABTI_xstream *p_xstream = p_xstreams[n + 1];
         while (ABTD_atomic_load_uint32((uint32_t *)p_xstream->state)
                != ABT_XSTREAM_STATE_TERMINATED) {
             ABT_thread_yield();
@@ -386,7 +391,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
     if (gp_ABTI_global->pm_connected == ABT_TRUE) {
         LOG_DEBUG("# of ESs: %d\n", gp_ABTI_global->num_xstreams);
         sprintf(send_buf, "[S] killed %d (%d)", num_xstreams,
-                          gp_ABTI_global->num_xstreams);
+                gp_ABTI_global->num_xstreams);
         n = write(gp_einfo->pfd.fd, send_buf, strlen(send_buf));
         ABTI_ASSERT(n == strlen(send_buf));
     }
@@ -404,10 +409,11 @@ ABT_bool ABTI_event_stop_xstream(ABTI_xstream *p_xstream)
 
     /* Ask whether the target ES can be stopped */
     for (i = 0; i < gp_einfo->max_stop_xstream_fn; i++) {
-        cb_fn = gp_einfo->stop_xstream_fn[i*2];
+        cb_fn = gp_einfo->stop_xstream_fn[i * 2];
         if (cb_fn) {
-            can_stop = cb_fn(gp_einfo->stop_xstream_arg[i*2], xstream);
-            if (can_stop == ABT_FALSE) break;
+            can_stop = cb_fn(gp_einfo->stop_xstream_arg[i * 2], xstream);
+            if (can_stop == ABT_FALSE)
+                break;
         }
     }
 
@@ -416,9 +422,9 @@ ABT_bool ABTI_event_stop_xstream(ABTI_xstream *p_xstream)
 
         /* Execute action callback functions */
         for (i = 0; i < gp_einfo->max_stop_xstream_fn; i++) {
-            cb_fn = gp_einfo->stop_xstream_fn[i*2+1];
+            cb_fn = gp_einfo->stop_xstream_fn[i * 2 + 1];
             if (cb_fn) {
-                cb_fn(gp_einfo->stop_xstream_arg[i*2+1], xstream);
+                cb_fn(gp_einfo->stop_xstream_arg[i * 2 + 1], xstream);
             }
         }
 
@@ -456,7 +462,8 @@ void ABTI_event_decrease_xstream(int target_rank)
             p_xstream = p_global->p_xstreams[rank];
             if (p_xstream) {
                 can_stop = ABTI_event_stop_xstream(p_xstream);
-                if (can_stop == ABT_TRUE) break;
+                if (can_stop == ABT_TRUE)
+                    break;
             }
         }
     } else {
@@ -509,26 +516,30 @@ void ABTI_event_shrink_xstreams(int num_xstreams)
             xstream = ABTI_xstream_get_handle(p_xstream);
             ABT_bool can_stop = ABT_TRUE;
             for (i = 0; i < gp_einfo->max_stop_xstream_fn; i++) {
-                cb_fn = gp_einfo->stop_xstream_fn[i*2];
+                cb_fn = gp_einfo->stop_xstream_fn[i * 2];
                 if (cb_fn) {
-                    can_stop = cb_fn(gp_einfo->stop_xstream_arg[i*2], xstream);
-                    if (can_stop == ABT_FALSE) break;
+                    can_stop =
+                        cb_fn(gp_einfo->stop_xstream_arg[i * 2], xstream);
+                    if (can_stop == ABT_FALSE)
+                        break;
                 }
             }
-            if (can_stop == ABT_FALSE) continue;
+            if (can_stop == ABT_FALSE)
+                continue;
 
             ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_STOP);
 
             /* Execute action callback functions */
             for (i = 0; i < gp_einfo->max_stop_xstream_fn; i++) {
-                cb_fn = gp_einfo->stop_xstream_fn[i*2+1];
+                cb_fn = gp_einfo->stop_xstream_fn[i * 2 + 1];
                 if (cb_fn) {
-                    cb_fn(gp_einfo->stop_xstream_arg[i*2+1], xstream);
+                    cb_fn(gp_einfo->stop_xstream_arg[i * 2 + 1], xstream);
                 }
             }
 
-            p_xstreams[n+1] = p_xstream;
-            if (++n == num_xstreams) break;
+            p_xstreams[n + 1] = p_xstream;
+            if (++n == num_xstreams)
+                break;
         }
     }
 
@@ -563,20 +574,23 @@ void ABTI_event_increase_xstream(int target_rank)
 
     for (i = 0; i < gp_einfo->max_add_xstream_fn; i++) {
         /* "ask" callback */
-        cb_fn = gp_einfo->add_xstream_fn[i*2];
-        if (!cb_fn) continue;
+        cb_fn = gp_einfo->add_xstream_fn[i * 2];
+        if (!cb_fn)
+            continue;
 
         /* TODO: fairness */
-        ret = cb_fn(gp_einfo->add_xstream_arg[i*2], abt_arg);
+        ret = cb_fn(gp_einfo->add_xstream_arg[i * 2], abt_arg);
         if (ret == ABT_TRUE) {
             /* "act" callback */
-            cb_fn = gp_einfo->add_xstream_fn[i*2+1];
-            if (!cb_fn) continue;
+            cb_fn = gp_einfo->add_xstream_fn[i * 2 + 1];
+            if (!cb_fn)
+                continue;
 
-            ret = cb_fn(gp_einfo->add_xstream_arg[i*2+1], abt_arg);
+            ret = cb_fn(gp_einfo->add_xstream_arg[i * 2 + 1], abt_arg);
             if (ret == ABT_TRUE) {
                 LOG_DEBUG("# of ESs: %d\n", gp_ABTI_global->num_xstreams);
-                sprintf(send_buf, "[S] created 1 (%d)", gp_ABTI_global->num_xstreams);
+                sprintf(send_buf, "[S] created 1 (%d)",
+                        gp_ABTI_global->num_xstreams);
                 goto send_ack;
             }
         }
@@ -602,29 +616,34 @@ void ABTI_event_expand_xstreams(int num_xstreams)
         can_add = ABT_FALSE;
         for (i = 0; i < gp_einfo->max_add_xstream_fn; i++) {
             /* "ask" callback */
-            cb_fn = gp_einfo->add_xstream_fn[i*2];
-            if (!cb_fn) continue;
+            cb_fn = gp_einfo->add_xstream_fn[i * 2];
+            if (!cb_fn)
+                continue;
 
             /* TODO: fairness */
-            can_add = cb_fn(gp_einfo->add_xstream_arg[i*2], abt_arg);
+            can_add = cb_fn(gp_einfo->add_xstream_arg[i * 2], abt_arg);
             if (can_add == ABT_TRUE) {
                 /* "act" callback */
-                cb_fn = gp_einfo->add_xstream_fn[i*2+1];
+                cb_fn = gp_einfo->add_xstream_fn[i * 2 + 1];
                 if (!cb_fn) {
                     can_add = ABT_FALSE;
                     continue;
                 }
 
-                can_add = cb_fn(gp_einfo->add_xstream_arg[i*2+1], abt_arg);
-                if (can_add == ABT_TRUE) break;
+                can_add = cb_fn(gp_einfo->add_xstream_arg[i * 2 + 1], abt_arg);
+                if (can_add == ABT_TRUE)
+                    break;
             }
         }
-        if (can_add == ABT_FALSE) break;
+        if (can_add == ABT_FALSE)
+            break;
     }
 
     if (n > 0) {
-        LOG_DEBUG("Create %d ESs (# of ESs: %d)\n", n, gp_ABTI_global->num_xstreams);
-        sprintf(send_buf, "[S] created %d (%d)", n, gp_ABTI_global->num_xstreams);
+        LOG_DEBUG("Create %d ESs (# of ESs: %d)\n", n,
+                  gp_ABTI_global->num_xstreams);
+        sprintf(send_buf, "[S] created %d (%d)", n,
+                gp_ABTI_global->num_xstreams);
     } else {
         /* We couldn't create a new ES */
         sprintf(send_buf, "[F] not possible");
@@ -662,12 +681,14 @@ ABT_bool ABTI_event_check_power(void)
     char recv_buf[ABTI_MSG_BUF_LEN];
     ABTI_xstream *p_xstream;
 
-    if (gp_ABTI_global->pm_connected == ABT_FALSE) goto fn_exit;
+    if (gp_ABTI_global->pm_connected == ABT_FALSE)
+        goto fn_exit;
 
     ABT_xstream_self_rank(&rank);
 
     ret = ABTI_mutex_trylock(&gp_einfo->mutex);
-    if (ret == ABT_ERR_MUTEX_LOCKED) goto fn_exit;
+    if (ret == ABT_ERR_MUTEX_LOCKED)
+        goto fn_exit;
     ABTI_ASSERT(ret == ABT_SUCCESS);
 
     ret = poll(&gp_einfo->pfd, 1, 1);
@@ -744,7 +765,7 @@ ABT_bool ABTI_event_check_power(void)
         stop_xstream = ABT_TRUE;
     }
 
- fn_exit:
+  fn_exit:
     return stop_xstream;
 }
 #endif /* ABT_CONFIG_HANDLE_POWER_EVENT */
@@ -797,19 +818,19 @@ int ABT_event_add_callback(ABT_event_kind event,
             }
             ABTI_ASSERT(cur_num < max_num);
 
-            if (gp_einfo->stop_xstream_fn[cur_num*2] == NULL) {
-                gp_einfo->stop_xstream_fn[cur_num*2] = ask_cb;
-                gp_einfo->stop_xstream_arg[cur_num*2] = ask_user_arg;
-                gp_einfo->stop_xstream_fn[cur_num*2+1] = act_cb;
-                gp_einfo->stop_xstream_arg[cur_num*2+1] = act_user_arg;
+            if (gp_einfo->stop_xstream_fn[cur_num * 2] == NULL) {
+                gp_einfo->stop_xstream_fn[cur_num * 2] = ask_cb;
+                gp_einfo->stop_xstream_arg[cur_num * 2] = ask_user_arg;
+                gp_einfo->stop_xstream_fn[cur_num * 2 + 1] = act_cb;
+                gp_einfo->stop_xstream_arg[cur_num * 2 + 1] = act_user_arg;
                 cid = cur_num;
             } else {
                 for (i = 0; i < max_num; i++) {
-                    if (gp_einfo->stop_xstream_fn[i*2] == NULL) {
-                        gp_einfo->stop_xstream_fn[i*2] = ask_cb;
-                        gp_einfo->stop_xstream_arg[i*2] = ask_user_arg;
-                        gp_einfo->stop_xstream_fn[i*2+1] = act_cb;
-                        gp_einfo->stop_xstream_arg[i*2+1] = act_user_arg;
+                    if (gp_einfo->stop_xstream_fn[i * 2] == NULL) {
+                        gp_einfo->stop_xstream_fn[i * 2] = ask_cb;
+                        gp_einfo->stop_xstream_arg[i * 2] = ask_user_arg;
+                        gp_einfo->stop_xstream_fn[i * 2 + 1] = act_cb;
+                        gp_einfo->stop_xstream_arg[i * 2 + 1] = act_user_arg;
                         cid = i;
                         break;
                     }
@@ -835,19 +856,19 @@ int ABT_event_add_callback(ABT_event_kind event,
             }
             ABTI_ASSERT(cur_num < max_num);
 
-            if (gp_einfo->add_xstream_fn[cur_num*2] == NULL) {
-                gp_einfo->add_xstream_fn[cur_num*2] = ask_cb;
-                gp_einfo->add_xstream_arg[cur_num*2] = ask_user_arg;
-                gp_einfo->add_xstream_fn[cur_num*2+1] = act_cb;
-                gp_einfo->add_xstream_arg[cur_num*2+1] = act_user_arg;
+            if (gp_einfo->add_xstream_fn[cur_num * 2] == NULL) {
+                gp_einfo->add_xstream_fn[cur_num * 2] = ask_cb;
+                gp_einfo->add_xstream_arg[cur_num * 2] = ask_user_arg;
+                gp_einfo->add_xstream_fn[cur_num * 2 + 1] = act_cb;
+                gp_einfo->add_xstream_arg[cur_num * 2 + 1] = act_user_arg;
                 cid = cur_num;
             } else {
                 for (i = 0; i < max_num; i++) {
-                    if (gp_einfo->add_xstream_fn[i*2] == NULL) {
-                        gp_einfo->add_xstream_fn[i*2] = ask_cb;
-                        gp_einfo->add_xstream_arg[i*2] = ask_user_arg;
-                        gp_einfo->add_xstream_fn[i*2+1] = act_cb;
-                        gp_einfo->add_xstream_arg[i*2+1] = act_user_arg;
+                    if (gp_einfo->add_xstream_fn[i * 2] == NULL) {
+                        gp_einfo->add_xstream_fn[i * 2] = ask_cb;
+                        gp_einfo->add_xstream_arg[i * 2] = ask_user_arg;
+                        gp_einfo->add_xstream_fn[i * 2 + 1] = act_cb;
+                        gp_einfo->add_xstream_arg[i * 2 + 1] = act_user_arg;
                         cid = i;
                         break;
                     }
@@ -895,18 +916,18 @@ int ABT_event_del_callback(ABT_event_kind event, int cb_id)
     ABTI_mutex_spinlock(&gp_einfo->mutex);
     switch (event) {
         case ABT_EVENT_STOP_XSTREAM:
-            gp_einfo->stop_xstream_fn[cb_id*2] = NULL;
-            gp_einfo->stop_xstream_fn[cb_id*2+1] = NULL;
-            gp_einfo->stop_xstream_arg[cb_id*2] = NULL;
-            gp_einfo->stop_xstream_arg[cb_id*2+1] = NULL;
+            gp_einfo->stop_xstream_fn[cb_id * 2] = NULL;
+            gp_einfo->stop_xstream_fn[cb_id * 2 + 1] = NULL;
+            gp_einfo->stop_xstream_arg[cb_id * 2] = NULL;
+            gp_einfo->stop_xstream_arg[cb_id * 2 + 1] = NULL;
             gp_einfo->num_stop_xstream_fn++;
             break;
 
         case ABT_EVENT_ADD_XSTREAM:
-            gp_einfo->add_xstream_fn[cb_id*2] = NULL;
-            gp_einfo->add_xstream_fn[cb_id*2+1] = NULL;
-            gp_einfo->add_xstream_arg[cb_id*2] = NULL;
-            gp_einfo->add_xstream_arg[cb_id*2+1] = NULL;
+            gp_einfo->add_xstream_fn[cb_id * 2] = NULL;
+            gp_einfo->add_xstream_fn[cb_id * 2 + 1] = NULL;
+            gp_einfo->add_xstream_arg[cb_id * 2] = NULL;
+            gp_einfo->add_xstream_arg[cb_id * 2 + 1] = NULL;
             gp_einfo->num_add_xstream_fn++;
             break;
 
@@ -936,7 +957,8 @@ void ABTI_event_realloc_pub_arrays(int size)
 
 void ABTI_event_inc_unit_cnt(ABTI_xstream *p_xstream, ABT_unit_type type)
 {
-    if (gp_ABTI_global->pub_needed == ABT_FALSE) return;
+    if (gp_ABTI_global->pub_needed == ABT_FALSE)
+        return;
 
     int rank = (int)p_xstream->rank;
 
@@ -962,7 +984,8 @@ void ABTI_event_publish_info(void)
     char *info, *info_ptr;
     ABT_bool is_first;
 
-    if (gp_ABTI_global->pub_needed == ABT_FALSE) return;
+    if (gp_ABTI_global->pub_needed == ABT_FALSE)
+        return;
 
     p_xstream = ABTI_local_get_xstream();
     rank = (int)p_xstream->rank;
@@ -975,7 +998,7 @@ void ABTI_event_publish_info(void)
 
     /* Update the idle time of the current ES */
     cur_num_units = gp_einfo->num_threads[rank]
-                  + gp_einfo->num_tasks[rank];
+        + gp_einfo->num_tasks[rank];
     if (gp_einfo->old_timestamp[rank] > 0.0) {
         if (cur_num_units == gp_einfo->old_num_units[rank]) {
             idle_time = cur_time - gp_einfo->old_timestamp[rank];
@@ -985,11 +1008,13 @@ void ABTI_event_publish_info(void)
     gp_einfo->old_num_units[rank] = cur_num_units;
     gp_einfo->old_timestamp[rank] = cur_time;
 
-    if (elapsed_time < gp_ABTI_global->pub_interval) return;
+    if (elapsed_time < gp_ABTI_global->pub_interval)
+        return;
 
     /* Only one scheduler has to write to the output file. */
     ret = ABTI_mutex_trylock(&gp_einfo->mutex);
-    if (ret == ABT_ERR_MUTEX_LOCKED) return;
+    if (ret == ABT_ERR_MUTEX_LOCKED)
+        return;
     ABTI_ASSERT(ret == ABT_SUCCESS);
 
     /* Update timestamp */
@@ -1000,7 +1025,7 @@ void ABTI_event_publish_info(void)
     info_ptr = info;
 
     sprintf(info_ptr, "{\"node\":\"%s\",\"sample\":\"argobots\","
-                      "\"time\":%.3f,\"num_es\":%d,",
+            "\"time\":%.3f,\"num_es\":%d,",
             gp_einfo->hostname, cur_time, gp_ABTI_global->num_xstreams);
     info_ptr += strlen(info_ptr);
 
@@ -1010,7 +1035,8 @@ void ABTI_event_publish_info(void)
     for (i = 0; i < gp_ABTI_global->max_xstreams; i++) {
         num_threads = gp_einfo->num_threads[i];
         if (num_threads > 0) {
-            ABTD_atomic_fetch_sub_uint32(&gp_einfo->num_threads[i], num_threads);
+            ABTD_atomic_fetch_sub_uint32(&gp_einfo->num_threads[i],
+                                         num_threads);
         }
         if (gp_ABTI_global->p_xstreams[i]) {
             if (is_first == ABT_TRUE) {
@@ -1108,7 +1134,8 @@ void ABTI_event_publish_info(void)
 int ABT_event_prof_start(void)
 {
 #ifdef ABT_CONFIG_PUBLISH_INFO
-    if (gp_ABTI_global->pub_needed == ABT_FALSE) return ABT_SUCCESS;
+    if (gp_ABTI_global->pub_needed == ABT_FALSE)
+        return ABT_SUCCESS;
 
     gp_einfo->prof_start_time = ABT_get_wtime();
     RAPLREADER_SAMPLE(&gp_einfo->rr);
@@ -1131,7 +1158,8 @@ int ABT_event_prof_start(void)
 int ABT_event_prof_stop(void)
 {
 #ifdef ABT_CONFIG_PUBLISH_INFO
-    if (gp_ABTI_global->pub_needed == ABT_FALSE) return ABT_SUCCESS;
+    if (gp_ABTI_global->pub_needed == ABT_FALSE)
+        return ABT_SUCCESS;
 
     gp_einfo->prof_stop_time = ABT_get_wtime();
     RAPLREADER_SAMPLE(&gp_einfo->rr);
@@ -1162,7 +1190,8 @@ int ABT_event_prof_publish(const char *unit_name, double local_work,
                            double global_work)
 {
 #ifdef ABT_CONFIG_PUBLISH_INFO
-    if (gp_ABTI_global->pub_needed == ABT_FALSE) return ABT_SUCCESS;
+    if (gp_ABTI_global->pub_needed == ABT_FALSE)
+        return ABT_SUCCESS;
 
     const char *sample_name = "application";
     double elapsed_time = gp_einfo->prof_stop_time - gp_einfo->prof_start_time;
@@ -1175,24 +1204,36 @@ int ABT_event_prof_publish(const char *unit_name, double local_work,
     char *info = (char *)ABTU_calloc(1024, sizeof(char));
 #if defined(HAVE_RAPLREADER_H) && defined(HAVE_LIBINTERCOOLR)
     sprintf(info,
-            "{\"node\":\"%s\",\"sample\":\"%s\",\"time\":%lf,\"%s_per_sec_per_node\":%lf,"
-            "\"%s_per_watt_per_node\":%lf,\"%s_per_sec\":%lf}\n",
-            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name, local_rate,
-            unit_name, local_work/power, unit_name, global_rate);
+            "{"
+            "\"node\":\"%s\","
+            "\"sample\":\"%s\","
+            "\"time\":%lf,"
+            "\"%s_per_sec_per_node\":%lf,"
+            "\"%s_per_watt_per_node\":%lf,"
+            "\"%s_per_sec\":%lf"
+            "}\n",
+            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name,
+            local_rate, unit_name, local_work / power, unit_name, global_rate);
 #else
     sprintf(info,
-            "{\"node\":\"%s\",\"sample\":\"%s\",\"time\":%lf,\"%s_per_sec_per_node\":%lf,"
-            "\"%s_per_sec\":%lf}\n",
-            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name, local_rate,
-            unit_name, global_rate);
+            "{"
+            "\"node\":\"%s\","
+            "\"sample\":\"%s\","
+            "\"time\":%lf,"
+            "\"%s_per_sec_per_node\":%lf,"
+            "\"%s_per_sec\":%lf"
+            "}\n",
+            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name,
+            local_rate, unit_name, global_rate);
 #endif
 
     if (gp_einfo->pub_type == ABTI_PUB_TYPE_BEACON) {
 #ifdef HAVE_BEACON_H
         EVT_DEBUG("%s", info);
         ABTU_strcpy(gp_einfo->eprop->topic_payload, info);
-        int ret = BEACON_Publish(gp_einfo->handle, gp_einfo->topic_info->topic_name,
-                                 gp_einfo->eprop);
+        int ret =
+            BEACON_Publish(gp_einfo->handle, gp_einfo->topic_info->topic_name,
+                           gp_einfo->eprop);
         if (ret != BEACON_SUCCESS) {
             printf("BEACON_Publish failed with ret=%d\n", ret);
             exit(-1);
@@ -1207,4 +1248,3 @@ int ABT_event_prof_publish(const char *unit_name, double local_work,
 
     return ABT_SUCCESS;
 }
-

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -72,7 +72,8 @@ int ABT_eventual_free(ABT_eventual *eventual)
     ABTI_spinlock_acquire(&p_eventual->lock);
 
     ABTI_spinlock_free(&p_eventual->lock);
-    if (p_eventual->value) ABTU_free(p_eventual->value);
+    if (p_eventual->value)
+        ABTU_free(p_eventual->value);
     ABTU_free(p_eventual);
 
     *eventual = ABT_EVENTUAL_NULL;
@@ -159,7 +160,8 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
     } else {
         ABTI_spinlock_release(&p_eventual->lock);
     }
-    if (value) *value = p_eventual->value;
+    if (value)
+        *value = p_eventual->value;
 
   fn_exit:
     return abt_errno;
@@ -193,12 +195,13 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
 
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready != ABT_FALSE) {
-        if (value) *value = p_eventual->value;
+        if (value)
+            *value = p_eventual->value;
         flag = ABT_TRUE;
     }
     ABTI_spinlock_release(&p_eventual->lock);
 
-   *is_ready = flag;
+    *is_ready = flag;
 
   fn_exit:
     return abt_errno;
@@ -236,7 +239,8 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     ABTI_spinlock_acquire(&p_eventual->lock);
 
     p_eventual->ready = ABT_TRUE;
-    if (p_eventual->value) memcpy(p_eventual->value, value, nbytes);
+    if (p_eventual->value)
+        memcpy(p_eventual->value, value, nbytes);
 
     if (p_eventual->p_head == NULL) {
         ABTI_spinlock_release(&p_eventual->lock);
@@ -311,4 +315,3 @@ int ABT_eventual_reset(ABT_eventual eventual)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/futures.c
+++ b/src/futures.c
@@ -54,7 +54,7 @@
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_future_create(uint32_t compartments, void (*cb_func)(void **arg),
+int ABT_future_create(uint32_t compartments, void (*cb_func) (void **arg),
                       ABT_future *newfuture)
 {
     int abt_errno = ABT_SUCCESS;
@@ -254,7 +254,7 @@ int ABT_future_set(ABT_future future, void *value)
     if (p_future->counter == p_future->compartments) {
         p_future->ready = ABT_TRUE;
         if (p_future->p_callback != NULL)
-            (*p_future->p_callback)(p_future->array);
+            (*p_future->p_callback) (p_future->array);
 
         if (p_future->p_head == NULL) {
             ABTI_spinlock_release(&p_future->lock);

--- a/src/global.c
+++ b/src/global.c
@@ -20,7 +20,8 @@ static uint8_t g_ABTI_init_lock = 0;
 /* A flag whether Argobots has been initialized or not */
 static uint32_t g_ABTI_initialized = 0;
 
-static inline void ABTI_init_lock_acquire() {
+static inline void ABTI_init_lock_acquire()
+{
     while (ABTD_atomic_test_and_set_uint8(&g_ABTI_init_lock)) {
         /* Busy-wait is allowed since this function may not be run in
          * ULT context. */
@@ -29,11 +30,13 @@ static inline void ABTI_init_lock_acquire() {
     }
 }
 
-static inline int ABTI_init_lock_is_locked() {
+static inline int ABTI_init_lock_is_locked()
+{
     return ABTD_atomic_load_uint8(&g_ABTI_init_lock) != 0;
 }
 
-static inline void ABTI_init_lock_release() {
+static inline void ABTI_init_lock_release()
+{
     ABTD_atomic_clear_uint8(&g_ABTI_init_lock);
 }
 
@@ -56,7 +59,8 @@ static inline void ABTI_init_lock_release() {
  */
 int ABT_init(int argc, char **argv)
 {
-    ABTI_UNUSED(argc); ABTI_UNUSED(argv);
+    ABTI_UNUSED(argc);
+    ABTI_UNUSED(argv);
     int abt_errno = ABT_SUCCESS;
 
     /* First, take a global lock protecting the initialization/finalization
@@ -85,8 +89,9 @@ int ABT_init(int argc, char **argv)
     ABTI_pool_reset_id();
 
     /* Initialize the ES array */
-    gp_ABTI_global->p_xstreams = (ABTI_xstream **)ABTU_calloc(
-            gp_ABTI_global->max_xstreams, sizeof(ABTI_xstream *));
+    gp_ABTI_global->p_xstreams =
+        (ABTI_xstream **)ABTU_calloc(gp_ABTI_global->max_xstreams,
+                                     sizeof(ABTI_xstream *));
     gp_ABTI_global->num_xstreams = 0;
 
     /* Create a spinlock */
@@ -189,7 +194,8 @@ int ABT_finalize(void)
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch to the top scheduler */
-        ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
+        ABTI_sched *p_sched =
+            ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
         ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
 
         /* Back to the original thread */
@@ -265,14 +271,16 @@ void ABTI_global_update_max_xstreams(int new_size)
 {
     int i;
 
-    if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams) return;
+    if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams)
+        return;
 
     ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
 
     new_size = (new_size > 0) ? new_size : gp_ABTI_global->max_xstreams * 2;
     gp_ABTI_global->max_xstreams = new_size;
-    gp_ABTI_global->p_xstreams = (ABTI_xstream **)ABTU_realloc(
-            gp_ABTI_global->p_xstreams, new_size * sizeof(ABTI_xstream *));
+    gp_ABTI_global->p_xstreams =
+        (ABTI_xstream **)ABTU_realloc(gp_ABTI_global->p_xstreams,
+                                      new_size * sizeof(ABTI_xstream *));
 
     for (i = gp_ABTI_global->num_xstreams; i < new_size; i++) {
         gp_ABTI_global->p_xstreams[i] = NULL;
@@ -280,4 +288,3 @@ void ABTI_global_update_max_xstreams(int new_size)
 
     ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
-

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -56,7 +56,11 @@ extern "C" {
 #define ABT_RELEASE_TYPE_PATCH  3
 
 #define ABT_CALC_VERSION(MAJOR, MINOR, REVISION, TYPE, PATCH) \
-    (((MAJOR) * 10000000) + ((MINOR) * 100000) + ((REVISION) * 1000) + ((TYPE) * 100) + (PATCH))
+    (   ((MAJOR)    * 10000000)                               \
+      + ((MINOR)    * 100000)                                 \
+      + ((REVISION) * 1000)                                   \
+      + ((TYPE)     * 100)                                    \
+      + (PATCH))
 
 
 /* Error Classes */
@@ -204,7 +208,7 @@ typedef enum ABT_pool_kind     ABT_pool_kind;       /* Pool kind */
 typedef enum ABT_pool_access   ABT_pool_access;     /* Pool access mode */
 typedef void *                 ABT_unit;            /* Unit */
 typedef enum ABT_unit_type     ABT_unit_type;       /* Unit type */
-typedef void *                 ABT_thread;          /* User-Level Thread (ULT) */
+typedef void *                 ABT_thread;          /* User-Level Thread */
 typedef void *                 ABT_thread_attr;     /* ULT attribute */
 typedef enum ABT_thread_state  ABT_thread_state;    /* ULT state */
 typedef uint64_t               ABT_thread_id;       /* ULT id */
@@ -226,45 +230,45 @@ typedef enum ABT_event_kind    ABT_event_kind;      /* Event kind */
 /* Null Object Handles */
 #define ABT_NULL @ABT_NULL@
 #if ABT_NULL == 1
-#define ABT_XSTREAM_NULL         ((ABT_xstream)        NULL)
-#define ABT_XSTREAM_BARRIER_NULL ((ABT_xstream_barrier)NULL)
-#define ABT_SCHED_NULL           ((ABT_sched)          NULL)
-#define ABT_SCHED_CONFIG_NULL    ((ABT_sched_config)   NULL)
-#define ABT_POOL_NULL            ((ABT_pool)           NULL)
-#define ABT_POOL_CONFIG_NULL     ((ABT_pool_config)    NULL)
-#define ABT_UNIT_NULL            ((ABT_unit)           NULL)
-#define ABT_THREAD_NULL          ((ABT_thread)         NULL)
-#define ABT_THREAD_ATTR_NULL     ((ABT_thread_attr)    NULL)
-#define ABT_TASK_NULL            ((ABT_task)           NULL)
-#define ABT_KEY_NULL             ((ABT_key)            NULL)
-#define ABT_MUTEX_NULL           ((ABT_mutex)          NULL)
-#define ABT_MUTEX_ATTR_NULL      ((ABT_mutex_attr)     NULL)
-#define ABT_COND_NULL            ((ABT_cond)           NULL)
-#define ABT_RWLOCK_NULL          ((ABT_rwlock)         NULL)
-#define ABT_EVENTUAL_NULL        ((ABT_eventual)       NULL)
-#define ABT_FUTURE_NULL          ((ABT_future)         NULL)
-#define ABT_BARRIER_NULL         ((ABT_barrier)        NULL)
-#define ABT_TIMER_NULL           ((ABT_timer)          NULL)
+#define ABT_XSTREAM_NULL         ((ABT_xstream)         NULL)
+#define ABT_XSTREAM_BARRIER_NULL ((ABT_xstream_barrier) NULL)
+#define ABT_SCHED_NULL           ((ABT_sched)           NULL)
+#define ABT_SCHED_CONFIG_NULL    ((ABT_sched_config)    NULL)
+#define ABT_POOL_NULL            ((ABT_pool)            NULL)
+#define ABT_POOL_CONFIG_NULL     ((ABT_pool_config)     NULL)
+#define ABT_UNIT_NULL            ((ABT_unit)            NULL)
+#define ABT_THREAD_NULL          ((ABT_thread)          NULL)
+#define ABT_THREAD_ATTR_NULL     ((ABT_thread_attr)     NULL)
+#define ABT_TASK_NULL            ((ABT_task)            NULL)
+#define ABT_KEY_NULL             ((ABT_key)             NULL)
+#define ABT_MUTEX_NULL           ((ABT_mutex)           NULL)
+#define ABT_MUTEX_ATTR_NULL      ((ABT_mutex_attr)      NULL)
+#define ABT_COND_NULL            ((ABT_cond)            NULL)
+#define ABT_RWLOCK_NULL          ((ABT_rwlock)          NULL)
+#define ABT_EVENTUAL_NULL        ((ABT_eventual)        NULL)
+#define ABT_FUTURE_NULL          ((ABT_future)          NULL)
+#define ABT_BARRIER_NULL         ((ABT_barrier)         NULL)
+#define ABT_TIMER_NULL           ((ABT_timer)           NULL)
 #else
-#define ABT_XSTREAM_NULL         ((ABT_xstream)        (0x01))
-#define ABT_XSTREAM_BARRIER_NULL ((ABT_xstream_barrier)(0x02))
-#define ABT_SCHED_NULL           ((ABT_sched)          (0x03))
-#define ABT_SCHED_CONFIG_NULL    ((ABT_sched_config)   (0x04))
-#define ABT_POOL_NULL            ((ABT_pool)           (0x05))
-#define ABT_POOL_CONFIG_NULL     ((ABT_pool_config)    (0x06))
-#define ABT_UNIT_NULL            ((ABT_unit)           (0x07))
-#define ABT_THREAD_NULL          ((ABT_thread)         (0x08))
-#define ABT_THREAD_ATTR_NULL     ((ABT_thread_attr)    (0x09))
-#define ABT_TASK_NULL            ((ABT_task)           (0x0a))
-#define ABT_KEY_NULL             ((ABT_key)            (0x0b))
-#define ABT_MUTEX_NULL           ((ABT_mutex)          (0x0c))
-#define ABT_MUTEX_ATTR_NULL      ((ABT_mutex_attr)     (0x0d))
-#define ABT_COND_NULL            ((ABT_cond)           (0x0e))
-#define ABT_RWLOCK_NULL          ((ABT_rwlock)         (0x0f))
-#define ABT_EVENTUAL_NULL        ((ABT_eventual)       (0x10))
-#define ABT_FUTURE_NULL          ((ABT_future)         (0x11))
-#define ABT_BARRIER_NULL         ((ABT_barrier)        (0x12))
-#define ABT_TIMER_NULL           ((ABT_timer)          (0x13))
+#define ABT_XSTREAM_NULL         ((ABT_xstream)         (0x01))
+#define ABT_XSTREAM_BARRIER_NULL ((ABT_xstream_barrier) (0x02))
+#define ABT_SCHED_NULL           ((ABT_sched)           (0x03))
+#define ABT_SCHED_CONFIG_NULL    ((ABT_sched_config)    (0x04))
+#define ABT_POOL_NULL            ((ABT_pool)            (0x05))
+#define ABT_POOL_CONFIG_NULL     ((ABT_pool_config)     (0x06))
+#define ABT_UNIT_NULL            ((ABT_unit)            (0x07))
+#define ABT_THREAD_NULL          ((ABT_thread)          (0x08))
+#define ABT_THREAD_ATTR_NULL     ((ABT_thread_attr)     (0x09))
+#define ABT_TASK_NULL            ((ABT_task)            (0x0a))
+#define ABT_KEY_NULL             ((ABT_key)             (0x0b))
+#define ABT_MUTEX_NULL           ((ABT_mutex)           (0x0c))
+#define ABT_MUTEX_ATTR_NULL      ((ABT_mutex_attr)      (0x0d))
+#define ABT_COND_NULL            ((ABT_cond)            (0x0e))
+#define ABT_RWLOCK_NULL          ((ABT_rwlock)          (0x0f))
+#define ABT_EVENTUAL_NULL        ((ABT_eventual)        (0x10))
+#define ABT_FUTURE_NULL          ((ABT_future)          (0x11))
+#define ABT_BARRIER_NULL         ((ABT_barrier)         (0x12))
+#define ABT_TIMER_NULL           ((ABT_timer)           (0x13))
 #endif
 
 /* Scheduler config */
@@ -366,14 +370,18 @@ int ABT_xstream_self(ABT_xstream *xstream) ABT_API_PUBLIC;
 int ABT_xstream_self_rank(int *rank) ABT_API_PUBLIC;
 int ABT_xstream_set_rank(ABT_xstream xstream, const int rank) ABT_API_PUBLIC;
 int ABT_xstream_get_rank(ABT_xstream xstream, int *rank) ABT_API_PUBLIC;
-int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched) ABT_API_PUBLIC;
+int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
+                               ABT_API_PUBLIC;
 int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
                                      ABT_sched_predef predef,
-                                     int num_pools, ABT_pool *pools) ABT_API_PUBLIC;
-int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched) ABT_API_PUBLIC;
+                                     int num_pools, ABT_pool *pools)
+                                     ABT_API_PUBLIC;
+int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched)
+                               ABT_API_PUBLIC;
 int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
                                ABT_pool *pools) ABT_API_PUBLIC;
-int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state) ABT_API_PUBLIC;
+int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state)
+                          ABT_API_PUBLIC;
 int ABT_xstream_equal(ABT_xstream xstream1, ABT_xstream xstream2,
                       ABT_bool *result) ABT_API_PUBLIC;
 int ABT_xstream_get_num(int *num_xstreams) ABT_API_PUBLIC;
@@ -388,14 +396,15 @@ int ABT_xstream_get_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset,
                              int *num_cpus) ABT_API_PUBLIC;
 
 /* ES Barrier */
-int ABT_xstream_barrier_create(uint32_t num_waiters, ABT_xstream_barrier *newbarrier)
-                               ABT_API_PUBLIC;
+int ABT_xstream_barrier_create(uint32_t num_waiters,
+                               ABT_xstream_barrier *newbarrier) ABT_API_PUBLIC;
 int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier) ABT_API_PUBLIC;
 int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier) ABT_API_PUBLIC;
 
 /* Scheduler */
 int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
-                     ABT_sched_config config, ABT_sched *newsched) ABT_API_PUBLIC;
+                     ABT_sched_config config, ABT_sched *newsched)
+                     ABT_API_PUBLIC;
 int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                            ABT_pool *pools, ABT_sched_config config,
                            ABT_sched *newsched) ABT_API_PUBLIC;
@@ -413,7 +422,8 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop) ABT_API_PUBLIC;
 
 /* Scheduler config */
 int ABT_sched_config_create(ABT_sched_config *config, ...) ABT_API_PUBLIC;
-int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...) ABT_API_PUBLIC;
+int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
+                          ABT_API_PUBLIC;
 int ABT_sched_config_free(ABT_sched_config *config) ABT_API_PUBLIC;
 
 /* Pool */
@@ -426,7 +436,8 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access) ABT_API_PUBLIC;
 int ABT_pool_get_size(ABT_pool pool, size_t *size) ABT_API_PUBLIC;
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size) ABT_API_PUBLIC;
 int ABT_pool_pop(ABT_pool pool, ABT_unit *unit) ABT_API_PUBLIC;
-int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *unit, double abstime_secs) ABT_API_PUBLIC;
+int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *unit, double abstime_secs)
+                           ABT_API_PUBLIC;
 int ABT_pool_remove(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
 int ABT_pool_push(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
 int ABT_pool_print_all(ABT_pool pool, void *arg,
@@ -441,10 +452,12 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool) ABT_API_PUBLIC;
 
 /* User-level Thread (ULT) */
 int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
-                      ABT_thread_attr attr, ABT_thread *newthread) ABT_API_PUBLIC;
+                      ABT_thread_attr attr, ABT_thread *newthread)
+                      ABT_API_PUBLIC;
 int ABT_thread_create_on_xstream(ABT_xstream xstream,
                       void (*thread_func)(void *), void *arg,
-                      ABT_thread_attr attr, ABT_thread *newthread) ABT_API_PUBLIC;
+                      ABT_thread_attr attr, ABT_thread *newthread)
+                      ABT_API_PUBLIC;
 int ABT_thread_create_many(int num, ABT_pool *pool_list,
                       void (**thread_func_list)(void *), void **arg_list,
                       ABT_thread_attr attr, ABT_thread *newthread_list)
@@ -454,24 +467,30 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
 int ABT_thread_free(ABT_thread *thread) ABT_API_PUBLIC;
 int ABT_thread_free_many(int num, ABT_thread *thread_list) ABT_API_PUBLIC;
 int ABT_thread_join(ABT_thread thread) ABT_API_PUBLIC;
-int ABT_thread_join_many(int num_threads, ABT_thread *thread_list) ABT_API_PUBLIC;
+int ABT_thread_join_many(int num_threads, ABT_thread *thread_list)
+                         ABT_API_PUBLIC;
 int ABT_thread_exit(void) ABT_API_PUBLIC;
 int ABT_thread_cancel(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_thread_self(ABT_thread *thread) ABT_API_PUBLIC;
 int ABT_thread_self_id(ABT_thread_id *id) ABT_API_PUBLIC;
-int ABT_thread_get_state(ABT_thread thread, ABT_thread_state *state) ABT_API_PUBLIC;
+int ABT_thread_get_state(ABT_thread thread, ABT_thread_state *state)
+                         ABT_API_PUBLIC;
 int ABT_thread_get_last_pool(ABT_thread thread, ABT_pool *pool) ABT_API_PUBLIC;
 int ABT_thread_get_last_pool_id(ABT_thread thread, int *id) ABT_API_PUBLIC;
-int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool) ABT_API_PUBLIC;
+int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
+                                   ABT_API_PUBLIC;
 int ABT_thread_yield_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_thread_yield(void) ABT_API_PUBLIC;
 int ABT_thread_resume(ABT_thread thread) ABT_API_PUBLIC;
-int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream) ABT_API_PUBLIC;
-int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched) ABT_API_PUBLIC;
+int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
+                                  ABT_API_PUBLIC;
+int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
+                                ABT_API_PUBLIC;
 int ABT_thread_migrate_to_pool(ABT_thread thread, ABT_pool pool) ABT_API_PUBLIC;
 int ABT_thread_migrate(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_thread_set_callback(ABT_thread thread,
-        void(*cb_func)(ABT_thread thread, void *cb_arg), void *cb_arg) ABT_API_PUBLIC;
+                            void(*cb_func)(ABT_thread thread, void *cb_arg),
+                            void *cb_arg) ABT_API_PUBLIC;
 int ABT_thread_set_migratable(ABT_thread thread, ABT_bool flag) ABT_API_PUBLIC;
 int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_thread_is_primary(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
@@ -479,11 +498,14 @@ int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
                      ABT_API_PUBLIC;
 int ABT_thread_retain(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_thread_release(ABT_thread thread) ABT_API_PUBLIC;
-int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize) ABT_API_PUBLIC;
-int ABT_thread_get_id(ABT_thread thread, ABT_thread_id *thread_id) ABT_API_PUBLIC;
+int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize)
+                             ABT_API_PUBLIC;
+int ABT_thread_get_id(ABT_thread thread, ABT_thread_id *thread_id)
+                      ABT_API_PUBLIC;
 int ABT_thread_set_arg(ABT_thread thread, void *arg) ABT_API_PUBLIC;
 int ABT_thread_get_arg(ABT_thread thread, void **arg) ABT_API_PUBLIC;
-int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr) ABT_API_PUBLIC;
+int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
+                        ABT_API_PUBLIC;
 
 /* ULT Attributes */
 int ABT_thread_attr_create(ABT_thread_attr *newattr) ABT_API_PUBLIC;
@@ -492,11 +514,15 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
                               size_t stacksize) ABT_API_PUBLIC;
 int ABT_thread_attr_get_stack(ABT_thread_attr attr, void **stackaddr,
                               size_t *stacksize) ABT_API_PUBLIC;
-int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize) ABT_API_PUBLIC;
-int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize) ABT_API_PUBLIC;
+int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
+                                  ABT_API_PUBLIC;
+int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
+                                  ABT_API_PUBLIC;
 int ABT_thread_attr_set_callback(ABT_thread_attr attr,
-        void(*cb_func)(ABT_thread thread, void *cb_arg), void *cb_arg) ABT_API_PUBLIC;
-int ABT_thread_attr_set_migratable(ABT_thread_attr attr, ABT_bool flag) ABT_API_PUBLIC;
+                                 void(*cb_func)(ABT_thread th, void *cb_arg),
+                                 void *cb_arg) ABT_API_PUBLIC;
+int ABT_thread_attr_set_migratable(ABT_thread_attr attr, ABT_bool flag)
+                                   ABT_API_PUBLIC;
 
 /* Tasklet */
 int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
@@ -516,7 +542,8 @@ int ABT_task_get_last_pool(ABT_task task, ABT_pool *pool) ABT_API_PUBLIC;
 int ABT_task_get_last_pool_id(ABT_task task, int *id) ABT_API_PUBLIC;
 int ABT_task_set_migratable(ABT_task task, ABT_bool flag) ABT_API_PUBLIC;
 int ABT_task_is_migratable(ABT_task task, ABT_bool *flag) ABT_API_PUBLIC;
-int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result) ABT_API_PUBLIC;
+int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result)
+                   ABT_API_PUBLIC;
 int ABT_task_retain(ABT_task task) ABT_API_PUBLIC;
 int ABT_task_release(ABT_task task) ABT_API_PUBLIC;
 int ABT_task_get_id(ABT_task task, uint64_t *task_id) ABT_API_PUBLIC;
@@ -532,14 +559,16 @@ int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;
 int ABT_self_get_arg(void **arg) ABT_API_PUBLIC;
 
 /* ULT-specific data */
-int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey) ABT_API_PUBLIC;
+int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
+                   ABT_API_PUBLIC;
 int ABT_key_free(ABT_key *key) ABT_API_PUBLIC;
 int ABT_key_set(ABT_key key, void *value) ABT_API_PUBLIC;
 int ABT_key_get(ABT_key key, void **value) ABT_API_PUBLIC;
 
 /* Mutex */
 int ABT_mutex_create(ABT_mutex *newmutex) ABT_API_PUBLIC;
-int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex) ABT_API_PUBLIC;
+int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
+                               ABT_API_PUBLIC;
 int ABT_mutex_free(ABT_mutex *mutex) ABT_API_PUBLIC;
 int ABT_mutex_lock(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_lock_high(ABT_mutex mutex) ABT_API_PUBLIC;
@@ -549,12 +578,14 @@ int ABT_mutex_spinlock(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_unlock(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_unlock_se(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_unlock_de(ABT_mutex mutex) ABT_API_PUBLIC;
-int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result) ABT_API_PUBLIC;
+int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
+                    ABT_API_PUBLIC;
 
 /* Mutex Attributes */
 int ABT_mutex_attr_create(ABT_mutex_attr *newattr) ABT_API_PUBLIC;
 int ABT_mutex_attr_free(ABT_mutex_attr *attr) ABT_API_PUBLIC;
-int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive) ABT_API_PUBLIC;
+int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
+                                 ABT_API_PUBLIC;
 
 /* Condition variable */
 int ABT_cond_create(ABT_cond *newcond) ABT_API_PUBLIC;
@@ -576,8 +607,10 @@ int ABT_rwlock_unlock(ABT_rwlock rwlock) ABT_API_PUBLIC;
 int ABT_eventual_create(int nbytes, ABT_eventual *neweventual) ABT_API_PUBLIC;
 int ABT_eventual_free(ABT_eventual *eventual) ABT_API_PUBLIC;
 int ABT_eventual_wait(ABT_eventual eventual, void **value) ABT_API_PUBLIC;
-int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready) ABT_API_PUBLIC;
-int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes) ABT_API_PUBLIC;
+int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
+                      ABT_API_PUBLIC;
+int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
+                     ABT_API_PUBLIC;
 int ABT_eventual_reset(ABT_eventual eventual) ABT_API_PUBLIC;
 
 /* Futures */
@@ -590,8 +623,10 @@ int ABT_future_set(ABT_future future, void *value) ABT_API_PUBLIC;
 int ABT_future_reset(ABT_future future) ABT_API_PUBLIC;
 
 /* Barrier */
-int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier) ABT_API_PUBLIC;
-int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters) ABT_API_PUBLIC;
+int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
+                       ABT_API_PUBLIC;
+int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
+                       ABT_API_PUBLIC;
 int ABT_barrier_free(ABT_barrier *barrier) ABT_API_PUBLIC;
 int ABT_barrier_wait(ABT_barrier barrier) ABT_API_PUBLIC;
 int ABT_barrier_get_num_waiters(ABT_barrier barrier, uint32_t *num_waiters)
@@ -634,7 +669,8 @@ int ABT_info_print_thread(FILE* fp, ABT_thread thread) ABT_API_PUBLIC;
 int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr) ABT_API_PUBLIC;
 int ABT_info_print_task(FILE* fp, ABT_task task) ABT_API_PUBLIC;
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread) ABT_API_PUBLIC;
-int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool) ABT_API_PUBLIC;
+int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
+                                         ABT_API_PUBLIC;
 int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
                                              void (*cb_func)(ABT_bool, void *),
                                              void *arg) ABT_API_PUBLIC;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -14,14 +14,14 @@
 #include "abtd_atomic.h"
 
 /* Data Types */
-typedef pthread_t           ABTD_xstream_context;
-typedef pthread_mutex_t     ABTD_xstream_mutex;
+typedef pthread_t ABTD_xstream_context;
+typedef pthread_mutex_t ABTD_xstream_mutex;
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-typedef pthread_barrier_t   ABTD_xstream_barrier;
+typedef pthread_barrier_t ABTD_xstream_barrier;
 #else
-typedef void *              ABTD_xstream_barrier;
+typedef void *ABTD_xstream_barrier;
 #endif
-typedef abt_ucontext_t      ABTD_thread_context;
+typedef abt_ucontext_t ABTD_thread_context;
 
 /* ES Storage Qualifier */
 #define ABTD_XSTREAM_LOCAL  __thread
@@ -30,7 +30,7 @@ typedef abt_ucontext_t      ABTD_thread_context;
 void ABTD_env_init(ABTI_global *p_global);
 
 /* ES Context */
-int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
+int ABTD_xstream_context_create(void *(*f_xstream) (void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_join(ABTD_xstream_context ctx);
@@ -66,8 +66,8 @@ typedef struct timeval ABTD_time;
 
 #endif
 
-void   ABTD_time_init(void);
-int    ABTD_time_get(ABTD_time *p_time);
+void ABTD_time_init(void);
+int ABTD_time_get(ABTD_time *p_time);
 double ABTD_time_read_sec(ABTD_time *p_time);
 
 #endif /* ABTD_H_INCLUDED */

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,9 +8,8 @@
 
 #include <stdint.h>
 
-static inline
-int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
-                                   int weak)
+static inline int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv,
+                                                 int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int32_t tmp_oldv = oldv;
@@ -22,9 +21,8 @@ int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
 #endif
 }
 
-static inline
-uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
-                                     uint32_t newv, int weak)
+static inline uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
+                                                   uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint32_t tmp_oldv = oldv;
@@ -36,9 +34,8 @@ uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
 #endif
 }
 
-static inline
-int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
-                                   int weak)
+static inline int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv,
+                                                 int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int64_t tmp_oldv = oldv;
@@ -50,9 +47,8 @@ int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
 #endif
 }
 
-static inline
-uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
-                                     uint64_t newv, int weak)
+static inline uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
+                                                   uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint64_t tmp_oldv = oldv;
@@ -64,8 +60,8 @@ uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
 #endif
 }
 
-static inline
-void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+static inline void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv,
+                                             int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     void *tmp_oldv = oldv;
@@ -77,9 +73,8 @@ void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
-                                int weak)
+static inline int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv,
+                                              int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
@@ -89,9 +84,8 @@ int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv,
-                                 int weak)
+static inline int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv,
+                                               uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
@@ -101,9 +95,8 @@ int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv,
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
-                                int weak)
+static inline int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv,
+                                              int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
@@ -113,9 +106,8 @@ int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv,
-                                 int weak)
+static inline int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv,
+                                               uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
@@ -125,8 +117,8 @@ int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv,
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+static inline int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv,
+                                            int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
@@ -136,138 +128,135 @@ int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv,
+                                                     int32_t newv)
 {
-   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline
-uint32_t ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
-                                         uint32_t newv)
+static inline uint32_t ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr,
+                                                       uint32_t oldv,
+                                                       uint32_t newv)
 {
-   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline
-int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv,
+                                                     int64_t newv)
 {
-   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline
-uint64_t ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
-                                         uint64_t newv)
+static inline uint64_t ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr,
+                                                       uint64_t oldv,
+                                                       uint64_t newv)
 {
-   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline
-void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+static inline void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv,
+                                                 void *newv)
 {
-   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline
-int32_t ABTD_atomic_val_cas_strong_int32(int32_t *ptr, int32_t oldv,
-                                         int32_t newv)
+static inline int32_t ABTD_atomic_val_cas_strong_int32(int32_t *ptr,
+                                                       int32_t oldv,
+                                                       int32_t newv)
 {
-   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
 }
 
-static inline
-uint32_t ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
-                                           uint32_t newv)
+static inline uint32_t ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr,
+                                                         uint32_t oldv,
+                                                         uint32_t newv)
 {
-   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline
-int64_t ABTD_atomic_val_cas_strong_int64(int64_t *ptr, int64_t oldv,
-                                         int64_t newv)
+static inline int64_t ABTD_atomic_val_cas_strong_int64(int64_t *ptr,
+                                                       int64_t oldv,
+                                                       int64_t newv)
 {
-   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
 }
 
-static inline
-uint64_t ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
-                                           uint64_t newv)
+static inline uint64_t ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr,
+                                                         uint64_t oldv,
+                                                         uint64_t newv)
 {
-   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline
-void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+static inline void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv,
+                                                   void *newv)
 {
-   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv,
+                                                  int32_t newv)
 {
-   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
-                                     uint32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
+                                                   uint32_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv,
+                                                  int64_t newv)
 {
-   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
-                                     uint64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
+                                                   uint64_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+static inline int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv,
+                                                void *newv)
 {
-   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv,
+                                                    int32_t newv)
 {
-   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
-                                       uint32_t newv)
+static inline int ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr,
+                                                     uint32_t oldv,
+                                                     uint32_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv,
+                                                    int64_t newv)
 {
-   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
-                                       uint64_t newv)
+static inline int ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr,
+                                                     uint64_t oldv,
+                                                     uint64_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+static inline int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv,
+                                                  void *newv)
 {
-   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline
-int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -276,8 +265,7 @@ int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -286,8 +274,7 @@ uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -296,8 +283,7 @@ int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -306,8 +292,7 @@ uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-double ABTD_atomic_fetch_add_double(double *ptr, double v)
+static inline double ABTD_atomic_fetch_add_double(double *ptr, double v)
 {
     union value {
         double d_val;
@@ -323,8 +308,7 @@ double ABTD_atomic_fetch_add_double(double *ptr, double v)
     return oldv.d_val;
 }
 
-static inline
-int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -333,8 +317,7 @@ int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -343,8 +326,7 @@ uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -353,8 +335,7 @@ int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -363,14 +344,12 @@ uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-double ABTD_atomic_fetch_sub_double(double *ptr, double v)
+static inline double ABTD_atomic_fetch_sub_double(double *ptr, double v)
 {
     return ABTD_atomic_fetch_add_double(ptr, -v);
 }
 
-static inline
-int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -379,8 +358,7 @@ int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -389,8 +367,7 @@ uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -399,8 +376,7 @@ int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -409,8 +385,7 @@ uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -419,8 +394,7 @@ int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -429,8 +403,7 @@ uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -439,8 +412,7 @@ int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -449,8 +421,7 @@ uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -459,8 +430,7 @@ int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -469,8 +439,7 @@ uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -479,8 +448,7 @@ int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -489,8 +457,7 @@ uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -500,8 +467,7 @@ uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-void ABTD_atomic_clear_uint8(uint8_t *ptr)
+static inline void ABTD_atomic_clear_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELEASE);
@@ -510,8 +476,7 @@ void ABTD_atomic_clear_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -523,8 +488,7 @@ uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_load_int32(int32_t *ptr)
+static inline int32_t ABTD_atomic_load_int32(int32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -536,8 +500,7 @@ int32_t ABTD_atomic_load_int32(int32_t *ptr)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
+static inline uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -549,8 +512,7 @@ uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_load_int64(int64_t *ptr)
+static inline int64_t ABTD_atomic_load_int64(int64_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -562,8 +524,7 @@ int64_t ABTD_atomic_load_int64(int64_t *ptr)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
+static inline uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -576,22 +537,20 @@ uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
 #endif
 }
 
-static inline
-void *ABTD_atomic_load_ptr(void **ptr)
+static inline void *ABTD_atomic_load_ptr(void **ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    void *val = *(void * volatile *)ptr;
+    void *val = *(void *volatile *)ptr;
     __sync_synchronize();
     return val;
 #endif
 }
 
-static inline
-void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
+static inline void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -602,8 +561,7 @@ void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
+static inline void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -614,8 +572,7 @@ void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
+static inline void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -626,8 +583,7 @@ void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
+static inline void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -638,20 +594,18 @@ void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_ptr(void **ptr, void *val)
+static inline void ABTD_atomic_store_ptr(void **ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(void * volatile *)ptr = val;
+    *(void *volatile *)ptr = val;
     __sync_synchronize();
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -664,8 +618,7 @@ int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -678,8 +631,7 @@ uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -692,8 +644,7 @@ int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -706,8 +657,7 @@ uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
+static inline void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -720,8 +670,7 @@ void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
 #endif
 }
 
-static inline
-void ABTD_atomic_mem_barrier(void)
+static inline void ABTD_atomic_mem_barrier(void)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_thread_fence(__ATOMIC_ACQ_REL);
@@ -730,17 +679,15 @@ void ABTD_atomic_mem_barrier(void)
 #endif
 }
 
-static inline
-void ABTD_compiler_barrier(void)
+static inline void ABTD_compiler_barrier(void)
 {
-    __asm__ __volatile__ ( "" ::: "memory" );
+    __asm__ __volatile__("":::"memory");
 }
 
-static inline
-void ABTD_atomic_pause(void)
+static inline void ABTD_atomic_pause(void)
 {
 #ifdef __x86_64__
-    __asm__ __volatile__ ( "pause" ::: "memory" );
+    __asm__ __volatile__("pause":::"memory");
 #endif
 }
 

--- a/src/include/abtd_stream.h
+++ b/src/include/abtd_stream.h
@@ -7,23 +7,20 @@
 #define ABTD_STREAM_H_INCLUDED
 
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-static inline
-int ABTD_xstream_barrier_init(uint32_t num_waiters,
-                              ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_init(uint32_t num_waiters,
+                                            ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_init(p_barrier, NULL, num_waiters);
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
 }
 
-static inline
-int ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_destroy(p_barrier);
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
 }
 
-static inline
-int ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
 {
     return pthread_barrier_wait(p_barrier);
 }

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -15,12 +15,12 @@
 #if defined(ABT_CONFIG_USE_FCONTEXT)
 void ABTD_thread_func_wrapper_thread(void *p_arg);
 void ABTD_thread_func_wrapper_sched(void *p_arg);
-fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func)(void *))
-                         ABT_API_PRIVATE;
+fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func) (void *))
+    ABT_API_PRIVATE;
 void *jump_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
 void *take_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-void init_and_call_fcontext(void *p_arg, void (*f_thread)(void *),
+void init_and_call_fcontext(void *p_arg, void (*f_thread) (void *),
                             void *p_stacktop, fcontext_t *old);
 void ABTD_thread_terminate_thread_no_arg();
 #endif
@@ -31,19 +31,19 @@ void ABTD_thread_func_wrapper(int func_upper, int func_lower,
 #define ABTD_thread_func_wrapper_sched  ABTD_thread_func_wrapper
 #endif
 
-static inline
-int ABTDI_thread_context_create(ABTD_thread_context *p_link,
-                               void (*f_wrapper)(void *),
-                               void (*f_thread)(void *), void *p_arg,
-                               size_t stacksize, void *p_stack,
-                               ABTD_thread_context *p_newctx)
+static inline int ABTDI_thread_context_create(ABTD_thread_context *p_link,
+                                              void (*f_wrapper) (void *),
+                                              void (*f_thread) (void *),
+                                              void *p_arg, size_t stacksize,
+                                              void *p_stack,
+                                              ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     void *p_stacktop;
 
     /* fcontext uses the top address of stack.
-       Note that the parameter, p_stack, points to the bottom of stack. */
+     * Note that the parameter, p_stack, points to the bottom of stack. */
     p_stacktop = (void *)(((char *)p_stack) + stacksize);
 
     p_newctx->fctx = make_fcontext(p_stacktop, stacksize, f_wrapper);
@@ -59,7 +59,8 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     size_t ptr_size, int_size;
 
     /* If stack is NULL, we don't need to make a new context */
-    if (p_stack == NULL) goto fn_exit;
+    if (p_stack == NULL)
+        goto fn_exit;
 
     abt_errno = getcontext(p_newctx);
     ABTI_CHECK_TRUE(!abt_errno, ABT_ERR_THREAD);
@@ -97,11 +98,13 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
 #endif
 }
 
-static inline
-int ABTD_thread_context_create_thread(ABTD_thread_context *p_link,
-                                      void (*f_thread)(void *), void *p_arg,
-                                      size_t stacksize, void *p_stack,
-                                      ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_create_thread(ABTD_thread_context *p_link,
+                                                    void (*f_thread) (void *),
+                                                    void *p_arg,
+                                                    size_t stacksize,
+                                                    void *p_stack,
+                                                    ABTD_thread_context
+                                                    *p_newctx)
 {
     return ABTDI_thread_context_create(p_link, ABTD_thread_func_wrapper_thread,
                                        f_thread, p_arg, stacksize, p_stack,
@@ -109,18 +112,19 @@ int ABTD_thread_context_create_thread(ABTD_thread_context *p_link,
 }
 
 static inline
-int ABTD_thread_context_create_sched(ABTD_thread_context *p_link,
-                                     void (*f_thread)(void *), void *p_arg,
-                                     size_t stacksize, void *p_stack,
-                                     ABTD_thread_context *p_newctx)
+    int ABTD_thread_context_create_sched(ABTD_thread_context *p_link,
+                                         void (*f_thread) (void *),
+                                         void *p_arg,
+                                         size_t stacksize,
+                                         void *p_stack,
+                                         ABTD_thread_context *p_newctx)
 {
     return ABTDI_thread_context_create(p_link, ABTD_thread_func_wrapper_sched,
                                        f_thread, p_arg, stacksize, p_stack,
                                        p_newctx);
 }
 
-static inline
-int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
 #if defined(ABT_CONFIG_USE_FCONTEXT)
@@ -139,10 +143,10 @@ int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-int ABTD_thread_context_init(ABTD_thread_context *p_link,
-                             void (*f_thread)(void *), void *p_arg,
-                             ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_init(ABTD_thread_context *p_link,
+                                           void (*f_thread) (void *),
+                                           void *p_arg,
+                                           ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
 #if defined(ABT_CONFIG_USE_FCONTEXT)
@@ -156,9 +160,9 @@ int ABTD_thread_context_init(ABTD_thread_context *p_link,
 #endif
 }
 
-static inline
-int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
-                                   ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_arm_thread(size_t stacksize,
+                                                 void *p_stack,
+                                                 ABTD_thread_context *p_newctx)
 {
     /* This function *arms* the dynamic promotion thread (initialized by
      * ABTD_thread_context_init) as if it were created by
@@ -167,7 +171,7 @@ int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
     int abt_errno = ABT_SUCCESS;
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     /* fcontext uses the top address of stack.
-       Note that the parameter, p_stack, points to the bottom of stack. */
+     * Note that the parameter, p_stack, points to the bottom of stack. */
     void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     p_newctx->fctx = make_fcontext(p_stacktop, stacksize,
                                    ABTD_thread_func_wrapper_thread);
@@ -181,9 +185,8 @@ int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
 /* Currently, nothing to do */
 #define ABTD_thread_context_free(p_ctx)
 
-static inline
-void ABTD_thread_context_switch(ABTD_thread_context *p_old,
-                                ABTD_thread_context *p_new)
+static inline void ABTD_thread_context_switch(ABTD_thread_context *p_old,
+                                              ABTD_thread_context *p_new)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     jump_fcontext(&p_old->fctx, p_new->fctx, p_new);
@@ -194,9 +197,8 @@ void ABTD_thread_context_switch(ABTD_thread_context *p_old,
 #endif
 }
 
-static inline
-void ABTD_thread_finish_context(ABTD_thread_context *p_old,
-                                ABTD_thread_context *p_new)
+static inline void ABTD_thread_finish_context(ABTD_thread_context *p_old,
+                                              ABTD_thread_context *p_new)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     take_fcontext(&p_old->fctx, p_new->fctx, p_new);
@@ -207,43 +209,41 @@ void ABTD_thread_finish_context(ABTD_thread_context *p_old,
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-void ABTD_thread_context_make_and_call(ABTD_thread_context *p_old,
-                                       void (*f_thread)(void *), void *p_arg,
-                                       void *p_stacktop)
+static inline void ABTD_thread_context_make_and_call(ABTD_thread_context *p_old,
+                                                     void (*f_thread) (void *),
+                                                     void *p_arg,
+                                                     void *p_stacktop)
 {
     init_and_call_fcontext(p_arg, f_thread, p_stacktop, &p_old->fctx);
 }
 
 static inline
-ABT_bool ABTD_thread_context_is_dynamic_promoted(ABTD_thread_context *p_ctx)
+    ABT_bool ABTD_thread_context_is_dynamic_promoted(ABTD_thread_context *p_ctx)
 {
     /* Check if the ULT has been dynamically promoted; internally, it checks if
      * the context is NULL. */
     return p_ctx->fctx ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline
-void ABTDI_thread_context_dynamic_promote(void *p_stacktop, void *jump_f)
+static inline void ABTDI_thread_context_dynamic_promote(void *p_stacktop,
+                                                        void *jump_f)
 {
     /* Perform dynamic promotion */
-    void **p_return_address = (void **)(((char *) p_stacktop) - 0x10);
-    void ***p_stack_pointer = (void ***)(((char *) p_stacktop) - 0x08);
+    void **p_return_address = (void **)(((char *)p_stacktop) - 0x10);
+    void ***p_stack_pointer = (void ***)(((char *)p_stacktop) - 0x08);
     *p_stack_pointer = p_return_address;
     *p_return_address = jump_f;
 }
 
-static inline
-void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
+static inline void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
 {
     void *jump_f = (void *)ABTD_thread_terminate_thread_no_arg;
     ABTDI_thread_context_dynamic_promote(p_stacktop, jump_f);
 }
 #endif
 
-static inline
-void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
-                                     ABTD_thread_context *p_link)
+static inline void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
+                                                   ABTD_thread_context *p_link)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     ABTD_atomic_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
@@ -256,7 +256,7 @@ void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
 
     /* Calulate the position where uc_link is saved. */
     sp = (unsigned long int *)
-         ((uintptr_t)p_ctx->uc_stack.ss_sp + p_ctx->uc_stack.ss_size);
+        ((uintptr_t)p_ctx->uc_stack.ss_sp + p_ctx->uc_stack.ss_size);
     sp -= 1;
     sp = (unsigned long int *)((((uintptr_t)sp) & -16L) - 8);
 
@@ -269,8 +269,8 @@ void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
 #endif
 }
 
-static inline
-void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx, void *arg)
+static inline void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx,
+                                               void *arg)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     p_ctx->p_arg = arg;
@@ -279,8 +279,7 @@ void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx, void *arg)
 #endif
 }
 
-static inline
-void *ABTD_thread_context_get_arg(ABTD_thread_context *p_ctx)
+static inline void *ABTD_thread_context_get_arg(ABTD_thread_context *p_ctx)
 {
 #if defined(ABT_CONFIG_USE_FCONTEXT)
     return p_ctx->p_arg;

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -9,19 +9,19 @@
 #include "abt_config.h"
 
 #if defined(ABT_CONFIG_USE_FCONTEXT)
-typedef void *  fcontext_t;
+typedef void *fcontext_t;
 
 typedef struct abt_ucontext_t {
-    fcontext_t             fctx;    /* actual context */
-    void (*f_thread)(void *);       /* ULT function */
-    void *                 p_arg;   /* ULT function argument */
-    struct abt_ucontext_t *p_link;  /* pointer to scheduler context */
+    fcontext_t fctx;            /* actual context */
+    void (*f_thread) (void *);  /* ULT function */
+    void *p_arg;                /* ULT function argument */
+    struct abt_ucontext_t *p_link;      /* pointer to scheduler context */
 } abt_ucontext_t;
 
 #else
 #define _XOPEN_SOURCE
 #include <ucontext.h>
-typedef ucontext_t  abt_ucontext_t;
+typedef ucontext_t abt_ucontext_t;
 
 #endif
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -80,10 +80,10 @@ enum ABTI_mutex_attr_val {
 };
 
 enum ABTI_stack_type {
-    ABTI_STACK_TYPE_MEMPOOL = 0, /* Stack taken from the memory pool */
-    ABTI_STACK_TYPE_MALLOC,      /* Stack allocated by malloc in Argobots */
-    ABTI_STACK_TYPE_USER,        /* Stack given by a user */
-    ABTI_STACK_TYPE_MAIN,        /* Stack of a main ULT. */
+    ABTI_STACK_TYPE_MEMPOOL = 0,        /* Stack taken from the memory pool */
+    ABTI_STACK_TYPE_MALLOC,     /* Stack allocated by malloc in Argobots */
+    ABTI_STACK_TYPE_USER,       /* Stack given by a user */
+    ABTI_STACK_TYPE_MAIN,       /* Stack of a main ULT. */
 };
 
 /* Macro functions */
@@ -91,45 +91,45 @@ enum ABTI_stack_type {
 
 
 /* Data Types */
-typedef struct ABTI_global          ABTI_global;
-typedef struct ABTI_local           ABTI_local;
-typedef struct ABTI_contn           ABTI_contn;
-typedef struct ABTI_elem            ABTI_elem;
-typedef struct ABTI_xstream         ABTI_xstream;
-typedef enum ABTI_xstream_type      ABTI_xstream_type;
-typedef struct ABTI_xstream_contn   ABTI_xstream_contn;
-typedef struct ABTI_sched           ABTI_sched;
-typedef char *                      ABTI_sched_config;
-typedef enum ABTI_sched_used        ABTI_sched_used;
-typedef void *                      ABTI_sched_id;      /* Scheduler id */
-typedef uint64_t                    ABTI_sched_kind;    /* Scheduler kind */
-typedef struct ABTI_pool            ABTI_pool;
-typedef struct ABTI_unit            ABTI_unit;
-typedef struct ABTI_thread_attr     ABTI_thread_attr;
-typedef struct ABTI_thread          ABTI_thread;
-typedef enum ABTI_thread_type       ABTI_thread_type;
-typedef enum ABTI_stack_type        ABTI_stack_type;
-typedef struct ABTI_thread_req_arg  ABTI_thread_req_arg;
-typedef struct ABTI_thread_list     ABTI_thread_list;
-typedef struct ABTI_thread_entry    ABTI_thread_entry;
-typedef struct ABTI_thread_htable   ABTI_thread_htable;
-typedef struct ABTI_thread_queue    ABTI_thread_queue;
-typedef struct ABTI_task            ABTI_task;
-typedef struct ABTI_key             ABTI_key;
-typedef struct ABTI_ktelem          ABTI_ktelem;
-typedef struct ABTI_ktable          ABTI_ktable;
-typedef struct ABTI_mutex_attr      ABTI_mutex_attr;
-typedef struct ABTI_mutex           ABTI_mutex;
-typedef struct ABTI_cond            ABTI_cond;
-typedef struct ABTI_rwlock          ABTI_rwlock;
-typedef struct ABTI_eventual        ABTI_eventual;
-typedef struct ABTI_future          ABTI_future;
-typedef struct ABTI_barrier         ABTI_barrier;
-typedef struct ABTI_timer           ABTI_timer;
+typedef struct ABTI_global ABTI_global;
+typedef struct ABTI_local ABTI_local;
+typedef struct ABTI_contn ABTI_contn;
+typedef struct ABTI_elem ABTI_elem;
+typedef struct ABTI_xstream ABTI_xstream;
+typedef enum ABTI_xstream_type ABTI_xstream_type;
+typedef struct ABTI_xstream_contn ABTI_xstream_contn;
+typedef struct ABTI_sched ABTI_sched;
+typedef char *ABTI_sched_config;
+typedef enum ABTI_sched_used ABTI_sched_used;
+typedef void *ABTI_sched_id;    /* Scheduler id */
+typedef uint64_t ABTI_sched_kind;       /* Scheduler kind */
+typedef struct ABTI_pool ABTI_pool;
+typedef struct ABTI_unit ABTI_unit;
+typedef struct ABTI_thread_attr ABTI_thread_attr;
+typedef struct ABTI_thread ABTI_thread;
+typedef enum ABTI_thread_type ABTI_thread_type;
+typedef enum ABTI_stack_type ABTI_stack_type;
+typedef struct ABTI_thread_req_arg ABTI_thread_req_arg;
+typedef struct ABTI_thread_list ABTI_thread_list;
+typedef struct ABTI_thread_entry ABTI_thread_entry;
+typedef struct ABTI_thread_htable ABTI_thread_htable;
+typedef struct ABTI_thread_queue ABTI_thread_queue;
+typedef struct ABTI_task ABTI_task;
+typedef struct ABTI_key ABTI_key;
+typedef struct ABTI_ktelem ABTI_ktelem;
+typedef struct ABTI_ktable ABTI_ktable;
+typedef struct ABTI_mutex_attr ABTI_mutex_attr;
+typedef struct ABTI_mutex ABTI_mutex;
+typedef struct ABTI_cond ABTI_cond;
+typedef struct ABTI_rwlock ABTI_rwlock;
+typedef struct ABTI_eventual ABTI_eventual;
+typedef struct ABTI_future ABTI_future;
+typedef struct ABTI_barrier ABTI_barrier;
+typedef struct ABTI_timer ABTI_timer;
 #ifdef ABT_CONFIG_USE_MEM_POOL
-typedef struct ABTI_stack_header    ABTI_stack_header;
-typedef struct ABTI_page_header     ABTI_page_header;
-typedef struct ABTI_sp_header       ABTI_sp_header;
+typedef struct ABTI_stack_header ABTI_stack_header;
+typedef struct ABTI_page_header ABTI_page_header;
+typedef struct ABTI_sp_header ABTI_sp_header;
 #endif
 
 
@@ -138,7 +138,7 @@ typedef struct ABTI_sp_header       ABTI_sp_header;
 
 
 /* Spinlock */
-typedef struct ABTI_spinlock        ABTI_spinlock;
+typedef struct ABTI_spinlock ABTI_spinlock;
 #include "abti_spinlock.h"
 
 
@@ -152,20 +152,21 @@ struct ABTI_mutex_attr {
 };
 
 struct ABTI_mutex {
-    uint32_t val;                   /* 0: unlocked, 1: locked */
-    ABTI_mutex_attr attr;           /* attributes */
-    ABTI_thread_htable *p_htable;   /* a set of queues */
-    ABTI_thread *p_handover;        /* next ULT for the mutex handover */
-    ABTI_thread *p_giver;           /* current ULT that hands over the mutex */
+    uint32_t val;               /* 0: unlocked, 1: locked */
+    ABTI_mutex_attr attr;       /* attributes */
+    ABTI_thread_htable *p_htable;       /* a set of queues */
+    ABTI_thread *p_handover;    /* next ULT for the mutex handover */
+    ABTI_thread *p_giver;       /* current ULT that hands over the mutex */
 };
 
 struct ABTI_global {
-    int max_xstreams;            /* Max. size of p_xstreams */
-    int num_xstreams;            /* Current # of ESs */
-    ABTI_xstream **p_xstreams;   /* ES array */
-    ABTI_spinlock xstreams_lock; /* Spinlock protecting p_xstreams. Any write
-                                  * to p_xstreams and p_xstreams[*] requires a
-                                  * lock. Dereference does not require a lock.*/
+    int max_xstreams;           /* Max. size of p_xstreams */
+    int num_xstreams;           /* Current # of ESs */
+    ABTI_xstream **p_xstreams;  /* ES array */
+    ABTI_spinlock xstreams_lock;        /* Spinlock protecting p_xstreams. Any
+                                         * write to p_xstreams and p_xstreams[*]
+                                         * requires a lock. Dereference does not
+                                         * require a lock.*/
 
     int num_cores;              /* Number of CPU cores */
     ABT_bool set_affinity;      /* Whether CPU affinity is used */
@@ -178,19 +179,19 @@ struct ABTI_global {
     long sched_sleep_nsec;      /* Default nanoseconds for scheduler sleep */
     ABTI_thread *p_thread_main; /* ULT of the main function */
 
-    uint32_t mutex_max_handovers;      /* Default max. # of local handovers */
-    uint32_t mutex_max_wakeups;        /* Default max. # of wakeups */
-    uint32_t os_page_size;             /* OS page size */
-    uint32_t huge_page_size;           /* Huge page size */
+    uint32_t mutex_max_handovers;       /* Default max. # of local handovers */
+    uint32_t mutex_max_wakeups; /* Default max. # of wakeups */
+    uint32_t os_page_size;      /* OS page size */
+    uint32_t huge_page_size;    /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    ABTI_spinlock mem_task_lock;       /* Spinlock protecting p_mem_task */
-    uint32_t mem_page_size;            /* Page size for memory allocation */
-    uint32_t mem_sp_size;              /* Stack page size */
-    uint32_t mem_max_stacks;           /* Max. # of stacks kept in each ES */
-    int mem_lp_alloc;                  /* How to allocate large pages */
-    ABTI_stack_header *p_mem_stack;    /* List of ULT stack */
-    ABTI_page_header *p_mem_task;      /* List of task block pages */
-    ABTI_sp_header *p_mem_sph;         /* List of stack pages */
+    ABTI_spinlock mem_task_lock;        /* Spinlock protecting p_mem_task */
+    uint32_t mem_page_size;     /* Page size for memory allocation */
+    uint32_t mem_sp_size;       /* Stack page size */
+    uint32_t mem_max_stacks;    /* Max. # of stacks kept in each ES */
+    int mem_lp_alloc;           /* How to allocate large pages */
+    ABTI_stack_header *p_mem_stack;     /* List of ULT stack */
+    ABTI_page_header *p_mem_task;       /* List of task block pages */
+    ABTI_sp_header *p_mem_sph;  /* List of stack pages */
 #endif
 
     ABT_bool pm_connected;      /* Is power mgmt. daemon connected? */
@@ -211,7 +212,7 @@ struct ABTI_local {
     ABTI_task *p_task;          /* Current running tasklet */
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    uint32_t num_stacks;                /* Current # of stacks */
+    uint32_t num_stacks;        /* Current # of stacks */
     ABTI_stack_header *p_mem_stack;     /* Free stack list */
     ABTI_page_header *p_mem_task_head;  /* Head of page list */
     ABTI_page_header *p_mem_task_tail;  /* Tail of page list */
@@ -219,17 +220,17 @@ struct ABTI_local {
 };
 
 struct ABTI_contn {
-    size_t     num_elems; /* Number of elements */
-    ABTI_elem *p_head;    /* The first element */
-    ABTI_elem *p_tail;    /* The last element */
+    size_t num_elems;           /* Number of elements */
+    ABTI_elem *p_head;          /* The first element */
+    ABTI_elem *p_tail;          /* The last element */
 };
 
 struct ABTI_elem {
-    ABTI_contn   *p_contn; /* Container to which this element belongs */
-    ABT_unit_type type;    /* Object type */
-    void         *p_obj;   /* Object */
-    ABTI_elem    *p_prev;  /* Previous element in list */
-    ABTI_elem    *p_next;  /* Next element in list */
+    ABTI_contn *p_contn;        /* Container to which this element belongs */
+    ABT_unit_type type;         /* Object type */
+    void *p_obj;                /* Object */
+    ABTI_elem *p_prev;          /* Previous element in list */
+    ABTI_elem *p_next;          /* Next element in list */
 };
 
 struct ABTI_xstream {
@@ -250,10 +251,10 @@ struct ABTI_xstream {
 };
 
 struct ABTI_xstream_contn {
-    ABTI_contn *created; /* ESes in CREATED state */
-    ABTI_contn *active;  /* ESes in READY or RUNNING state */
-    ABTI_contn *deads;   /* ESes in TERMINATED state but not freed */
-    ABTI_mutex mutex;    /* Mutex */
+    ABTI_contn *created;        /* ESes in CREATED state */
+    ABTI_contn *active;         /* ESes in READY or RUNNING state */
+    ABTI_contn *deads;          /* ESes in TERMINATED state but not freed */
+    ABTI_mutex mutex;           /* Mutex */
 };
 
 struct ABTI_sched {
@@ -272,7 +273,7 @@ struct ABTI_sched {
 
     /* Scheduler functions */
     ABT_sched_init_fn init;
-    ABT_sched_run_fn  run;
+    ABT_sched_run_fn run;
     ABT_sched_free_fn free;
     ABT_sched_get_migr_pool_fn get_migr_pool;
 
@@ -282,39 +283,39 @@ struct ABTI_sched {
 };
 
 struct ABTI_pool {
-    ABT_pool_access access;  /* Access mode */
-    ABT_bool automatic;      /* To know if automatic data free */
-    int32_t num_scheds;      /* Number of associated schedulers */
-                             /* NOTE: int32_t to check if still positive */
+    ABT_pool_access access;     /* Access mode */
+    ABT_bool automatic;         /* To know if automatic data free */
+    int32_t num_scheds;         /* Number of associated schedulers */
+    /* NOTE: int32_t to check if still positive */
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    ABTI_xstream *consumer;  /* Associated consumer ES */
+    ABTI_xstream *consumer;     /* Associated consumer ES */
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    ABTI_xstream *producer;  /* Associated producer ES */
+    ABTI_xstream *producer;     /* Associated producer ES */
 #endif
-    uint32_t num_blocked;    /* Number of blocked ULTs */
-    int32_t num_migrations;  /* Number of migrating ULTs */
-    void *data;              /* Specific data */
-    uint64_t id;             /* ID */
+    uint32_t num_blocked;       /* Number of blocked ULTs */
+    int32_t num_migrations;     /* Number of migrating ULTs */
+    void *data;                 /* Specific data */
+    uint64_t id;                /* ID */
 
     /* Functions to manage units */
-    ABT_unit_get_type_fn           u_get_type;
-    ABT_unit_get_thread_fn         u_get_thread;
-    ABT_unit_get_task_fn           u_get_task;
-    ABT_unit_is_in_pool_fn         u_is_in_pool;
+    ABT_unit_get_type_fn u_get_type;
+    ABT_unit_get_thread_fn u_get_thread;
+    ABT_unit_get_task_fn u_get_task;
+    ABT_unit_is_in_pool_fn u_is_in_pool;
     ABT_unit_create_from_thread_fn u_create_from_thread;
-    ABT_unit_create_from_task_fn   u_create_from_task;
-    ABT_unit_free_fn               u_free;
+    ABT_unit_create_from_task_fn u_create_from_task;
+    ABT_unit_free_fn u_free;
 
     /* Functions to manage the pool */
-    ABT_pool_init_fn               p_init;
-    ABT_pool_get_size_fn           p_get_size;
-    ABT_pool_push_fn               p_push;
-    ABT_pool_pop_fn                p_pop;
-    ABT_pool_pop_timedwait_fn      p_pop_timedwait;
-    ABT_pool_remove_fn             p_remove;
-    ABT_pool_free_fn               p_free;
-    ABT_pool_print_all_fn          p_print_all;
+    ABT_pool_init_fn p_init;
+    ABT_pool_get_size_fn p_get_size;
+    ABT_pool_push_fn p_push;
+    ABT_pool_pop_fn p_pop;
+    ABT_pool_pop_timedwait_fn p_pop_timedwait;
+    ABT_pool_remove_fn p_remove;
+    ABT_pool_free_fn p_free;
+    ABT_pool_print_all_fn p_print_all;
 };
 
 struct ABTI_unit {
@@ -323,40 +324,40 @@ struct ABTI_unit {
     ABT_pool pool;
     union {
         ABT_thread thread;
-        ABT_task   task;
+        ABT_task task;
     };
     ABT_unit_type type;
 };
 
 struct ABTI_thread_attr {
-    void *p_stack;                      /* Stack address */
-    size_t stacksize;                   /* Stack size (in bytes) */
-    ABTI_stack_type stacktype;          /* Stack type */
+    void *p_stack;              /* Stack address */
+    size_t stacksize;           /* Stack size (in bytes) */
+    ABTI_stack_type stacktype;  /* Stack type */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABT_bool migratable;                /* Migratability */
-    void (*f_cb)(ABT_thread, void *);   /* Callback function */
-    void *p_cb_arg;                     /* Callback function argument */
+    ABT_bool migratable;        /* Migratability */
+    void (*f_cb) (ABT_thread, void *);  /* Callback function */
+    void *p_cb_arg;             /* Callback function argument */
 #endif
 };
 
 struct ABTI_thread {
-    ABTD_thread_context ctx;        /* Context */
-    ABTI_unit unit_def;             /* Internal unit definition */
-    ABT_thread_state state;         /* State */
-    uint32_t request;               /* Request */
-    ABTI_xstream *p_last_xstream;   /* Last ES where it ran */
+    ABTD_thread_context ctx;    /* Context */
+    ABTI_unit unit_def;         /* Internal unit definition */
+    ABT_thread_state state;     /* State */
+    uint32_t request;           /* Request */
+    ABTI_xstream *p_last_xstream;       /* Last ES where it ran */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched;           /* If it is a scheduler, its ptr */
+    ABTI_sched *is_sched;       /* If it is a scheduler, its ptr */
 #endif
-    ABT_unit unit;                  /* Unit enclosing this thread */
-    ABTI_pool *p_pool;              /* Associated pool */
-    uint32_t refcount;              /* Reference count */
-    ABTI_thread_type type;          /* Type */
-    ABTI_thread_req_arg *p_req_arg; /* Request argument */
-    ABTI_spinlock lock;             /* Spinlock */
-    ABTI_ktable *p_keytable;        /* ULT-specific data */
-    ABTI_thread_attr attr;          /* Attributes */
-    ABT_thread_id id;               /* ID */
+    ABT_unit unit;              /* Unit enclosing this thread */
+    ABTI_pool *p_pool;          /* Associated pool */
+    uint32_t refcount;          /* Reference count */
+    ABTI_thread_type type;      /* Type */
+    ABTI_thread_req_arg *p_req_arg;     /* Request argument */
+    ABTI_spinlock lock;         /* Spinlock */
+    ABTI_ktable *p_keytable;    /* ULT-specific data */
+    ABTI_thread_attr attr;      /* Attributes */
+    ABT_thread_id id;           /* ID */
 };
 
 struct ABTI_thread_req_arg {
@@ -377,27 +378,27 @@ struct ABTI_thread_entry {
 };
 
 struct ABTI_task {
-    ABTI_xstream *p_xstream;   /* Associated ES */
-    ABT_task_state state;      /* State */
-    uint32_t request;          /* Request */
-    void (*f_task)(void *);    /* Task function */
-    void *p_arg;               /* Task arguments */
+    ABTI_xstream *p_xstream;    /* Associated ES */
+    ABT_task_state state;       /* State */
+    uint32_t request;           /* Request */
+    void (*f_task) (void *);    /* Task function */
+    void *p_arg;                /* Task arguments */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched;      /* If it is a scheduler, its ptr */
+    ABTI_sched *is_sched;       /* If it is a scheduler, its ptr */
 #endif
-    ABTI_pool *p_pool;         /* Associated pool */
-    ABT_unit unit;             /* Unit enclosing this task */
-    ABTI_unit unit_def;        /* Internal unit definition */
-    uint32_t refcount;         /* Reference count */
-    ABTI_ktable *p_keytable;   /* Tasklet-specific data */
+    ABTI_pool *p_pool;          /* Associated pool */
+    ABT_unit unit;              /* Unit enclosing this task */
+    ABTI_unit unit_def;         /* Internal unit definition */
+    uint32_t refcount;          /* Reference count */
+    ABTI_ktable *p_keytable;    /* Tasklet-specific data */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABT_bool migratable;       /* Migratability */
+    ABT_bool migratable;        /* Migratability */
 #endif
-    uint64_t id;               /* ID */
+    uint64_t id;                /* ID */
 };
 
 struct ABTI_key {
-    void (*f_destructor)(void *value);
+    void (*f_destructor) (void *value);
     uint32_t id;
     uint32_t refcount;          /* Reference count */
     ABT_bool freed;             /* TRUE: freed, FALSE: not */
@@ -425,7 +426,7 @@ struct ABTI_cond {
 
 struct ABTI_rwlock {
     ABTI_mutex mutex;
-    ABTI_cond  cond;
+    ABTI_cond cond;
     size_t reader_count;
     int write_flag;
 };
@@ -445,7 +446,7 @@ struct ABTI_future {
     uint32_t counter;
     uint32_t compartments;
     void **array;
-    void (*p_callback)(void **arg);
+    void (*p_callback) (void **arg);
     ABTI_unit *p_head;          /* Head of waiters */
     ABTI_unit *p_tail;          /* Tail of waiters */
 };
@@ -478,27 +479,27 @@ int ABTI_local_init(void);
 int ABTI_local_finalize(void);
 
 /* Container */
-void       ABTI_contn_create(ABTI_contn **pp_contn);
-int        ABTI_contn_free(ABTI_contn **pp_contn);
-size_t     ABTI_contn_get_size(ABTI_contn *p_contn);
-void       ABTI_contn_push(ABTI_contn *p_contn, ABTI_elem *p_elem);
+void ABTI_contn_create(ABTI_contn **pp_contn);
+int ABTI_contn_free(ABTI_contn **pp_contn);
+size_t ABTI_contn_get_size(ABTI_contn *p_contn);
+void ABTI_contn_push(ABTI_contn *p_contn, ABTI_elem *p_elem);
 ABTI_elem *ABTI_contn_pop(ABTI_contn *p_contn);
-void       ABTI_contn_remove(ABTI_contn *p_contn, ABTI_elem *p_elem);
-void       ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent,
-                            ABT_bool detail);
+void ABTI_contn_remove(ABTI_contn *p_contn, ABTI_elem *p_elem);
+void ABTI_contn_print(ABTI_contn *p_contn, FILE *p_os, int indent,
+                      ABT_bool detail);
 
 /* Element */
 ABT_unit_type ABTI_elem_get_type(ABTI_elem *p_elem);
 ABTI_xstream *ABTI_elem_get_xstream(ABTI_elem *p_elem);
-ABTI_thread  *ABTI_elem_get_thread(ABTI_elem *p_elem);
-ABTI_task    *ABTI_elem_get_task(ABTI_elem *p_elem);
-ABTI_elem    *ABTI_elem_get_next(ABTI_elem *p_elem);
-ABTI_elem    *ABTI_elem_create_from_xstream(ABTI_xstream *p_xstream);
-ABTI_elem    *ABTI_elem_create_from_thread(ABTI_thread *p_thread);
-ABTI_elem    *ABTI_elem_create_from_task(ABTI_task *p_task);
-void          ABTI_elem_free(ABTI_elem **pp_elem);
-void          ABTI_elem_print(ABTI_elem *p_elem, FILE *p_os, int indent,
-                              ABT_bool detail);
+ABTI_thread *ABTI_elem_get_thread(ABTI_elem *p_elem);
+ABTI_task *ABTI_elem_get_task(ABTI_elem *p_elem);
+ABTI_elem *ABTI_elem_get_next(ABTI_elem *p_elem);
+ABTI_elem *ABTI_elem_create_from_xstream(ABTI_xstream *p_xstream);
+ABTI_elem *ABTI_elem_create_from_thread(ABTI_thread *p_thread);
+ABTI_elem *ABTI_elem_create_from_task(ABTI_task *p_task);
+void ABTI_elem_free(ABTI_elem **pp_elem);
+void ABTI_elem_print(ABTI_elem *p_elem, FILE *p_os, int indent,
+                     ABT_bool detail);
 
 /* Execution Stream (ES) */
 int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream);
@@ -556,29 +557,29 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
 
 /* User-level Thread (ULT)  */
-int   ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool);
-int   ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread);
-int   ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
-int   ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched);
-void  ABTI_thread_free(ABTI_thread *p_thread);
-void  ABTI_thread_free_main(ABTI_thread *p_thread);
-void  ABTI_thread_free_main_sched(ABTI_thread *p_thread);
-int   ABTI_thread_set_blocked(ABTI_thread *p_thread);
-void  ABTI_thread_suspend(ABTI_thread *p_thread);
-int   ABTI_thread_set_ready(ABTI_thread *p_thread);
-void  ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
-int   ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
+int ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool);
+int ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread);
+int ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
+int ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched);
+void ABTI_thread_free(ABTI_thread *p_thread);
+void ABTI_thread_free_main(ABTI_thread *p_thread);
+void ABTI_thread_free_main_sched(ABTI_thread *p_thread);
+int ABTI_thread_set_blocked(ABTI_thread *p_thread);
+void ABTI_thread_suspend(ABTI_thread *p_thread);
+int ABTI_thread_set_ready(ABTI_thread *p_thread);
+void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
+int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-void  ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
+void ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
 void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);
-void  ABTI_thread_put_req_arg(ABTI_thread *p_thread,
-                              ABTI_thread_req_arg *p_req_arg);
+void ABTI_thread_put_req_arg(ABTI_thread *p_thread,
+                             ABTI_thread_req_arg *p_req_arg);
 ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
                                              uint32_t req);
 #endif
-void  ABTI_thread_retain(ABTI_thread *p_thread);
-void  ABTI_thread_release(ABTI_thread *p_thread);
-void  ABTI_thread_reset_id(void);
+void ABTI_thread_retain(ABTI_thread *p_thread);
+void ABTI_thread_release(ABTI_thread *p_thread);
+void ABTI_thread_reset_id(void);
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread);
 ABT_thread_id ABTI_thread_self_id(void);
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread);
@@ -597,7 +598,7 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
 ABT_bool ABTI_thread_htable_add(ABTI_thread_htable *p_htable, int idx,
                                 ABTI_thread *p_thread);
 void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
-                             ABTI_thread *p_thread);
+                                 ABTI_thread *p_thread);
 ABT_bool ABTI_thread_htable_add_low(ABTI_thread_htable *p_htable, int idx,
                                     ABTI_thread *p_thread);
 ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,

--- a/src/include/abti_barrier.h
+++ b/src/include/abti_barrier.h
@@ -9,8 +9,7 @@
 /* Inlined functions for Barrier */
 
 /* Barrier */
-static inline
-ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
+static inline ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_barrier *p_barrier;
@@ -25,8 +24,7 @@ ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
 #endif
 }
 
-static inline
-ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
+static inline ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_barrier h_barrier;
@@ -42,4 +40,3 @@ ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
 }
 
 #endif /* BARRIER_H_INCLUDED */
-

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -10,18 +10,16 @@
 
 /* Inlined functions for Condition Variable  */
 
-static inline
-void ABTI_cond_init(ABTI_cond *p_cond)
+static inline void ABTI_cond_init(ABTI_cond *p_cond)
 {
     ABTI_spinlock_create(&p_cond->lock);
     p_cond->p_waiter_mutex = NULL;
-    p_cond->num_waiters  = 0;
+    p_cond->num_waiters = 0;
     p_cond->p_head = NULL;
     p_cond->p_tail = NULL;
 }
 
-static inline
-void ABTI_cond_fini(ABTI_cond *p_cond)
+static inline void ABTI_cond_fini(ABTI_cond *p_cond)
 {
     /* The lock needs to be acquired to safely free the condition structure.
      * However, we do not have to unlock it because the entire structure is
@@ -31,8 +29,7 @@ void ABTI_cond_fini(ABTI_cond *p_cond)
     ABTI_spinlock_free(&p_cond->lock);
 }
 
-static inline
-ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
+static inline ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_cond *p_cond;
@@ -47,8 +44,7 @@ ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
 #endif
 }
 
-static inline
-ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
+static inline ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_cond h_cond;
@@ -63,8 +59,7 @@ ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 #endif
 }
 
-static inline
-int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
+static inline int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -130,7 +125,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
         /* Suspend the current ULT */
         ABTI_thread_suspend(p_thread);
 
-    } else { /* TYPE == ABT_UNIT_TYPE_EXT */
+    } else {    /* TYPE == ABT_UNIT_TYPE_EXT */
         ABTI_spinlock_release(&p_cond->lock);
         ABTI_mutex_unlock(p_mutex);
 
@@ -151,8 +146,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
     goto fn_exit;
 }
 
-static inline
-void ABTI_cond_broadcast(ABTI_cond *p_cond)
+static inline void ABTI_cond_broadcast(ABTI_cond *p_cond)
 {
     ABTI_spinlock_acquire(&p_cond->lock);
 
@@ -196,4 +190,3 @@ void ABTI_cond_broadcast(ABTI_cond *p_cond)
 }
 
 #endif /* COND_H_INCLUDED */
-

--- a/src/include/abti_config.h
+++ b/src/include/abti_config.h
@@ -9,7 +9,7 @@
 /* Inlined functions for Config */
 
 static inline
-ABTI_sched_config *ABTI_sched_config_get_ptr(ABT_sched_config config)
+    ABTI_sched_config *ABTI_sched_config_get_ptr(ABT_sched_config config)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_sched_config *p_config;
@@ -25,7 +25,7 @@ ABTI_sched_config *ABTI_sched_config_get_ptr(ABT_sched_config config)
 }
 
 static inline
-ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
+    ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_sched_config h_config;
@@ -41,4 +41,3 @@ ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
 }
 
 #endif /* CONFIG_H_INCLUDED */
-

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -21,7 +21,7 @@
             abt_errno = ABT_ERR_UNINITIALIZED;  \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_INITIALIZED()
 #endif
@@ -40,7 +40,7 @@
             HANDLE_ERROR(msg);                  \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_ERROR_MSG(abt_errno,msg)
 #endif
@@ -52,13 +52,13 @@
             abt_errno = (val);                  \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #define ABTI_CHECK_TRUE_RET(cond,val)           \
     do {                                        \
         if (!(cond)) {                          \
             return (val);                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_TRUE(cond,val)
 #define ABTI_CHECK_TRUE_RET(cond,val)
@@ -72,14 +72,14 @@
             HANDLE_ERROR(msg);                  \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)   \
     do {                                        \
         if (!(cond)) {                          \
             HANDLE_ERROR(msg);                  \
             return (val);                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_TRUE_MSG(cond,val,msg)
 #define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)
@@ -92,7 +92,7 @@
             abt_errno = ABT_ERR_INV_XSTREAM;    \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_XSTREAM_PTR(p)
 #endif
@@ -104,7 +104,7 @@
             abt_errno = ABT_ERR_INV_POOL;       \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_POOL_PTR(p)
 #endif
@@ -116,7 +116,7 @@
             abt_errno = ABT_ERR_INV_SCHED;      \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_SCHED_PTR(p)
 #endif
@@ -128,7 +128,7 @@
             abt_errno = ABT_ERR_INV_THREAD;     \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_THREAD_PTR(p)
 #endif
@@ -140,7 +140,7 @@
             abt_errno = ABT_ERR_INV_THREAD_ATTR;    \
             goto fn_fail;                           \
         }                                           \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)
 #endif
@@ -152,7 +152,7 @@
             abt_errno = ABT_ERR_INV_TASK;       \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_TASK_PTR(p)
 #endif
@@ -164,7 +164,7 @@
             abt_errno = ABT_ERR_INV_KEY;        \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_KEY_PTR(p)
 #endif
@@ -176,7 +176,7 @@
             abt_errno = ABT_ERR_INV_MUTEX;      \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_MUTEX_PTR(p)
 #endif
@@ -188,7 +188,7 @@
             abt_errno = ABT_ERR_INV_MUTEX_ATTR; \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)
 #endif
@@ -200,7 +200,7 @@
             abt_errno = ABT_ERR_INV_COND;       \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_COND_PTR(p)
 #endif
@@ -212,14 +212,14 @@
             abt_errno = ABT_ERR_INV_RWLOCK;       \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_RWLOCK_PTR(p) \
     do {                              \
         if (0) {                      \
             goto fn_fail;             \
         }                             \
-    } while(0)
+    } while (0)
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
@@ -229,7 +229,7 @@
             abt_errno = ABT_ERR_INV_FUTURE;     \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_FUTURE_PTR(p)
 #endif
@@ -241,7 +241,7 @@
             abt_errno = ABT_ERR_INV_EVENTUAL;   \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_EVENTUAL_PTR(p)
 #endif
@@ -265,21 +265,18 @@
             abt_errno = ABT_ERR_INV_TIMER;      \
             goto fn_fail;                       \
         }                                       \
-    } while(0)
+    } while (0)
 #else
 #define ABTI_CHECK_NULL_TIMER_PTR(p)
 #endif
 
 #define HANDLE_ERROR(msg) \
     fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg)
-    //fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); exit(-1)
 
 #define HANDLE_ERROR_WITH_CODE(msg,n) \
     fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n)
-    //fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n); exit(-1)
 
 #define HANDLE_ERROR_FUNC_WITH_CODE(n) \
     fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n)
-    //fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n); exit(-1)
 
 #endif /* ABTI_ERROR_H_INCLUDED */

--- a/src/include/abti_eventual.h
+++ b/src/include/abti_eventual.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Eventual */
 
-static inline
-ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
+static inline ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_eventual *p_eventual;
@@ -24,8 +23,7 @@ ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
 #endif
 }
 
-static inline
-ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
+static inline ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_eventual h_eventual;
@@ -41,4 +39,3 @@ ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
 }
 
 #endif /* EVENTUAL_H_INCLUDED */
-

--- a/src/include/abti_future.h
+++ b/src/include/abti_future.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Future */
 
-static inline
-ABTI_future *ABTI_future_get_ptr(ABT_future future)
+static inline ABTI_future *ABTI_future_get_ptr(ABT_future future)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_future *p_future;
@@ -24,8 +23,7 @@ ABTI_future *ABTI_future_get_ptr(ABT_future future)
 #endif
 }
 
-static inline
-ABT_future ABTI_future_get_handle(ABTI_future *p_future)
+static inline ABT_future ABTI_future_get_handle(ABTI_future *p_future)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_future h_future;
@@ -41,4 +39,3 @@ ABT_future ABTI_future_get_handle(ABTI_future *p_future)
 }
 
 #endif /* FUTURE_H_INCLUDED */
-

--- a/src/include/abti_global.h
+++ b/src/include/abti_global.h
@@ -8,47 +8,39 @@
 
 /* Inlined functions for Global Data */
 
-static inline
-size_t ABTI_global_get_thread_stacksize(void)
+static inline size_t ABTI_global_get_thread_stacksize(void)
 {
     return gp_ABTI_global->thread_stacksize;
 }
 
-static inline
-size_t ABTI_global_get_sched_stacksize(void)
+static inline size_t ABTI_global_get_sched_stacksize(void)
 {
     return gp_ABTI_global->sched_stacksize;
 }
 
-static inline
-size_t ABTI_global_get_sched_event_freq(void)
+static inline size_t ABTI_global_get_sched_event_freq(void)
 {
     return gp_ABTI_global->sched_event_freq;
 }
 
-static inline
-long ABTI_global_get_sched_sleep_nsec(void)
+static inline long ABTI_global_get_sched_sleep_nsec(void)
 {
     return gp_ABTI_global->sched_sleep_nsec;
 }
 
-static inline
-ABTI_thread *ABTI_global_get_main(void)
+static inline ABTI_thread *ABTI_global_get_main(void)
 {
     return gp_ABTI_global->p_thread_main;
 }
 
-static inline
-uint32_t ABTI_global_get_mutex_max_handovers(void)
+static inline uint32_t ABTI_global_get_mutex_max_handovers(void)
 {
     return gp_ABTI_global->mutex_max_handovers;
 }
 
-static inline
-uint32_t ABTI_global_get_mutex_max_wakeups(void)
+static inline uint32_t ABTI_global_get_mutex_max_wakeups(void)
 {
     return gp_ABTI_global->mutex_max_wakeups;
 }
 
 #endif /* GLOBAL_H_INCLUDED */
-

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Work unit-specific data key */
 
-static inline
-ABTI_key *ABTI_key_get_ptr(ABT_key key)
+static inline ABTI_key *ABTI_key_get_ptr(ABT_key key)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_key *p_key;
@@ -24,8 +23,7 @@ ABTI_key *ABTI_key_get_ptr(ABT_key key)
 #endif
 }
 
-static inline
-ABT_key ABTI_key_get_handle(ABTI_key *p_key)
+static inline ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_key h_key;
@@ -41,4 +39,3 @@ ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 }
 
 #endif /* KEY_H_INCLUDED */
-

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -8,35 +8,34 @@
 
 /* Inlined functions for ES Local Data */
 
-static inline
-ABTI_xstream *ABTI_local_get_xstream(void) {
+static inline ABTI_xstream *ABTI_local_get_xstream(void)
+{
     return lp_ABTI_local->p_xstream;
 }
 
-static inline
-void ABTI_local_set_xstream(ABTI_xstream *p_xstream) {
+static inline void ABTI_local_set_xstream(ABTI_xstream *p_xstream)
+{
     lp_ABTI_local->p_xstream = p_xstream;
 }
 
-static inline
-ABTI_thread *ABTI_local_get_thread(void) {
+static inline ABTI_thread *ABTI_local_get_thread(void)
+{
     return lp_ABTI_local->p_thread;
 }
 
-static inline
-void ABTI_local_set_thread(ABTI_thread *p_thread) {
+static inline void ABTI_local_set_thread(ABTI_thread *p_thread)
+{
     lp_ABTI_local->p_thread = p_thread;
 }
 
-static inline
-ABTI_task *ABTI_local_get_task(void) {
+static inline ABTI_task *ABTI_local_get_task(void)
+{
     return lp_ABTI_local->p_task;
 }
 
-static inline
-void ABTI_local_set_task(ABTI_task *p_task) {
+static inline void ABTI_local_set_task(ABTI_task *p_task)
+{
     lp_ABTI_local->p_task = p_task;
 }
 
 #endif /* LOCAL_H_INCLUDED */
-

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -21,7 +21,7 @@
                           * ABT_CONFIG_STATIC_CACHELINE_SIZE)
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-typedef struct ABTI_blk_header  ABTI_blk_header;
+typedef struct ABTI_blk_header ABTI_blk_header;
 
 enum {
     ABTI_MEM_LP_MALLOC = 0,
@@ -101,8 +101,8 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize);
 
 /* Inline functions */
 static inline
-ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
-                                                  ABTI_thread_attr *p_attr)
+    ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
+                                                      ABTI_thread_attr *p_attr)
 {
     size_t actual_stacksize;
     char *p_blk;
@@ -137,8 +137,7 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
+static inline ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
 {
     /* Basic idea: allocate a memory for stack and use the first some memory as
      * ABTI_stack_header and ABTI_thread. So, the effective stack area is
@@ -217,7 +216,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
 
     /* Get the ABTI_thread pointer and stack pointer */
     p_thread = (ABTI_thread *)p_blk;
-    p_stack  = p_sh->p_stack;
+    p_stack = p_sh->p_stack;
 
     /* Set attributes */
     if (p_attr == NULL) {
@@ -234,8 +233,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
     return p_thread;
 }
 
-static inline
-void ABTI_mem_free_thread(ABTI_thread *p_thread)
+static inline void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
     ABTI_local *p_local;
     ABTI_stack_header *p_sh;
@@ -266,8 +264,7 @@ void ABTI_mem_free_thread(ABTI_thread *p_thread)
     }
 }
 
-static inline
-ABTI_task *ABTI_mem_alloc_task(void)
+static inline ABTI_task *ABTI_mem_alloc_task(void)
 {
     ABTI_task *p_task = NULL;
     ABTI_local *p_local = lp_ABTI_local;
@@ -287,7 +284,8 @@ ABTI_task *ABTI_mem_alloc_task(void)
     /* Find the page that has an empty block */
     ABTI_page_header *p_ph = p_local->p_mem_task_head;
     while (p_ph) {
-        if (p_ph->p_head) break;
+        if (p_ph->p_head)
+            break;
         if (p_ph->p_free) {
             ABTI_mem_take_free(p_ph);
             break;
@@ -323,8 +321,7 @@ ABTI_task *ABTI_mem_alloc_task(void)
     return p_task;
 }
 
-static inline
-void ABTI_mem_free_task(ABTI_task *p_task)
+static inline void ABTI_mem_free_task(ABTI_task *p_task)
 {
     ABTI_local *p_local;
     ABTI_blk_header *p_head;
@@ -368,7 +365,7 @@ void ABTI_mem_free_task(ABTI_task *p_task)
 #define ABTI_mem_finalize_local(p)
 
 static inline
-ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
+    ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
 {
     size_t stacksize, actual_stacksize;
     char *p_blk;
@@ -394,8 +391,8 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
+static inline ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr,
+                                                 size_t *p_stacksize)
 {
     ABTI_thread *p_thread;
 
@@ -428,8 +425,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
+static inline ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
 {
     ABTI_thread *p_thread;
 
@@ -443,21 +439,18 @@ ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
     return p_thread;
 }
 
-static inline
-void ABTI_mem_free_thread(ABTI_thread *p_thread)
+static inline void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
     ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
     ABTU_free(p_thread);
 }
 
-static inline
-ABTI_task *ABTI_mem_alloc_task(void)
+static inline ABTI_task *ABTI_mem_alloc_task(void)
 {
     return (ABTI_task *)ABTU_CA_MALLOC(sizeof(ABTI_task));
 }
 
-static inline
-void ABTI_mem_free_task(ABTI_task *p_task)
+static inline void ABTI_mem_free_task(ABTI_task *p_task)
 {
     ABTU_free(p_task);
 }
@@ -465,4 +458,3 @@ void ABTI_mem_free_task(ABTI_task *p_task)
 #endif /* ABT_CONFIG_USE_MEM_POOL */
 
 #endif /* ABTI_MEM_H_INCLUDED */
-

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -6,8 +6,7 @@
 #ifndef MUTEX_H_INCLUDED
 #define MUTEX_H_INCLUDED
 
-static inline
-ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
+static inline ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_mutex *p_mutex;
@@ -22,8 +21,7 @@ ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
 #endif
 }
 
-static inline
-ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
+static inline ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_mutex h_mutex;
@@ -38,8 +36,7 @@ ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline
-void ABTI_mutex_init(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_init(ABTI_mutex *p_mutex)
 {
     p_mutex->val = 0;
     p_mutex->attr.attrs = ABTI_MUTEX_ATTR_NONE;
@@ -55,15 +52,13 @@ void ABTI_mutex_init(ABTI_mutex *p_mutex)
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
 #define ABTI_mutex_fini(p_mutex)
 #else
-static inline
-void ABTI_mutex_fini(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_fini(ABTI_mutex *p_mutex)
 {
     ABTI_thread_htable_free(p_mutex->p_htable);
 }
 #endif
 
-static inline
-void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
 {
     /* ABTI_spinlock_ functions cannot be used since p_mutex->val can take
      * other values (i.e., not UNLOCKED nor LOCKED.) */
@@ -73,8 +68,7 @@ void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
     LOG_EVENT("%p: spinlock\n", p_mutex);
 }
 
-static inline
-void ABTI_mutex_lock(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_lock(ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABT_unit_type type;
@@ -132,7 +126,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     }
 
   fn_exit:
-    return ;
+    return;
 
   fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
@@ -140,8 +134,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline
-int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
+static inline int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
 {
     if (!ABTD_atomic_bool_cas_strong_uint32(&p_mutex->val, 0, 1)) {
         return ABT_ERR_MUTEX_LOCKED;
@@ -149,8 +142,7 @@ int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
     return ABT_SUCCESS;
 }
 
-static inline
-void ABTI_mutex_unlock(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_unlock(ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTD_atomic_mem_barrier();
@@ -167,11 +159,10 @@ void ABTI_mutex_unlock(ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline
-ABT_bool ABTI_mutex_equal(ABTI_mutex *p_mutex1, ABTI_mutex *p_mutex2)
+static inline ABT_bool ABTI_mutex_equal(ABTI_mutex *p_mutex1,
+                                        ABTI_mutex *p_mutex2)
 {
     return (p_mutex1 == p_mutex2) ? ABT_TRUE : ABT_FALSE;
 }
 
 #endif /* MUTEX_H_INCLUDED */
-

--- a/src/include/abti_mutex_attr.h
+++ b/src/include/abti_mutex_attr.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for mutex attributes */
 
-static inline
-ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
+static inline ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_mutex_attr *p_attr;
@@ -24,8 +23,7 @@ ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
 #endif
 }
 
-static inline
-ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
+static inline ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_mutex_attr h_attr;
@@ -44,4 +42,3 @@ ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
     memcpy(p_dest, p_src, sizeof(ABTI_mutex_attr))
 
 #endif /* MUTEX_ATTR_H_INCLUDED */
-

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -10,8 +10,7 @@
 
 static inline ABTI_xstream *ABTI_xstream_self(void);
 
-static inline
-ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
+static inline ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_pool *p_pool;
@@ -26,8 +25,7 @@ ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
 #endif
 }
 
-static inline
-ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
+static inline ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_pool h_pool;
@@ -43,36 +41,31 @@ ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
 }
 
 /* A ULT is blocked and is waiting for going back to this pool */
-static inline
-void ABTI_pool_inc_num_blocked(ABTI_pool *p_pool)
+static inline void ABTI_pool_inc_num_blocked(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_uint32(&p_pool->num_blocked, 1);
 }
 
 /* A blocked ULT is back in the pool */
-static inline
-void ABTI_pool_dec_num_blocked(ABTI_pool *p_pool)
+static inline void ABTI_pool_dec_num_blocked(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_sub_uint32(&p_pool->num_blocked, 1);
 }
 
 /* The pool will receive a migrated ULT */
-static inline
-void ABTI_pool_inc_num_migrations(ABTI_pool *p_pool)
+static inline void ABTI_pool_inc_num_migrations(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_int32(&p_pool->num_migrations, 1);
 }
 
 /* The pool has received a migrated ULT */
-static inline
-void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
+static inline void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_sub_int32(&p_pool->num_migrations, 1);
 }
 
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-static inline
-void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
+static inline void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 {
     LOG_EVENT_POOL_PUSH(p_pool, unit, ABTI_xstream_self());
 
@@ -80,8 +73,7 @@ void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
     p_pool->p_push(ABTI_pool_get_handle(p_pool), unit);
 }
 
-static inline
-void ABTI_pool_add_thread(ABTI_thread *p_thread)
+static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
 {
     /* Set the ULT's state as READY */
     p_thread->state = ABT_THREAD_STATE_READY;
@@ -98,8 +90,8 @@ void ABTI_pool_add_thread(ABTI_thread *p_thread)
 
 #else /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
 
-static inline
-int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_producer)
+static inline int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit,
+                                 ABTI_xstream *p_producer)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -120,8 +112,8 @@ int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_producer)
     goto fn_exit;
 }
 
-static inline
-int ABTI_pool_add_thread(ABTI_thread *p_thread, ABTI_xstream *p_producer)
+static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
+                                       ABTI_xstream *p_producer)
 {
     int abt_errno;
 
@@ -144,19 +136,18 @@ int ABTI_pool_add_thread(ABTI_thread *p_thread, ABTI_xstream *p_producer)
     do {                                                        \
         abt_errno = ABTI_pool_push(p_pool, unit, p_producer);   \
         ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_pool_push");      \
-    } while(0)
+    } while (0)
 
 #define ABTI_POOL_ADD_THREAD(p_thread,p_producer)               \
     do {                                                        \
         abt_errno = ABTI_pool_add_thread(p_thread, p_producer); \
         ABTI_CHECK_ERROR(abt_errno);                            \
-    } while(0)
+    } while (0)
 
 #endif /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
 
 #ifdef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-static inline
-int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
+static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -179,8 +170,8 @@ int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 
 #else /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
-static inline
-int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_consumer)
+static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
+                                   ABTI_xstream *p_consumer)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -206,12 +197,12 @@ int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit, ABTI_xstream *p_consumer)
     do {                                                        \
         abt_errno = ABTI_pool_set_consumer(p_pool, p_consumer); \
         ABTI_CHECK_ERROR(abt_errno);                            \
-    } while(0)
+    } while (0)
 
 #endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
-static inline
-ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs)
+static inline ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool,
+                                               double abstime_secs)
 {
     ABT_unit unit;
 
@@ -221,8 +212,7 @@ ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs)
     return unit;
 }
 
-static inline
-ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
+static inline ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
 {
     ABT_unit unit;
 
@@ -234,32 +224,27 @@ ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
 
 /* Increase num_scheds to mark the pool as having another scheduler. If the
  * pool is not available, it returns ABT_ERR_INV_POOL_ACCESS.  */
-static inline
-void ABTI_pool_retain(ABTI_pool *p_pool)
+static inline void ABTI_pool_retain(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_int32(&p_pool->num_scheds, 1);
 }
 
 /* Decrease the num_scheds to realease this pool from a scheduler. Call when
  * the pool is removed from a scheduler or when it stops. */
-static inline
-int32_t ABTI_pool_release(ABTI_pool *p_pool)
+static inline int32_t ABTI_pool_release(ABTI_pool *p_pool)
 {
     ABTI_ASSERT(p_pool->num_scheds > 0);
     return ABTD_atomic_fetch_sub_int32(&p_pool->num_scheds, 1) - 1;
 }
 
-static inline
-void *ABTI_pool_get_data(ABTI_pool *p_pool)
+static inline void *ABTI_pool_get_data(ABTI_pool *p_pool)
 {
     return p_pool->data;
 }
 
-static inline
-size_t ABTI_pool_get_size(ABTI_pool *p_pool)
+static inline size_t ABTI_pool_get_size(ABTI_pool *p_pool)
 {
     return p_pool->p_get_size(ABTI_pool_get_handle(p_pool));
 }
 
 #endif /* POOL_H_INCLUDED */
-

--- a/src/include/abti_rwlock.h
+++ b/src/include/abti_rwlock.h
@@ -11,8 +11,7 @@
 
 /* Inlined functions for RWLock */
 
-static inline
-ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
+static inline ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_rwlock *p_rwlock;
@@ -27,8 +26,7 @@ ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
 #endif
 }
 
-static inline
-ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
+static inline ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_rwlock h_rwlock;
@@ -43,8 +41,7 @@ ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
 #endif
 }
 
-static inline
-void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_init(&p_rwlock->mutex);
     ABTI_cond_init(&p_rwlock->cond);
@@ -52,15 +49,13 @@ void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
     p_rwlock->write_flag = 0;
 }
 
-static inline
-void ABTI_rwlock_fini(ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_fini(ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_fini(&p_rwlock->mutex);
     ABTI_cond_fini(&p_rwlock->cond);
 }
 
-static inline
-int ABTI_rwlock_rdlock(ABTI_rwlock *p_rwlock)
+static inline int ABTI_rwlock_rdlock(ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -78,14 +73,13 @@ int ABTI_rwlock_rdlock(ABTI_rwlock *p_rwlock)
     return abt_errno;
 }
 
-static inline
-int ABTI_rwlock_wrlock(ABTI_rwlock *p_rwlock)
+static inline int ABTI_rwlock_wrlock(ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_mutex_lock(&p_rwlock->mutex);
 
     while ((p_rwlock->write_flag || p_rwlock->reader_count)
-            && abt_errno == ABT_SUCCESS) {
+           && abt_errno == ABT_SUCCESS) {
         abt_errno = ABTI_cond_wait(&p_rwlock->cond, &p_rwlock->mutex);
     }
 
@@ -97,15 +91,13 @@ int ABTI_rwlock_wrlock(ABTI_rwlock *p_rwlock)
     return abt_errno;
 }
 
-static inline
-void ABTI_rwlock_unlock(ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_unlock(ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_lock(&p_rwlock->mutex);
 
     if (p_rwlock->write_flag) {
         p_rwlock->write_flag = 0;
-    }
-    else {
+    } else {
         p_rwlock->reader_count--;
     }
 
@@ -116,4 +108,3 @@ void ABTI_rwlock_unlock(ABTI_rwlock *p_rwlock)
 }
 
 #endif /* RWLOCK_H_INCLUDED */
-

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Scheduler */
 
-static inline
-ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
+static inline ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_sched *p_sched;
@@ -24,8 +23,7 @@ ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
 #endif
 }
 
-static inline
-ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
+static inline ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_sched h_sched;
@@ -42,8 +40,7 @@ ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 
 /* Set `used` of p_sched to NOT_USED and free p_sched if its `automatic` is
  * ABT_TRUE, which means it is safe to free p_sched inside the runtime. */
-static inline
-int ABTI_sched_discard_and_free(ABTI_sched *p_sched)
+static inline int ABTI_sched_discard_and_free(ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     p_sched->used = ABTI_SCHED_NOT_USED;
@@ -53,20 +50,17 @@ int ABTI_sched_discard_and_free(ABTI_sched *p_sched)
     return abt_errno;
 }
 
-static inline
-void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)
+static inline void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_sched->request, req);
 }
 
-static inline
-void ABTI_sched_unset_request(ABTI_sched *p_sched, uint32_t req)
+static inline void ABTI_sched_unset_request(ABTI_sched *p_sched, uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_sched->request, ~req);
 }
 
-static inline
-ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
+static inline ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
 {
     int p;
     size_t s;
@@ -75,7 +69,8 @@ ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
         ABT_pool pool = p_sched->pools[p];
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
         s = ABTI_pool_get_size(p_pool);
-        if (s > 0) return ABT_TRUE;
+        if (s > 0)
+            return ABT_TRUE;
     }
 
     return ABT_FALSE;
@@ -94,4 +89,3 @@ ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
 #endif
 
 #endif /* SCHED_H_INCLUDED */
-

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -6,8 +6,7 @@
 #ifndef SELF_H_INCLUDED
 #define SELF_H_INCLUDED
 
-static inline
-ABTI_unit *ABTI_self_get_unit(void)
+static inline ABTI_unit *ABTI_self_get_unit(void)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
@@ -39,4 +38,3 @@ ABTI_unit *ABTI_self_get_unit(void)
 }
 
 #endif /* SELF_H_INCLUDED */
-

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Execution Stream (ES) */
 
-static inline
-ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
+static inline ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_xstream *p_xstream;
@@ -24,8 +23,7 @@ ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
 #endif
 }
 
-static inline
-ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
+static inline ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_xstream h_xstream;
@@ -40,20 +38,19 @@ ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
 #endif
 }
 
-static inline
-void ABTI_xstream_set_request(ABTI_xstream *p_xstream, uint32_t req)
+static inline void ABTI_xstream_set_request(ABTI_xstream *p_xstream,
+                                            uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_xstream->request, req);
 }
 
-static inline
-void ABTI_xstream_unset_request(ABTI_xstream *p_xstream, uint32_t req)
+static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
+                                              uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_xstream->request, ~req);
 }
 
-static inline
-ABTI_xstream *ABTI_xstream_self(void)
+static inline ABTI_xstream *ABTI_xstream_self(void)
 {
     ABTI_xstream *p_xstream;
     if (lp_ABTI_local != NULL) {
@@ -70,31 +67,28 @@ ABTI_xstream *ABTI_xstream_self(void)
 }
 
 /* Get the top scheduler from the sched stack (field scheds) */
-static inline
-ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
+static inline ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
 {
-    return p_xstream->scheds[p_xstream->num_scheds-1];
+    return p_xstream->scheds[p_xstream->num_scheds - 1];
 }
 
 /* Get the parent scheduler of the current scheduler */
-static inline
-ABTI_sched *ABTI_xstream_get_parent_sched(ABTI_xstream *p_xstream)
+static inline ABTI_sched *ABTI_xstream_get_parent_sched(ABTI_xstream *p_xstream)
 {
     ABTI_ASSERT(p_xstream->num_scheds >= 2);
-    return p_xstream->scheds[p_xstream->num_scheds-2];
+    return p_xstream->scheds[p_xstream->num_scheds - 2];
 }
 
 /* Get the scheduling context */
 static inline
-ABTD_thread_context *ABTI_xstream_get_sched_ctx(ABTI_xstream *p_xstream)
+    ABTD_thread_context *ABTI_xstream_get_sched_ctx(ABTI_xstream *p_xstream)
 {
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_xstream);
     return p_sched->p_ctx;
 }
 
 /* Remove the top scheduler from the sched stack (field scheds) */
-static inline
-void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
+static inline void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
 {
     p_xstream->num_scheds--;
     ABTI_ASSERT(p_xstream->num_scheds >= 0);
@@ -102,20 +96,20 @@ void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
 
 /* Replace the top scheduler of the sched stack (field scheds) with the target
  * scheduler */
-static inline
-void ABTI_xstream_replace_top_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
+static inline void ABTI_xstream_replace_top_sched(ABTI_xstream *p_xstream,
+                                                  ABTI_sched *p_sched)
 {
-    p_xstream->scheds[p_xstream->num_scheds-1] = p_sched;
+    p_xstream->scheds[p_xstream->num_scheds - 1] = p_sched;
 }
 
 /* Add the specified scheduler to the sched stack (field scheds) */
-static inline
-void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
+static inline void ABTI_xstream_push_sched(ABTI_xstream *p_xstream,
+                                           ABTI_sched *p_sched)
 {
     if (p_xstream->num_scheds == p_xstream->max_scheds) {
-        int max_size = p_xstream->max_scheds+10;
+        int max_size = p_xstream->max_scheds + 10;
         void *temp;
-        temp = ABTU_realloc(p_xstream->scheds, max_size*sizeof(ABTI_sched *));
+        temp = ABTU_realloc(p_xstream->scheds, max_size * sizeof(ABTI_sched *));
         p_xstream->scheds = (ABTI_sched **)temp;
         p_xstream->max_scheds = max_size;
     }
@@ -123,8 +117,7 @@ void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     p_xstream->scheds[p_xstream->num_scheds++] = p_sched;
 }
 
-static inline
-void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
+static inline void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
 {
     LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
@@ -150,8 +143,7 @@ void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
     }
 }
 
-static inline
-void ABTI_xstream_terminate_task(ABTI_task *p_task)
+static inline void ABTI_xstream_terminate_task(ABTI_task *p_task)
 {
     LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n",
               ABTI_task_get_id(p_task), p_task->p_xstream->rank);

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Tasklet  */
 
-static inline
-ABTI_task *ABTI_task_get_ptr(ABT_task task)
+static inline ABTI_task *ABTI_task_get_ptr(ABT_task task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_task *p_task;
@@ -24,8 +23,7 @@ ABTI_task *ABTI_task_get_ptr(ABT_task task)
 #endif
 }
 
-static inline
-ABT_task ABTI_task_get_handle(ABTI_task *p_task)
+static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_task h_task;
@@ -40,17 +38,14 @@ ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 #endif
 }
 
-static inline
-void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_task->request, req);
 }
 
-static inline
-void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }
 
 #endif /* TASK_H_INCLUDED */
-

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for User-level Thread (ULT) */
 
-static inline
-ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
+static inline ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_thread *p_thread;
@@ -24,8 +23,7 @@ ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
 #endif
 }
 
-static inline
-ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
+static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_thread h_thread;
@@ -41,8 +39,7 @@ ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
+static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
 {
     /*
      * Create a context and switch to it. The flow of the dynamic promotion
@@ -126,8 +123,7 @@ ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
     return ABTD_thread_context_is_dynamic_promoted(&p_thread->ctx);
 }
 
-static inline
-void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
+static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 {
     LOG_EVENT("[U%" PRIu64 "] dynamic-promote ULT\n",
               ABTI_thread_get_id(p_thread));
@@ -138,10 +134,10 @@ void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 }
 #endif
 
-static inline
-void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
-                                                          ABTI_thread *p_new,
-                                                          ABT_bool is_finish)
+static inline void
+ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
+                                                     ABTI_thread *p_new,
+                                                     ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
@@ -166,9 +162,9 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
-                                                         ABTI_sched *p_new,
-                                                         ABT_bool is_finish)
+    void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
+                                                             ABTI_sched *p_new,
+                                                             ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched);
@@ -190,23 +186,23 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
-                                                         ABTI_thread *p_new,
-                                                         ABT_bool is_finish)
+    void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
+                                                             ABTI_thread *p_new,
+                                                             ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->is_sched);
 #endif
     ABTI_LOG_SET_SCHED(NULL);
     ABTI_local_set_thread(p_new);
-    ABTI_local_set_task(NULL); /* A tasklet scheduler can invoke ULT. */
+    ABTI_local_set_task(NULL);  /* A tasklet scheduler can invoke ULT. */
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be eagerly initialized. */
     ABTI_ASSERT(!p_old->p_thread
                 || ABTI_thread_is_dynamic_promoted(p_old->p_thread));
     if (!ABTI_thread_is_dynamic_promoted(p_new)) {
-        void *p_stacktop = ((char *)p_new->attr.p_stack) +
-                            p_new->attr.stacksize;
+        void *p_stacktop = (((char *)p_new->attr.p_stack) +
+                            p_new->attr.stacksize);
         LOG_EVENT("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
                   ABTI_thread_get_id(p_new));
         ABTD_thread_context_make_and_call(p_old->p_ctx, p_new->ctx.f_thread,
@@ -237,8 +233,10 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                 ABTD_atomic_store_uint32(&p_prev->request,
                                          ABTI_THREAD_REQ_TERMINATE);
             } else {
-                uint32_t req = ABTD_atomic_fetch_or_uint32(&p_prev->request,
-                        ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+                uint32_t req;
+                req = ABTD_atomic_fetch_or_uint32(&p_prev->request,
+                                                  ABTI_THREAD_REQ_JOIN |
+                                                  ABTI_THREAD_REQ_TERMINATE);
                 if (req & ABTI_THREAD_REQ_JOIN) {
                     /* This case means there has been a join request and the
                      * joiner has blocked.  We have to wake up the joiner ULT.
@@ -265,9 +263,9 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
-                                                        ABTI_sched *p_new,
-                                                        ABT_bool is_finish)
+    void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
+                                                            ABTI_sched *p_new,
+                                                            ABT_bool is_finish)
 {
     ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -285,89 +283,86 @@ void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_thread_to_thread(ABTI_thread *p_old,
-                                                 ABTI_thread *p_new)
+    void ABTI_thread_context_switch_thread_to_thread(ABTI_thread *p_old,
+                                                     ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_thread_to_thread_internal(p_old, p_new,
                                                          ABT_FALSE);
 }
 
 static inline
-void ABTI_thread_context_switch_thread_to_sched(ABTI_thread *p_old,
-                                                ABTI_sched *p_new)
+    void ABTI_thread_context_switch_thread_to_sched(ABTI_thread *p_old,
+                                                    ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new,
                                                         ABT_FALSE);
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_thread(ABTI_sched *p_old,
-                                                ABTI_thread *p_new)
+    void ABTI_thread_context_switch_sched_to_thread(ABTI_sched *p_old,
+                                                    ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_sched_to_thread_internal(p_old, p_new,
                                                         ABT_FALSE);
 }
 
-static inline
-void ABTI_thread_context_switch_sched_to_sched(ABTI_sched *p_old,
-                                               ABTI_sched *p_new)
+static inline void ABTI_thread_context_switch_sched_to_sched(ABTI_sched *p_old,
+                                                             ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_FALSE);
 }
 
 static inline
-void ABTI_thread_finish_context_thread_to_thread(ABTI_thread *p_old,
-                                                 ABTI_thread *p_new)
+    void ABTI_thread_finish_context_thread_to_thread(ABTI_thread *p_old,
+                                                     ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_thread_to_thread_internal(p_old, p_new,
                                                          ABT_TRUE);
 }
 
 static inline
-void ABTI_thread_finish_context_thread_to_sched(ABTI_thread *p_old,
-                                                ABTI_sched *p_new)
+    void ABTI_thread_finish_context_thread_to_sched(ABTI_thread *p_old,
+                                                    ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new, ABT_TRUE);
 }
 
 static inline
-void ABTI_thread_finish_context_sched_to_thread(ABTI_sched *p_old,
-                                                ABTI_thread *p_new)
+    void ABTI_thread_finish_context_sched_to_thread(ABTI_sched *p_old,
+                                                    ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_sched_to_thread_internal(p_old, p_new, ABT_TRUE);
 }
 
 static inline
-void ABTI_thread_finish_context_sched_to_sched(ABTI_sched *p_old,
-                                               ABTI_sched *p_new)
+    void ABTI_thread_finish_context_sched_to_sched(ABTI_sched *p_old,
+                                                   ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_TRUE);
 }
 
-static inline
-void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
+static inline void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_thread->request, req);
 }
 
-static inline
-void ABTI_thread_unset_request(ABTI_thread *p_thread, uint32_t req)
+static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
+                                             uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_thread->request, ~req);
 }
 
 #ifdef ABT_CONFIG_DISABLE_MIGRATION
-static inline
-void  ABTI_thread_put_req_arg(ABTI_thread *p_thread,
-                              ABTI_thread_req_arg *p_req_arg)
+static inline void ABTI_thread_put_req_arg(ABTI_thread *p_thread,
+                                           ABTI_thread_req_arg *p_req_arg)
 {
     ABTI_ASSERT(p_thread->p_req_arg == NULL);
     p_thread->p_req_arg = p_req_arg;
 }
 
 static inline
-ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
-                                             uint32_t req)
+    ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
+                                                 uint32_t req)
 {
     ABTI_thread_req_arg *p_result = p_thread->p_req_arg;
     p_thread->p_req_arg = NULL;
@@ -375,8 +370,7 @@ ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
 }
 #endif /* ABT_CONFIG_DISABLE_MIGRATION */
 
-static inline
-void ABTI_thread_yield(ABTI_thread *p_thread)
+static inline void ABTI_thread_yield(ABTI_thread *p_thread)
 {
     ABTI_sched *p_sched;
 
@@ -396,4 +390,3 @@ void ABTI_thread_yield(ABTI_thread *p_thread)
 }
 
 #endif /* THREAD_H_INCLUDED */
-

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -19,8 +19,7 @@
  * @param[in] attr  handle to the ULT attribute
  * @return ABTI_thread_attr pointer
  */
-static inline
-ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
+static inline ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_thread_attr *p_attr;
@@ -47,7 +46,7 @@ ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
  * @return ABT_thread_attr handle
  */
 static inline
-ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
+    ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_thread_attr h_attr;
@@ -63,34 +62,32 @@ ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static inline
-void ABTI_thread_attr_init_migration(ABTI_thread_attr *p_attr,
-                                     ABT_bool migratable)
+static inline void ABTI_thread_attr_init_migration(ABTI_thread_attr *p_attr,
+                                                   ABT_bool migratable)
 {
     p_attr->migratable = migratable;
-    p_attr->f_cb       = NULL;
-    p_attr->p_cb_arg   = NULL;
+    p_attr->f_cb = NULL;
+    p_attr->p_cb_arg = NULL;
 }
 #endif
 
-static inline
-void ABTI_thread_attr_init(ABTI_thread_attr *p_attr, void *p_stack,
-                           size_t stacksize, ABTI_stack_type stacktype,
-                           ABT_bool migratable)
+static inline void ABTI_thread_attr_init(ABTI_thread_attr *p_attr,
+                                         void *p_stack, size_t stacksize,
+                                         ABTI_stack_type stacktype,
+                                         ABT_bool migratable)
 {
-    p_attr->p_stack    = p_stack;
-    p_attr->stacksize  = stacksize;
-    p_attr->stacktype  = stacktype;
+    p_attr->p_stack = p_stack;
+    p_attr->stacksize = stacksize;
+    p_attr->stacktype = stacktype;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_attr_init_migration(p_attr, migratable);
 #endif
 }
 
-static inline
-void ABTI_thread_attr_copy(ABTI_thread_attr *p_dest, ABTI_thread_attr *p_src)
+static inline void ABTI_thread_attr_copy(ABTI_thread_attr *p_dest,
+                                         ABTI_thread_attr *p_src)
 {
     memcpy(p_dest, p_src, sizeof(ABTI_thread_attr));
 }
 
 #endif /* THREAD_ATTR_H_INCLUDED */
-

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -17,27 +17,27 @@
 #endif
 
 struct ABTI_thread_queue {
-    uint32_t mutex; /* can be initialized by just assigning 0*/
+    uint32_t mutex;             /* can be initialized by just assigning 0 */
     uint32_t num_handovers;
     uint32_t num_threads;
     uint32_t pad0;
     ABTI_thread *head;
     ABTI_thread *tail;
-    char pad1[64-8*4];
+    char pad1[64 - 8 * 4];
 
     /* low priority queue */
-    uint32_t low_mutex; /* can be initialized by just assigning 0*/
+    uint32_t low_mutex;         /* can be initialized by just assigning 0 */
     uint32_t low_num_threads;
     ABTI_thread *low_head;
     ABTI_thread *low_tail;
-    char pad2[64-8*3];
+    char pad2[64 - 8 * 3];
 
     /* two doubly-linked lists */
     ABTI_thread_queue *p_h_next;
     ABTI_thread_queue *p_h_prev;
     ABTI_thread_queue *p_l_next;
     ABTI_thread_queue *p_l_prev;
-    char pad3[64-8*4];
+    char pad3[64 - 8 * 4];
 };
 
 struct ABTI_thread_htable {
@@ -48,7 +48,7 @@ struct ABTI_thread_htable {
 #elif defined(USE_PTHREAD_MUTEX)
     pthread_mutex_t mutex;
 #else
-    ABTI_spinlock mutex;          /* To protect table */
+    ABTI_spinlock mutex;        /* To protect table */
 #endif
     uint32_t num_elems;
     uint32_t num_rows;
@@ -72,33 +72,34 @@ struct ABTI_thread_htable {
 #define ABTI_THREAD_HTABLE_UNLOCK(m)    ABTI_spinlock_release(&m)
 #endif
 
-static inline
-void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue) {
+static inline void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue)
+{
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->mutex)) {
         while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->mutex) != 0);
     }
 }
 
-static inline
-void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue) {
+static inline void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue)
+{
     ABTD_atomic_clear_uint8((uint8_t *)&p_queue->mutex);
 }
 
 static inline
-void ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue) {
+    void ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
+{
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->low_mutex)) {
         while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->low_mutex) != 0);
     }
 }
 
 static inline
-void ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue) {
+    void ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue)
+{
     ABTD_atomic_clear_uint8((uint8_t *)&p_queue->low_mutex);
 }
 
-static inline
-void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
-                                   ABTI_thread_queue *p_node)
+static inline void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
+                                                 ABTI_thread_queue *p_node)
 {
     ABTI_thread_queue *p_curr = p_htable->h_list;
     if (!p_curr) {
@@ -113,8 +114,7 @@ void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
     }
 }
 
-static inline
-void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
+static inline void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
 {
     ABTI_thread_queue *p_prev, *p_next;
     ABTI_thread_queue *p_node = p_htable->h_list;
@@ -134,9 +134,8 @@ void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
     }
 }
 
-static inline
-void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
-                                   ABTI_thread_queue *p_node)
+static inline void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
+                                                 ABTI_thread_queue *p_node)
 {
     ABTI_thread_queue *p_curr = p_htable->l_list;
     if (!p_curr) {
@@ -151,8 +150,7 @@ void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
     }
 }
 
-static inline
-void ABTI_thread_htable_del_l_head(ABTI_thread_htable *p_htable)
+static inline void ABTI_thread_htable_del_l_head(ABTI_thread_htable *p_htable)
 {
     ABTI_thread_queue *p_prev, *p_next;
     ABTI_thread_queue *p_node = p_htable->l_list;

--- a/src/include/abti_timer.h
+++ b/src/include/abti_timer.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Timer */
 
-static inline
-ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
+static inline ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_timer *p_timer;
@@ -24,8 +23,7 @@ ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
 #endif
 }
 
-static inline
-ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
+static inline ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_timer h_timer;
@@ -41,4 +39,3 @@ ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
 }
 
 #endif /* TIMER_H_INCLUDED */
-

--- a/src/include/abti_valgrind.h
+++ b/src/include/abti_valgrind.h
@@ -20,8 +20,8 @@ void ABTI_valgrind_unregister_stack(const void *p_stack);
 
 #else
 
-#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)   do { } while(0)
-#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)       do { } while(0)
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)   do { } while (0)
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)       do { } while (0)
 
 #endif /* HAVE_VALGRIND_SUPPORT */
 

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -26,8 +26,7 @@
 #define ABTU_free(a)            free((void *)(a))
 #define ABTU_realloc(a,b)       realloc((void *)(a),(size_t)(b))
 
-static inline
-void *ABTU_memalign(size_t alignment, size_t size)
+static inline void *ABTU_memalign(size_t alignment, size_t size)
 {
     void *p_ptr;
     int ret = posix_memalign(&p_ptr, alignment, size);

--- a/src/info.c
+++ b/src/info.c
@@ -37,33 +37,33 @@ int ABT_info_print_config(FILE *fp)
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
     fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
     fprintf(fp, " - ES affinity: %s\n",
-                (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
+            (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - logging: %s\n",
-                (p_global->use_logging == ABT_TRUE) ? "on" : "off");
+            (p_global->use_logging == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - debug output: %s\n",
-                (p_global->use_debug == ABT_TRUE) ? "on" : "off");
+            (p_global->use_debug == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - key table entries: %d\n", p_global->key_table_size);
     fprintf(fp, " - ULT stack size: %u KB\n",
-                (unsigned)(p_global->thread_stacksize / 1024));
+            (unsigned)(p_global->thread_stacksize / 1024));
     fprintf(fp, " - scheduler stack size: %u KB\n",
-                (unsigned)(p_global->sched_stacksize / 1024));
+            (unsigned)(p_global->sched_stacksize / 1024));
     fprintf(fp, " - scheduler event check frequency: %u\n",
-                p_global->sched_event_freq);
+            p_global->sched_event_freq);
 
     fprintf(fp, " - timer function: "
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
-                "clock_gettime"
+            "clock_gettime"
 #elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
-                "mach_absolute_time"
+            "mach_absolute_time"
 #elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
-                "gettimeofday"
+            "gettimeofday"
 #endif
-                "\n");
+            "\n");
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
     fprintf(fp, "Memory Pool:\n");
     fprintf(fp, " - page size for allocation: %u KB\n",
-                p_global->mem_page_size / 1024);
+            p_global->mem_page_size / 1024);
     fprintf(fp, " - stack page size: %u KB\n", p_global->mem_sp_size / 1024);
     fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
     switch (p_global->mem_lp_alloc) {
@@ -75,7 +75,7 @@ int ABT_info_print_config(FILE *fp)
             break;
         case ABTI_MEM_LP_MMAP_HP_RP:
             fprintf(fp, " - large page allocation: mmap huge pages + "
-                        "regular pages\n");
+                    "regular pages\n");
             break;
         case ABTI_MEM_LP_MMAP_HP_THP:
             fprintf(fp, " - large page allocation: mmap huge pages + THPs\n");
@@ -91,14 +91,14 @@ int ABT_info_print_config(FILE *fp)
 
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
     fprintf(fp, " - pm daemon connected: %s\n",
-                (p_global->pm_connected == ABT_TRUE) ? "yes" : "no");
+            (p_global->pm_connected == ABT_TRUE) ? "yes" : "no");
     fprintf(fp, " - pm hostname: %s\n", p_global->pm_host);
     fprintf(fp, " - pm port: %d\n", p_global->pm_port);
 #endif /* ABT_CONFIG_HANDLE_POWER_EVENT */
 
 #ifdef ABT_CONFIG_PUBLISH_INFO
     fprintf(fp, " - publishing needed: %s\n",
-                (p_global->pub_needed == ABT_TRUE) ? "yes" : "no");
+            (p_global->pub_needed == ABT_TRUE) ? "yes" : "no");
     fprintf(fp, " - publishing filename: %s\n", p_global->pub_filename);
     fprintf(fp, " - publishing interval: %lf sec.\n", p_global->pub_interval);
 #endif /* ABT_CONFIG_PUBLISH_INFO */
@@ -228,7 +228,7 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_pool(FILE* fp, ABT_pool pool)
+int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -257,7 +257,7 @@ int ABT_info_print_pool(FILE* fp, ABT_pool pool)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_thread(FILE* fp, ABT_thread thread)
+int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
@@ -287,7 +287,7 @@ int ABT_info_print_thread(FILE* fp, ABT_thread thread)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr)
+int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
@@ -316,7 +316,7 @@ int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_task(FILE* fp, ABT_task task)
+int ABT_info_print_task(FILE *fp, ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_task *p_task = ABTI_task_get_ptr(task);
@@ -382,14 +382,11 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
         ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
         ABT_thread_id thread_id = ABTI_thread_get_id(p_thread);
         fprintf(fp, "id        : %" PRIu64 "\n"
-                    "ctx       : %p\n",
-                    (uint64_t)thread_id,
-                    &p_thread->ctx);
+                "ctx       : %p\n", (uint64_t)thread_id, &p_thread->ctx);
         ABTD_thread_print_context(p_thread, fp, 2);
         fprintf(fp, "stack     : %p\n"
-                    "stacksize : %" PRIu64 "\n",
-                    p_thread->attr.p_stack,
-                    (uint64_t)p_thread->attr.stacksize);
+                "stacksize : %" PRIu64 "\n",
+                p_thread->attr.p_stack, (uint64_t)p_thread->attr.stacksize);
         int abt_errno = ABT_info_print_thread_stack(fp, thread);
         if (abt_errno != ABT_SUCCESS)
             fprintf(fp, "Failed to print stack.\n");
@@ -444,7 +441,7 @@ struct ABTI_info_pool_set_t {
 };
 
 static inline
-void ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
+    void ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
 {
     size_t default_len = 16;
     p_set->pools = (ABT_pool *)ABTU_malloc(sizeof(ABT_pool) * default_len);
@@ -453,13 +450,14 @@ void ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
 }
 
 static inline
-void ABTI_info_finalize_pool_set(struct ABTI_info_pool_set_t *p_set)
+    void ABTI_info_finalize_pool_set(struct ABTI_info_pool_set_t *p_set)
 {
     ABTU_free(p_set->pools);
 }
 
 static inline
-void ABTI_info_add_pool_set(ABT_pool pool, struct ABTI_info_pool_set_t *p_set)
+    void ABTI_info_add_pool_set(ABT_pool pool,
+                                struct ABTI_info_pool_set_t *p_set)
 {
     size_t i;
     for (i = 0; i < p_set->num; i++) {
@@ -484,7 +482,7 @@ void ABTI_info_add_pool_set(ABT_pool pool, struct ABTI_info_pool_set_t *p_set)
 static uint32_t print_stack_flag = PRINT_STACK_FLAG_UNSET;
 static FILE *print_stack_fp = NULL;
 static double print_stack_timeout = 0.0;
-static void (*print_cb_func)(ABT_bool, void *) = NULL;
+static void (*print_cb_func) (ABT_bool, void *) = NULL;
 static void *print_arg = NULL;
 static uint32_t print_stack_barrier = 0;
 
@@ -493,9 +491,9 @@ static uint32_t print_stack_barrier = 0;
  * @brief   Dump stacks of threads in pools existing in Argobots.
  *
  * \c ABT_info_trigger_print_all_thread_stacks() tries to dump call stacks of
- * all threads stored in pools in the Argobots runtime. This function itself does
- * not print stacks; it immediately returns after updating a flag. Stacks are
- * printed when all execution streams stop in \c ABT_xstream_check_events().
+ * all threads stored in pools in the Argobots runtime. This function itself
+ * does not print stacks; it immediately returns after updating a flag. Stacks
+ * are printed when all execution streams stop in \c ABT_xstream_check_events().
  *
  * If some execution streams do not stop within a certain time period, one of
  * the stopped execution streams starts to print stack information. In this
@@ -505,10 +503,10 @@ static uint32_t print_stack_barrier = 0;
  *
  * \c cb_func is called after completing stack dump unless it is NULL. The first
  * argument is set to \c ABT_TRUE if not all the execution streams stop within
- * \c timeout. Otherwise, \c ABT_FALSE is set. The second argument is user-defined
- * data \c arg. Since \c cb_func is not called by a thread or an execution
- * stream, \c ABT_self_...() functions in \c cb_func return undefined values.
- * Neither signal-safety nor thread-safety is required for \c cb_func.
+ * \c timeout. Otherwise, \c ABT_FALSE is set. The second argument is user-
+ * defined data \c arg. Since \c cb_func is not called by a thread or an
+ * execution stream, \c ABT_self_...() functions in \c cb_func return undefined
+ * values. Neither signal-safety nor thread-safety is required for \c cb_func.
  *
  * In Argobots, \c ABT_info_trigger_print_all_thread_stacks is exceptionally
  * signal-safe; it can be safely called in a signal handler.
@@ -525,7 +523,7 @@ static uint32_t print_stack_barrier = 0;
  * @retval ABT_SUCCESS on success
  */
 int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
-                                             void (*cb_func)(ABT_bool, void *),
+                                             void (*cb_func) (ABT_bool, void *),
                                              void *arg)
 {
     /* This function is signal-safe, so it may not call other functions unless
@@ -576,8 +574,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
         FILE *fp = print_stack_fp;
         if (force_print) {
             fprintf(fp, "ABT_info_trigger_print_all_thread_stacks: "
-                        "timeout (only %d ESs stop)\n",
-                        (int)print_stack_barrier);
+                    "timeout (only %d ESs stop)\n", (int)print_stack_barrier);
         }
         for (i = 0; i < gp_ABTI_global->num_xstreams; i++) {
             ABTI_xstream *p_xstream = gp_ABTI_global->p_xstreams[i];

--- a/src/key.c
+++ b/src/key.c
@@ -43,7 +43,7 @@ static uint32_t g_key_id = 0;
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
+int ABT_key_create(void (*destructor) (void *value), ABT_key *newkey)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_key *p_newkey;
@@ -219,7 +219,8 @@ ABTI_ktable *ABTI_ktable_alloc(int size)
     p_ktable = (ABTI_ktable *)ABTU_malloc(sizeof(ABTI_ktable));
     p_ktable->size = size;
     p_ktable->num = 0;
-    p_ktable->p_elems = (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
+    p_ktable->p_elems =
+        (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
 
     return p_ktable;
 }
@@ -329,4 +330,3 @@ void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key)
         p_elem = p_elem->p_next;
     }
 }
-

--- a/src/local.c
+++ b/src/local.c
@@ -52,4 +52,3 @@ int ABTI_local_finalize(void)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/log.c
+++ b/src/log.c
@@ -24,7 +24,8 @@ void ABTI_log_finalize(void)
 
 void ABTI_log_print(FILE *fh, const char *format, ...)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     va_list list;
     va_start(list, format);
@@ -35,7 +36,8 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
 
 void ABTI_log_event(FILE *fh, const char *format, ...)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     ABT_unit_type type;
     ABTI_xstream *p_xstream = NULL;
@@ -120,7 +122,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
 
 void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
 {
-    if (gp_ABTI_global->use_debug == ABT_FALSE) return;
+    if (gp_ABTI_global->use_debug == ABT_FALSE)
+        return;
 
     int line_len;
     size_t newfmt_len;
@@ -143,7 +146,8 @@ void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                         ABTI_xstream *p_producer)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -155,14 +159,12 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                           "(producer: E%d)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank,
-                          p_pool->id,
-                          p_producer->rank);
+                          p_pool->id, p_producer->rank);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: E%d)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_pool->id,
-                          p_producer->rank);
+                          p_pool->id, p_producer->rank);
             }
             break;
 
@@ -173,14 +175,12 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                           "(producer: E%d)\n",
                           ABTI_task_get_id(p_task),
                           p_task->p_xstream->rank,
-                          p_pool->id,
-                          p_producer->rank);
+                          p_pool->id, p_producer->rank);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: E%d)\n",
                           ABTI_task_get_id(p_task),
-                          p_pool->id,
-                          p_producer->rank);
+                          p_pool->id, p_producer->rank);
             }
             break;
 
@@ -193,7 +193,8 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           ABTI_xstream *p_consumer)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -205,14 +206,12 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           "P%" PRIu64 " (consumer: E%d)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank,
-                          p_pool->id,
-                          p_consumer->rank);
+                          p_pool->id, p_consumer->rank);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: E%d)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_pool->id,
-                          p_consumer->rank);
+                          p_pool->id, p_consumer->rank);
             }
             break;
 
@@ -223,14 +222,12 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           "P%" PRIu64 " (consumer: E%d)\n",
                           ABTI_task_get_id(p_task),
                           p_task->p_xstream->rank,
-                          p_pool->id,
-                          p_consumer->rank);
+                          p_pool->id, p_consumer->rank);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: E%d)\n",
                           ABTI_task_get_id(p_task),
-                          p_pool->id,
-                          p_consumer->rank);
+                          p_pool->id, p_consumer->rank);
             }
             break;
 
@@ -242,8 +239,10 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
 
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
-    if (unit == ABT_UNIT_NULL) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
+    if (unit == ABT_UNIT_NULL)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -254,12 +253,10 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
                 LOG_EVENT("[U%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->p_last_xstream->rank,
-                          p_pool->id);
+                          p_thread->p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_thread),
-                          p_pool->id);
+                          ABTI_thread_get_id(p_thread), p_pool->id);
             }
             break;
 
@@ -269,12 +266,10 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
                 LOG_EVENT("[T%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task),
-                          p_task->p_xstream->rank,
-                          p_pool->id);
+                          p_task->p_xstream->rank, p_pool->id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_task_get_id(p_task),
-                          p_pool->id);
+                          ABTI_task_get_id(p_task), p_pool->id);
             }
             break;
 

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -123,7 +123,8 @@ void ABTI_mem_finalize_local(ABTI_local *p_local)
             }
         }
 
-        if (p_cur == p_local->p_mem_task_head) break;
+        if (p_cur == p_local->p_mem_task_head)
+            break;
     }
     p_local->p_mem_task_head = NULL;
     p_local->p_mem_task_tail = NULL;
@@ -276,7 +277,8 @@ char *ABTI_mem_take_global_stack(ABTI_local *p_local)
         old = (void *)p_sh;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, NULL));
 
-    if (p_sh == NULL) return NULL;
+    if (p_sh == NULL)
+        return NULL;
 
     /* TODO: need a better counting method */
     /* TODO: if there are too many stacks in the global stack pool, we should
@@ -342,7 +344,7 @@ static char *ABTI_mem_alloc_large_page(int pgsize, ABT_bool *p_is_mmapped)
             p_page = (char *)mmap(NULL, pgsize, PROTS, FLAGS_HP, 0, 0);
             if ((void *)p_page != MAP_FAILED) {
                 *p_is_mmapped = ABT_TRUE;
-                LOG_DEBUG(MMAP_DBG_MSG" (%d): %p\n", pgsize, p_page);
+                LOG_DEBUG(MMAP_DBG_MSG " (%d): %p\n", pgsize, p_page);
             } else {
                 /* Huge pages are run out of. Use a normal mmap. */
                 p_page = (char *)mmap(NULL, pgsize, PROTS, FLAGS_RP, 0, 0);
@@ -366,7 +368,7 @@ static char *ABTI_mem_alloc_large_page(int pgsize, ABT_bool *p_is_mmapped)
             p_page = (char *)mmap(NULL, pgsize, PROTS, FLAGS_HP, 0, 0);
             if ((void *)p_page != MAP_FAILED) {
                 *p_is_mmapped = ABT_TRUE;
-                LOG_DEBUG(MMAP_DBG_MSG" (%d): %p\n", pgsize, p_page);
+                LOG_DEBUG(MMAP_DBG_MSG " (%d): %p\n", pgsize, p_page);
             } else {
                 *p_is_mmapped = ABT_FALSE;
                 size_t alignment = gp_ABTI_global->huge_page_size;
@@ -401,7 +403,8 @@ ABTI_page_header *ABTI_mem_alloc_page(ABTI_local *p_local, size_t blk_size)
     ABT_bool is_mmapped;
 
     /* Make the page header size a multiple of cache line size */
-    const size_t ph_size = (sizeof(ABTI_page_header)+clsize) / clsize * clsize;
+    const size_t ph_size =
+        (sizeof(ABTI_page_header) + clsize) / clsize * clsize;
 
     uint32_t num_blks = (pgsize - ph_size) / blk_size;
     char *p_page = ABTI_mem_alloc_large_page(pgsize, &is_mmapped);
@@ -433,7 +436,8 @@ ABTI_page_header *ABTI_mem_alloc_page(ABTI_local *p_local, size_t blk_size)
 void ABTI_mem_free_page(ABTI_local *p_local, ABTI_page_header *p_ph)
 {
     /* We keep one page for future use. */
-    if (p_local->p_mem_task_head == p_local->p_mem_task_tail) return;
+    if (p_local->p_mem_task_head == p_local->p_mem_task_tail)
+        return;
 
     uint32_t num_free_blks = p_ph->num_empty_blks + p_ph->num_remote_free;
     if (num_free_blks == p_ph->num_total_blks) {
@@ -510,8 +514,10 @@ ABTI_page_header *ABTI_mem_take_global_page(ABTI_local *p_local)
 
     if (p_ph) {
         ABTI_mem_add_page(p_local, p_ph);
-        if (p_ph->p_free) ABTI_mem_take_free(p_ph);
-        if (p_ph->p_head == NULL) p_ph = NULL;
+        if (p_ph->p_free)
+            ABTI_mem_take_free(p_ph);
+        if (p_ph->p_head == NULL)
+            p_ph = NULL;
     }
 
     return p_ph;
@@ -576,8 +582,8 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
     p_first = p_sp + actual_stacksize * first_pos;
     p_sh = (ABTI_stack_header *)(p_first + sizeof(ABTI_thread));
     p_sh->p_sph = p_sph;
-    p_stack = (first_pos == 0)
-            ? (void *)(p_first + header_size * num_stacks) : (void *)p_sp;
+    p_stack = ((first_pos == 0)
+               ? (void *)(p_first + header_size * num_stacks) : (void *)p_sp);
     p_sh->p_stack = p_stack;
 
     if (num_stacks > 1) {
@@ -588,19 +594,21 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
         p_local->p_mem_stack = p_sh;
 
         for (i = 1; i < num_stacks; i++) {
-            p_next = (i + 1) < num_stacks
-                   ? (ABTI_stack_header *)((char *)p_sh + header_size)
-                   : NULL;
+            p_next = ((i + 1) < num_stacks
+                      ? (ABTI_stack_header *)((char *)p_sh + header_size)
+                      : NULL);
             p_sh->p_next = p_next;
             p_sh->p_sph = p_sph;
             if (first_pos == 0) {
-                p_sh->p_stack = (void *)((char *)p_stack + i * actual_stacksize);
+                p_sh->p_stack =
+                    (void *)((char *)p_stack + i * actual_stacksize);
             } else {
                 if (i < first_pos) {
                     p_sh->p_stack = (void *)(p_sp + i * actual_stacksize);
                 } else {
-                    p_sh->p_stack = (void *)(p_first + header_size * num_stacks
-                                  + (i - first_pos) * actual_stacksize);
+                    p_sh->p_stack = (void *)
+                        (p_first + header_size * num_stacks +
+                         (i - first_pos) * actual_stacksize);
                 }
             }
 
@@ -620,4 +628,3 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
 }
 
 #endif /* ABT_CONFIG_USE_MEM_POOL */
-

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -27,31 +27,32 @@ uint8_t g_valgrind_id_list_lock = 0;
 ABTI_valgrind_id_list *gp_valgrind_id_list_head = NULL;
 ABTI_valgrind_id_list *gp_valgrind_id_list_tail = NULL;
 
-static inline
-void ABTI_valgrind_lock_acquire() {
+static inline void ABTI_valgrind_lock_acquire()
+{
     while (ABTD_atomic_test_and_set_uint8(&g_valgrind_id_list_lock)) {
         while (ABTD_atomic_load_uint8(&g_valgrind_id_list_lock) != 0);
     }
 }
 
-static inline
-void ABTI_valgrind_lock_release() {
+static inline void ABTI_valgrind_lock_release()
+{
     ABTD_atomic_clear_uint8(&g_valgrind_id_list_lock);
 }
 
 #include <valgrind/valgrind.h>
 
-void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
+void ABTI_valgrind_register_stack(const void *p_stack, size_t size)
+{
     if (p_stack == 0)
         return;
 
     const void *p_start = (char *)(p_stack);
-    const void *p_end   = (char *)(p_stack) + size;
+    const void *p_end = (char *)(p_stack) + size;
 
     ABTI_valgrind_lock_acquire();
     ABTI_valgrind_id valgrind_id = VALGRIND_STACK_REGISTER(p_start, p_end);
     ABTI_valgrind_id_list *p_valgrind_id_list =
-                 (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
+        (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
     p_valgrind_id_list->p_stack = p_stack;
     p_valgrind_id_list->valgrind_id = valgrind_id;
     p_valgrind_id_list->p_next = 0;
@@ -63,11 +64,12 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
         gp_valgrind_id_list_tail = p_valgrind_id_list;
     }
     LOG_DEBUG("valgrind : register stack %p (id = %d)\n",
-              p_stack, (int) valgrind_id);
+              p_stack, (int)valgrind_id);
     ABTI_valgrind_lock_release();
 }
 
-void ABTI_valgrind_unregister_stack(const void *p_stack) {
+void ABTI_valgrind_unregister_stack(const void *p_stack)
+{
     if (p_stack == 0)
         return;
 
@@ -81,13 +83,13 @@ void ABTI_valgrind_unregister_stack(const void *p_stack) {
             gp_valgrind_id_list_tail = NULL;
     } else {
         /* Do linear search to find the corresponding valgrind_id. */
-        ABTI_valgrind_id_list *p_prev    = gp_valgrind_id_list_head;
+        ABTI_valgrind_id_list *p_prev = gp_valgrind_id_list_head;
         ABTI_valgrind_id_list *p_current = gp_valgrind_id_list_head->p_next;
         ABT_bool deregister_flag = ABT_FALSE;
         while (p_current) {
             if (p_current->p_stack == p_stack) {
                 LOG_DEBUG("valgrind : deregister stack %p (id = %d)\n",
-                          p_stack, (int) p_current->valgrind_id);
+                          p_stack, (int)p_current->valgrind_id);
                 VALGRIND_STACK_DEREGISTER(p_current->valgrind_id);
                 p_prev->p_next = p_current->p_next;
                 if (!p_prev->p_next)
@@ -96,7 +98,7 @@ void ABTI_valgrind_unregister_stack(const void *p_stack) {
                 deregister_flag = ABT_TRUE;
                 break;
             }
-            p_prev    = p_current;
+            p_prev = p_current;
             p_current = p_current->p_next;
         }
         ABTI_ASSERT(deregister_flag);

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -100,7 +100,8 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
     if (recursive == ABT_TRUE) {
         ABTD_atomic_fetch_or_uint32(&p_attr->attrs, ABTI_MUTEX_ATTR_RECURSIVE);
     } else {
-        ABTD_atomic_fetch_and_uint32(&p_attr->attrs, ~ABTI_MUTEX_ATTR_RECURSIVE);
+        ABTD_atomic_fetch_and_uint32(&p_attr->attrs,
+                                     ~ABTI_MUTEX_ATTR_RECURSIVE);
     }
 
   fn_exit:
@@ -134,16 +135,6 @@ void ABTI_mutex_attr_get_str(ABTI_mutex_attr *p_attr, char *p_buf)
         return;
     }
 
-    sprintf(p_buf,
-        "["
-        "attrs:%x "
-        "nesting_cnt:%u "
-        "p_owner:%p "
-        "]",
-        p_attr->attrs,
-        p_attr->nesting_cnt,
-        p_attr->p_owner
-    );
+    sprintf(p_buf, "[attrs:%x nesting_cnt:%u p_owner:%p ]",
+            p_attr->attrs, p_attr->nesting_cnt, p_attr->p_owner);
 }
-
-

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -6,8 +6,7 @@
 #include "abti.h"
 #include <time.h>
 
-static inline
-double get_cur_time(void)
+static inline double get_cur_time(void)
 {
 #if defined(HAVE_CLOCK_GETTIME)
     struct timespec ts;
@@ -25,18 +24,18 @@ double get_cur_time(void)
 
 /* FIFO pool implementation */
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push_shared(ABT_pool pool, ABT_unit unit);
-static void     pool_push_private(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push_shared(ABT_pool pool, ABT_unit unit);
+static void pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
-static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
-static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
-static int      pool_print_all(ABT_pool pool, void *arg,
-                               void (*print_fn)(void *, ABT_unit));
+static int pool_remove_shared(ABT_pool pool, ABT_unit unit);
+static int pool_remove_private(ABT_pool pool, ABT_unit unit);
+static int pool_print_all(ABT_pool pool, void *arg,
+                          void (*print_fn) (void *, ABT_unit));
 
 typedef ABTI_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -70,8 +69,8 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     /* FIXME: need better implementation, e.g., lock-free one */
     switch (access) {
         case ABT_POOL_ACCESS_PRIV:
-            p_def->p_push   = pool_push_private;
-            p_def->p_pop    = pool_pop_private;
+            p_def->p_push = pool_push_private;
+            p_def->p_pop = pool_pop_private;
             p_def->p_remove = pool_remove_private;
             break;
 
@@ -79,8 +78,8 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
         case ABT_POOL_ACCESS_MPSC:
         case ABT_POOL_ACCESS_SPMC:
         case ABT_POOL_ACCESS_MPMC:
-            p_def->p_push   = pool_push_shared;
-            p_def->p_pop    = pool_pop_shared;
+            p_def->p_push = pool_push_shared;
+            p_def->p_pop = pool_pop_shared;
             p_def->p_remove = pool_remove_shared;
             break;
 
@@ -89,19 +88,19 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     }
 
     /* Common definitions regardless of the access type */
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->p_pop_timedwait      = pool_pop_timedwait;
-    p_def->p_print_all          = pool_print_all;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->p_pop_timedwait = pool_pop_timedwait;
+    p_def->p_print_all = pool_print_all;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
   fn_exit:
     return abt_errno;
@@ -252,14 +251,14 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
             ABTI_spinlock_release(&p_data->mutex);
             /* Sleep. */
             const int sleep_nsecs = 100;
-            struct timespec ts = {0, sleep_nsecs};
+            struct timespec ts = { 0, sleep_nsecs };
             nanosleep(&ts, NULL);
 
             double elapsed = get_cur_time() - time_start;
             if (elapsed > abstime_secs)
                 break;
         }
-    } while(h_unit == ABT_UNIT_NULL);
+    } while (h_unit == ABT_UNIT_NULL);
 
     return h_unit;
 }
@@ -395,7 +394,8 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
 
 
 static int pool_print_all(ABT_pool pool, void *arg,
-                          void (*print_fn)(void *, ABT_unit)) {
+                          void (*print_fn) (void *, ABT_unit))
+{
     ABT_pool_access access;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     void *data = ABTI_pool_get_data(p_pool);
@@ -427,8 +427,8 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -467,9 +467,9 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -480,9 +480,9 @@ static ABT_unit unit_create_from_task(ABT_task task)
     unit_t *p_unit = &p_task->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->pool = ABT_POOL_NULL;
+    p_unit->task = task;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }
@@ -491,4 +491,3 @@ static void unit_free(ABT_unit *unit)
 {
     *unit = ABT_UNIT_NULL;
 }
-

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -7,15 +7,15 @@
 
 /* FIFO_WAIT pool implementation */
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop(ABT_pool pool);
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
-static int      pool_remove(ABT_pool pool, ABT_unit unit);
-static int      pool_print_all(ABT_pool pool, void *arg,
-                               void (*print_fn)(void *, ABT_unit));
+static int pool_remove(ABT_pool pool, ABT_unit unit);
+static int pool_print_all(ABT_pool pool, void *arg,
+                          void (*print_fn) (void *, ABT_unit));
 
 typedef ABTI_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -42,22 +42,22 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 
 int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def)
 {
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->p_push               = pool_push;
-    p_def->p_pop                = pool_pop;
-    p_def->p_pop_timedwait      = pool_pop_timedwait;
-    p_def->p_remove             = pool_remove;
-    p_def->p_print_all          = pool_print_all;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->p_push = pool_push;
+    p_def->p_pop = pool_pop;
+    p_def->p_pop_timedwait = pool_pop_timedwait;
+    p_def->p_remove = pool_remove;
+    p_def->p_print_all = pool_print_all;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
     return ABT_SUCCESS;
 }
@@ -136,10 +136,10 @@ static void pool_push(ABT_pool pool, ABT_unit unit)
 }
 
 static inline void convert_double_sec_to_timespec(struct timespec *ts_out,
-    double seconds)
+                                                  double seconds)
 {
     ts_out->tv_sec = (time_t)seconds;
-    ts_out->tv_nsec = (long)((seconds-ts_out->tv_sec) * 1000000000.0);
+    ts_out->tv_nsec = (long)((seconds - ts_out->tv_sec) * 1000000000.0);
 }
 
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
@@ -152,8 +152,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
 
     pthread_mutex_lock(&p_data->mutex);
 
-    if(!p_data->num_units)
-    {
+    if (!p_data->num_units) {
         struct timespec ts;
         convert_double_sec_to_timespec(&ts, abstime_secs);
         pthread_cond_timedwait(&p_data->cond, &p_data->mutex, &ts);
@@ -250,7 +249,8 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
 }
 
 static int pool_print_all(ABT_pool pool, void *arg,
-                          void (*print_fn)(void *, ABT_unit)) {
+                          void (*print_fn) (void *, ABT_unit))
+{
     ABT_pool_access access;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     void *data = ABTI_pool_get_data(p_pool);
@@ -277,8 +277,8 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -317,9 +317,9 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -330,9 +330,9 @@ static ABT_unit unit_create_from_task(ABT_task task)
     unit_t *p_unit = &p_task->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->pool = ABT_POOL_NULL;
+    p_unit->task = task;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -35,36 +35,36 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     ABTI_pool *p_pool;
 
     p_pool = (ABTI_pool *)ABTU_malloc(sizeof(ABTI_pool));
-    p_pool->access               = def->access;
-    p_pool->automatic            = ABT_FALSE;
-    p_pool->num_scheds           = 0;
+    p_pool->access = def->access;
+    p_pool->automatic = ABT_FALSE;
+    p_pool->num_scheds = 0;
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    p_pool->consumer             = NULL;
+    p_pool->consumer = NULL;
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    p_pool->producer             = NULL;
+    p_pool->producer = NULL;
 #endif
-    p_pool->num_blocked          = 0;
-    p_pool->num_migrations       = 0;
-    p_pool->data                 = NULL;
+    p_pool->num_blocked = 0;
+    p_pool->num_migrations = 0;
+    p_pool->data = NULL;
 
     /* Set up the pool functions from def */
-    p_pool->u_get_type           = def->u_get_type;
-    p_pool->u_get_thread         = def->u_get_thread;
-    p_pool->u_get_task           = def->u_get_task;
-    p_pool->u_is_in_pool         = def->u_is_in_pool;
+    p_pool->u_get_type = def->u_get_type;
+    p_pool->u_get_thread = def->u_get_thread;
+    p_pool->u_get_task = def->u_get_task;
+    p_pool->u_is_in_pool = def->u_is_in_pool;
     p_pool->u_create_from_thread = def->u_create_from_thread;
-    p_pool->u_create_from_task   = def->u_create_from_task;
-    p_pool->u_free               = def->u_free;
-    p_pool->p_init               = def->p_init;
-    p_pool->p_get_size           = def->p_get_size;
-    p_pool->p_push               = def->p_push;
-    p_pool->p_pop                = def->p_pop;
-    p_pool->p_pop_timedwait      = def->p_pop_timedwait;
-    p_pool->p_remove             = def->p_remove;
-    p_pool->p_free               = def->p_free;
-    p_pool->p_print_all          = def->p_print_all;
-    p_pool->id                   = ABTI_pool_get_new_id();
+    p_pool->u_create_from_task = def->u_create_from_task;
+    p_pool->u_free = def->u_free;
+    p_pool->p_init = def->p_init;
+    p_pool->p_get_size = def->p_get_size;
+    p_pool->p_push = def->p_push;
+    p_pool->p_pop = def->p_pop;
+    p_pool->p_pop_timedwait = def->p_pop_timedwait;
+    p_pool->p_remove = def->p_remove;
+    p_pool->p_free = def->p_free;
+    p_pool->p_print_all = def->p_print_all;
+    p_pool->id = ABTI_pool_get_new_id();
     LOG_EVENT("[P%" PRIu64 "] created\n", p_pool->id);
 
     *newpool = ABTI_pool_get_handle(p_pool);
@@ -149,7 +149,8 @@ int ABT_pool_free(ABT_pool *pool)
     ABT_pool h_pool = *pool;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(h_pool);
 
-    ABTI_CHECK_TRUE(p_pool != NULL && h_pool != ABT_POOL_NULL, ABT_ERR_INV_POOL);
+    ABTI_CHECK_TRUE(p_pool != NULL && h_pool != ABT_POOL_NULL,
+                    ABT_ERR_INV_POOL);
 
     LOG_EVENT("[P%" PRIu64 "] freed\n", p_pool->id);
 
@@ -395,7 +396,8 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
  * @retval ABT_SUCCESS on success
  */
 int ABT_pool_print_all(ABT_pool pool, void *arg,
-                       void (*print_fn)(void *, ABT_unit)) {
+                       void (*print_fn) (void *, ABT_unit))
+{
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -406,10 +408,10 @@ int ABT_pool_print_all(ABT_pool pool, void *arg,
 
     p_pool->p_print_all(pool, arg, print_fn);
 
-fn_exit:
+  fn_exit:
     return abt_errno;
 
-fn_fail:
+  fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -435,10 +437,10 @@ int ABT_pool_set_data(ABT_pool pool, void *data)
 
     p_pool->data = data;
 
-fn_exit:
+  fn_exit:
     return abt_errno;
 
-fn_fail:
+  fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -531,8 +533,8 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
             for (p = 0; p < p_sched->num_pools; p++) {
                 ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
                 ABTI_CHECK_TRUE(p_pool->access != ABT_POOL_ACCESS_PRIV &&
-                                  p_pool->access != ABT_POOL_ACCESS_SPSC &&
-                                  p_pool->access != ABT_POOL_ACCESS_MPSC,
+                                p_pool->access != ABT_POOL_ACCESS_SPSC &&
+                                p_pool->access != ABT_POOL_ACCESS_MPSC,
                                 ABT_ERR_POOL);
             }
             break;
@@ -549,17 +551,17 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         abt_errno = ABTI_thread_create_sched(p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-    } else if (p_sched->type == ABT_SCHED_TYPE_TASK){
+    } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
         abt_errno = ABTI_task_create_sched(p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
         ABTI_CHECK_TRUE(0, ABT_ERR_SCHED);
     }
 
-fn_exit:
+  fn_exit:
     return abt_errno;
 
-fn_fail:
+  fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
@@ -608,46 +610,57 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
     char *access;
 
     switch (p_pool->access) {
-        case ABT_POOL_ACCESS_PRIV: access = "PRIV"; break;
-        case ABT_POOL_ACCESS_SPSC: access = "SPSC"; break;
-        case ABT_POOL_ACCESS_MPSC: access = "MPSC"; break;
-        case ABT_POOL_ACCESS_SPMC: access = "SPMC"; break;
-        case ABT_POOL_ACCESS_MPMC: access = "MPMC"; break;
-        default:                   access = "UNKNOWN"; break;
+        case ABT_POOL_ACCESS_PRIV:
+            access = "PRIV";
+            break;
+        case ABT_POOL_ACCESS_SPSC:
+            access = "SPSC";
+            break;
+        case ABT_POOL_ACCESS_MPSC:
+            access = "MPSC";
+            break;
+        case ABT_POOL_ACCESS_SPMC:
+            access = "SPMC";
+            break;
+        case ABT_POOL_ACCESS_MPMC:
+            access = "MPMC";
+            break;
+        default:
+            access = "UNKNOWN";
+            break;
     }
 
     fprintf(p_os,
-        "%s== POOL (%p) ==\n"
-        "%sid            : %" PRIu64 "\n"
-        "%saccess        : %s\n"
-        "%sautomatic     : %s\n"
-        "%snum_scheds    : %d\n"
+            "%s== POOL (%p) ==\n"
+            "%sid            : %" PRIu64 "\n"
+            "%saccess        : %s\n"
+            "%sautomatic     : %s\n" "%snum_scheds    : %d\n"
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        "%sconsumer ES   : %p (%d)\n"
+            "%sconsumer ES   : %p (%d)\n"
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-        "%sproducer ES   : %p (%d)\n"
+            "%sproducer ES   : %p (%d)\n"
 #endif
-        "%ssize          : %zu\n"
-        "%snum_blocked   : %u\n"
-        "%snum_migrations: %d\n"
-        "%sdata          : %p\n",
-        prefix, p_pool,
-        prefix, p_pool->id,
-        prefix, access,
-        prefix, (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
-        prefix, p_pool->num_scheds,
+            "%ssize          : %zu\n"
+            "%snum_blocked   : %u\n"
+            "%snum_migrations: %d\n"
+            "%sdata          : %p\n",
+            prefix, p_pool,
+            prefix, p_pool->id,
+            prefix, access,
+            prefix, (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
+            prefix, p_pool->num_scheds,
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        prefix, p_pool->consumer, p_pool->consumer ? p_pool->consumer->rank : 0,
+            prefix, p_pool->consumer,
+            p_pool->consumer ? p_pool->consumer->rank : 0,
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-        prefix, p_pool->producer, p_pool->producer ? p_pool->producer->rank : 0,
+            prefix, p_pool->producer,
+            p_pool->producer ? p_pool->producer->rank : 0,
 #endif
-        prefix, ABTI_pool_get_size(p_pool),
-        prefix, p_pool->num_blocked,
-        prefix, p_pool->num_migrations,
-        prefix, p_pool->data
-    );
+            prefix, ABTI_pool_get_size(p_pool),
+            prefix, p_pool->num_blocked,
+            prefix, p_pool->num_migrations, prefix, p_pool->data);
 
   fn_exit:
     fflush(p_os);
@@ -655,8 +668,8 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
 }
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-/* Set the associated consumer ES of a pool. This function has no effect on pools
- * of shared-read access mode.
+/* Set the associated consumer ES of a pool. This function has no effect on
+ * pools of shared-read access mode.
  * If a pool is private-read to an ES, we check that the previous value of the
  * field "p_xstream" is the same as the argument of the function "p_xstream"
  * */
@@ -697,18 +710,18 @@ int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_xstream *p_xstream)
             ABTI_CHECK_ERROR(abt_errno);
     }
 
-fn_exit:
+  fn_exit:
     return abt_errno;
 
-fn_fail:
+  fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-/* Set the associated producer ES of a pool. This function has no effect on pools
- * of shared-write access mode.
+/* Set the associated producer ES of a pool. This function has no effect on
+ * pools of shared-write access mode.
  * If a pool is private-write to an ES, we check that the previous value of the
  * field "p_xstream" is the same as the argument of the function "p_xstream"
  * */
@@ -745,10 +758,10 @@ int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_xstream *p_xstream)
             ABTI_CHECK_ERROR(abt_errno);
     }
 
-fn_exit:
+  fn_exit:
     return abt_errno;
 
-fn_fail:
+  fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -761,12 +774,11 @@ int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source)
 {
 #if !defined(ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK) && \
     !defined(ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK)
-    switch (p_pool->access)
-    {
-        /* Need producer in the same ES */
+    switch (p_pool->access) {
         case ABT_POOL_ACCESS_PRIV:
         case ABT_POOL_ACCESS_SPSC:
         case ABT_POOL_ACCESS_SPMC:
+            /* Need producer in the same ES */
             if (p_pool->consumer == source->producer)
                 return ABT_TRUE;
             return ABT_FALSE;

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -31,8 +31,7 @@ int ABT_rwlock_create(ABT_rwlock *newrwlock)
     p_newrwlock = (ABTI_rwlock *)ABTU_malloc(sizeof(ABTI_rwlock));
     if (p_newrwlock == NULL) {
         abt_errno = ABT_ERR_MEM;
-    }
-    else {
+    } else {
         ABTI_rwlock_init(p_newrwlock);
     }
 
@@ -150,9 +149,9 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
  * @brief Unlock the rwlock
  *
  * \c ABT_rwlock_unlock unlocks the rwlock \c rwlock.
- * If the caller ULT locked the rwlock, this routine unlocks the rwlock. However,
- * if the caller ULT did not lock the rwlock, this routine may result in
- * undefined behavior.
+ * If the caller ULT locked the rwlock, this routine unlocks the rwlock.
+ * However, if the caller ULT did not lock the rwlock, this routine may result
+ * in undefined behavior.
  *
  * @param[in] rwlock  handle to the rwlock
  * @return Error code

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -9,9 +9,9 @@
  * This group is for the basic scheudler.
  */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_def = {
@@ -70,7 +70,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Sort pools according to their access mode so the scheduler can execute
-       work units from the private pools. */
+     * work units from the private pools. */
     if (num_pools > 1) {
         sched_sort_pools(num_pools, p_data->pools);
     }
@@ -102,8 +102,8 @@ static void sched_run(ABT_sched sched)
     ABT_sched_get_data(sched, &data);
     p_data = sched_data_get_ptr(data);
     event_freq = p_data->event_freq;
-    num_pools  = p_data->num_pools;
-    pools      = p_data->pools;
+    num_pools = p_data->num_pools;
+    pools = p_data->pools;
 
     while (1) {
         CNT_INIT(run_cnt, 0);
@@ -152,12 +152,20 @@ static int pool_get_access_num(ABT_pool *p_pool)
 
     ABT_pool_get_access(*p_pool, &access);
     switch (access) {
-        case ABT_POOL_ACCESS_PRIV: num = 0; break;
+        case ABT_POOL_ACCESS_PRIV:
+            num = 0;
+            break;
         case ABT_POOL_ACCESS_SPSC:
-        case ABT_POOL_ACCESS_MPSC: num = 1; break;
+        case ABT_POOL_ACCESS_MPSC:
+            num = 1;
+            break;
         case ABT_POOL_ACCESS_SPMC:
-        case ABT_POOL_ACCESS_MPMC: num = 2; break;
-        default: ABTI_ASSERT(0); break;
+        case ABT_POOL_ACCESS_MPMC:
+            num = 2;
+            break;
+        default:
+            ABTI_ASSERT(0);
+            break;
     }
 
     return num;
@@ -183,4 +191,3 @@ static void sched_sort_pools(int num_pools, ABT_pool *pools)
 {
     qsort(pools, num_pools, sizeof(ABT_pool), sched_cmp_pools);
 }
-

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -9,9 +9,9 @@
  * This group is for the basic waiting scheudler.
  */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_wait_def = {
@@ -63,7 +63,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Sort pools according to their access mode so the scheduler can execute
-       work units from the private pools. */
+     * work units from the private pools. */
     if (num_pools > 1) {
         sched_sort_pools(num_pools, p_data->pools);
     }
@@ -95,8 +95,8 @@ static void sched_run(ABT_sched sched)
     ABT_sched_get_data(sched, &data);
     p_data = sched_data_get_ptr(data);
     event_freq = p_data->event_freq;
-    num_pools  = p_data->num_pools;
-    pools      = p_data->pools;
+    num_pools = p_data->num_pools;
+    pools = p_data->pools;
 
     while (1) {
         run_cnt_nowait = 0;
@@ -117,14 +117,14 @@ static void sched_run(ABT_sched sched)
         /* Block briefly on pop_timedwait() if we didn't find work to do in
          * main loop above.
          */
-        if(!run_cnt_nowait) {
+        if (!run_cnt_nowait) {
             double abstime = ABT_get_wtime();
             abstime += 0.1;
-            ABT_unit unit = ABTI_pool_pop_timedwait(
-                ABTI_pool_get_ptr(pools[0]), abstime);
+            ABT_unit unit =
+                ABTI_pool_pop_timedwait(ABTI_pool_get_ptr(pools[0]), abstime);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_xstream_run_unit(p_xstream, unit,
-                    ABTI_pool_get_ptr(pools[0]));
+                                      ABTI_pool_get_ptr(pools[0]));
                 break;
             }
         }
@@ -165,12 +165,20 @@ static int pool_get_access_num(ABT_pool *p_pool)
 
     ABT_pool_get_access(*p_pool, &access);
     switch (access) {
-        case ABT_POOL_ACCESS_PRIV: num = 0; break;
+        case ABT_POOL_ACCESS_PRIV:
+            num = 0;
+            break;
         case ABT_POOL_ACCESS_SPSC:
-        case ABT_POOL_ACCESS_MPSC: num = 1; break;
+        case ABT_POOL_ACCESS_MPSC:
+            num = 1;
+            break;
         case ABT_POOL_ACCESS_SPMC:
-        case ABT_POOL_ACCESS_MPMC: num = 2; break;
-        default: ABTI_ASSERT(0); break;
+        case ABT_POOL_ACCESS_MPMC:
+            num = 2;
+            break;
+        default:
+            ABTI_ASSERT(0);
+            break;
     }
 
     return num;

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -49,7 +49,8 @@ ABT_sched_config_var ABT_sched_config_access = {
  *
  * For example, if you want to configure the basic scheduler to have a
  * frequency for checking events equal to 5, you will have this call:
- * ABT_sched_config_create(&config, ABT_sched_basic_freq, 5, ABT_sched_config_var_end);
+ * ABT_sched_config_create(&config, ABT_sched_basic_freq, 5,
+ *                         ABT_sched_config_var_end);
  *
  * @param[out] config   configuration to create
  * @param[in]  ...      list of arguments
@@ -62,7 +63,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
     ABTI_sched_config *p_config;
 
     char *buffer = NULL;
-    size_t alloc_size = 8*sizeof(size_t);
+    size_t alloc_size = 8 * sizeof(size_t);
 
     int num_params = 0;
     size_t offset = sizeof(num_params);
@@ -73,7 +74,8 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
     va_list varg_list;
     va_start(varg_list, config);
 
-    /* We read each couple (var, value) until we find ABT_sched_config_var_end */
+    /* We read each couple (var, value) until we find
+     * ABT_sched_config_var_end */
     while (1) {
         ABT_sched_config_var var = va_arg(varg_list, ABT_sched_config_var);
         if (var.idx == ABT_sched_config_var_end.idx)
@@ -84,16 +86,16 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
         num_params++;
 
         size_t size = ABTI_sched_config_type_size(type);
-        if (offset+sizeof(param)+sizeof(type)+size > buffer_size) {
+        if (offset + sizeof(param) + sizeof(type) + size > buffer_size) {
             buffer_size += alloc_size;
             buffer = ABTU_realloc(buffer, buffer_size);
         }
         /* Copy the parameter index */
-        memcpy(buffer+offset, (void *)&param, sizeof(param));
+        memcpy(buffer + offset, (void *)&param, sizeof(param));
         offset += sizeof(param);
 
         /* Copy the size of the argument */
-        memcpy(buffer+offset, (void *)&size, sizeof(size));
+        memcpy(buffer + offset, (void *)&size, sizeof(size));
         offset += sizeof(size);
 
         /* Copy the argument */
@@ -119,7 +121,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 goto fn_fail;
         }
 
-        memcpy(buffer+offset, ptr, size);
+        memcpy(buffer + offset, ptr, size);
         offset += size;
     }
     va_end(varg_list);
@@ -163,7 +165,7 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
     int v;
 
     /* We read all the variables and save the addresses */
-    void **variables = (void *)ABTU_malloc(num_vars*sizeof(void *));
+    void **variables = (void *)ABTU_malloc(num_vars * sizeof(void *));
     va_list varg_list;
     va_start(varg_list, num_vars);
     for (v = 0; v < num_vars; v++) {
@@ -226,7 +228,7 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
     int access_i = -1;
     int automatic_i = -1;
 
-    void **variables = (void **)ABTU_malloc(num_vars*sizeof(void *));
+    void **variables = (void **)ABTU_malloc(num_vars * sizeof(void *));
     variables[0] = &access_i;
     variables[1] = &automatic_i;
 
@@ -234,8 +236,10 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
     ABTU_free(variables);
     ABTI_CHECK_ERROR(abt_errno);
 
-    if (access_i != -1) *access = (ABT_pool_access)access_i;
-    if (automatic_i != -1) *automatic = (ABT_bool)automatic_i;
+    if (access_i != -1)
+        *access = (ABT_pool_access)access_i;
+    if (automatic_i != -1)
+        *automatic = (ABT_bool)automatic_i;
 
   fn_exit:
     return abt_errno;
@@ -266,16 +270,15 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
 
     /* Copy the data from buffer to the right variables */
     int p;
-    for (p = 0; p < num_params; p++)
-    {
+    for (p = 0; p < num_params; p++) {
         int var_idx;
         size_t size;
 
         /* Get the variable index of the next parameter */
-        memcpy(&var_idx, buffer+offset, sizeof(var_idx));
+        memcpy(&var_idx, buffer + offset, sizeof(var_idx));
         offset += sizeof(var_idx);
         /* Get the size of the next parameter */
-        memcpy(&size, buffer+offset, sizeof(size));
+        memcpy(&size, buffer + offset, sizeof(size));
         offset += sizeof(size);
         /* Get the next argument */
         /* We save it only if
@@ -284,18 +287,19 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
          */
         if (type == 0) {
             if (var_idx < 0) {
-                var_idx = (var_idx+2)*-1;
-                if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                var_idx = (var_idx + 2) * -1;
+                if (var_idx >= num_vars)
+                    return ABT_ERR_INV_SCHED_CONFIG;
+                memcpy(variables[var_idx], buffer + offset, size);
             }
         } else {
             if (var_idx >= 0) {
-                if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                if (var_idx >= num_vars)
+                    return ABT_ERR_INV_SCHED_CONFIG;
+                memcpy(variables[var_idx], buffer + offset, size);
             }
         }
         offset += size;
     }
     return ABT_SUCCESS;
 }
-

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -8,9 +8,9 @@
 
 /* Priority Scheduler Implementation */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 
 static ABT_sched_def sched_prio_def = {
     .type = ABT_SCHED_TYPE_TASK,
@@ -105,7 +105,8 @@ static void sched_run(ABT_sched sched)
 
         if (++work_count >= event_freq) {
             ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);
             SCHED_SLEEP(run_cnt, p_data->sleep_time);
@@ -127,4 +128,3 @@ static int sched_free(ABT_sched sched)
 
     return abt_errno;
 }
-

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -7,9 +7,9 @@
 
 /* Random Work-stealing Scheduler Implementation */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 
 static ABT_sched_def sched_randws_def = {
     .type = ABT_SCHED_TYPE_TASK,
@@ -88,7 +88,8 @@ static void sched_run(ABT_sched sched)
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             pool = p_pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
             unit = ABTI_pool_pop(p_pool);
@@ -102,7 +103,8 @@ static void sched_run(ABT_sched sched)
 
         if (++work_count >= p_data->event_freq) {
             ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);
             SCHED_SLEEP(run_cnt, p_data->sleep_time);
@@ -121,4 +123,3 @@ static int sched_free(ABT_sched sched)
 
     return ABT_SUCCESS;
 }
-

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -47,7 +47,7 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 
     /* Copy of the contents of pools */
     ABT_pool *pool_list;
-    pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+    pool_list = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
     for (p = 0; p < num_pools; p++) {
         if (pools[p] == ABT_POOL_NULL) {
             abt_errno = ABT_pool_create_basic(ABT_POOL_FIFO,
@@ -64,25 +64,25 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
         ABTI_pool_retain(ABTI_pool_get_ptr(pool_list[p]));
     }
 
-    p_sched->used          = ABTI_SCHED_NOT_USED;
-    p_sched->automatic     = ABT_FALSE;
-    p_sched->kind          = ABTI_sched_get_kind(def);
-    p_sched->state         = ABT_SCHED_STATE_READY;
-    p_sched->request       = 0;
-    p_sched->pools         = pool_list;
-    p_sched->num_pools     = num_pools;
-    p_sched->type          = def->type;
-    p_sched->p_thread      = NULL;
-    p_sched->p_task        = NULL;
-    p_sched->p_ctx         = NULL;
+    p_sched->used = ABTI_SCHED_NOT_USED;
+    p_sched->automatic = ABT_FALSE;
+    p_sched->kind = ABTI_sched_get_kind(def);
+    p_sched->state = ABT_SCHED_STATE_READY;
+    p_sched->request = 0;
+    p_sched->pools = pool_list;
+    p_sched->num_pools = num_pools;
+    p_sched->type = def->type;
+    p_sched->p_thread = NULL;
+    p_sched->p_task = NULL;
+    p_sched->p_ctx = NULL;
 
-    p_sched->init          = def->init;
-    p_sched->run           = def->run;
-    p_sched->free          = def->free;
+    p_sched->init = def->init;
+    p_sched->run = def->run;
+    p_sched->free = def->free;
     p_sched->get_migr_pool = def->get_migr_pool;
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-    p_sched->id            = ABTI_sched_get_new_id();
+    p_sched->id = ABTI_sched_get_new_id();
 #endif
     LOG_EVENT("[S%" PRIu64 "] created\n", p_sched->id);
 
@@ -153,7 +153,7 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
     if (pools != NULL) {
         /* Copy of the contents of pools */
         ABT_pool *pool_list;
-        pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+        pool_list = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
         for (p = 0; p < num_pools; p++) {
             if (pools[p] == ABT_POOL_NULL) {
                 abt_errno = ABT_pool_create_basic(ABT_POOL_FIFO, access,
@@ -170,26 +170,22 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
             case ABT_SCHED_BASIC:
                 abt_errno = ABT_sched_create(ABTI_sched_get_basic_def(),
                                              num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
+                                             ABT_SCHED_CONFIG_NULL, newsched);
                 break;
             case ABT_SCHED_BASIC_WAIT:
                 abt_errno = ABT_sched_create(ABTI_sched_get_basic_wait_def(),
                                              num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
+                                             ABT_SCHED_CONFIG_NULL, newsched);
                 break;
             case ABT_SCHED_PRIO:
                 abt_errno = ABT_sched_create(ABTI_sched_get_prio_def(),
                                              num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
+                                             ABT_SCHED_CONFIG_NULL, newsched);
                 break;
             case ABT_SCHED_RANDWS:
                 abt_errno = ABT_sched_create(ABTI_sched_get_randws_def(),
                                              num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
+                                             ABT_SCHED_CONFIG_NULL, newsched);
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
@@ -230,7 +226,7 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
         int p;
         for (p = 0; p < num_pools; p++) {
             abt_errno = ABT_pool_create_basic(kind, access, ABT_TRUE,
-                                              pool_list+p);
+                                              pool_list + p);
             ABTI_CHECK_ERROR(abt_errno);
         }
 
@@ -361,11 +357,11 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    ABTI_CHECK_TRUE(idx+max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE(idx + max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
 
     int p;
-    for (p = idx; p < idx+max_pools; p++) {
-        pools[p-idx] = p_sched->pools[p];
+    for (p = idx; p < idx + max_pools; p++) {
+        pools[p - idx] = p_sched->pools[p];
     }
 
   fn_exit:
@@ -408,7 +404,8 @@ int ABT_sched_finish(ABT_sched sched)
  * @brief   Ask a scheduler to stop as soon as possible
  *
  * The scheduler will stop even if its pools are not empty. It is the user's
- * responsibility to ensure that the left work will be done by another scheduler.
+ * responsibility to ensure that the left work will be done by another
+ * scheduler.
  *
  * @param[in] sched  handle to the target scheduler
  * @return Error code
@@ -705,7 +702,8 @@ size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
                 }
 #endif
                 break;
-            default: break;
+            default:
+                break;
         }
     }
 
@@ -734,7 +732,7 @@ int ABTI_sched_free(ABTI_sched *p_sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         int32_t num_scheds = ABTI_pool_release(p_pool);
         if (p_pool->automatic == ABT_TRUE && num_scheds == 0) {
-            abt_errno = ABT_pool_free(p_sched->pools+p);
+            abt_errno = ABT_pool_free(p_sched->pools + p);
             ABTI_CHECK_ERROR(abt_errno);
         }
     }
@@ -786,17 +784,17 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
     if (p_sched->get_migr_pool == NULL) {
         if (p_sched->num_pools == 0)
             p_pool = NULL;
-        else
+        else {
             p_pool = p_sched->pools[0];
-    }
-    else
+        }
+    } else {
         p_pool = p_sched->get_migr_pool(sched);
+    }
 
     /* Check the pool */
     if (ABTI_pool_accept_migration(p_pool, source_pool) == ABT_TRUE) {
         *pp_pool = p_pool;
-    }
-    else {
+    } else {
         ABTI_CHECK_TRUE(0, ABT_ERR_INV_POOL_ACCESS);
     }
 
@@ -811,7 +809,7 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
 
 ABTI_sched_kind ABTI_sched_get_kind(ABT_sched_def *def)
 {
-  return (ABTI_sched_kind)def;
+    return (ABTI_sched_kind)def;
 }
 
 void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
@@ -842,22 +840,46 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     }
 
     switch (p_sched->type) {
-        case ABT_SCHED_TYPE_ULT:  type = "ULT"; break;
-        case ABT_SCHED_TYPE_TASK: type = "TASKLET"; break;
-        default:                  type = "UNKNOWN"; break;
+        case ABT_SCHED_TYPE_ULT:
+            type = "ULT";
+            break;
+        case ABT_SCHED_TYPE_TASK:
+            type = "TASKLET";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_sched->state) {
-        case ABT_SCHED_STATE_READY:      state = "READY"; break;
-        case ABT_SCHED_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_SCHED_STATE_STOPPED:    state = "STOPPED"; break;
-        case ABT_SCHED_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                         state = "UNKNOWN"; break;
+        case ABT_SCHED_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_SCHED_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_SCHED_STATE_STOPPED:
+            state = "STOPPED";
+            break;
+        case ABT_SCHED_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
     switch (p_sched->used) {
-        case ABTI_SCHED_NOT_USED: used = "NOT_USED"; break;
-        case ABTI_SCHED_MAIN:     used = "MAIN"; break;
-        case ABTI_SCHED_IN_POOL:  used = "IN_POOL"; break;
-        default:                  used = "UNKNOWN"; break;
+        case ABTI_SCHED_NOT_USED:
+            used = "NOT_USED";
+            break;
+        case ABTI_SCHED_MAIN:
+            used = "MAIN";
+            break;
+        case ABTI_SCHED_IN_POOL:
+            used = "IN_POOL";
+            break;
+        default:
+            used = "UNKNOWN";
+            break;
     }
 
     size = sizeof(char) * (p_sched->num_pools * 20 + 4);
@@ -872,38 +894,33 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     }
     pools_str[pos] = ']';
 
-    fprintf(p_os,
-        "%s== SCHED (%p) ==\n"
+    fprintf(p_os, "%s== SCHED (%p) ==\n"
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-        "%sid       : %" PRIu64 "\n"
+            "%sid       : %" PRIu64 "\n"
 #endif
-        "%skind     : %" PRIu64 " (%s)\n"
-        "%stype     : %s\n"
-        "%sstate    : %s\n"
-        "%sused     : %s\n"
-        "%sautomatic: %s\n"
-        "%srequest  : 0x%x\n"
-        "%snum_pools: %d\n"
-        "%spools    : %s\n"
-        "%ssize     : %zu\n"
-        "%stot_size : %zu\n"
-        "%sdata     : %p\n",
-        prefix, p_sched,
+            "%skind     : %" PRIu64 " (%s)\n"
+            "%stype     : %s\n"
+            "%sstate    : %s\n"
+            "%sused     : %s\n"
+            "%sautomatic: %s\n"
+            "%srequest  : 0x%x\n"
+            "%snum_pools: %d\n"
+            "%spools    : %s\n"
+            "%ssize     : %zu\n"
+            "%stot_size : %zu\n" "%sdata     : %p\n", prefix, p_sched,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-        prefix, p_sched->id,
+            prefix, p_sched->id,
 #endif
-        prefix, p_sched->kind, kind_str,
-        prefix, type,
-        prefix, state,
-        prefix, used,
-        prefix, (p_sched->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
-        prefix, p_sched->request,
-        prefix, p_sched->num_pools,
-        prefix, pools_str,
-        prefix, ABTI_sched_get_size(p_sched),
-        prefix, ABTI_sched_get_total_size(p_sched),
-        prefix, p_sched->data
-    );
+            prefix, p_sched->kind, kind_str,
+            prefix, type,
+            prefix, state,
+            prefix, used,
+            prefix, (p_sched->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
+            prefix, p_sched->request,
+            prefix, p_sched->num_pools,
+            prefix, pools_str,
+            prefix, ABTI_sched_get_size(p_sched),
+            prefix, ABTI_sched_get_total_size(p_sched), prefix, p_sched->data);
     ABTU_free(pools_str);
 
     if (print_sub == ABT_TRUE) {

--- a/src/self.c
+++ b/src/self.c
@@ -40,7 +40,6 @@ int ABT_self_get_type(ABT_unit_type *type)
         *type = ABT_UNIT_TYPE_EXT;
         goto fn_exit;
     }
-
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (lp_ABTI_local == NULL) {
@@ -91,7 +90,6 @@ int ABT_self_is_primary(ABT_bool *flag)
         *flag = ABT_FALSE;
         goto fn_exit;
     }
-
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (lp_ABTI_local == NULL) {
@@ -104,7 +102,7 @@ int ABT_self_is_primary(ABT_bool *flag)
     p_thread = ABTI_local_get_thread();
     if (p_thread) {
         *flag = (p_thread->type == ABTI_THREAD_TYPE_MAIN)
-              ? ABT_TRUE : ABT_FALSE;
+            ? ABT_TRUE : ABT_FALSE;
     } else {
         abt_errno = ABT_ERR_INV_THREAD;
         *flag = ABT_FALSE;
@@ -140,7 +138,6 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
         *flag = ABT_FALSE;
         goto fn_exit;
     }
-
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (lp_ABTI_local == NULL) {
@@ -155,7 +152,7 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
 
     /* Return value */
     *flag = (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
-          ? ABT_TRUE : ABT_FALSE;
+        ? ABT_TRUE : ABT_FALSE;
 
   fn_exit:
     return abt_errno;
@@ -195,7 +192,6 @@ int ABT_self_get_last_pool_id(int *pool_id)
         *pool_id = -1;
         goto fn_exit;
     }
-
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (lp_ABTI_local == NULL) {
@@ -339,7 +335,6 @@ int ABT_self_get_arg(void **arg)
         *arg = NULL;
         goto fn_exit;
     }
-
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* When an external thread called this routine */
     if (lp_ABTI_local == NULL) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -73,13 +73,13 @@ int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream)
     /* Create a wrapper unit */
     ABTI_elem_create_from_xstream(p_newxstream);
 
-    p_newxstream->type         = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state        = ABT_XSTREAM_STATE_CREATED;
-    p_newxstream->scheds       = NULL;
-    p_newxstream->num_scheds   = 0;
-    p_newxstream->max_scheds   = 0;
-    p_newxstream->request      = 0;
-    p_newxstream->p_req_arg    = NULL;
+    p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
+    p_newxstream->state = ABT_XSTREAM_STATE_CREATED;
+    p_newxstream->scheds = NULL;
+    p_newxstream->num_scheds = 0;
+    p_newxstream->max_scheds = 0;
+    p_newxstream->request = 0;
+    p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
     /* Create the spinlock */
@@ -211,13 +211,13 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     /* Create a wrapper unit */
     ABTI_elem_create_from_xstream(p_newxstream);
 
-    p_newxstream->type         = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state        = ABT_XSTREAM_STATE_CREATED;
-    p_newxstream->scheds       = NULL;
-    p_newxstream->num_scheds   = 0;
-    p_newxstream->max_scheds   = 0;
-    p_newxstream->request      = 0;
-    p_newxstream->p_req_arg    = NULL;
+    p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
+    p_newxstream->state = ABT_XSTREAM_STATE_CREATED;
+    p_newxstream->scheds = NULL;
+    p_newxstream->num_scheds = 0;
+    p_newxstream->max_scheds = 0;
+    p_newxstream->request = 0;
+    p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
     /* Create the spinlock */
@@ -303,9 +303,9 @@ int ABTI_xstream_start(ABTI_xstream *p_xstream)
 
     } else {
         /* Start the main scheduler on a different ES */
-        abt_errno = ABTD_xstream_context_create(
-                ABTI_xstream_launch_main_sched, (void *)p_xstream,
-                &p_xstream->ctx);
+        abt_errno =
+            ABTD_xstream_context_create(ABTI_xstream_launch_main_sched,
+                                        (void *)p_xstream, &p_xstream->ctx);
         ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_create");
     }
 
@@ -390,12 +390,13 @@ int ABT_xstream_free(ABT_xstream *xstream)
     ABT_xstream h_xstream = *xstream;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(h_xstream);
-    if (p_xstream == NULL) goto fn_exit;
+    if (p_xstream == NULL)
+        goto fn_exit;
 
     /* We first need to check whether lp_ABTI_local is NULL because this
      * routine might be called by external threads. */
     ABTI_CHECK_TRUE_MSG(lp_ABTI_local == NULL ||
-                          p_xstream != ABTI_local_get_xstream(),
+                        p_xstream != ABTI_local_get_xstream(),
                         ABT_ERR_INV_XSTREAM,
                         "The current xstream cannot be freed.");
 
@@ -787,7 +788,8 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
         }
     }
 
-    /* TODO: permit to change the scheduler even when having work units in pools */
+    /* TODO: permit to change the scheduler even when having work units in
+     * pools */
     if (p_xstream->p_main_sched) {
         /* We only allow to change the main scheduler when the current main
          * scheduler of p_xstream has no work unit in its associated pools. */
@@ -833,7 +835,8 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
  * @retval ABT_SUCCESS on success
  */
 int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
-        ABT_sched_predef predef, int num_pools, ABT_pool *pools)
+                                     ABT_sched_predef predef, int num_pools,
+                                     ABT_pool *pools)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -1025,7 +1028,7 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *flag)
 
     /* Return value */
     *flag = (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
-          ? ABT_TRUE : ABT_FALSE;
+        ? ABT_TRUE : ABT_FALSE;
 
   fn_exit:
     return abt_errno;
@@ -1153,7 +1156,6 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
         abt_errno = ABT_sched_exit(sched);
         ABTI_CHECK_ERROR(abt_errno);
     }
-
     // TODO: check event queue
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
     if (ABTI_event_check_power() == ABT_TRUE) {
@@ -1378,7 +1380,8 @@ void ABTI_xstream_schedule(void *p_arg)
         request = ABTD_atomic_load_uint32(&p_xstream->request);
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
         /* If there is a stop request, the ES has to be terminated/ */
-        if (request & ABTI_XSTREAM_REQ_STOP) break;
+        if (request & ABTI_XSTREAM_REQ_STOP)
+            break;
 #endif
 
         /* If there is an exit or a cancel request, the ES terminates
@@ -1391,7 +1394,8 @@ void ABTI_xstream_schedule(void *p_arg)
          * execution of all work units. */
         if (request & ABTI_XSTREAM_REQ_JOIN) {
             if (ABTI_sched_get_effective_size(p_xstream->p_main_sched) == 0) {
-                /* If a ULT has been blocked on the join call, we make it ready */
+                /* If a ULT has been blocked on the join call, we make it
+                 * ready */
                 if (p_xstream->p_req_arg) {
                     ABTI_thread_set_ready((ABTI_thread *)p_xstream->p_req_arg);
                     p_xstream->p_req_arg = NULL;
@@ -1489,8 +1493,8 @@ int ABTI_xstream_schedule_thread(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
         LOG_EVENT("[U%" PRIu64 ":E%d] %s\n",
                   ABTI_thread_get_id(p_thread), p_xstream->rank,
                   (p_thread->request & ABTI_THREAD_REQ_TERMINATE ? "finished" :
-                  ((p_thread->request & ABTI_THREAD_REQ_EXIT) ? "exit called" :
-                  "UNKNOWN")));
+                   ((p_thread->request & ABTI_THREAD_REQ_EXIT) ? "exit called" :
+                    "UNKNOWN")));
         ABTI_xstream_terminate_thread(p_thread);
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
     } else if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
@@ -1622,11 +1626,11 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
         p_thread->attr.f_cb(thread, p_thread->attr.p_cb_arg);
     }
 
-    ABTI_spinlock_acquire(&p_thread->lock); // TODO: mutex useful?
+    ABTI_spinlock_acquire(&p_thread->lock);     // TODO: mutex useful?
     {
         /* extracting argument in migration request */
-        p_pool = (ABTI_pool *)ABTI_thread_extract_req_arg(p_thread,
-                ABTI_THREAD_REQ_MIGRATE);
+        p_pool = (ABTI_pool *)
+            ABTI_thread_extract_req_arg(p_thread, ABTI_THREAD_REQ_MIGRATE);
         pool = ABTI_pool_get_handle(p_pool);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
@@ -1634,8 +1638,8 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
         newstream = p_pool->consumer;
 #endif
         LOG_EVENT("[U%" PRIu64 "] migration: E%d -> E%d\n",
-                ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
-                newstream ? newstream->rank : -1);
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
+                  newstream ? newstream->rank : -1);
 
         /* Change the associated pool */
         p_thread->p_pool = p_pool;
@@ -1717,7 +1721,8 @@ int ABTI_xstream_set_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_thread->type == ABTI_THREAD_TYPE_MAIN, ABT_ERR_THREAD);
+        ABTI_CHECK_TRUE(p_thread->type == ABTI_THREAD_TYPE_MAIN,
+                        ABT_ERR_THREAD);
 
         /* Free the current main scheduler */
         abt_errno = ABTI_sched_discard_and_free(p_main_sched);
@@ -1795,16 +1800,32 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     size_t size, pos;
 
     switch (p_xstream->type) {
-        case ABTI_XSTREAM_TYPE_PRIMARY:   type = "PRIMARY"; break;
-        case ABTI_XSTREAM_TYPE_SECONDARY: type = "SECONDARY"; break;
-        default:                          type = "UNKNOWN"; break;
+        case ABTI_XSTREAM_TYPE_PRIMARY:
+            type = "PRIMARY";
+            break;
+        case ABTI_XSTREAM_TYPE_SECONDARY:
+            type = "SECONDARY";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_xstream->state) {
-        case ABT_XSTREAM_STATE_CREATED:    state = "CREATED"; break;
-        case ABT_XSTREAM_STATE_READY:      state = "READY"; break;
-        case ABT_XSTREAM_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_XSTREAM_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                           state = "UNKNOWN"; break;
+        case ABT_XSTREAM_STATE_CREATED:
+            state = "CREATED";
+            break;
+        case ABT_XSTREAM_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_XSTREAM_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_XSTREAM_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
 
     size = sizeof(char) * (p_xstream->num_scheds * 20 + 4);
@@ -1819,25 +1840,23 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     scheds_str[pos] = ']';
 
     fprintf(p_os,
-        "%s== ES (%p) ==\n"
-        "%srank      : %d\n"
-        "%stype      : %s\n"
-        "%sstate     : %s\n"
-        "%srequest   : 0x%x\n"
-        "%smax_scheds: %d\n"
-        "%snum_scheds: %d\n"
-        "%sscheds    : %s\n"
-        "%smain_sched: %p\n",
-        prefix, p_xstream,
-        prefix, p_xstream->rank,
-        prefix, type,
-        prefix, state,
-        prefix, p_xstream->request,
-        prefix, p_xstream->max_scheds,
-        prefix, p_xstream->num_scheds,
-        prefix, scheds_str,
-        prefix, p_xstream->p_main_sched
-    );
+            "%s== ES (%p) ==\n"
+            "%srank      : %d\n"
+            "%stype      : %s\n"
+            "%sstate     : %s\n"
+            "%srequest   : 0x%x\n"
+            "%smax_scheds: %d\n"
+            "%snum_scheds: %d\n"
+            "%sscheds    : %s\n"
+            "%smain_sched: %p\n",
+            prefix, p_xstream,
+            prefix, p_xstream->rank,
+            prefix, type,
+            prefix, state,
+            prefix, p_xstream->request,
+            prefix, p_xstream->max_scheds,
+            prefix, p_xstream->num_scheds,
+            prefix, scheds_str, prefix, p_xstream->p_main_sched);
     ABTU_free(scheds_str);
 
     if (print_sub == ABT_TRUE) {
@@ -1957,4 +1976,3 @@ static void ABTI_xstream_return_rank(ABTI_xstream *p_xstream)
     gp_ABTI_global->num_xstreams--;
     ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
-

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -18,7 +18,8 @@ typedef struct {
 
 #ifdef HAVE_PTHREAD_BARRIER_INIT
 static inline
-ABTI_xstream_barrier *ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
+    ABTI_xstream_barrier *ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier
+                                                       barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_xstream_barrier *p_barrier;
@@ -33,8 +34,8 @@ ABTI_xstream_barrier *ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
 #endif
 }
 
-static inline
-ABT_xstream_barrier ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barrier)
+static inline ABT_xstream_barrier
+ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_xstream_barrier h_barrier;
@@ -65,13 +66,15 @@ ABT_xstream_barrier ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barr
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_xstream_barrier_create(uint32_t num_waiters, ABT_xstream_barrier *newbarrier)
+int ABT_xstream_barrier_create(uint32_t num_waiters,
+                               ABT_xstream_barrier *newbarrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream_barrier *p_newbarrier;
 
-    p_newbarrier = (ABTI_xstream_barrier *)ABTU_malloc(sizeof(ABTI_xstream_barrier));
+    p_newbarrier =
+        (ABTI_xstream_barrier *)ABTU_malloc(sizeof(ABTI_xstream_barrier));
 
     p_newbarrier->num_waiters = num_waiters;
     abt_errno = ABTD_xstream_barrier_init(num_waiters, &p_newbarrier->bar);
@@ -162,4 +165,3 @@ int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
     return ABT_ERR_FEATURE_NA;
 #endif
 }
-

--- a/src/task.c
+++ b/src/task.c
@@ -35,8 +35,7 @@ static inline uint64_t ABTI_task_get_new_id(void);
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_task_create(ABT_pool pool,
-                    void (*task_func)(void *), void *arg,
+int ABT_task_create(ABT_pool pool, void (*task_func) (void *), void *arg,
                     ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
@@ -48,21 +47,21 @@ int ABT_task_create(ABT_pool pool,
     /* Allocate a task object */
     p_newtask = ABTI_mem_alloc_task();
 
-    p_newtask->p_xstream  = NULL;
-    p_newtask->state      = ABT_TASK_STATE_READY;
-    p_newtask->request    = 0;
-    p_newtask->f_task     = task_func;
-    p_newtask->p_arg      = arg;
+    p_newtask->p_xstream = NULL;
+    p_newtask->state = ABT_TASK_STATE_READY;
+    p_newtask->request = 0;
+    p_newtask->f_task = task_func;
+    p_newtask->p_arg = arg;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched   = NULL;
+    p_newtask->is_sched = NULL;
 #endif
-    p_newtask->p_pool     = p_pool;
-    p_newtask->refcount   = (newtask != NULL) ? 1 : 0;
+    p_newtask->p_pool = p_pool;
+    p_newtask->refcount = (newtask != NULL) ? 1 : 0;
     p_newtask->p_keytable = NULL;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     p_newtask->migratable = ABT_TRUE;
 #endif
-    p_newtask->id         = ABTI_TASK_INIT_ID;
+    p_newtask->id = ABTI_TASK_INIT_ID;
 
     /* Create a wrapper work unit */
     h_newtask = ABTI_task_get_handle(p_newtask);
@@ -82,13 +81,15 @@ int ABT_task_create(ABT_pool pool,
 #endif
 
     /* Return value */
-    if (newtask) *newtask = h_newtask;
+    if (newtask)
+        *newtask = h_newtask;
 
   fn_exit:
     return abt_errno;
 
   fn_fail:
-    if (newtask) *newtask = ABT_TASK_NULL;
+    if (newtask)
+        *newtask = ABT_TASK_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -114,21 +115,21 @@ int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
     /* Allocate a task object */
     p_newtask = ABTI_mem_alloc_task();
 
-    p_newtask->p_xstream  = NULL;
-    p_newtask->state      = ABT_TASK_STATE_READY;
-    p_newtask->request    = 0;
-    p_newtask->f_task     = p_sched->run;
-    p_newtask->p_arg      = (void *)ABTI_sched_get_handle(p_sched);
+    p_newtask->p_xstream = NULL;
+    p_newtask->state = ABT_TASK_STATE_READY;
+    p_newtask->request = 0;
+    p_newtask->f_task = p_sched->run;
+    p_newtask->p_arg = (void *)ABTI_sched_get_handle(p_sched);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched   = p_sched;
+    p_newtask->is_sched = p_sched;
 #endif
-    p_newtask->p_pool     = p_pool;
-    p_newtask->refcount   = 1;
+    p_newtask->p_pool = p_pool;
+    p_newtask->refcount = 1;
     p_newtask->p_keytable = NULL;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     p_newtask->migratable = ABT_TRUE;
 #endif
-    p_newtask->id         = ABTI_TASK_INIT_ID;
+    p_newtask->id = ABTI_TASK_INIT_ID;
 
     /* Create a wrapper unit */
     h_newtask = ABTI_task_get_handle(p_newtask);
@@ -191,7 +192,7 @@ int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
+int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func) (void *),
                                void *arg, ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
@@ -208,7 +209,8 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     return abt_errno;
 
   fn_fail:
-    if (newtask) *newtask = ABT_TASK_NULL;
+    if (newtask)
+        *newtask = ABT_TASK_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -231,7 +233,7 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
+int ABT_task_revive(ABT_pool pool, void (*task_func) (void *), void *arg,
                     ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
@@ -244,12 +246,12 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    p_task->p_xstream  = NULL;
-    p_task->state      = ABT_TASK_STATE_READY;
-    p_task->request    = 0;
-    p_task->f_task     = task_func;
-    p_task->p_arg      = arg;
-    p_task->refcount   = 1;
+    p_task->p_xstream = NULL;
+    p_task->state = ABT_TASK_STATE_READY;
+    p_task->request = 0;
+    p_task->f_task = task_func;
+    p_task->p_arg = arg;
+    p_task->refcount = 1;
     p_task->p_keytable = NULL;
 
     if (p_task->p_pool != p_pool) {
@@ -827,46 +829,49 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
     int xstream_rank = p_xstream ? p_xstream->rank : 0;
     char *state;
     switch (p_task->state) {
-        case ABT_TASK_STATE_READY:      state = "READY"; break;
-        case ABT_TASK_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_TASK_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                        state = "UNKNOWN";
+        case ABT_TASK_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_TASK_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_TASK_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
     }
 
     fprintf(p_os,
-        "%s== TASKLET (%p) ==\n"
-        "%sid        : %" PRIu64 "\n"
-        "%sstate     : %s\n"
-        "%sES        : %p (%d)\n"
+            "%s== TASKLET (%p) ==\n"
+            "%sid        : %" PRIu64 "\n"
+            "%sstate     : %s\n" "%sES        : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        "%sis_sched  : %p\n"
+            "%sis_sched  : %p\n"
 #endif
-        "%spool      : %p\n"
+            "%spool      : %p\n"
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        "%smigratable: %s\n"
+            "%smigratable: %s\n"
 #endif
-        "%srefcount  : %u\n"
-        "%srequest   : 0x%x\n"
-        "%sf_task    : %p\n"
-        "%sp_arg     : %p\n"
-        "%skeytable  : %p\n",
-        prefix, p_task,
-        prefix, ABTI_task_get_id(p_task),
-        prefix, state,
-        prefix, p_task->p_xstream, xstream_rank,
+            "%srefcount  : %u\n"
+            "%srequest   : 0x%x\n"
+            "%sf_task    : %p\n"
+            "%sp_arg     : %p\n"
+            "%skeytable  : %p\n",
+            prefix, p_task,
+            prefix, ABTI_task_get_id(p_task),
+            prefix, state, prefix, p_task->p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, p_task->is_sched,
+            prefix, p_task->is_sched,
 #endif
-        prefix, p_task->p_pool,
+            prefix, p_task->p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
+            prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
 #endif
-        prefix, p_task->refcount,
-        prefix, p_task->request,
-        prefix, p_task->f_task,
-        prefix, p_task->p_arg,
-        prefix, p_task->p_keytable
-    );
+            prefix, p_task->refcount,
+            prefix, p_task->request,
+            prefix, p_task->f_task,
+            prefix, p_task->p_arg, prefix, p_task->p_keytable);
 
   fn_exit:
     fflush(p_os);
@@ -911,4 +916,3 @@ static inline uint64_t ABTI_task_get_new_id(void)
 {
     return ABTD_atomic_fetch_add_uint64(&g_task_id, 1);
 }
-

--- a/src/thread.c
+++ b/src/thread.c
@@ -6,8 +6,8 @@
 #include "abti.h"
 
 static inline int ABTI_thread_create(ABTI_pool *p_pool,
-                                     void (*thread_func)(void *),
-                                     void *arg, ABTI_thread_attr *p_attr,
+                                     void (*thread_func) (void *), void *arg,
+                                     ABTI_thread_attr *p_attr,
                                      ABTI_thread_type thread_type,
                                      ABTI_sched *p_sched, int refcount,
                                      ABTI_xstream *p_parent_xstream,
@@ -44,9 +44,8 @@ static inline ABT_thread_id ABTI_thread_get_new_id(void);
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
-                      void *arg, ABT_thread_attr attr,
-                      ABT_thread *newthread)
+int ABT_thread_create(ABT_pool pool, void (*thread_func) (void *), void *arg,
+                      ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newthread;
@@ -61,13 +60,15 @@ int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
                                    ABT_TRUE, &p_newthread);
 
     /* Return value */
-    if (newthread) *newthread = ABTI_thread_get_handle(p_newthread);
+    if (newthread)
+        *newthread = ABTI_thread_get_handle(p_newthread);
 
   fn_exit:
     return abt_errno;
 
   fn_fail:
-    if (newthread) *newthread = ABT_THREAD_NULL;
+    if (newthread)
+        *newthread = ABT_THREAD_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -113,8 +114,8 @@ int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_create_on_xstream(ABT_xstream xstream,
-                      void (*thread_func)(void *), void *arg,
-                      ABT_thread_attr attr, ABT_thread *newthread)
+                                 void (*thread_func) (void *), void *arg,
+                                 ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABT_pool pool;
@@ -130,7 +131,8 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
     return abt_errno;
 
   fn_fail:
-    if (newthread) *newthread = ABT_THREAD_NULL;
+    if (newthread)
+        *newthread = ABT_THREAD_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -159,7 +161,7 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_create_many(int num, ABT_pool *pool_list,
-                           void (**thread_func_list)(void *), void **arg_list,
+                           void (**thread_func_list) (void *), void **arg_list,
                            ABT_thread_attr attr, ABT_thread *newthread_list)
 {
     int abt_errno = ABT_SUCCESS;
@@ -175,7 +177,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
     if (newthread_list == NULL) {
         for (i = 0; i < num; i++) {
             ABT_pool pool = pool_list[i];
-            void (*thread_f)(void *) = thread_func_list[i];
+            void (*thread_f) (void *) = thread_func_list[i];
             void *arg = arg_list ? arg_list[i] : NULL;
             abt_errno = ABT_thread_create(pool, thread_f, arg, attr, NULL);
             ABTI_CHECK_ERROR(abt_errno);
@@ -183,7 +185,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
     } else {
         for (i = 0; i < num; i++) {
             ABT_pool pool = pool_list[i];
-            void (*thread_f)(void *) = thread_func_list[i];
+            void (*thread_f) (void *) = thread_func_list[i];
             void *arg = arg_list ? arg_list[i] : NULL;
             abt_errno = ABT_thread_create(pool, thread_f, arg, attr,
                                           &newthread_list[i]);
@@ -219,7 +221,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
+int ABT_thread_revive(ABT_pool pool, void (*thread_func) (void *), void *arg,
                       ABT_thread *thread)
 {
     int abt_errno = ABT_SUCCESS;
@@ -238,23 +240,25 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_thread->is_sched) {
         abt_errno = ABTD_thread_context_create_sched(NULL, thread_func, arg,
-                                           stacksize, p_thread->attr.p_stack,
-                                           &p_thread->ctx);
+                                                     stacksize,
+                                                     p_thread->attr.p_stack,
+                                                     &p_thread->ctx);
     } else {
 #endif
         abt_errno = ABTD_thread_context_create_thread(NULL, thread_func, arg,
-                                           stacksize, p_thread->attr.p_stack,
-                                           &p_thread->ctx);
+                                                      stacksize,
+                                                      p_thread->attr.p_stack,
+                                                      &p_thread->ctx);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_thread->state          = ABT_THREAD_STATE_READY;
-    p_thread->request        = 0;
+    p_thread->state = ABT_THREAD_STATE_READY;
+    p_thread->request = 0;
     p_thread->p_last_xstream = NULL;
-    p_thread->refcount       = 1;
-    p_thread->type           = ABTI_THREAD_TYPE_USER;
+    p_thread->refcount = 1;
+    p_thread->type = ABTI_THREAD_TYPE_USER;
 
     if (p_thread->p_pool != p_pool) {
         /* Free the unit for the old pool */
@@ -309,12 +313,12 @@ int ABT_thread_free(ABT_thread *thread)
     /* We first need to check whether lp_ABTI_local is NULL because external
      * threads might call this routine. */
     ABTI_CHECK_TRUE_MSG(lp_ABTI_local == NULL ||
-                          p_thread != ABTI_local_get_thread(),
+                        p_thread != ABTI_local_get_thread(),
                         ABT_ERR_INV_THREAD,
                         "The current thread cannot be freed.");
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be freed explicitly.");
 
@@ -384,17 +388,18 @@ int ABT_thread_join(ABT_thread thread)
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    if (p_thread->state == ABT_THREAD_STATE_TERMINATED) return abt_errno;
+    if (p_thread->state == ABT_THREAD_STATE_TERMINATED)
+        return abt_errno;
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
-                        ABT_ERR_INV_THREAD,
-                        "The main ULT cannot be joined.");
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        ABT_ERR_INV_THREAD, "The main ULT cannot be joined.");
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     ABT_unit_type type;
     ABT_self_get_type(&type);
-    if (type != ABT_UNIT_TYPE_THREAD) goto yield_based;
+    if (type != ABT_UNIT_TYPE_THREAD)
+        goto yield_based;
 #endif
 
     ABTI_CHECK_TRUE_MSG(p_thread != ABTI_local_get_thread(), ABT_ERR_INV_THREAD,
@@ -416,7 +421,7 @@ int ABT_thread_join(ABT_thread thread)
          * changes the state first followed by pushing p_thread to the pool.
          * Therefore, we have to check whether p_thread is in the pool, and if
          * not, we need to wait until it is added. */
-        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {}
+        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE);
 
         /* Increase the number of blocked units.  Be sure to execute
          * ABTI_pool_inc_num_blocked before ABTI_POOL_REMOVE in order not to
@@ -458,7 +463,8 @@ int ABT_thread_join(ABT_thread thread)
          * We can't block p_self in this case. */
         uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
                                                    ABTI_THREAD_REQ_JOIN);
-        if (req & ABTI_THREAD_REQ_JOIN) goto yield_based;
+        if (req & ABTI_THREAD_REQ_JOIN)
+            goto yield_based;
 
         ABTI_thread_set_blocked(p_self);
         LOG_EVENT("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
@@ -591,7 +597,7 @@ int ABT_thread_cancel(ABT_thread thread)
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be canceled.");
 
@@ -844,7 +850,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     if (lp_ABTI_local != NULL) {
         p_cur_thread = ABTI_local_get_thread();
     }
-    if (p_cur_thread == NULL) goto fn_exit;
+    if (p_cur_thread == NULL)
+        goto fn_exit;
 #endif
 
     ABTI_xstream *p_xstream = ABTI_local_get_xstream();
@@ -937,7 +944,8 @@ int ABT_thread_yield(void)
     if (lp_ABTI_local != NULL) {
         p_thread = ABTI_local_get_thread();
     }
-    if (p_thread == NULL) goto fn_exit;
+    if (p_thread == NULL)
+        goto fn_exit;
 #endif
 
     ABTI_CHECK_TRUE(p_thread->p_last_xstream == ABTI_local_get_xstream(),
@@ -1019,7 +1027,7 @@ int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
     ABTI_CHECK_TRUE(p_xstream->state != ABT_XSTREAM_STATE_TERMINATED,
                     ABT_ERR_INV_XSTREAM);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                    p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -1111,7 +1119,7 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
     ABTI_CHECK_TRUE(p_sched->state == ABT_SCHED_STATE_RUNNING,
                     ABT_ERR_INV_XSTREAM);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                    p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -1224,7 +1232,7 @@ int ABT_thread_migrate(ABT_thread thread)
                 xstream = ABTI_xstream_get_handle(p_xstream);
                 abt_errno = ABT_thread_migrate_to_xstream(thread, xstream);
                 if (abt_errno != ABT_ERR_INV_XSTREAM &&
-                        abt_errno != ABT_ERR_MIGRATION_TARGET) {
+                    abt_errno != ABT_ERR_MIGRATION_TARGET) {
                     ABTI_CHECK_ERROR(abt_errno);
                     break;
                 }
@@ -1257,7 +1265,7 @@ int ABT_thread_migrate(ABT_thread thread)
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_set_callback(ABT_thread thread,
-                            void(*cb_func)(ABT_thread thread, void *cb_arg),
+                            void (*cb_func) (ABT_thread thread, void *cb_arg),
                             void *cb_arg)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -1265,7 +1273,7 @@ int ABT_thread_set_callback(ABT_thread thread,
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    p_thread->attr.f_cb     = cb_func;
+    p_thread->attr.f_cb = cb_func;
     p_thread->attr.p_cb_arg = cb_arg;
 
   fn_exit:
@@ -1616,12 +1624,14 @@ int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-static inline
-int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
-                       void *arg, ABTI_thread_attr *p_attr,
-                       ABTI_thread_type thread_type, ABTI_sched *p_sched,
-                       int refcount, ABTI_xstream *p_parent_xstream,
-                       ABT_bool push_pool, ABTI_thread **pp_newthread)
+static inline int ABTI_thread_create(ABTI_pool *p_pool,
+                                     void (*thread_func) (void *), void *arg,
+                                     ABTI_thread_attr *p_attr,
+                                     ABTI_thread_type thread_type,
+                                     ABTI_sched *p_sched, int refcount,
+                                     ABTI_xstream *p_parent_xstream,
+                                     ABT_bool push_pool,
+                                     ABTI_thread **pp_newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newthread;
@@ -1631,7 +1641,7 @@ int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
     p_newthread = ABTI_mem_alloc_thread(p_attr);
     if ((thread_type == ABTI_THREAD_TYPE_MAIN ||
          thread_type == ABTI_THREAD_TYPE_MAIN_SCHED)
-         && p_newthread->attr.p_stack == NULL) {
+        && p_newthread->attr.p_stack == NULL) {
         /* We don't need to initialize the context of 1. the main thread, and
          * 2. the main scheduler thread which runs on OS-level threads
          * (p_stack == NULL). Invalidate the context here. */
@@ -1657,18 +1667,18 @@ int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
     }
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_newthread->state          = ABT_THREAD_STATE_READY;
-    p_newthread->request        = 0;
+    p_newthread->state = ABT_THREAD_STATE_READY;
+    p_newthread->request = 0;
     p_newthread->p_last_xstream = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newthread->is_sched       = p_sched;
+    p_newthread->is_sched = p_sched;
 #endif
-    p_newthread->p_pool         = p_pool;
-    p_newthread->refcount       = refcount;
-    p_newthread->type           = thread_type;
-    p_newthread->p_req_arg      = NULL;
-    p_newthread->p_keytable     = NULL;
-    p_newthread->id             = ABTI_THREAD_INIT_ID;
+    p_newthread->p_pool = p_pool;
+    p_newthread->refcount = refcount;
+    p_newthread->type = thread_type;
+    p_newthread->p_req_arg = NULL;
+    p_newthread->p_keytable = NULL;
+    p_newthread->id = ABTI_THREAD_INIT_ID;
 
     /* Create a spinlock */
     ABTI_spinlock_create(&p_newthread->lock);
@@ -1694,8 +1704,8 @@ int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
         ABTI_pool_push(p_pool, p_newthread->unit);
 #else
-        ABTI_xstream *p_producer = p_parent_xstream ? p_parent_xstream
-                                                    : ABTI_xstream_self();
+        ABTI_xstream *p_producer = (p_parent_xstream ? p_parent_xstream
+                                    : ABTI_xstream_self());
         abt_errno = ABTI_pool_push(p_pool, p_newthread->unit, p_producer);
         if (abt_errno != ABT_SUCCESS) {
             if (thread_type == ABTI_THREAD_TYPE_MAIN) {
@@ -1731,10 +1741,9 @@ int ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool)
 
     /* checking for cases when migration is not allowed */
     ABTI_CHECK_TRUE(ABTI_pool_accept_migration(p_pool, p_thread->p_pool)
-                      == ABT_TRUE,
-                    ABT_ERR_INV_POOL);
+                    == ABT_TRUE, ABT_ERR_INV_POOL);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                    p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -1882,8 +1891,7 @@ int ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
     goto fn_exit;
 }
 
-static inline
-void ABTI_thread_free_internal(ABTI_thread *p_thread)
+static inline void ABTI_thread_free_internal(ABTI_thread *p_thread)
 {
     /* Free the unit */
     p_thread->p_pool->u_free(&p_thread->unit);
@@ -1904,7 +1912,7 @@ void ABTI_thread_free(ABTI_thread *p_thread)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* p_thread's lock may have been acquired somewhere. We free p_thread when
-       the lock can be acquired here. */
+     * the lock can be acquired here. */
     ABTI_spinlock_acquire(&p_thread->lock);
 #endif
 
@@ -1998,7 +2006,8 @@ int ABTI_thread_set_ready(ABTI_thread *p_thread)
     int abt_errno = ABT_SUCCESS;
 
     /* The ULT should be in BLOCKED state. */
-    ABTI_CHECK_TRUE(p_thread->state == ABT_THREAD_STATE_BLOCKED, ABT_ERR_THREAD);
+    ABTI_CHECK_TRUE(p_thread->state == ABT_THREAD_STATE_BLOCKED,
+                    ABT_ERR_THREAD);
 
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
      * request. Otherwise, the ULT can be pushed to a pool here and be
@@ -2059,50 +2068,62 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
     char attr[100];
 
     switch (p_thread->type) {
-        case ABTI_THREAD_TYPE_MAIN:       type = "MAIN"; break;
-        case ABTI_THREAD_TYPE_MAIN_SCHED: type = "MAIN_SCHED"; break;
-        case ABTI_THREAD_TYPE_USER:       type = "USER"; break;
-        default:                          type = "UNKNOWN"; break;
+        case ABTI_THREAD_TYPE_MAIN:
+            type = "MAIN";
+            break;
+        case ABTI_THREAD_TYPE_MAIN_SCHED:
+            type = "MAIN_SCHED";
+            break;
+        case ABTI_THREAD_TYPE_USER:
+            type = "USER";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_thread->state) {
-        case ABT_THREAD_STATE_READY:      state = "READY"; break;
-        case ABT_THREAD_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_THREAD_STATE_BLOCKED:    state = "BLOCKED"; break;
-        case ABT_THREAD_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                          state = "UNKNOWN"; break;
+        case ABT_THREAD_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_THREAD_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_THREAD_STATE_BLOCKED:
+            state = "BLOCKED";
+            break;
+        case ABT_THREAD_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
     ABTI_thread_attr_get_str(&p_thread->attr, attr);
 
     fprintf(p_os,
-        "%s== ULT (%p) ==\n"
-        "%sid      : %" PRIu64 "\n"
-        "%stype    : %s\n"
-        "%sstate   : %s\n"
-        "%slast_ES : %p (%d)\n"
+            "%s== ULT (%p) ==\n"
+            "%sid      : %" PRIu64 "\n"
+            "%stype    : %s\n" "%sstate   : %s\n" "%slast_ES : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        "%sis_sched: %p\n"
+            "%sis_sched: %p\n"
 #endif
-        "%spool    : %p\n"
-        "%srefcount: %u\n"
-        "%srequest : 0x%x\n"
-        "%sreq_arg : %p\n"
-        "%skeytable: %p\n"
-        "%sattr    : %s\n",
-        prefix, p_thread,
-        prefix, ABTI_thread_get_id(p_thread),
-        prefix, type,
-        prefix, state,
-        prefix, p_xstream, xstream_rank,
+            "%spool    : %p\n"
+            "%srefcount: %u\n"
+            "%srequest : 0x%x\n"
+            "%sreq_arg : %p\n"
+            "%skeytable: %p\n"
+            "%sattr    : %s\n",
+            prefix, p_thread,
+            prefix, ABTI_thread_get_id(p_thread),
+            prefix, type, prefix, state, prefix, p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, p_thread->is_sched,
+            prefix, p_thread->is_sched,
 #endif
-        prefix, p_thread->p_pool,
-        prefix, p_thread->refcount,
-        prefix, p_thread->request,
-        prefix, p_thread->p_req_arg,
-        prefix, p_thread->p_keytable,
-        prefix, attr
-    );
+            prefix, p_thread->p_pool,
+            prefix, p_thread->refcount,
+            prefix, p_thread->request,
+            prefix, p_thread->p_req_arg,
+            prefix, p_thread->p_keytable, prefix, attr);
 
   fn_exit:
     fflush(p_os);
@@ -2277,7 +2298,8 @@ void ABTI_thread_reset_id(void)
 
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread)
 {
-    if (p_thread == NULL) return ABTI_THREAD_INIT_ID;
+    if (p_thread == NULL)
+        return ABTI_THREAD_INIT_ID;
 
     if (p_thread->id == ABTI_THREAD_INIT_ID) {
         p_thread->id = ABTI_thread_get_new_id();
@@ -2288,13 +2310,15 @@ ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread)
 ABT_thread_id ABTI_thread_self_id(void)
 {
     ABTI_thread *p_self = NULL;
-    if (lp_ABTI_local) p_self = ABTI_local_get_thread();
+    if (lp_ABTI_local)
+        p_self = ABTI_local_get_thread();
     return ABTI_thread_get_id(p_self);
 }
 
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread)
 {
-    if (p_thread == NULL) return -1;
+    if (p_thread == NULL)
+        return -1;
 
     if (p_thread->p_last_xstream) {
         return p_thread->p_last_xstream->rank;
@@ -2306,7 +2330,8 @@ int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread)
 int ABTI_thread_self_xstream_rank(void)
 {
     ABTI_thread *p_self = NULL;
-    if (lp_ABTI_local) p_self = ABTI_local_get_thread();
+    if (lp_ABTI_local)
+        p_self = ABTI_local_get_thread();
     return ABTI_thread_get_xstream_rank(p_self);
 }
 
@@ -2318,4 +2343,3 @@ static inline ABT_thread_id ABTI_thread_get_new_id(void)
 {
     return (ABT_thread_id)ABTD_atomic_fetch_add_uint64(&g_thread_id, 1);
 }
-

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -107,7 +107,7 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
             abt_errno = ABT_ERR_OTHER;
             goto fn_fail;
         }
-        p_attr->p_stack   = stackaddr;
+        p_attr->p_stack = stackaddr;
         p_attr->stacktype = ABTI_STACK_TYPE_USER;
     } else {
         p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;
@@ -227,7 +227,8 @@ int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_attr_set_callback(ABT_thread_attr attr,
-        void(*cb_func)(ABT_thread thread, void *cb_arg), void *cb_arg)
+                                 void (*cb_func) (ABT_thread th, void *cb_arg),
+                                 void *cb_arg)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
@@ -235,7 +236,7 @@ int ABT_thread_attr_set_callback(ABT_thread_attr attr,
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     /* Set the value */
-    p_attr->f_cb     = cb_func;
+    p_attr->f_cb = cb_func;
     p_attr->p_cb_arg = cb_arg;
 
   fn_exit:
@@ -328,41 +329,42 @@ void ABTI_thread_attr_get_str(ABTI_thread_attr *p_attr, char *p_buf)
 
     char *stacktype;
     switch (p_attr->stacktype) {
-        case ABTI_STACK_TYPE_MEMPOOL: stacktype = "MEMPOOL"; break;
-        case ABTI_STACK_TYPE_MALLOC:  stacktype = "MALLOC"; break;
-        case ABTI_STACK_TYPE_USER:    stacktype = "USER"; break;
-        case ABTI_STACK_TYPE_MAIN:    stacktype = "MAIN"; break;
-        default:                      stacktype = "UNKNOWN"; break;
+        case ABTI_STACK_TYPE_MEMPOOL:
+            stacktype = "MEMPOOL";
+            break;
+        case ABTI_STACK_TYPE_MALLOC:
+            stacktype = "MALLOC";
+            break;
+        case ABTI_STACK_TYPE_USER:
+            stacktype = "USER";
+            break;
+        case ABTI_STACK_TYPE_MAIN:
+            stacktype = "MAIN";
+            break;
+        default:
+            stacktype = "UNKNOWN";
+            break;
     }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     sprintf(p_buf,
-        "["
-        "stack:%p "
-        "stacksize:%zu "
-        "stacktype:%s "
-        "migratable:%s "
-        "cb_func:%p "
-        "cb_arg:%p"
-        "]",
-        p_attr->p_stack,
-        p_attr->stacksize,
-        stacktype,
-        (p_attr->migratable == ABT_TRUE ? "TRUE" : "FALSE"),
-        p_attr->f_cb,
-        p_attr->p_cb_arg
-    );
+            "["
+            "stack:%p "
+            "stacksize:%zu "
+            "stacktype:%s "
+            "migratable:%s "
+            "cb_func:%p "
+            "cb_arg:%p"
+            "]",
+            p_attr->p_stack, p_attr->stacksize, stacktype,
+            (p_attr->migratable == ABT_TRUE ? "TRUE" : "FALSE"),
+            p_attr->f_cb, p_attr->p_cb_arg);
 #else
     sprintf(p_buf,
-        "["
-        "stack:%p "
-        "stacksize:%zu "
-        "stacktype:%s "
-        "]",
-        p_attr->p_stack,
-        p_attr->stacksize,
-        stacktype
-    );
+            "["
+            "stack:%p "
+            "stacksize:%zu "
+            "stacktype:%s " "]", p_attr->p_stack, p_attr->stacksize, stacktype);
 #endif
 }
 
@@ -375,4 +377,3 @@ ABTI_thread_attr *ABTI_thread_attr_dup(ABTI_thread_attr *p_attr)
 
     return p_dupattr;
 }
-

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -62,8 +62,8 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
         /* Increase the hash table */
         uint32_t new_size;
         new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
-        p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, new_size * sizeof(ABTI_thread_queue));
+        p_htable->queue = (ABTI_thread_queue *)
+            ABTU_realloc(p_htable->queue, new_size * sizeof(ABTI_thread_queue));
         memset(&p_htable->queue[p_htable->num_rows], 0,
                (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
@@ -121,8 +121,8 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
         /* Increase the hash table */
         uint32_t new_size;
         new_size = (idx / p_htable->num_rows + 1) * p_htable->num_rows;
-        p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, new_size * sizeof(ABTI_thread_queue));
+        p_htable->queue = (ABTI_thread_queue *)
+            ABTU_realloc(p_htable->queue, new_size * sizeof(ABTI_thread_queue));
         memset(&p_htable->queue[p_htable->num_rows], 0,
                (new_size - p_htable->num_rows) * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
@@ -253,4 +253,3 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
         return ABT_FALSE;
     }
 }
-

--- a/src/timer.c
+++ b/src/timer.c
@@ -217,7 +217,7 @@ int ABT_timer_read(ABT_timer timer, double *secs)
     double start, end;
 
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
 
@@ -254,7 +254,7 @@ int ABT_timer_stop_and_read(ABT_timer timer, double *secs)
 
     ABTD_time_get(&p_timer->end);
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
 
@@ -291,7 +291,7 @@ int ABT_timer_stop_and_add(ABT_timer timer, double *secs)
 
     ABTD_time_get(&p_timer->end);
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs += (end - start);
 
@@ -346,4 +346,3 @@ int ABT_timer_get_overhead(double *overhead)
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -14,7 +14,8 @@ char *ABTU_get_indent_str(int indent)
 {
     char *space;
     space = (char *)ABTU_malloc(sizeof(char) * (indent + 1));
-    if (indent > 0) memset(space, ' ', indent);
+    if (indent > 0)
+        memset(space, ' ', indent);
     space[indent] = '\0';
     return space;
 }
@@ -32,16 +33,18 @@ char *ABTU_strtrim(char *str)
     char *end;
 
     /* Trim leading white spaces */
-    while (isspace(*str)) str++;
+    while (isspace(*str))
+        str++;
 
-    if (*str == 0) return str;
+    if (*str == 0)
+        return str;
 
     /* Trim trailing white spaces */
     end = str + strlen(str) - 1;
-    while (end > str && isspace(*end)) end--;
+    while (end > str && isspace(*end))
+        end--;
 
     *(end + 1) = 0;
 
     return str;
 }
-

--- a/test/basic/barrier.c
+++ b/test/basic/barrier.c
@@ -23,17 +23,19 @@ void run(void *args)
 
     assert(values[i] == i);
     ABT_barrier_wait(row_barrier[i]);
-    if (!j) values[i] = i+N;
+    if (!j)
+        values[i] = i + N;
 
     ABT_barrier_wait(row_barrier[i]);
-    assert(values[i] == i+N);
+    assert(values[i] == i + N);
 
     ABT_barrier_wait(global_barrier);
     ABT_barrier_wait(global_barrier);
-    if (!i) values[j] = j+2*N;
+    if (!i)
+        values[j] = j + 2 * N;
 
     ABT_barrier_wait(col_barrier[j]);
-    assert(values[j] == j+2*N);
+    assert(values[j] == j + 2 * N);
 }
 
 int main(int argc, char *argv[])
@@ -106,10 +108,12 @@ int main(int argc, char *argv[])
         }
         for (i = 0; i < N; i++) {
             for (j = 0; j < N; j++) {
-                args[2*(i*N+j)] = i;
-                args[2*(i*N+j)+1] = j;
-                ret = ABT_thread_create(pools[es], run, (void *)&args[2*(i*N+j)],
-                                        ABT_THREAD_ATTR_NULL, &threads[i*N+j]);
+                args[2 * (i * N + j)] = i;
+                args[2 * (i * N + j) + 1] = j;
+                ret = ABT_thread_create(pools[es], run,
+                                        (void *)&args[2 * (i * N + j)],
+                                        ABT_THREAD_ATTR_NULL,
+                                        &threads[i * N + j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 es = (es + 1) % num_xstreams;
             }
@@ -118,7 +122,7 @@ int main(int argc, char *argv[])
         /* Join and free ULTs */
         for (i = 0; i < N; i++) {
             for (j = 0; j < N; j++) {
-                ret = ABT_thread_free(&threads[i*N+j]);
+                ret = ABT_thread_free(&threads[i * N + j]);
                 ATS_ERROR(ret, "ABT_thread_free");
             }
         }
@@ -159,4 +163,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_join.c
+++ b/test/basic/cond_join.c
@@ -12,9 +12,9 @@
 #define NUM_XSTREAMS    NUM_THREADS
 
 typedef struct {
-    ABT_mutex    mutex;
-    ABT_cond     cond;
-    int          count;
+    ABT_mutex mutex;
+    ABT_cond cond;
+    int count;
     volatile int curcount;
     volatile int generation;
 } barrier_t;
@@ -61,7 +61,7 @@ void barrier_free(barrier_t *barrier)
 void thread_wait(thread_arg_t *my_arg)
 {
     int generation;
-    barrier_t* barrier = my_arg->barrier;
+    barrier_t *barrier = my_arg->barrier;
 
     ABT_mutex_lock(barrier->mutex);
     if ((barrier->curcount + 1) == barrier->count) {
@@ -69,25 +69,25 @@ void thread_wait(thread_arg_t *my_arg)
         barrier->curcount = 0;
 
         ATS_printf(3, "<S%d:TH%d> T%d broadcast-1\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+                   my_arg->eid, my_arg->uid, my_arg->tid);
         ABT_cond_broadcast(barrier->cond);
         ABT_mutex_unlock(barrier->mutex);
         ATS_printf(3, "<S%d:TH%d> T%d broadcast-2\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+                   my_arg->eid, my_arg->uid, my_arg->tid);
         return;
     }
     barrier->curcount++;
     generation = barrier->generation;
     do {
         ATS_printf(3, "<S%d:TH%d> T%d wait-1\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+                   my_arg->eid, my_arg->uid, my_arg->tid);
         ABT_cond_wait(barrier->cond, barrier->mutex);
         ATS_printf(3, "<S%d:TH%d> T%d wait-2\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+                   my_arg->eid, my_arg->uid, my_arg->tid);
     } while (generation == barrier->generation);
     ABT_mutex_unlock(barrier->mutex);
     ATS_printf(3, "<S%d:TH%d> T%d wait-3\n",
-                    my_arg->eid, my_arg->uid, my_arg->tid);
+               my_arg->eid, my_arg->uid, my_arg->tid);
 }
 
 void cond_test(void *arg)
@@ -111,11 +111,11 @@ void cond_test(void *arg)
 
 void thread_work(void *arg)
 {
-    ABT_xstream  xstreams[NUM_XSTREAMS];
-    ABT_pool     pools[NUM_XSTREAMS];
-    ABT_thread   threads[NUM_THREADS];
+    ABT_xstream xstreams[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_THREADS];
     thread_arg_t args[NUM_THREADS];
-    barrier_t   *barrier;
+    barrier_t *barrier;
     int i, t, ret;
     int iter = (int)(size_t)arg;
 
@@ -172,12 +172,13 @@ void thread_work(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstream;
-    ABT_pool    pool;
-    ABT_thread  thread;
+    ABT_pool pool;
+    ABT_thread thread;
     int ret;
     int iter = 5;
 
-    if (argc > 1) iter = atoi(argv[1]);
+    if (argc > 1)
+        iter = atoi(argv[1]);
 
     /* Initialize */
     ATS_read_args(argc, argv);
@@ -206,4 +207,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/cond_signal_in_main.c
+++ b/test/basic/cond_signal_in_main.c
@@ -78,4 +78,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_test.c
+++ b/test/basic/cond_test.c
@@ -28,8 +28,8 @@ ABT_cond cond = ABT_COND_NULL;
 ABT_cond broadcast = ABT_COND_NULL;
 
 typedef struct thread_arg {
-    int sid;    /* stream ID */
-    int tid;    /* thread ID */
+    int sid;                    /* stream ID */
+    int tid;                    /* thread ID */
 } thread_arg_t;
 
 void inc_counter(void *arg)
@@ -45,10 +45,10 @@ void inc_counter(void *arg)
 
         if (g_counter == COUNT_LIMIT) {
             ATS_printf(1, "[ES%d:TH%d] inc_counter(): threshold(%d) "
-                    "reached\n", es_id, my_id, g_counter);
+                       "reached\n", es_id, my_id, g_counter);
             ABT_cond_signal(cond);
             ATS_printf(1, "[ES%d:TH%d] inc_counter(): sent signal\n",
-                    es_id, my_id);
+                       es_id, my_id);
         }
 
         ABT_mutex_unlock(mutex);
@@ -73,11 +73,10 @@ void watch_counter(void *arg)
 
     ABT_mutex_lock(mutex);
     while (g_counter < COUNT_LIMIT) {
-        ATS_printf(1, "[ES%d:TH%d] watch_count(): waiting\n",
-                es_id, my_id);
+        ATS_printf(1, "[ES%d:TH%d] watch_count(): waiting\n", es_id, my_id);
         ABT_cond_wait(cond, mutex);
         ATS_printf(1, "[ES%d:TH%d] watch_count(): received signal\n",
-                es_id, my_id);
+                   es_id, my_id);
         g_waiting = 1;
         g_counter += 100;
     }
@@ -96,9 +95,11 @@ int main(int argc, char *argv[])
 {
     int i, j;
     int ret, expected;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     if (num_xstreams * num_threads < 3) {
@@ -135,7 +136,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -153,18 +154,18 @@ int main(int argc, char *argv[])
     args[0][0].sid = 0;
     args[0][0].tid = 1;
     ret = ABT_thread_create(pools[0], watch_counter, (void *)&args[0][0],
-            ABT_THREAD_ATTR_NULL, NULL);
+                            ABT_THREAD_ATTR_NULL, NULL);
     ATS_ERROR(ret, "ABT_thread_create");
 
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            if (!i && !j) continue;
+            if (!i && !j)
+                continue;
             int tid = i * num_threads + j + 1;
             args[i][j].sid = i;
             args[i][j].tid = tid;
-            ret = ABT_thread_create(pools[i],
-                    inc_counter, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], inc_counter, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -172,7 +173,8 @@ int main(int argc, char *argv[])
     /* Join and free ULTs */
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            if (!i && !j) continue;
+            if (!i && !j)
+                continue;
             ret = ABT_thread_free(&threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_free");
         }
@@ -220,4 +222,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_timedwait.c
+++ b/test/basic/cond_timedwait.c
@@ -22,7 +22,7 @@ void cond_test(void *arg)
 {
     int ret;
     struct timespec ts;
-    struct timeval  tv;
+    struct timeval tv;
     int eid;
     ABT_thread_id tid;
 
@@ -34,7 +34,7 @@ void cond_test(void *arg)
     ret = gettimeofday(&tv, NULL);
     assert(!ret);
 
-    ts.tv_sec  = tv.tv_sec;
+    ts.tv_sec = tv.tv_sec;
     ts.tv_nsec = tv.tv_usec * 1000;
     ts.tv_sec += 1;
 
@@ -73,10 +73,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
         ret = ABT_thread_create(pools[pidx], cond_test, NULL,
-                ABT_THREAD_ATTR_NULL, &threads[i]);
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
         pidx = (pidx + 1) % num_xstreams;
     }
@@ -171,4 +171,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -18,11 +18,11 @@ void fn1(void *args)
 {
     ATS_UNUSED(args);
     int i = 0;
-    void *data =  malloc(EVENTUAL_SIZE);
+    void *data = malloc(EVENTUAL_SIZE);
     ATS_printf(1, "Thread 1 iteration %d waiting for eventual\n", i);
-    ABT_eventual_wait(myeventual,&data);
+    ABT_eventual_wait(myeventual, &data);
     ATS_printf(1, "Thread 1 continue iteration %d returning from "
-            "eventual\n", i);
+               "eventual\n", i);
 }
 
 void fn2(void *args)
@@ -31,14 +31,14 @@ void fn2(void *args)
     int i = 0, is_ready = 0;
     void *data = malloc(EVENTUAL_SIZE);
     ATS_printf(1, "Thread 2 iteration %d waiting from eventual\n", i);
-    ABT_eventual_test(myeventual,&data, &is_ready);
+    ABT_eventual_test(myeventual, &data, &is_ready);
     while (!is_ready) {
-       ABT_thread_yield();
-       ABT_eventual_test(myeventual,&data, &is_ready);
+        ABT_thread_yield();
+        ABT_eventual_test(myeventual, &data, &is_ready);
     }
-    ABT_eventual_wait(myeventual,&data);
+    ABT_eventual_wait(myeventual, &data);
     ATS_printf(1, "Thread 2 continue iteration %d returning from "
-            "eventual\n", i);
+               "eventual\n", i);
 }
 
 void fn3(void *args)
@@ -46,7 +46,7 @@ void fn3(void *args)
     ATS_UNUSED(args);
     int i = 0;
     ATS_printf(1, "Thread 3 iteration %d signal eventual \n", i);
-    char *data = (char *) malloc(EVENTUAL_SIZE);
+    char *data = (char *)malloc(EVENTUAL_SIZE);
     ABT_eventual_set(myeventual, data, EVENTUAL_SIZE);
     ATS_printf(1, "Thread 3 continue iteration %d \n", i);
 }
@@ -82,9 +82,9 @@ int main(int argc, char *argv[])
 
     void *data;
     ATS_printf(1, "Thread main iteration %d waiting for eventual\n", 0);
-    ABT_eventual_wait(myeventual,&data);
+    ABT_eventual_wait(myeventual, &data);
     ATS_printf(1, "Thread main continue iteration %d returning from "
-            "eventual\n", 0);
+               "eventual\n", 0);
 
     /* Join and free other threads */
     ret = ABT_thread_free(&th1);

--- a/test/basic/eventual_test.c
+++ b/test/basic/eventual_test.c
@@ -36,7 +36,7 @@ void thread_func(void *arg)
     arg_t *my_arg = (arg_t *)arg;
 
     ATS_printf(3, "[U%d:E%d] %s\n", my_arg->tid, my_arg->eid,
-                       my_arg->op_type == OP_WAIT ? "wait" : "set");
+               my_arg->op_type == OP_WAIT ? "wait" : "set");
 
     if (my_arg->op_type == OP_WAIT) {
         if (my_arg->nbytes == 0) {
@@ -101,14 +101,14 @@ void eventual_test(void *arg)
     thread_args = (arg_t *)malloc(num_threads * sizeof(arg_t));
     nbytes = (int *)malloc(num_tasks * sizeof(int));
     evs1 = (ABT_eventual *)malloc(num_tasks * sizeof(ABT_eventual));
-    assert(threads && thread_args && nbytes && evs1);
+    assert(threads && thread_args &&nbytes && evs1);
 
     waiters = (ABT_thread *)malloc(num_tasks * sizeof(ABT_thread));
     waiter_args = (arg_t *)malloc(num_tasks * sizeof(arg_t));
     tasks = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
     task_args = (arg_t *)malloc(num_tasks * sizeof(arg_t));
     evs2 = (ABT_eventual *)malloc(num_tasks * sizeof(ABT_eventual));
-    assert(waiters && waiter_args && tasks && task_args && evs2);
+    assert(waiters && waiter_args && tasks && task_args &&evs2);
 
     for (t = 0; t < num_tasks; t++) {
         nbytes[t] = (t & 1) ? sizeof(int) : 0;
@@ -127,21 +127,22 @@ void eventual_test(void *arg)
         for (t = 0; t < num_threads; t += 2) {
             thread_args[t].eid = eid;
             thread_args[t].tid = t;
-            thread_args[t].ev = evs1[t/2];
-            thread_args[t].nbytes = nbytes[t/2];
+            thread_args[t].ev = evs1[t / 2];
+            thread_args[t].nbytes = nbytes[t / 2];
             thread_args[t].op_type = OP_WAIT;
             ret = ABT_thread_create(pools[pid], thread_func, &thread_args[t],
                                     ABT_THREAD_ATTR_NULL, &threads[t]);
             ATS_ERROR(ret, "ABT_thread_create");
             pid = (pid + 1) % num_xstreams;
 
-            thread_args[t+1].eid = eid;
-            thread_args[t+1].tid = t + 1;
-            thread_args[t+1].ev = evs1[t/2];
-            thread_args[t+1].nbytes = nbytes[t/2];
-            thread_args[t+1].op_type = OP_SET;
-            ret = ABT_thread_create(pools[pid], thread_func, &thread_args[t+1],
-                                    ABT_THREAD_ATTR_NULL, &threads[t+1]);
+            thread_args[t + 1].eid = eid;
+            thread_args[t + 1].tid = t + 1;
+            thread_args[t + 1].ev = evs1[t / 2];
+            thread_args[t + 1].nbytes = nbytes[t / 2];
+            thread_args[t + 1].op_type = OP_SET;
+            ret = ABT_thread_create(pools[pid], thread_func,
+                                    &thread_args[t + 1], ABT_THREAD_ATTR_NULL,
+                                    &threads[t + 1]);
             ATS_ERROR(ret, "ABT_thread_create");
             pid = (pid + 1) % num_xstreams;
         }
@@ -159,7 +160,8 @@ void eventual_test(void *arg)
             task_args[t].ev = evs2[t];
             task_args[t].nbytes = nbytes[t];
             task_args[t].op_type = OP_SET;
-            ret = ABT_task_create(pools[pid], task_func, &task_args[t], &tasks[t]);
+            ret = ABT_task_create(pools[pid], task_func, &task_args[t],
+                                  &tasks[t]);
             ATS_ERROR(ret, "ABT_task_create");
             pid = (pid + 1) % num_xstreams;
         }
@@ -216,14 +218,14 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_tasks    = DEFAULT_NUM_TASKS;
-        num_iter     = DEFAULT_NUM_ITER;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_tasks = DEFAULT_NUM_TASKS;
+        num_iter = DEFAULT_NUM_ITER;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
-        num_threads  = num_tasks * 2;
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_threads = num_tasks * 2;
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -233,8 +235,8 @@ int main(int argc, char *argv[])
     ATS_printf(1, "# of iter       : %d\n", num_iter);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);
@@ -282,4 +284,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/ext_thread.c
+++ b/test/basic/ext_thread.c
@@ -16,9 +16,10 @@
 #define BUF_SIZE 10
 
 ABT_mutex g_mutex = ABT_MUTEX_NULL;
-ABT_cond  g_cond  = ABT_COND_NULL;
-ABT_eventual g_eventual[2] = {ABT_EVENTUAL_NULL, ABT_EVENTUAL_NULL};
-ABT_future   g_future[2]   = {ABT_FUTURE_NULL, ABT_FUTURE_NULL};
+ABT_cond g_cond = ABT_COND_NULL;
+ABT_eventual g_eventual[2] = { ABT_EVENTUAL_NULL, ABT_EVENTUAL_NULL };
+ABT_future g_future[2] = { ABT_FUTURE_NULL, ABT_FUTURE_NULL };
+
 int g_counter = 0;
 volatile int g_threads = 0;
 
@@ -61,7 +62,8 @@ void thread_func(void *arg)
 
     /* ULT 1 and pthread are waiting, and ULT 0 broadcasts. */
     if (my_id == 0) {
-        while (g_threads < 2) ABT_thread_yield();
+        while (g_threads < 2)
+            ABT_thread_yield();
         ABT_mutex_lock(g_mutex);
         ABT_cond_broadcast(g_cond);
         ABT_mutex_unlock(g_mutex);
@@ -237,4 +239,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/future_create.c
+++ b/test/basic/future_create.c
@@ -43,11 +43,11 @@ void future_cb(void **args)
     for (i = 0; i < total_num_threads; i++) {
         total += (int)(intptr_t)args[i];
     }
-    if (total_num_threads*(total_num_threads-1)/2 != total) {
+    if (total_num_threads * (total_num_threads - 1) / 2 != total) {
         ATS_ERROR(ABT_ERR_OTHER, "Wrong value!");
     }
 
-    ABT_future_set(myfuture2,  NULL);
+    ABT_future_set(myfuture2, NULL);
     ATS_printf(1, "Callback signals future\n");
 }
 
@@ -55,11 +55,13 @@ int main(int argc, char *argv[])
 {
     int i, j;
     int ret;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
-    total_num_threads = num_threads*num_xstreams;
+    total_num_threads = num_threads * num_xstreams;
 
     /* init and thread creation */
     ATS_read_args(argc, argv);
@@ -67,7 +69,7 @@ int main(int argc, char *argv[])
 
     /* Create Execution Streams */
     ABT_xstream *xstreams =
-      (ABT_xstream *)malloc(num_xstreams*sizeof(ABT_xstream));
+        (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     ret = ABT_xstream_self(&xstreams[0]);
     ATS_ERROR(ret, "ABT_xstream_self");
     for (i = 1; i < num_xstreams; i++) {
@@ -76,9 +78,9 @@ int main(int argc, char *argv[])
     }
 
     /* Get the pools attached to an execution stream */
-    ABT_pool *pools = (ABT_pool *)malloc(num_xstreams*sizeof(ABT_pool));
+    ABT_pool *pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -89,9 +91,9 @@ int main(int argc, char *argv[])
 
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            int idx = i*num_threads+j;
+            int idx = i * num_threads + j;
             ret = ABT_thread_create(pools[i], future_wait,
-                                    (void *)(intptr_t)(idx+total_num_threads),
+                                    (void *)(intptr_t)(idx + total_num_threads),
                                     ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
             ret = ABT_thread_create(pools[i], future_set, (void *)(intptr_t)idx,

--- a/test/basic/info_print.c
+++ b/test/basic/info_print.c
@@ -62,10 +62,10 @@ int main(int argc, char *argv[])
     ATS_printf(1, "# of ESs        : %d\n", num_xstreams);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    scheds   = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    threads  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
-    tasks    = (ABT_task *)malloc(num_xstreams * sizeof(ABT_task));
+    scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    tasks = (ABT_task *)malloc(num_xstreams * sizeof(ABT_task));
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);
@@ -144,5 +144,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-
-

--- a/test/basic/info_stackdump.c
+++ b/test/basic/info_stackdump.c
@@ -131,8 +131,8 @@ int main(int argc, char *argv[])
         for (j = 0; j < num_threads; j++) {
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
-            args[i][j].issue_signal = (i == num_xstreams / 2)
-                                      && (j == num_threads / 2);
+            args[i][j].issue_signal = ((i == num_xstreams / 2)
+                                       && (j == num_threads / 2));
             args[i][j].dummy_ptr = NULL;
             args[i][j].stack = NULL;
             if (tid % 3 == 0) {

--- a/test/basic/info_stackdump2.c
+++ b/test/basic/info_stackdump2.c
@@ -144,8 +144,8 @@ int main(int argc, char *argv[])
         for (j = 0; j < num_threads; j++) {
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
-            args[i][j].issue_signal = (i == ((num_xstreams - 1) / 2) + 1)
-                                      && (j == num_threads / 2);
+            args[i][j].issue_signal = ((i == ((num_xstreams - 1) / 2) + 1)
+                                       && (j == num_threads / 2));
             args[i][j].stop = (j == num_threads / 2);
             args[i][j].num_xstreams = num_xstreams;
             args[i][j].dummy_ptr = NULL;
@@ -162,8 +162,8 @@ int main(int argc, char *argv[])
                 ret = ABT_thread_attr_set_stacksize(attr, 32768);
                 ATS_ERROR(ret, "ABT_thread_attr_set_stacksize");
                 ret = ABT_thread_create(pools[i], thread_func,
-                                        (void *)&args[i][j],
-                                        attr, &threads[i][j]);
+                                        (void *)&args[i][j], attr,
+                                        &threads[i][j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 ret = ABT_thread_attr_free(&attr);
                 ATS_ERROR(ret, "ABT_thread_attr_free");

--- a/test/basic/init_finalize.c
+++ b/test/basic/init_finalize.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 2) {
         num_threads = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_iter    = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_threads);
 

--- a/test/basic/mutex.c
+++ b/test/basic/mutex.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -107,9 +107,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -158,4 +157,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_prio.c
+++ b/test/basic/mutex_prio.c
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -117,9 +117,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -168,4 +167,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_recursive.c
+++ b/test/basic/mutex_recursive.c
@@ -52,10 +52,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 
     /* Get the main pool associated with each ES */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
             args[i][j].id = tid;
             args[i][j].depth = RECURSIVE_DEPTH;
             ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
-                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -153,4 +153,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_spinlock.c
+++ b/test/basic/mutex_spinlock.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -109,9 +109,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -160,4 +159,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_unlock_se.c
+++ b/test/basic/mutex_unlock_se.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -107,9 +107,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -158,4 +157,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/pool_access.c
+++ b/test/basic/pool_access.c
@@ -10,8 +10,8 @@
 
 
 ABT_pool_access accesses[5] = {
-  ABT_POOL_ACCESS_PRIV, ABT_POOL_ACCESS_SPSC, ABT_POOL_ACCESS_MPSC,
-  ABT_POOL_ACCESS_SPMC, ABT_POOL_ACCESS_MPMC,
+    ABT_POOL_ACCESS_PRIV, ABT_POOL_ACCESS_SPSC, ABT_POOL_ACCESS_MPSC,
+    ABT_POOL_ACCESS_SPMC, ABT_POOL_ACCESS_MPMC,
 };
 
 int add_to_another_ES(int accessIdx, int result)
@@ -47,14 +47,14 @@ int add_to_another_ES(int accessIdx, int result)
     ATS_ERROR(ret, "ABT_xstream_get_main_pools");
 
     /* Use the pool with two schedulers in the same ES */
-    ret =  ABT_pool_add_sched(pool1, scheds[0]);
+    ret = ABT_pool_add_sched(pool1, scheds[0]);
     ATS_ERROR(ret, "ABT_pool_add_sched");
 
-    ret =  ABT_pool_add_sched(pool1, scheds[1]);
+    ret = ABT_pool_add_sched(pool1, scheds[1]);
     ATS_ERROR(ret, "ABT_pool_add_sched");
 
     /* Use the pool with another scheduler in another ES */
-    ret =  ABT_pool_add_sched(pool2, scheds[2]);
+    ret = ABT_pool_add_sched(pool2, scheds[2]);
 
     /* Free scheds[2] if it was not added to pool2 */
     if (ret != ABT_SUCCESS) {
@@ -77,11 +77,11 @@ void task_func1(void *arg)
 {
     int ret;
     void **args = (void **)arg;
-    int result           = *(int *)      args[0];
-    ABT_pool pool_main   = *(ABT_pool *) args[1];
-    ABT_pool pool_dest   = *(ABT_pool *) args[2];
+    int result = *(int *)args[0];
+    ABT_pool pool_main = *(ABT_pool *)args[1];
+    ABT_pool pool_dest = *(ABT_pool *)args[2];
     ABT_sched sched_dest = *(ABT_sched *)args[3];
-    ABT_sched sched      = *(ABT_sched *)args[4];
+    ABT_sched sched = *(ABT_sched *)args[4];
 
     ret = ABT_pool_add_sched(pool_main, sched_dest);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -121,7 +121,8 @@ int add_to_another_access(int accessIdx, int *results)
 
         /* Test */
         ABT_pool pool_dest;
-        ret = ABT_pool_create_basic(ABT_POOL_FIFO, accesses[p], ABT_TRUE, &pool_dest);
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, accesses[p], ABT_TRUE,
+                                    &pool_dest);
         ATS_ERROR(ret, "ABT_pool_create_basic");
         ABT_sched sched_dest;
         ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_dest,
@@ -129,18 +130,23 @@ int add_to_another_access(int accessIdx, int *results)
         ATS_ERROR(ret, "ABT_sched_create_basic");
 
         ABT_sched_config config;
-        ret = ABT_sched_config_create(&config,
-                                      ABT_sched_config_access, access,
+        ret = ABT_sched_config_create(&config, ABT_sched_config_access, access,
                                       ABT_sched_config_var_end);
         ATS_ERROR(ret, "ABT_sched_config_create");
         ABT_sched sched;
-        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config, &sched);
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config,
+                                     &sched);
         ATS_ERROR(ret, "ABT_sched_create_basic");
         ret = ABT_sched_config_free(&config);
         ATS_ERROR(ret, "ABT_sched_config_free");
         /* We need to use a task for the test to be in the same ES */
-        void *args[5] = { &results[p], &pool_main, &pool_dest, &sched_dest,
-                          &sched };
+        void *args[5] = {
+            &results[p],
+            &pool_main,
+            &pool_dest,
+            &sched_dest,
+            &sched
+        };
         ret = ABT_task_create(pool_main, task_func1, args, NULL);
         ATS_ERROR(ret, "ABT_task_create");
 
@@ -167,7 +173,7 @@ void task_func2(void *arg)
         ret = ABT_task_create(pool, task_func2, NULL, NULL);
         if ((ret != ABT_SUCCESS && result == ABT_SUCCESS) ||
             (ret == ABT_SUCCESS && result != ABT_SUCCESS))
-            ret =  ABT_ERR_INV_POOL_ACCESS;
+            ret = ABT_ERR_INV_POOL_ACCESS;
         else
             ret = ABT_SUCCESS;
         ATS_ERROR(ret, "ABT_task_create");
@@ -183,8 +189,7 @@ int push_from_another_es(int accessIdx, int *results)
 
     /* Creation of the ES */
     ABT_sched_config config;
-    ret = ABT_sched_config_create(&config,
-                                  ABT_sched_config_access, access,
+    ret = ABT_sched_config_create(&config, ABT_sched_config_access, access,
                                   ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
     ABT_sched sched;
@@ -231,37 +236,37 @@ int main(int argc, char *argv[])
 
     /* ABT_POOL_ACCESS_PRIV */
     ret_add_to_another_ES[0] = error;
-    int temp00[5] = {success, success, success, error, error};
+    int temp00[5] = { success, success, success, error, error };
     ret_add_to_another_access[0] = temp00;
-    int temp01[2] = {error, error};
+    int temp01[2] = { error, error };
     ret_push_from_another_pool[0] = temp01;
 
     /* ABT_POOL_ACCESS_SPSC */
     ret_add_to_another_ES[1] = error;
-    int temp10[5] = {success, success, success, error, error};
+    int temp10[5] = { success, success, success, error, error };
     ret_add_to_another_access[1] = temp10;
-    int temp11[2] = {success, error};
+    int temp11[2] = { success, error };
     ret_push_from_another_pool[1] = temp11;
 
     /* ABT_POOL_ACCESS_MPSC */
     ret_add_to_another_ES[2] = error;
-    int temp20[5] = {success, success, success, error, error};
+    int temp20[5] = { success, success, success, error, error };
     ret_add_to_another_access[2] = temp20;
-    int temp21[2] = {success, success};
+    int temp21[2] = { success, success };
     ret_push_from_another_pool[2] = temp21;
 
     /* ABT_POOL_ACCESS_SPMC */
     ret_add_to_another_ES[3] = success;
-    int temp30[5] = {success, success, success, success, success};
+    int temp30[5] = { success, success, success, success, success };
     ret_add_to_another_access[3] = temp30;
-    int temp31[2] = {success, error};
+    int temp31[2] = { success, error };
     ret_push_from_another_pool[3] = temp31;
 
     /* ABT_POOL_ACCESS_MPMC */
     ret_add_to_another_ES[4] = success;
-    int temp40[5] = {success, success, success, success, success};
+    int temp40[5] = { success, success, success, success, success };
     ret_add_to_another_access[4] = temp40;
-    int temp41[2] = {success, success};
+    int temp41[2] = { success, success };
     ret_push_from_another_pool[4] = temp41;
 
     for (i = 0; i < 5; i++) {
@@ -277,5 +282,3 @@ int main(int argc, char *argv[])
     ret = ATS_finalize(0);
     return ret;
 }
-
-

--- a/test/basic/rwlock_reader_incl.c
+++ b/test/basic/rwlock_reader_incl.c
@@ -28,8 +28,8 @@ struct test_arg {
     ABT_rwlock rwlock;
     ABT_barrier barrier;
     ABT_pool *pools;
-    ABT_thread **threads; /* malloc'd by caller, set by test */
-    thread_arg_t **args;  /* malloc'd by caller, set by test */
+    ABT_thread **threads;       /* malloc'd by caller, set by test */
+    thread_arg_t **args;        /* malloc'd by caller, set by test */
 };
 
 void thread_func(void *arg)
@@ -63,9 +63,9 @@ void run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -88,13 +88,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -128,7 +132,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -138,7 +142,7 @@ int main(int argc, char *argv[])
 
     /* Create a barrier */
     ret = ABT_barrier_create(targ.num_xstreams * targ.num_threads,
-            &targ.barrier);
+                             &targ.barrier);
     ATS_ERROR(ret, "ABT_barrier_create");
 
     /* Execute tests */
@@ -176,4 +180,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/rwlock_reader_writer_excl.c
+++ b/test/basic/rwlock_reader_writer_excl.c
@@ -24,8 +24,8 @@ struct test_arg {
     int iters;
     ABT_rwlock rwlock;
     ABT_pool *pools;
-    ABT_thread **threads; /* malloc'd by caller, set by test */
-    thread_arg_t **args;  /* malloc'd by caller, set by test */
+    ABT_thread **threads;       /* malloc'd by caller, set by test */
+    thread_arg_t **args;        /* malloc'd by caller, set by test */
 };
 
 struct thread_arg {
@@ -48,12 +48,10 @@ void thread_func(void *arg)
             if (t_arg->id == 1) {
                 g_counter++;
                 ATS_printf(1, "[TH%d] read+increased\n", t_arg->id);
-            }
-            else {
+            } else {
                 ATS_printf(1, "[TH%d] read\n", t_arg->id);
             }
-        }
-        else {
+        } else {
             ret = ABT_rwlock_wrlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_wrlock");
             g_counter++;
@@ -79,9 +77,9 @@ int run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -100,8 +98,7 @@ int run_test(test_arg_t *targ)
                 "g_counter = %d, expected = %d (%d xstreams, %d threads)\n",
                 g_counter, expected, targ->num_xstreams, targ->num_threads);
         return 1;
-    }
-    else {
+    } else {
         return 0;
     }
 }
@@ -115,13 +112,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -199,4 +200,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/rwlock_writer_excl.c
+++ b/test/basic/rwlock_writer_excl.c
@@ -29,8 +29,8 @@ struct test_arg {
     int iters;
     ABT_rwlock rwlock;
     ABT_pool *pools;
-    ABT_thread **threads; /* malloc'd by caller, set by test */
-    thread_arg_t **args;  /* malloc'd by caller, set by test */
+    ABT_thread **threads;       /* malloc'd by caller, set by test */
+    thread_arg_t **args;        /* malloc'd by caller, set by test */
 };
 
 static void thread_func(void *arg)
@@ -45,8 +45,7 @@ static void thread_func(void *arg)
             ret = ABT_rwlock_rdlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_rdlock");
             ATS_printf(1, "[TH%d] read\n", t_arg->id);
-        }
-        else {
+        } else {
             ret = ABT_rwlock_wrlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_wrlock");
             g_counter++;
@@ -59,8 +58,7 @@ static void thread_func(void *arg)
 
 int run_test(test_arg_t *targ)
 {
-    int expected = ((targ->num_xstreams * targ->num_threads) / 2) *
-        targ->iters;
+    int expected = ((targ->num_xstreams * targ->num_threads) / 2) * targ->iters;
     int i, j;
     int ret;
 
@@ -72,9 +70,9 @@ int run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -93,8 +91,7 @@ int run_test(test_arg_t *targ)
                 "g_counter = %d, expected = %d (%d xstreams, %d threads)\n",
                 g_counter, expected, targ->num_xstreams, targ->num_threads);
         return 1;
-    }
-    else {
+    } else {
         return 0;
     }
 }
@@ -108,13 +105,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -148,7 +149,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -192,4 +193,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_basic.c
+++ b/test/basic/sched_basic.c
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -47,8 +49,8 @@ int main(int argc, char *argv[])
                                   ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                     config, &scheds[i]);
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config,
+                                     &scheds[i]);
         ATS_ERROR(ret, "ABT_sched_create_basic");
     }
     ret = ABT_sched_config_free(&config);
@@ -66,7 +68,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -74,9 +76,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -102,4 +103,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_basic_wait.c
+++ b/test/basic/sched_basic_wait.c
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -60,7 +62,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -68,9 +70,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/sched_config.c
+++ b/test/basic/sched_config.c
@@ -12,13 +12,13 @@
 #include "abttest.h"
 
 ABT_sched_config_var param_a = {
-  .idx = 0,
-  .type = ABT_SCHED_CONFIG_INT
+    .idx = 0,
+    .type = ABT_SCHED_CONFIG_INT
 };
 
 ABT_sched_config_var param_b = {
-  .idx = 1,
-  .type = ABT_SCHED_CONFIG_DOUBLE
+    .idx = 1,
+    .type = ABT_SCHED_CONFIG_DOUBLE
 };
 
 int main(int argc, char *argv[])
@@ -35,27 +35,31 @@ int main(int argc, char *argv[])
     ATS_init(argc, argv, 1);
 
     ABT_sched_config_create(&config1, param_a, a, ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config1, 2, &a2, &b2);
     ABT_sched_config_free(&config1);
     assert(a2 == a && b2 == 0.0);
 
     ABT_sched_config_create(&config2, param_b, b, ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config2, 2, &a2, &b2);
     ABT_sched_config_free(&config2);
     assert(a2 == 0 && b2 == b);
 
     ABT_sched_config_create(&config3, param_a, a, param_b, b,
-                          ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+                            ABT_sched_config_var_end);
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config3, 2, &a2, &b2);
     ABT_sched_config_free(&config3);
     assert(a2 == a && b2 == b);
 
     ABT_sched_config_create(&config4, param_b, b, param_a, a,
-                          ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+                            ABT_sched_config_var_end);
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config4, 2, &a2, &b2);
     ABT_sched_config_free(&config4);
     assert(a2 == a && b2 == b);
@@ -63,4 +67,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/sched_prio.c
+++ b/test/basic/sched_prio.c
@@ -46,7 +46,8 @@ int main(int argc, char *argv[])
 {
     int i, ret;
 
-    if (argc > 1) num_units = atoi(argv[1]);
+    if (argc > 1)
+        num_units = atoi(argv[1]);
     assert(num_units >= 0);
 
     /* Initialize */
@@ -89,7 +90,8 @@ static void fini_global_data(void)
     int i;
 
     for (i = 0; i < g_data.num_scheds; i++) {
-        if (g_data.pools[i]) free(g_data.pools[i]);
+        if (g_data.pools[i])
+            free(g_data.pools[i]);
     }
 
     free(g_data.num_pools);
@@ -108,7 +110,7 @@ static void create_scheds_and_xstreams(void)
     ABT_xstream *xstreams = g_data.xstreams;
 
     for (i = 0; i < num_scheds; i++) {
-        if (i == num_scheds-1) {
+        if (i == num_scheds - 1) {
             /* Create pools and then create a scheduler */
             num_pools[i] = 2;
             pools[i] = (ABT_pool *)malloc(num_pools[i] * sizeof(ABT_pool));
@@ -120,14 +122,13 @@ static void create_scheds_and_xstreams(void)
             }
 
             ret = ABT_sched_create_basic(ABT_SCHED_PRIO, num_pools[i], pools[i],
-                                         ABT_SCHED_CONFIG_NULL,
-                                         &scheds[i]);
+                                         ABT_SCHED_CONFIG_NULL, &scheds[i]);
             ATS_ERROR(ret, "ABT_sched_create_basic");
         } else {
             /* Create a scheduler and then get the list of pools */
             ABT_sched_config config;
-            ret = ABT_sched_config_create(&config,
-                                          ABT_sched_config_access, accesses[i],
+            ret = ABT_sched_config_create(&config, ABT_sched_config_access,
+                                          accesses[i],
                                           ABT_sched_config_var_end);
             ATS_ERROR(ret, "ABT_sched_config_create");
             ret = ABT_sched_create_basic(ABT_SCHED_PRIO, 0, NULL, config,
@@ -151,8 +152,8 @@ static void create_scheds_and_xstreams(void)
             ATS_ERROR(ret, "ABT_xstream_set_main_sched");
         } else {
             /* If the predefined scheduler is associated with PW pools,
-               we will stack it so that the primary ULT can add the initial
-               work unit. */
+             * we will stack it so that the primary ULT can add the initial
+             * work unit. */
             if (accesses[i] == ABT_POOL_ACCESS_PRIV ||
                 accesses[i] == ABT_POOL_ACCESS_SPSC ||
                 accesses[i] == ABT_POOL_ACCESS_SPMC) {
@@ -189,7 +190,8 @@ typedef struct {
 
 static ABT_bool verify_exec_order(int es_id, int my_prio)
 {
-    if (my_prio == 0) return ABT_TRUE;
+    if (my_prio == 0)
+        return ABT_TRUE;
 
     ABT_pool *my_pools = g_data.pools[es_id];
     size_t pool_size;
@@ -198,7 +200,8 @@ static ABT_bool verify_exec_order(int es_id, int my_prio)
     for (i = 0; i < my_prio; i++) {
         ret = ABT_pool_get_size(my_pools[i], &pool_size);
         ATS_ERROR(ret, "ABT_pool_get_size");
-        if (pool_size > 0) return ABT_FALSE;
+        if (pool_size > 0)
+            return ABT_FALSE;
     }
     return ABT_TRUE;
 }
@@ -211,14 +214,14 @@ static void thread_func(void *arg)
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
     ATS_printf(1, "[E%d:U%d:P%d] before yield\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+               my_arg->es_id, my_arg->my_id, my_arg->prio);
 
     ABT_thread_yield();
 
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
     ATS_printf(1, "[E%d:U%d:P%d] after yield\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+               my_arg->es_id, my_arg->my_id, my_arg->prio);
 
     free(my_arg);
 }
@@ -231,7 +234,7 @@ static void task_func(void *arg)
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
     ATS_printf(1, "[E%d:T%d:P%d] running\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+               my_arg->es_id, my_arg->my_id, my_arg->prio);
 
     free(my_arg);
 }
@@ -256,14 +259,12 @@ static void gen_work(void *arg)
         my_arg->prio = rand_r(&seed) % num_pools;
 
         if (i & 1) {
-            ret = ABT_thread_create(my_pools[my_arg->prio],
-                                    thread_func, (void *)my_arg,
-                                    ABT_THREAD_ATTR_NULL, NULL);
+            ret = ABT_thread_create(my_pools[my_arg->prio], thread_func,
+                                    (void *)my_arg, ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         } else {
-            ret = ABT_task_create(my_pools[my_arg->prio],
-                                  task_func, (void *)my_arg,
-                                  NULL);
+            ret = ABT_task_create(my_pools[my_arg->prio], task_func,
+                                  (void *)my_arg, NULL);
             ATS_ERROR(ret, "ABT_task_create");
         }
     }
@@ -275,12 +276,12 @@ static void gen_work(void *arg)
         if (accesses[idx] == ABT_POOL_ACCESS_PRIV ||
             accesses[idx] == ABT_POOL_ACCESS_SPSC ||
             accesses[idx] == ABT_POOL_ACCESS_SPMC) {
-                ABT_pool main_pool;
-                ret = ABT_xstream_get_main_pools(g_data.xstreams[idx],
-                                                 1, &main_pool);
-                ATS_ERROR(ret, "ABT_xstream_get_main_pools");
-                ret = ABT_pool_add_sched(main_pool, g_data.scheds[idx]);
-                ATS_ERROR(ret, "ABT_pool_add_sched");
+            ABT_pool main_pool;
+            ret = ABT_xstream_get_main_pools(g_data.xstreams[idx], 1,
+                                             &main_pool);
+            ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+            ret = ABT_pool_add_sched(main_pool, g_data.scheds[idx]);
+            ATS_ERROR(ret, "ABT_pool_add_sched");
         }
     }
 }
@@ -301,4 +302,3 @@ static void create_work_units(void)
         ATS_ERROR(ret, "ABT_thread_create");
     }
 }
-

--- a/test/basic/sched_randws.c
+++ b/test/basic/sched_randws.c
@@ -79,8 +79,8 @@ static void create_threads(void *arg)
     ATS_printf(1, "[U%lu:E%d] creating ULTs\n", id, rank);
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ret = ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -106,18 +106,17 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "# of ESs    : %d\n"
-                       "# of ULTs/ES: %d\n",
-                       num_xstreams, num_threads);
+               "# of ULTs/ES: %d\n", num_xstreams, num_threads);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    scheds   = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create a mutex */
     ret = ABT_mutex_create(&g_mutex);
@@ -136,7 +135,6 @@ int main(int argc, char *argv[])
         for (k = 0; k < num_xstreams; k++) {
             my_pools[k] = pools[(i + k) % num_xstreams];
         }
-
         ret = ABT_sched_create_basic(ABT_SCHED_RANDWS, num_xstreams, my_pools,
                                      ABT_SCHED_CONFIG_NULL, &scheds[i]);
         ATS_ERROR(ret, "ABT_sched_create_basic");
@@ -195,4 +193,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_set_main.c
+++ b/test/basic/sched_set_main.c
@@ -89,12 +89,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "num_xstreams=%d num_threads=%d\n",
-                    num_xstreams, num_threads);
+               num_xstreams, num_threads);
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_create");
 
         /* Get the first associated pool */
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -144,4 +144,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_stack.c
+++ b/test/basic/sched_stack.c
@@ -20,8 +20,8 @@ long int value = 0;
 
 void task_func(void *arg)
 {
-    long int v = (long int) arg;
-    assert(v == value+1);
+    long int v = (long int)arg;
+    assert(v == value + 1);
     value++;
 }
 
@@ -31,7 +31,8 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_tasks = DEFAULT_NUM_TASKS;
 
-    if (argc > 1) num_tasks = atoi(argv[1]);
+    if (argc > 1)
+        num_tasks = atoi(argv[1]);
     assert(num_tasks >= 0);
 
     ABT_xstream xstream;
@@ -44,8 +45,9 @@ int main(int argc, char *argv[])
     ATS_init(argc, argv, 1);
 
     /* Creation of the main pool/sched */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_mainsched);
+    ret =
+        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                              &pool_mainsched);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_mainsched,
                                  ABT_SCHED_CONFIG_NULL, &mainsched);
@@ -59,16 +61,18 @@ int main(int argc, char *argv[])
 
 
     /* Creation of subsched1 */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_subsched1);
+    ret =
+        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                              &pool_subsched1);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_subsched1,
                                  ABT_SCHED_CONFIG_NULL, &subsched1);
     ATS_ERROR(ret, "ABT_sched_create_basic");
 
     /* Creation of subsched2 */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_subsched2);
+    ret =
+        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                              &pool_subsched2);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_subsched2,
                                  ABT_SCHED_CONFIG_NULL, &subsched2);
@@ -80,8 +84,8 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_task_create");
 
     for (i = 0; i < num_tasks; i++) {
-      ret = ABT_task_create(pool_subsched1, task_func, (void *)++num, NULL);
-      ATS_ERROR(ret, "ABT_task_create");
+        ret = ABT_task_create(pool_subsched1, task_func, (void *)++num, NULL);
+        ATS_ERROR(ret, "ABT_task_create");
     }
     ret = ABT_pool_add_sched(pool_mainsched, subsched1);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -90,8 +94,8 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_task_create");
 
     for (i = 0; i < num_tasks; i++) {
-      ret = ABT_task_create(pool_subsched2, task_func, (void *)++num, NULL);
-      ATS_ERROR(ret, "ABT_task_create");
+        ret = ABT_task_create(pool_subsched2, task_func, (void *)++num, NULL);
+        ATS_ERROR(ret, "ABT_task_create");
     }
     ret = ABT_pool_add_sched(pool_mainsched, subsched2);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -102,8 +106,6 @@ int main(int argc, char *argv[])
     /* Finalize */
     ret = ATS_finalize(0);
 
-    assert(value == 3+2*num_tasks);
+    assert(value == 3 + 2 * num_tasks);
     return ret;
 }
-
-

--- a/test/basic/sched_user_ws.c
+++ b/test/basic/sched_user_ws.c
@@ -77,7 +77,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, my_pool);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool tar_pool = pools[target];
             ABT_pool_get_size(tar_pool, &size);
             if (size > 0) {
@@ -93,7 +94,8 @@ static void sched_run(ABT_sched sched)
             ABT_bool stop;
             ret = ABT_sched_has_to_stop(sched, &stop);
             ATS_ERROR(ret, "ABT_sched_has_to_stop");
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABT_xstream_check_events(sched);
         }
@@ -151,9 +153,9 @@ static ABT_sched *create_scheds(int num, ABT_pool *pools)
 
     /* Create a scheduler config */
     /* NOTE: The same scheduler config can be used for all schedulers. */
-    ret = ABT_sched_config_create(&config,
-                                  cv_event_freq, 10,
-                                  ABT_sched_config_var_end);
+    ret =
+        ABT_sched_config_create(&config, cv_event_freq, 10,
+                                ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
 
     my_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num);
@@ -249,8 +251,9 @@ static void create_threads(void *arg)
     ATS_printf(1, "[U%lu:E%d] creating ULTs\n", id, rank);
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ret =
+            ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -274,12 +277,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "num_xstreams=%d num_threads=%d\n", num_xstreams,
-                    num_threads);
+               num_threads);
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
 
@@ -301,8 +304,9 @@ int main(int argc, char *argv[])
 
     /* Create ULTs */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_thread_create(pools[i], create_threads, NULL,
-                                ABT_THREAD_ATTR_NULL, NULL);
+        ret =
+            ABT_thread_create(pools[i], create_threads, NULL,
+                              ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -324,4 +328,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -36,7 +36,7 @@ void task_hello(void *arg)
     assert(ret == ABT_SUCCESS);
 
     ATS_printf(1, "TASK %d: running on the %s\n", (int)(size_t)arg,
-                    (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
+               (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
 }
 
 void thread_hello(void *arg)
@@ -82,7 +82,7 @@ void thread_hello(void *arg)
     assert(ret == ABT_SUCCESS);
 
     ATS_printf(1, "ULT %lu running on the %s\n", my_id,
-                    (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
+               (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
 }
 
 void *pthread_hello(void *arg)
@@ -214,4 +214,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/task_create.c
+++ b/test/basic/task_create.c
@@ -43,9 +43,11 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -71,16 +73,16 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create tasks with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func1, (void *)num,
-                              NULL);
+        ret =
+            ABT_task_create(pools[i % num_xstreams], task_func1, (void *)num,
+                            NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -88,9 +90,9 @@ int main(int argc, char *argv[])
     /* Create tasks with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         args[i].num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func2, (void *)&args[i],
-                              &tasks[i]);
+        ret =
+            ABT_task_create(pools[i % num_xstreams], task_func2,
+                            (void *)&args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -103,7 +105,7 @@ int main(int argc, char *argv[])
         } while (state != ABT_TASK_STATE_TERMINATED);
 
         ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-               args[i].num, args[i].result);
+                   args[i].num, args[i].result);
 
         /* Free named tasks */
         ret = ABT_task_free(&tasks[i]);
@@ -132,4 +134,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/task_create_on_xstream.c
+++ b/test/basic/task_create_on_xstream.c
@@ -43,9 +43,11 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -71,9 +73,9 @@ int main(int argc, char *argv[])
     /* Create tasklets with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams],
-                              task_func1, (void *)num,
-                              NULL);
+        ret =
+            ABT_task_create_on_xstream(xstreams[i % num_xstreams], task_func1,
+                                       (void *)num, NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -81,9 +83,9 @@ int main(int argc, char *argv[])
     /* Create tasklets with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         args[i].num = 100 + i;
-        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams],
-                              task_func2, (void *)&args[i],
-                              &tasks[i]);
+        ret =
+            ABT_task_create_on_xstream(xstreams[i % num_xstreams], task_func2,
+                                       (void *)&args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -96,7 +98,7 @@ int main(int argc, char *argv[])
         } while (state != ABT_TASK_STATE_TERMINATED);
 
         ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-                        args[i].num, args[i].result);
+                   args[i].num, args[i].result);
 
         /* Free named tasklets */
         ret = ABT_task_free(&tasks[i]);
@@ -124,4 +126,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -115,10 +115,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_tasks  = DEFAULT_NUM_TASKS;
+        num_tasks = DEFAULT_NUM_TASKS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 

--- a/test/basic/task_revive.c
+++ b/test/basic/task_revive.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -170,4 +170,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_attr.c
+++ b/test/basic/thread_attr.c
@@ -40,9 +40,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_thread_attr attr;
@@ -65,7 +67,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -78,10 +80,9 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid,
-                    (tid % 2 ? attr : ABT_THREAD_ATTR_NULL),
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    (tid % 2 ? attr : ABT_THREAD_ATTR_NULL),
+                                    NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_create.c
+++ b/test/basic/thread_create.c
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -48,7 +50,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -56,9 +58,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_create2.c
+++ b/test/basic/thread_create2.c
@@ -34,9 +34,8 @@ void thread_create(void *arg)
     /* Create threads */
     for (i = 0; i < num_threads; i++) {
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create(my_pool,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(my_pool, thread_func, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -48,9 +47,11 @@ int main(int argc, char *argv[])
     int i;
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -73,16 +74,15 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create one thread for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create(pools[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(pools[i], thread_create, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -106,4 +106,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_create_on_xstream.c
+++ b/test/basic/thread_create_on_xstream.c
@@ -31,9 +31,8 @@ void thread_create(void *arg)
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create_on_xstream(my_xstream,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create_on_xstream(my_xstream, thread_func, (void *)tid,
+                                           ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create_on_xstream");
     }
 
@@ -45,9 +44,11 @@ int main(int argc, char *argv[])
     int i;
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -71,9 +72,9 @@ int main(int argc, char *argv[])
     /* Create one ULT for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create_on_xstream(xstreams[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                &threads[i]);
+        ret = ABT_thread_create_on_xstream(xstreams[i], thread_create,
+                                           (void *)tid, ABT_THREAD_ATTR_NULL,
+                                           &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create_on_xstream");
     }
 
@@ -101,4 +102,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -122,10 +122,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 

--- a/test/basic/thread_id.c
+++ b/test/basic/thread_id.c
@@ -27,9 +27,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -51,7 +53,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -59,9 +61,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_migrate.c
+++ b/test/basic/thread_migrate.c
@@ -38,9 +38,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -67,7 +69,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -75,9 +77,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -102,7 +103,7 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_free");
     }
 
-    if (value != num_xstreams*num_threads)
+    if (value != num_xstreams * num_threads)
         ATS_ERROR(ABT_ERR_OTHER, "wrong value");
 
     /* Finalize */
@@ -117,4 +118,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_revive.c
+++ b/test/basic/thread_revive.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -172,4 +172,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_self_suspend_resume.c
+++ b/test/basic/thread_self_suspend_resume.c
@@ -102,12 +102,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_iter     = DEFAULT_NUM_ITER;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_iter = DEFAULT_NUM_ITER;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    for (i = 0; i< num_xstreams; i++) {
+    for (i = 0; i < num_xstreams; i++) {
         free(threads[i]);
         free(values[i]);
     }
@@ -196,4 +196,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task.c
+++ b/test/basic/thread_task.c
@@ -37,7 +37,8 @@ ABT_thread pick_one(ABT_thread *threads, int num_threads, unsigned *seed,
         next = threads[i];
         ret = ABT_thread_equal(next, caller, &is_same);
         ATS_ERROR(ret, "ABT_thread_equal");
-        if (is_same == ABT_TRUE) continue;
+        if (is_same == ABT_TRUE)
+            continue;
 
         if (next != ABT_THREAD_NULL) {
             ret = ABT_thread_get_state(next, &state);
@@ -147,11 +148,14 @@ int main(int argc, char *argv[])
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
-    if (argc > 3) num_tasks = atoi(argv[3]);
+    if (argc > 3)
+        num_tasks = atoi(argv[3]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -162,7 +166,8 @@ int main(int argc, char *argv[])
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     threads = (ABT_thread **)malloc(sizeof(ABT_thread *) * num_xstreams);
-    thread_args = (thread_arg_t **)malloc(sizeof(thread_arg_t*) * num_xstreams);
+    thread_args =
+        (thread_arg_t **)malloc(sizeof(thread_arg_t *) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
         threads[i] = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
         for (j = 0; j < num_threads; j++) {
@@ -190,7 +195,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -201,10 +206,9 @@ int main(int argc, char *argv[])
             thread_args[i][j].id = tid;
             thread_args[i][j].num_threads = num_threads;
             thread_args[i][j].threads = &threads[i][0];
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&thread_args[i][j],
-                    ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func,
+                                    (void *)&thread_args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -212,18 +216,17 @@ int main(int argc, char *argv[])
     /* Create tasks with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func1, (void *)num,
-                              NULL);
+        ret =
+            ABT_task_create(pools[i % num_xstreams], task_func1, (void *)num,
+                            NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
     /* Create tasks with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         task_args[i].num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func2, (void *)&task_args[i],
-                              &tasks[i]);
+        ret = ABT_task_create(pools[i % num_xstreams], task_func2,
+                              (void *)&task_args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -236,7 +239,7 @@ int main(int argc, char *argv[])
         } while (state != ABT_TASK_STATE_TERMINATED);
 
         ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-               task_args[i].num, task_args[i].result);
+                   task_args[i].num, task_args[i].result);
 
         /* Free named tasks */
         ret = ABT_task_free(&tasks[i]);
@@ -256,7 +259,8 @@ int main(int argc, char *argv[])
             ATS_ERROR(ret, "ABT_thread_free");
         }
 
-        if (i == 0) continue;
+        if (i == 0)
+            continue;
 
         ret = ABT_xstream_free(&xstreams[i]);
         ATS_ERROR(ret, "ABT_xstream_free");
@@ -278,4 +282,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task_arg.c
+++ b/test/basic/thread_task_arg.c
@@ -64,12 +64,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_tasks    = DEFAULT_NUM_TASKS;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_tasks = DEFAULT_NUM_TASKS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -129,4 +129,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task_num.c
+++ b/test/basic/thread_task_num.c
@@ -28,12 +28,14 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_threads = DEFAULT_NUM_THREADS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_threads = atoi(argv[1]);
+    if (argc > 1)
+        num_threads = atoi(argv[1]);
     assert(num_threads >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
-    unsigned long num_units = (unsigned long)(num_threads+num_tasks);
+    unsigned long num_units = (unsigned long)(num_threads + num_tasks);
 
     ABT_xstream xstream;
     size_t n_units;
@@ -55,8 +57,9 @@ int main(int argc, char *argv[])
 
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                ABT_THREAD_ATTR_NULL, NULL);
+        ret =
+            ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -100,4 +103,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_yield.c
+++ b/test/basic/thread_yield.c
@@ -27,9 +27,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -51,7 +53,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -59,9 +61,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_yield_to.c
+++ b/test/basic/thread_yield_to.c
@@ -31,7 +31,8 @@ ABT_thread pick_one(ABT_thread *threads, int num_threads, unsigned *seed,
         next = threads[i];
         ret = ABT_thread_equal(next, caller, &is_same);
         ATS_ERROR(ret, "ABT_thread_equal");
-        if (is_same == ABT_TRUE) continue;
+        if (is_same == ABT_TRUE)
+            continue;
 
         if (next != ABT_THREAD_NULL) {
             ret = ABT_thread_get_state(next, &state);
@@ -80,9 +81,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -115,7 +118,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -126,9 +129,8 @@ int main(int argc, char *argv[])
             args[i][j].id = tid;
             args[i][j].num_threads = num_threads;
             args[i][j].threads = &threads[i][0];
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -146,7 +148,8 @@ int main(int argc, char *argv[])
             ATS_ERROR(ret, "ABT_thread_free");
         }
 
-        if (i == 0) continue;
+        if (i == 0)
+            continue;
 
         ret = ABT_xstream_free(&xstreams[i]);
         ATS_ERROR(ret, "ABT_xstream_free");

--- a/test/basic/timer.c
+++ b/test/basic/timer.c
@@ -27,7 +27,7 @@ void thread_create(void *arg)
     ABT_thread my_thread;
     ABT_pool my_pool;
     ABT_timer my_timer;
-    double t_start  = 0.0;
+    double t_start = 0.0;
     double t_create = 0.0;
 
     ret = ABT_timer_dup(timer, &my_timer);
@@ -44,15 +44,14 @@ void thread_create(void *arg)
     for (i = 0; i < num_threads; i++) {
         ABT_timer_start(my_timer);
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create(my_pool,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(my_pool, thread_func, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
         ABT_timer_stop_and_add(my_timer, &t_create);
     }
 
     ATS_printf(1, "[T%d] start: %.9f, %d ULTs creation time: %.9f\n",
-                    (int)my_id, t_start, num_threads, t_create);
+               (int)my_id, t_start, num_threads, t_create);
     ret = ABT_timer_free(&my_timer);
     ATS_ERROR(ret, "ABT_timer_free");
 }
@@ -61,9 +60,11 @@ int main(int argc, char *argv[])
 {
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     double t_init = 0.0;
@@ -99,16 +100,15 @@ int main(int argc, char *argv[])
 
     /* Get the first pool attached to each ES */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create one ULT for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create(pools[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(pools[i], thread_create, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -140,10 +140,9 @@ int main(int argc, char *argv[])
     ATS_printf(1, "Timer overhead: %.9f sec\n", t_overhead);
     ATS_printf(1, "Init. time    : %.9f sec\n", t_init);
     ATS_printf(1, "Exec. time    : %.9f sec (w/o overhead: %.9f sec)\n",
-                    t_exec, t_exec - t_overhead);
+               t_exec, t_exec - t_overhead);
     ATS_printf(1, "Fini. time    : %.9f sec (w/o overhead: %.9f sec)\n",
-                    t_fini, t_fini - t_overhead);
+               t_fini, t_fini - t_overhead);
 
     return ret;
 }
-

--- a/test/basic/xstream_affinity.c
+++ b/test/basic/xstream_affinity.c
@@ -32,8 +32,7 @@ static void print_cpuset(int rank, int cpuset_size, int *cpuset)
         len = strlen(&cpuset_str[pos]);
         pos += len;
     }
-    ATS_printf(1, "[E%d] CPU set (%d): {%s}\n",
-                    rank, cpuset_size, cpuset_str);
+    ATS_printf(1, "[E%d] CPU set (%d): {%s}\n", rank, cpuset_size, cpuset_str);
 
     free(cpuset_str);
 }
@@ -57,8 +56,7 @@ static void test_affinity(void *arg)
     ATS_printf(1, "[E%d] CPU bind: %d\n", rank, cpuid);
 
     new_cpuid = (cpuid + 1) % num_xstreams;
-    ATS_printf(1, "[E%d] change binding: %d -> %d\n",
-                    rank, cpuid, new_cpuid);
+    ATS_printf(1, "[E%d] change binding: %d -> %d\n", rank, cpuid, new_cpuid);
     ret = ABT_xstream_set_cpubind(xstream, new_cpuid);
     ATS_ERROR(ret, "ABT_xstream_set_cpubind");
     ret = ABT_xstream_get_cpubind(xstream, &cpuid);
@@ -179,4 +177,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/xstream_barrier.c
+++ b/test/basic/xstream_barrier.c
@@ -21,7 +21,8 @@ void test_xstream_barrier(void *arg)
     int i, ret;
 
     for (i = 0; i < num_iter; i++) {
-        if (rank == 0) value = i;
+        if (rank == 0)
+            value = i;
         ret = ABT_xstream_barrier_wait(barrier);
         ATS_ERROR(ret, "ABT_xstream_barrier_wait");
 
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -109,4 +110,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/benchmark/bench_util.h
+++ b/test/benchmark/bench_util.h
@@ -87,7 +87,8 @@ static inline void print_header(char *wu, int need_join)
     line_size = need_join ? 86 : 65;
     ATS_print_line(stdout, '-', line_size);
     printf("%-3s %8s %8s %22s ", "ES#", wu, "#Iter", "Create: cycles [std]");
-    if (need_join) printf("%20s ", "Join: cycles [std]");
+    if (need_join)
+        printf("%20s ", "Join: cycles [std]");
     printf("%20s\n", "Free: cycles [std]");
 #else
 
@@ -96,27 +97,39 @@ static inline void print_header(char *wu, int need_join)
     printf("%-3s %8s %8s ", "ES#", wu, "#Iter");
 #if (defined __MIC__) || (defined __KNC__)
 #ifdef USE_PAPI_L1M_L2M
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Dm [std]", "L1Im [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Dm [std]",
+           "L1Im [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "L1Dm [std]", "L1Im [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Dm [std]", "L1Im [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "L1Dm [std]",
+               "L1Im [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Dm [std]",
+           "L1Im [std]");
 #else
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L2Dm [std]", "TLBm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L2Dm [std]",
+           "TLBm [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "L2Dm [std]", "TLBm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L2Dm [std]", "TLBm [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "L2Dm [std]",
+               "TLBm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L2Dm [std]",
+           "TLBm [std]");
 #endif /* USE_PAPI_L1M_L2M */
 #else
 #ifdef USE_PAPI_L1M_L2M
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Cm [std]", "L2Cm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Cm [std]",
+           "L2Cm [std]");
     if (need_join)
-    printf("%20s %14s %14s", "Join: cycles [std]", "L1Cm [std]", "L2Cm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Cm [std]", "L2Cm [std]");
+        printf("%20s %14s %14s", "Join: cycles [std]", "L1Cm [std]",
+               "L2Cm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Cm [std]",
+           "L2Cm [std]");
 #else
-    printf("%22s %14s %14s ", "Create: cycles [std]", "LLCm [std]", "TLBm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "LLCm [std]",
+           "TLBm [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "LLCm [std]", "TLBm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "LLCm [std]", "TLBm [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "LLCm [std]",
+               "TLBm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "LLCm [std]",
+           "TLBm [std]");
 #endif /* USE_PAPI_L1M_L2M */
 #endif
 #endif /* USE_PAPI */
@@ -125,7 +138,8 @@ static inline void print_header(char *wu, int need_join)
 }
 
 #ifdef USE_PAPI
-static inline unsigned long ABTX_xstream_get_self(void) {
+static inline unsigned long ABTX_xstream_get_self(void)
+{
     ABT_xstream self;
     ABT_xstream_self(&self);
     return (unsigned long)self;
@@ -141,17 +155,16 @@ static inline unsigned long ABTX_xstream_get_self(void) {
 /* The following data-structure holds the state of the sequence generator */
 typedef struct seq_state_t {
     int base;
-    int prev_term;     /* previously generated term */
-    int cur_stride;    /* current stride */
-    int last_pow_term; /* last term which is power of base */
+    int prev_term;              /* previously generated term */
+    int cur_stride;             /* current stride */
+    int last_pow_term;          /* last term which is power of base */
     /* maximum number of terms non-power of base between two
      * successive powers of base */
     int max_nonpow_terms;
 } seq_state_t;
 
-static inline void seq_init(seq_state_t* state, const int base,
-                            const int prev_term,
-                            const int last_pow_term,
+static inline void seq_init(seq_state_t *state, const int base,
+                            const int prev_term, const int last_pow_term,
                             const int max_nonpow_terms)
 {
     state->base = base;
@@ -162,12 +175,12 @@ static inline void seq_init(seq_state_t* state, const int base,
 }
 
 /* Core of the sequence generator */
-static inline int seq_get_next_term(seq_state_t* state)
+static inline int seq_get_next_term(seq_state_t *state)
 {
-    int cur_term; /* term to return */
+    int cur_term;               /* term to return */
     cur_term = state->prev_term + state->cur_stride;
-    if (cur_term == state->last_pow_term*state->base) {
-        while (cur_term/state->cur_stride - 1 > state->max_nonpow_terms)
+    if (cur_term == state->last_pow_term * state->base) {
+        while (cur_term / state->cur_stride - 1 > state->max_nonpow_terms)
             state->cur_stride *= state->base;
         state->last_pow_term = cur_term;
     }
@@ -176,4 +189,3 @@ static inline int seq_get_next_term(seq_state_t* state)
 }
 
 #endif /* BENCH_UTIL_H_INCLUDED */
-

--- a/test/benchmark/init_finalize.c
+++ b/test/benchmark/init_finalize.c
@@ -49,7 +49,8 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_timers[i] = 0.0;
+    for (i = 0; i < T_LAST; i++)
+        t_timers[i] = 0.0;
 
     /* measure init/finalize time (cold) */
     ABT_timer_start(timer);
@@ -82,8 +83,7 @@ int main(int argc, char *argv[])
 
         ABT_xstream_create(ABT_SCHED_NULL, &xstream);
         ABT_xstream_get_main_pools(xstream, 1, &pool);
-        ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
-                          NULL);
+        ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL, NULL);
         ABT_xstream_join(xstream);
         ABT_xstream_free(&xstream);
 
@@ -108,4 +108,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/sync_ops.c
+++ b/test/benchmark/sync_ops.c
@@ -32,7 +32,7 @@ static char *t_names[] = {
 };
 
 typedef struct {
-    int eid;            /* ES id */
+    int eid;                    /* ES id */
     int test_kind;
 } launch_t;
 
@@ -71,7 +71,8 @@ void mutex_lock_unlock(void *arg)
     ABT_barrier_wait(g_barrier);
 
     /* start timer */
-    if (eid == 0 && tid == 0) ABT_timer_start(timer);
+    if (eid == 0 && tid == 0)
+        ABT_timer_start(timer);
 
     /* measure mutex lock/unlock time */
     for (i = 0; i < iter; i++) {
@@ -97,9 +98,9 @@ void launch_test(void *arg)
     int test_kind = my_arg->test_kind;
 
     ABT_xstream xstream;
-    ABT_pool    pool;
+    ABT_pool pool;
     ABT_thread *threads;
-    void (*test_fn)(void *);
+    void (*test_fn) (void *);
     int i;
 
     ATS_printf(1, "[E%d] main ULT: start\n", eid);
@@ -138,9 +139,9 @@ void launch_test(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream *xstreams;
-    ABT_pool    *pools;
-    ABT_thread  *threads;
-    ABT_mutex   *mutexes;
+    ABT_pool *pools;
+    ABT_thread *threads;
+    ABT_mutex *mutexes;
     ABT_timer timer;
     launch_t *largs;
     double t_time;
@@ -149,7 +150,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -160,12 +161,13 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_timers[i] = 0.0;
+    for (i = 0; i < T_LAST; i++)
+        t_timers[i] = 0.0;
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    threads  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
-    mutexes  = (ABT_mutex *)malloc(iter * sizeof(ABT_mutex));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    mutexes = (ABT_mutex *)malloc(iter * sizeof(ABT_mutex));
 
     /* mutex create (cold) time */
     ABT_timer_start(timer);
@@ -185,7 +187,7 @@ int main(int argc, char *argv[])
 
     /* mutex create/free (cold) time */
     t_timers[T_MUTEX_CREATE_FREE_COLD] = t_timers[T_MUTEX_CREATE_COLD]
-                                       + t_timers[T_MUTEX_FREE_COLD];
+        + t_timers[T_MUTEX_FREE_COLD];
 
     /* mutex create time */
     ABT_timer_start(timer);
@@ -205,7 +207,7 @@ int main(int argc, char *argv[])
 
     /* mutex create/free time */
     t_timers[T_MUTEX_CREATE_FREE] = t_timers[T_MUTEX_CREATE]
-                                  + t_timers[T_MUTEX_FREE];
+        + t_timers[T_MUTEX_FREE];
 
     /* mutex lock/unlock time */
     ABT_timer_start(timer);
@@ -265,4 +267,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_fork_join.c
+++ b/test/benchmark/task_fork_join.c
@@ -66,7 +66,7 @@ do {                                                                \
 #define START_NTASKS    64
 
 static ABT_xstream *xstreams;
-static ABT_pool    *pools;
+static ABT_pool *pools;
 static int niter, max_tasks, ness;
 static ABT_xstream_barrier g_xbarrier = ABT_XSTREAM_BARRIER_NULL;
 
@@ -93,7 +93,7 @@ static void master_thread_func(void *arg)
     ABTX_papi_add_event(event_set);
 #endif /* USE_PAPI */
 
-    ABT_task *my_tasks = (ABT_task *)malloc(max_tasks*sizeof(ABT_task));
+    ABT_task *my_tasks = (ABT_task *)malloc(max_tasks * sizeof(ABT_task));
 
     /* warm-up */
     for (t = 0; t < max_tasks; t++)
@@ -102,7 +102,7 @@ static void master_thread_func(void *arg)
         ABT_task_free(&my_tasks[t]);
 
     seq_state_t state;
-    seq_init(&state, 2, START_NTASKS/2, START_NTASKS/2, 1);
+    seq_init(&state, 2, START_NTASKS / 2, START_NTASKS / 2, 1);
     while ((ntasks = seq_get_next_term(&state)) <= max_tasks) {
         ABT_xstream_barrier_wait(g_xbarrier);
         float crea_time = 0.0, crea_timestd = 0.0;
@@ -115,8 +115,9 @@ static void master_thread_func(void *arg)
 #endif
         int i;
 
-        /* The following line tries to keep the total number of iterations constant */
-        int iter = niter/(ntasks/START_NTASKS);
+        /* The following line tries to keep the total number of iterations
+         * constant */
+        int iter = niter / (ntasks / START_NTASKS);
         for (i = 0; i < iter; i++) {
             unsigned long long start_time;
 
@@ -163,11 +164,11 @@ int main(int argc, char *argv[])
     int i;
     ATS_read_args(argc, argv);
     niter = ATS_get_arg_val(ATS_ARG_N_ITER);
-    ness  = ATS_get_arg_val(ATS_ARG_N_ES);
+    ness = ATS_get_arg_val(ATS_ARG_N_ES);
     max_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
 
-    xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
-    pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
+    xstreams = (ABT_xstream *)malloc(ness * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(ness * sizeof(ABT_pool));
 
     ATS_init(argc, argv, ness);
 
@@ -204,9 +205,10 @@ int main(int argc, char *argv[])
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
-    /* Create ESs*/
+    /* Create ESs */
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1, &pools[0]);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &pools[0]);
     for (i = 1; i < ness; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pools[i],
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
@@ -228,4 +230,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_ops.c
+++ b/test/benchmark/task_ops.c
@@ -63,7 +63,7 @@ void task_func(void *arg)
 void task_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_task *my_tasks = g_tasks[eid];
     uint64_t *my_times = t_times[eid];
     uint64_t t_all_start, t_start, t_time;
@@ -74,7 +74,8 @@ void task_test(void *arg)
     /*************************************************************************/
     /* tasklet: create/join (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     for (i = 0; i < num_tasks; i++) {
@@ -96,7 +97,7 @@ void task_test(void *arg)
     my_times[T_CREATE_COLD] /= num_tasks;
     my_times[T_FREE_COLD] /= num_tasks;
     my_times[T_CREATE_FREE_COLD] = my_times[T_CREATE_COLD]
-                                 + my_times[T_FREE_COLD];
+        + my_times[T_FREE_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -122,7 +123,8 @@ void task_test(void *arg)
 
     /* measure tasklet create/free time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_tasks; t++) {
@@ -144,7 +146,8 @@ void task_test(void *arg)
 
     /* measure tasklet create (unnamed) time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_tasks; t++) {
@@ -154,7 +157,8 @@ void task_test(void *arg)
             ABT_thread_yield();
             size_t size;
             ABT_pool_get_size(my_pool, &size);
-            if (size == 0) break;
+            if (size == 0)
+                break;
         }
     }
     my_times[T_CREATE_UNNAMED] = ATS_get_cycles() - t_start;
@@ -178,7 +182,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -195,12 +199,13 @@ int main(int argc, char *argv[])
 
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_tasks    = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_tasks = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
     for (i = 0; i < num_xstreams; i++) {
         g_tasks[i] = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -220,8 +225,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -240,8 +245,10 @@ int main(int argc, char *argv[])
     /* find min, max, avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -282,4 +289,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_ops_all.c
+++ b/test/benchmark/task_ops_all.c
@@ -38,7 +38,7 @@ void task_func(void *arg)
 void test_create_join(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_task *my_tasks = g_tasks[eid];
     int i, t;
 
@@ -56,7 +56,7 @@ void test_create_join(void *arg)
 void test_create_unnamed(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     int i, t;
 
     for (i = 0; i < iter; i++) {
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -90,8 +90,8 @@ int main(int argc, char *argv[])
 
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_tasks    = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_tasks = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
     for (i = 0; i < num_xstreams; i++) {
         g_tasks[i] = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
     }
@@ -120,14 +120,17 @@ int main(int argc, char *argv[])
 
     /* benchmarking */
     for (t = 0; t < T_LAST; t++) {
-        void (*test_fn)(void *);
+        void (*test_fn) (void *);
 
         switch (t) {
-            case T_CREATE_JOIN:    test_fn = test_create_join;
-                                   break;
-            case T_CREATE_UNNAMED: test_fn = test_create_unnamed;
-                                   break;
-            default: assert(0);
+            case T_CREATE_JOIN:
+                test_fn = test_create_join;
+                break;
+            case T_CREATE_UNNAMED:
+                test_fn = test_create_unnamed;
+                break;
+            default:
+                assert(0);
         }
 
         /* warm-up */
@@ -192,4 +195,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_fork_join.c
+++ b/test/benchmark/thread_fork_join.c
@@ -70,7 +70,7 @@ do {                                                                           \
 #define START_NULTS     64
 
 static ABT_xstream *xstreams;
-static ABT_pool    *pools;
+static ABT_pool *pools;
 static int niter, max_ults, ness;
 static ABT_xstream_barrier g_xbarrier = ABT_XSTREAM_BARRIER_NULL;
 
@@ -97,12 +97,12 @@ static void master_thread_func(void *arg)
     ABTX_papi_add_event(event_set);
 #endif /* USE_PAPI */
 
-    ABT_thread *my_ults = (ABT_thread *)malloc(max_ults*sizeof(ABT_thread));
+    ABT_thread *my_ults = (ABT_thread *)malloc(max_ults * sizeof(ABT_thread));
 
     /* warm-up */
     for (t = 0; t < max_ults; t++)
-        ABT_thread_create(pools[my_es], thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, &my_ults[t]);
+        ABT_thread_create(pools[my_es], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          &my_ults[t]);
 #ifdef USE_JOIN_MANY
     ABT_thread_join_many(max_ults, my_ults);
 #else
@@ -113,7 +113,7 @@ static void master_thread_func(void *arg)
         ABT_thread_free(&my_ults[t]);
 
     seq_state_t state;
-    seq_init(&state, 2, START_NULTS/2, START_NULTS/2, 1);
+    seq_init(&state, 2, START_NULTS / 2, START_NULTS / 2, 1);
     while ((nults = seq_get_next_term(&state)) <= max_ults) {
         ABT_xstream_barrier_wait(g_xbarrier);
         float crea_time = 0.0, crea_timestd = 0.0;
@@ -129,8 +129,9 @@ static void master_thread_func(void *arg)
 #endif
         int i;
 
-        /* The following line tries to keep the total number of iterations constant */
-        int iter = niter/(nults/START_NULTS);
+        /* The following line tries to keep the total number of iterations
+         * constant */
+        int iter = niter / (nults / START_NULTS);
         for (i = 0; i < iter; i++) {
             unsigned long long start_time;
 
@@ -190,11 +191,11 @@ int main(int argc, char *argv[])
     int i;
     ATS_read_args(argc, argv);
     niter = ATS_get_arg_val(ATS_ARG_N_ITER);
-    ness  = ATS_get_arg_val(ATS_ARG_N_ES);
+    ness = ATS_get_arg_val(ATS_ARG_N_ES);
     max_ults = ATS_get_arg_val(ATS_ARG_N_ULT);
 
-    xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
-    pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
+    xstreams = (ABT_xstream *)malloc(ness * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(ness * sizeof(ABT_pool));
 
     ATS_init(argc, argv, ness);
 
@@ -205,7 +206,7 @@ int main(int argc, char *argv[])
     ABT_xstream_barrier_create(ness, &g_xbarrier);
 
 #ifndef USE_PRIV_POOL
-    /* Create ESs*/
+    /* Create ESs */
     ABT_xstream_self(&xstreams[0]);
     ABT_xstream_get_main_pools(xstreams[0], 1, &pools[0]);
     for (i = 1; i < ness; i++) {
@@ -231,9 +232,10 @@ int main(int argc, char *argv[])
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
-    /* Create ESs*/
+    /* Create ESs */
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1, &pools[0]);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &pools[0]);
     for (i = 1; i < ness; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pools[i],
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
@@ -255,4 +257,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_many_ops.c
+++ b/test/benchmark/thread_many_ops.c
@@ -122,11 +122,11 @@ void thread_func_migrate_to_xstream(void *arg)
 void thread_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
-    uint64_t   *my_times   = t_times[eid];
+    uint64_t *my_times = t_times[eid];
     ABT_pool *pool_list;
-    void (**thread_func_list)(void *);
+    void (**thread_func_list) (void *);
 
     uint64_t t_all_start = 0;
     uint64_t t_start, t_time;
@@ -136,7 +136,7 @@ void thread_test(void *arg)
 
     pool_list = (ABT_pool *)malloc(num_threads * sizeof(ABT_pool));
     thread_func_list = (void (**)(void *))
-                       malloc(num_threads * sizeof(void (*)(void *)));
+        malloc(num_threads * sizeof(void (*)(void *)));
     for (i = 0; i < num_threads; i++) {
         pool_list[i] = my_pool;
         thread_func_list[i] = thread_func;
@@ -145,7 +145,8 @@ void thread_test(void *arg)
     /*************************************************************************/
     /* ULT: create_many/join_many (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
@@ -159,12 +160,13 @@ void thread_test(void *arg)
     ABT_xstream_barrier_wait(g_xbarrier);
     if (eid == 0) {
         /* execution time for all ESs */
-        t_all[T_ALL_CREATE_MANY_JOIN_MANY_COLD] = ATS_get_cycles() - t_all_start;
+        t_all[T_ALL_CREATE_MANY_JOIN_MANY_COLD] =
+            ATS_get_cycles() - t_all_start;
     }
     my_times[T_CREATE_MANY_COLD] /= num_threads;
     my_times[T_JOIN_MANY_COLD] /= num_threads;
     my_times[T_CREATE_MANY_JOIN_MANY_COLD] = my_times[T_CREATE_MANY_COLD]
-                                           + my_times[T_JOIN_MANY_COLD];
+        + my_times[T_JOIN_MANY_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -186,7 +188,8 @@ void thread_test(void *arg)
 
     /* measure the time for create/join operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
@@ -215,7 +218,8 @@ void thread_test(void *arg)
 
     /* measure the time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
                            ABT_THREAD_ATTR_NULL, my_threads);
@@ -249,7 +253,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -265,12 +269,13 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -290,8 +295,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -310,8 +315,10 @@ int main(int argc, char *argv[])
     /* find min, max, and avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -354,4 +361,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_ops.c
+++ b/test/benchmark/thread_ops.c
@@ -150,9 +150,9 @@ void thread_func_migrate_to_xstream(void *arg)
 void thread_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
-    uint64_t   *my_times   = t_times[eid];
+    uint64_t *my_times = t_times[eid];
 
     uint64_t t_all_start, t_start, t_time;
     int i, t;
@@ -163,12 +163,13 @@ void thread_test(void *arg)
     /*************************************************************************/
     /* ULT: create/join (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
-        ABT_thread_create(my_pool, thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, &my_threads[i]);
+        ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          &my_threads[i]);
     }
     my_times[T_CREATE_COLD] = ATS_get_cycles() - t_start;
 
@@ -187,7 +188,7 @@ void thread_test(void *arg)
     my_times[T_CREATE_COLD] /= num_threads;
     my_times[T_JOIN_COLD] /= num_threads;
     my_times[T_CREATE_JOIN_COLD] = my_times[T_CREATE_COLD]
-                                 + my_times[T_JOIN_COLD];
+        + my_times[T_JOIN_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -214,12 +215,13 @@ void thread_test(void *arg)
 
     /* measure the time for create/join operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, &my_threads[t]);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              &my_threads[t]);
         }
 
         ABT_THREAD_JOIN_MANY(num_threads, my_threads);
@@ -238,18 +240,20 @@ void thread_test(void *arg)
 
     /* measure the time for create (unnamed) operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         while (1) {
             ABT_thread_yield();
             size_t size;
             ABT_pool_get_size(my_pool, &size);
-            if (size == 0) break;
+            if (size == 0)
+                break;
         }
     }
     my_times[T_CREATE_UNNAMED] = ATS_get_cycles() - t_start;
@@ -276,7 +280,8 @@ void thread_test(void *arg)
 
     /* measure the time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         ABT_thread_create(my_pool, thread_func_yield, NULL,
@@ -320,7 +325,8 @@ void thread_test(void *arg)
     /* measure the time */
     args = (arg_t *)malloc(num_threads * sizeof(arg_t));
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         args[i].eid = eid;
@@ -353,7 +359,8 @@ void thread_test(void *arg)
     /* ULT: migrate_to_xstream */
     args = (arg_t *)malloc(num_threads * sizeof(arg_t));
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         args[i].eid = eid;
@@ -394,7 +401,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -410,12 +417,13 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -435,8 +443,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -455,8 +463,10 @@ int main(int argc, char *argv[])
     /* find min, max, and avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -499,4 +509,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_ops_all.c
+++ b/test/benchmark/thread_ops_all.c
@@ -150,14 +150,14 @@ void thread_func_migrate_to_xstream(void *arg)
 void test_create_join(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i, t;
 
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, &my_threads[t]);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              &my_threads[t]);
         }
 
         ABT_THREAD_JOIN_MANY(num_threads, my_threads);
@@ -175,8 +175,8 @@ void test_create_unnamed(void *arg)
 
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         ABT_thread_yield();
     }
@@ -185,7 +185,7 @@ void test_create_unnamed(void *arg)
 void test_yield_overhead(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -202,7 +202,7 @@ void test_yield_overhead(void *arg)
 void test_yield(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -219,7 +219,7 @@ void test_yield(void *arg)
 void test_yield_to_overhead(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -241,7 +241,7 @@ void test_yield_to_overhead(void *arg)
 void test_yield_to(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -263,7 +263,7 @@ void test_yield_to(void *arg)
 void test_migrate_to_xstream(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -306,8 +306,8 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
@@ -336,7 +336,7 @@ int main(int argc, char *argv[])
 
     /* benchmarking */
     for (t = 0; t < T_LAST; t++) {
-        void (*test_fn)(void *);
+        void (*test_fn) (void *);
 
         if (t == T_YIELD) {
             if (t_times[T_YIELD_ALL] > t_times[T_YIELD_OVERHEAD]) {
@@ -347,7 +347,8 @@ int main(int argc, char *argv[])
             continue;
         } else if (t == T_YIELD_TO) {
             if (t_times[T_YIELD_TO_ALL] > t_times[T_YIELD_TO_OVERHEAD]) {
-                t_times[t] = t_times[T_YIELD_TO_ALL] - t_times[T_YIELD_TO_OVERHEAD];
+                t_times[t] =
+                    t_times[T_YIELD_TO_ALL] - t_times[T_YIELD_TO_OVERHEAD];
             } else {
                 t_times[t] = 0;
             }
@@ -355,23 +356,31 @@ int main(int argc, char *argv[])
         }
 
         switch (t) {
-            case T_CREATE_JOIN:        test_fn = test_create_join;
-                                       break;
-            case T_CREATE_UNNAMED:     test_fn = test_create_unnamed;
-                                       break;
-            case T_YIELD_OVERHEAD:     test_fn = test_yield_overhead;
-                                       break;
-            case T_YIELD_ALL:          test_fn = test_yield;
-                                       break;
-            case T_YIELD_TO_OVERHEAD:  test_fn = test_yield_to_overhead;
-                                       break;
-            case T_YIELD_TO_ALL:       test_fn = test_yield_to;
-                                       break;
+            case T_CREATE_JOIN:
+                test_fn = test_create_join;
+                break;
+            case T_CREATE_UNNAMED:
+                test_fn = test_create_unnamed;
+                break;
+            case T_YIELD_OVERHEAD:
+                test_fn = test_yield_overhead;
+                break;
+            case T_YIELD_ALL:
+                test_fn = test_yield;
+                break;
+            case T_YIELD_TO_OVERHEAD:
+                test_fn = test_yield_to_overhead;
+                break;
+            case T_YIELD_TO_ALL:
+                test_fn = test_yield_to;
+                break;
 #ifdef TEST_MIGRATE_TO
-            case T_MIGRATE_TO_XSTREAM: test_fn = test_migrate_to_xstream;
-                                       break;
+            case T_MIGRATE_TO_XSTREAM:
+                test_fn = test_migrate_to_xstream;
+                break;
 #endif
-            default: assert(0);
+            default:
+                assert(0);
         }
 
         /* warm-up */
@@ -450,4 +459,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/xstream_ops.c
+++ b/test/benchmark/xstream_ops.c
@@ -54,7 +54,8 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_times[i] = 0.0;
+    for (i = 0; i < T_LAST; i++)
+        t_times[i] = 0.0;
 
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
@@ -64,8 +65,8 @@ int main(int argc, char *argv[])
     for (t = 0; t < num_xstreams; t++) {
         ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
         ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-        ABT_thread_create(pools[t], thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, NULL);
+        ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          NULL);
     }
     for (t = 0; t < num_xstreams; t++) {
         ABT_xstream_join(xstreams[t]);
@@ -111,8 +112,8 @@ int main(int argc, char *argv[])
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
             ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-            ABT_thread_create(pools[t], thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_join(xstreams[t]);
@@ -132,8 +133,8 @@ int main(int argc, char *argv[])
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
             ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-            ABT_thread_create(pools[t], thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_join(xstreams[t]);
@@ -170,4 +171,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/util/abttest.c
+++ b/test/util/abttest.c
@@ -46,8 +46,7 @@ void ATS_init(int argc, char **argv, int num_xstreams)
             g_verbose = val;
         } else {
             /* Negative value */
-            fprintf(stderr, "WARNING: %s is invalid for ATS_VERBOSE\n",
-                    envval);
+            fprintf(stderr, "WARNING: %s is invalid for ATS_VERBOSE\n", envval);
             fflush(stderr);
         }
     }
@@ -94,7 +93,8 @@ void ATS_error(int err, const char *msg, const char *file, int line)
     size_t len;
     int ret;
 
-    if (err == ABT_SUCCESS) return;
+    if (err == ABT_SUCCESS)
+        return;
     if (err == ABT_ERR_FEATURE_NA) {
         printf("Skipped\n");
         fflush(stdout);
@@ -107,8 +107,7 @@ void ATS_error(int err, const char *msg, const char *file, int line)
     assert(err_str != NULL);
     ret = ABT_error_get_str(err, err_str, NULL);
 
-    fprintf(stderr, "%s (%d): %s (%s:%d)\n",
-            err_str, err, msg, file, line);
+    fprintf(stderr, "%s (%d): %s (%s:%d)\n", err_str, err, msg, file, line);
 
     free(err_str);
 
@@ -120,7 +119,7 @@ void ATS_error(int err, const char *msg, const char *file, int line)
 static void ATS_print_help(char *prog)
 {
     fprintf(stderr, "Usage: %s [-e num_es] [-u num_ult] [-t num_task] "
-                    "[-i iter] [-v verbose_level]\n", prog);
+            "[-i iter] [-v verbose_level]\n", prog);
     fflush(stderr);
 }
 
@@ -129,8 +128,10 @@ void ATS_read_args(int argc, char **argv)
     static int read = 0;
     int i, opt;
 
-    if (read == 0) read = 1;
-    else return;
+    if (read == 0)
+        read = 1;
+    else
+        return;
 
     for (i = 0; i < NUM_ARG_KINDS; i++) {
         g_arg_val[i] = 1;
@@ -181,4 +182,3 @@ void ATS_print_line(FILE *fp, char c, int len)
     fprintf(fp, "\n");
     fflush(fp);
 }
-

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -84,10 +84,10 @@ void ATS_error(int err, const char *msg, const char *file, int line);
 
 
 typedef enum {
-    ATS_ARG_N_ES   = 0,    /* # of ESs */
-    ATS_ARG_N_ULT  = 1,    /* # of ULTs */
-    ATS_ARG_N_TASK = 2,    /* # of tasklets */
-    ATS_ARG_N_ITER = 3     /* # of iterations */
+    ATS_ARG_N_ES = 0,           /* # of ESs */
+    ATS_ARG_N_ULT = 1,  /* # of ULTs */
+    ATS_ARG_N_TASK = 2, /* # of tasklets */
+    ATS_ARG_N_ITER = 3  /* # of iterations */
 } ATS_arg;
 
 /**
@@ -134,7 +134,7 @@ void ATS_print_line(FILE *fp, char c, int len);
 static inline uint64_t ATS_get_cycles()
 {
     unsigned hi, lo;
-    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    __asm__ __volatile__("rdtsc":"=a"(lo), "=d"(hi));
     uint64_t cycle = ((uint64_t)lo) | (((int64_t)hi) << 32);
     return cycle;
 }
@@ -142,7 +142,7 @@ static inline uint64_t ATS_get_cycles()
 static inline uint64_t ATS_get_cycles()
 {
     register uint64_t cycle;
-    __asm__ __volatile__ ("isb; mrs %0, cntvct_el0" : "=r"(cycle));
+    __asm__ __volatile__("isb; mrs %0, cntvct_el0":"=r"(cycle));
     return cycle;
 }
 #else


### PR DESCRIPTION
This PR updates `maint/code-cleanup.sh` to use Travis CI effectively.

Note that this PR is a GNU indent version; the other is a Clang-format version (#110).

Any feedback is welcome!

---
**Changes in common:**

- No single-line `if`/`while`/`for`
```cpp
BEFORE:
    if (stop == ABT_TRUE) break;
AFTER:
    if (stop == ABT_TRUE)
        break;
```

- No aligned assignment/declaration.
```cpp
BEFORE:
    p_def->p_free               = pool_free;
    p_def->p_get_size           = pool_get_size;

    ABT_sched   scheds[NUM_XSTREAMS];
    ABT_pool    shared_pool;
AFTER:
    p_def->p_free = pool_free;
    p_def->p_get_size = pool_get_size;

    ABT_sched scheds[NUM_XSTREAMS];
    ABT_pool shared_pool;
```
---
**GNU Indent-specific changes / side effects:**

- Need to list typedefs in `code-cleanup.sh` (see the first commit. indent does not understand C types)
```
$ cat code-cleanup.sh
    $indent --k-and-r-style --line-length80 --else-endif-column1 \ [...]
            -T ABT_xstream -T ABT_xstream_state -T ABT_xstream_barrier \
            -T ABT_sched -T ABT_sched_config -T ABT_sched_predef \
            -T ABT_sched_def -T ABT_sched_state -T ABT_sched_type \
            ...
```

- Weird space after a function pointer (indent cannot interpret it properly)
```cpp
BEFORE:
int ABTD_xstream_context_create(void *(*f_xstream)(void *)) {
    (*p_future->p_callback)(p_future->array);
AFTER:
int ABTD_xstream_context_create(void *(*f_xstream) (void *)) {
    (*p_future->p_callback) (p_future->array);
```

- Weird spacing before comments (I don't know what rules are internally used).
```cpp
BEFORE:
    ucontext_t             uctx;         /* ucontext entity pointed by p_ctx */
    void (*f_uctx_thread)(void *);       /* root function called by ucontext */
    void *                 p_uctx_arg;   /* argument for root function */
AFTER:
    ucontext_t uctx;            /* ucontext entity pointed by p_ctx */
    void (*f_uctx_thread) (void *);     /* root function called by ucontext */
    void *p_uctx_arg;           /* argument for root function */
```

- Weird arrangement of call parameters (then why doesn't it pack all the arguments???)
```cpp
BEFORE:
    sprintf(p_buf,
        "["
        "stack:%p "
        "stacksize:%zu "
        "stacktype:%s "
        "]",
        p_attr->p_stack,
        p_attr->stacksize,
        stacktype
    );
AFTER:
    sprintf(p_buf,
            "["
            "stack:%p "
            "stacksize:%zu "
            "stacktype:%s " "]", p_attr->p_stack, p_attr->stacksize, stacktype);
```