### PR TITLE
Update the cleanup script: Clang-format version

### DIFF
--- a/examples/fibonacci_future.c
+++ b/examples/fibonacci_future.c
@@ -12,8 +12,8 @@
 #include <string.h>
 #include <abt.h>
 
-#define N               10
-#define NUM_XSTREAMS    4
+#define N 10
+#define NUM_XSTREAMS 4
 
 /* global variables */
 ABT_pool g_pool = ABT_POOL_NULL;
@@ -28,11 +28,11 @@ typedef struct {
 /* Callback function passed to future */
 void callback(void **args)
 {
-	int n1, n2;
+    int n1, n2;
 
-	n1 = *(int *)args[1];
-	n2 = *(int *)args[2];
-	*(int *)args[0] = n1 + n2;
+    n1 = *(int *)args[1];
+    n2 = *(int *)args[2];
+    *(int *)args[0] = n1 + n2;
 }
 
 /* Function to compute Fibonacci numbers */
@@ -77,7 +77,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {
@@ -114,8 +115,8 @@ int main(int argc, char *argv[])
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pool);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pool);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pool,
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);

--- a/examples/fibonacci_task.c
+++ b/examples/fibonacci_task.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <abt.h>
 
-#define N               10
-#define NUM_XSTREAMS    4
+#define N 10
+#define NUM_XSTREAMS 4
 
 /* global variables */
 ABT_pool g_pool = ABT_POOL_NULL;
@@ -110,7 +110,8 @@ void aggregate_fibonacci(void *arguments)
         ABT_mutex_lock(parent->mutex);
         parent->result += result;
         flag = parent->flag;
-        if (!flag) parent->flag = 1;
+        if (!flag)
+            parent->flag = 1;
         ABT_mutex_unlock(parent->mutex);
         if (flag) {
             /* creating an aggregate task */
@@ -162,7 +163,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {
@@ -197,8 +199,8 @@ int main(int argc, char *argv[])
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pool);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pool);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pool,
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);

--- a/examples/fibonacci_thread_task.c
+++ b/examples/fibonacci_thread_task.c
@@ -13,8 +13,8 @@
 #include <string.h>
 #include <abt.h>
 
-#define N               10
-#define NUM_XSTREAMS    4
+#define N 10
+#define NUM_XSTREAMS 4
 
 /* global variables */
 ABT_pool g_pool = ABT_POOL_NULL;
@@ -95,7 +95,8 @@ void fibonacci_task(void *arguments)
         while (flag && parent != NULL) {
             ABT_mutex_lock(parent->mutex);
             parent->result += result;
-            if (result == parent->result) flag = 0;
+            if (result == parent->result)
+                flag = 0;
             ABT_mutex_unlock(parent->mutex);
             result = parent->result;
             temp = parent->parent;
@@ -135,7 +136,8 @@ int verify(int n)
     int i;
     int old[2], val;
 
-    if (n <= 2) return 1;
+    if (n <= 2)
+        return 1;
 
     old[0] = old[1] = 1;
     for (i = 3; i <= n; i++) {
@@ -180,8 +182,8 @@ int main(int argc, char *argv[])
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pool);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pool);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pool,
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
@@ -191,7 +193,8 @@ int main(int argc, char *argv[])
     /* creating thread */
     args_thread.n = n - 1;
     args_thread.eventual = ABT_EVENTUAL_NULL;
-    ABT_thread_create(g_pool, fibonacci_thread, &args_thread, ABT_THREAD_ATTR_NULL, &thread);
+    ABT_thread_create(g_pool, fibonacci_thread, &args_thread,
+                      ABT_THREAD_ATTR_NULL, &thread);
 
     /* creating task */
     args_task = (task_args *)malloc(sizeof(task_args));
@@ -218,7 +221,7 @@ int main(int argc, char *argv[])
 
     free(xstreams);
 
-  fn_result:
+fn_result:
     printf("Fib(%d): %d\n", n, result);
     expected = verify(n);
     if (result != expected) {

--- a/examples/hello_world.c
+++ b/examples/hello_world.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
+#define NUM_XSTREAMS 4
 
 void task_hello(void *arg)
 {
@@ -28,8 +28,8 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     size_t i;
 
     ABT_init(argc, argv);

--- a/examples/hello_world_thread.c
+++ b/examples/hello_world_thread.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
+#define NUM_XSTREAMS 4
 
 void thread_hello(void *arg)
 {
@@ -18,8 +18,8 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);

--- a/examples/sched_and_pool_user.c
+++ b/examples/sched_and_pool_user.c
@@ -8,8 +8,8 @@
 #include <time.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
-#define NUM_THREADS     4
+#define NUM_XSTREAMS 4
+#define NUM_THREADS 4
 
 static void create_scheds(int num, ABT_pool *pools, ABT_sched *scheds);
 static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def);
@@ -19,9 +19,9 @@ static void thread_hello(void *arg);
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     ABT_pool_def pool_def;
     int i;
 
@@ -114,7 +114,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, pools[0]);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool_pop(pools[target], &unit);
             if (unit != ABT_UNIT_NULL) {
                 ABT_xstream_run_unit(unit, pools[target]);
@@ -124,7 +125,8 @@ static void sched_run(ABT_sched sched)
         if (++work_count >= p_data->event_freq) {
             work_count = 0;
             ABT_sched_has_to_stop(sched, &stop);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             ABT_xstream_check_events(sched);
         }
     }
@@ -148,18 +150,14 @@ static void create_scheds(int num, ABT_pool *pools, ABT_sched *scheds)
     ABT_pool *my_pools;
     int i, k;
 
-    ABT_sched_config_var cv_event_freq = {
-        .idx = 0,
-        .type = ABT_SCHED_CONFIG_INT
-    };
+    ABT_sched_config_var cv_event_freq = { .idx = 0,
+                                           .type = ABT_SCHED_CONFIG_INT };
 
-    ABT_sched_def sched_def = {
-        .type = ABT_SCHED_TYPE_ULT,
-        .init = sched_init,
-        .run = sched_run,
-        .free = sched_free,
-        .get_migr_pool = NULL
-    };
+    ABT_sched_def sched_def = { .type = ABT_SCHED_TYPE_ULT,
+                                .init = sched_init,
+                                .run = sched_run,
+                                .free = sched_free,
+                                .get_migr_pool = NULL };
 
     /* Create a scheduler config */
     ABT_sched_config_create(&config, cv_event_freq, 10,
@@ -194,8 +192,8 @@ static void create_threads(void *arg)
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
     for (i = 0; i < NUM_THREADS; i++) {
         size_t id = (rank + 1) * 10 + i;
-        ABT_thread_create(pool, thread_hello, (void *)id,
-                          ABT_THREAD_ATTR_NULL, &threads[i]);
+        ABT_thread_create(pool, thread_hello, (void *)id, ABT_THREAD_ATTR_NULL,
+                          &threads[i]);
     }
 
     ABT_xstream_get_rank(xstream, &rank);
@@ -231,8 +229,8 @@ static void thread_hello(void *arg)
     printf("  [U%d:E%d] Goodbye, world!%s\n", tid, cur_rank, msg);
 }
 
-/* FIFO pool implementation 
- * 
+/* FIFO pool implementation
+ *
  * Based on src/pool/fifo.c, but modified to avoid the use of internal data
  * structures.
  */
@@ -245,7 +243,7 @@ struct example_unit {
     ABT_pool pool;
     union {
         ABT_thread thread;
-        ABT_task   task;
+        ABT_task task;
     };
     ABT_unit_type type;
 };
@@ -257,15 +255,15 @@ struct example_pool_data {
     struct example_unit *p_tail;
 };
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push_shared(ABT_pool pool, ABT_unit unit);
-static void     pool_push_private(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push_shared(ABT_pool pool, ABT_unit unit);
+static void pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
-static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
-static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
+static int pool_remove_shared(ABT_pool pool, ABT_unit unit);
+static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 
 typedef struct example_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -283,7 +281,6 @@ static inline data_t *pool_get_data_ptr(void *p_data)
     return (data_t *)p_data;
 }
 
-
 /* Obtain the FIFO pool definition according to the access type */
 static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
 {
@@ -293,8 +290,8 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
     /* FIXME: need better implementation, e.g., lock-free one */
     switch (access) {
         case ABT_POOL_ACCESS_PRIV:
-            p_def->p_push   = pool_push_private;
-            p_def->p_pop    = pool_pop_private;
+            p_def->p_push = pool_push_private;
+            p_def->p_pop = pool_pop_private;
             p_def->p_remove = pool_remove_private;
             break;
 
@@ -302,8 +299,8 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
         case ABT_POOL_ACCESS_MPSC:
         case ABT_POOL_ACCESS_SPMC:
         case ABT_POOL_ACCESS_MPMC:
-            p_def->p_push   = pool_push_shared;
-            p_def->p_pop    = pool_pop_shared;
+            p_def->p_push = pool_push_shared;
+            p_def->p_pop = pool_pop_shared;
             p_def->p_remove = pool_remove_shared;
             break;
 
@@ -312,21 +309,20 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
     }
 
     /* Common definitions regardless of the access type */
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
     return abt_errno;
 }
-
 
 /* Pool functions */
 
@@ -336,7 +332,8 @@ int pool_init(ABT_pool pool, ABT_pool_config config)
     ABT_pool_access access;
 
     data_t *p_data = (data_t *)malloc(sizeof(data_t));
-    if (!p_data) return ABT_ERR_MEM;
+    if (!p_data)
+        return ABT_ERR_MEM;
 
     ABT_pool_get_access(pool, &access);
 
@@ -497,8 +494,10 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(data);
     unit_t *p_unit = (unit_t *)unit;
 
-    if (p_data->num_units == 0) return ABT_ERR_POOL;
-    if (p_unit->pool == ABT_POOL_NULL) return ABT_ERR_POOL;
+    if (p_data->num_units == 0)
+        return ABT_ERR_POOL;
+    if (p_unit->pool == ABT_POOL_NULL)
+        return ABT_ERR_POOL;
 
     if (p_unit->pool != pool) {
         return ABT_ERR_INV_POOL;
@@ -535,8 +534,10 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(data);
     unit_t *p_unit = (unit_t *)unit;
 
-    if (p_data->num_units == 0) return ABT_ERR_POOL;
-    if (p_unit->pool == ABT_POOL_NULL) return ABT_ERR_POOL;
+    if (p_data->num_units == 0)
+        return ABT_ERR_POOL;
+    if (p_unit->pool == ABT_POOL_NULL)
+        return ABT_ERR_POOL;
 
     if (p_unit->pool != pool) {
         return ABT_ERR_INV_POOL;
@@ -563,13 +564,12 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
     return ABT_SUCCESS;
 }
 
-
 /* Unit functions */
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -605,13 +605,14 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     unit_t *p_unit = malloc(sizeof(unit_t));
-    if (!p_unit) return ABT_UNIT_NULL;
+    if (!p_unit)
+        return ABT_UNIT_NULL;
 
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -619,13 +620,14 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 static ABT_unit unit_create_from_task(ABT_task task)
 {
     unit_t *p_unit = malloc(sizeof(unit_t));
-    if (!p_unit) return ABT_UNIT_NULL;
+    if (!p_unit)
+        return ABT_UNIT_NULL;
 
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->pool = ABT_POOL_NULL;
+    p_unit->task = task;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }
@@ -635,4 +637,3 @@ static void unit_free(ABT_unit *unit)
     free(*unit);
     *unit = ABT_UNIT_NULL;
 }
-

--- a/examples/sched_predef.c
+++ b/examples/sched_predef.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
+#define NUM_XSTREAMS 4
 
 void thread_hello(void *arg)
 {
@@ -19,9 +19,9 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    int         num_pools[NUM_XSTREAMS];
-    ABT_pool   *pools[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    int num_pools[NUM_XSTREAMS];
+    ABT_pool *pools[NUM_XSTREAMS];
     int i, k;
 
     ABT_init(argc, argv);

--- a/examples/sched_shared_pool.c
+++ b/examples/sched_shared_pool.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
-#define NUM_THREADS     (NUM_XSTREAMS * 2)
+#define NUM_XSTREAMS 4
+#define NUM_THREADS (NUM_XSTREAMS * 2)
 
 void thread_hello(void *arg)
 {
@@ -20,16 +20,16 @@ void thread_hello(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    shared_pool;
-    ABT_thread  threads[NUM_THREADS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool shared_pool;
+    ABT_thread threads[NUM_THREADS];
     int i;
 
     ABT_init(argc, argv);
 
     /* Create a shared pool */
-    ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
-                          ABT_TRUE, &shared_pool);
+    ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE,
+                          &shared_pool);
 
     /* Create schedulers */
     for (i = 0; i < NUM_XSTREAMS; i++) {
@@ -65,4 +65,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-

--- a/examples/sched_stack.c
+++ b/examples/sched_stack.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    2
-#define NUM_TASKS       10
+#define NUM_XSTREAMS 2
+#define NUM_TASKS 10
 
 void task_hello(void *arg)
 {
@@ -47,8 +47,8 @@ void add_sched(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);

--- a/examples/sched_user.c
+++ b/examples/sched_user.c
@@ -8,8 +8,8 @@
 #include <time.h>
 #include "abt.h"
 
-#define NUM_XSTREAMS    4
-#define NUM_THREADS     4
+#define NUM_XSTREAMS 4
+#define NUM_THREADS 4
 
 static void create_scheds(int num, ABT_pool *pools, ABT_sched *scheds);
 static void create_threads(void *arg);
@@ -18,17 +18,17 @@ static void thread_hello(void *arg);
 int main(int argc, char *argv[])
 {
     ABT_xstream xstreams[NUM_XSTREAMS];
-    ABT_sched   scheds[NUM_XSTREAMS];
-    ABT_pool    pools[NUM_XSTREAMS];
-    ABT_thread  threads[NUM_XSTREAMS];
+    ABT_sched scheds[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_XSTREAMS];
     int i;
 
     ABT_init(argc, argv);
 
     /* Create pools */
     for (i = 0; i < NUM_XSTREAMS; i++) {
-        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
-                              ABT_TRUE, &pools[i]);
+        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE,
+                              &pools[i]);
     }
 
     /* Create schedulers */
@@ -112,7 +112,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, pools[0]);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool_pop(pools[target], &unit);
             if (unit != ABT_UNIT_NULL) {
                 ABT_xstream_run_unit(unit, pools[target]);
@@ -122,7 +123,8 @@ static void sched_run(ABT_sched sched)
         if (++work_count >= p_data->event_freq) {
             work_count = 0;
             ABT_sched_has_to_stop(sched, &stop);
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             ABT_xstream_check_events(sched);
         }
     }
@@ -146,18 +148,14 @@ static void create_scheds(int num, ABT_pool *pools, ABT_sched *scheds)
     ABT_pool *my_pools;
     int i, k;
 
-    ABT_sched_config_var cv_event_freq = {
-        .idx = 0,
-        .type = ABT_SCHED_CONFIG_INT
-    };
+    ABT_sched_config_var cv_event_freq = { .idx = 0,
+                                           .type = ABT_SCHED_CONFIG_INT };
 
-    ABT_sched_def sched_def = {
-        .type = ABT_SCHED_TYPE_ULT,
-        .init = sched_init,
-        .run = sched_run,
-        .free = sched_free,
-        .get_migr_pool = NULL
-    };
+    ABT_sched_def sched_def = { .type = ABT_SCHED_TYPE_ULT,
+                                .init = sched_init,
+                                .run = sched_run,
+                                .free = sched_free,
+                                .get_migr_pool = NULL };
 
     /* Create a scheduler config */
     ABT_sched_config_create(&config, cv_event_freq, 10,
@@ -192,8 +190,8 @@ static void create_threads(void *arg)
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
     for (i = 0; i < NUM_THREADS; i++) {
         size_t id = (rank + 1) * 10 + i;
-        ABT_thread_create(pool, thread_hello, (void *)id,
-                          ABT_THREAD_ATTR_NULL, &threads[i]);
+        ABT_thread_create(pool, thread_hello, (void *)id, ABT_THREAD_ATTR_NULL,
+                          &threads[i]);
     }
 
     ABT_xstream_get_rank(xstream, &rank);
@@ -228,4 +226,3 @@ static void thread_hello(void *arg)
     msg = (cur_rank == old_rank) ? "" : " (stolen)";
     printf("  [U%d:E%d] Goodbye, world!%s\n", tid, cur_rank, msg);
 }
-

--- a/examples/stencil_task.c
+++ b/examples/stencil_task.c
@@ -8,24 +8,24 @@
 #include <assert.h>
 #include <abt.h>
 
-#define N                       4
-#define NBLOCKS                 32
-#define NITER                   50
-#define DEFAULT_NUM_XSTREAMS    4
-#define PRINT                   0
+#define N 4
+#define NBLOCKS 32
+#define NITER 50
+#define DEFAULT_NUM_XSTREAMS 4
+#define PRINT 0
 
-#define HANDLE_ERROR(ret,msg)                       \
-  if (ret != ABT_SUCCESS) {                         \
-    fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);   \
-    exit(EXIT_FAILURE);                             \
-  }
+#define HANDLE_ERROR(ret, msg)                                                 \
+    if (ret != ABT_SUCCESS) {                                                  \
+        fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);                          \
+        exit(EXIT_FAILURE);                                                    \
+    }
 
-#define totalSize  (ncells+2)
-#define here(x,y)  ((x)*totalSize+y)
-#define left(x,y)  ((x-1)*totalSize+y)
-#define right(x,y) ((x+1)*totalSize+y)
-#define up(x,y)    ((x)*totalSize+y-1)
-#define down(x,y)  ((x)*totalSize+y+1)
+#define totalSize (ncells + 2)
+#define here(x, y) ((x)*totalSize + y)
+#define left(x, y) ((x - 1) * totalSize + y)
+#define right(x, y) ((x + 1) * totalSize + y)
+#define up(x, y) ((x)*totalSize + y - 1)
+#define down(x, y) ((x)*totalSize + y + 1)
 
 static void compute(void *args);
 static void update(void *args);
@@ -50,10 +50,12 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[x*totalSize+y] = (values[left(x,y)]+values[right(x,y)]
-                                     +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[x * totalSize + y] =
+                (values[left(x, y)] + values[right(x, y)] + values[up(x, y)] +
+                 values[down(x, y)]) /
+                4.0;
         }
     }
 }
@@ -65,17 +67,17 @@ static void update(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_task *tasks = malloc(nBlocks*nBlocks*sizeof(ABT_task));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_task *tasks = malloc(nBlocks * nBlocks * sizeof(ABT_task));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int taskIdx, argsIdx;
 
     int s = 0;
@@ -84,11 +86,11 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         taskIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = taskIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_task_create(pools[s], compute, (void *)&args[argsIdx],
                                       &tasks[taskIdx]);
                 HANDLE_ERROR(ret, "ABT_task_create");
@@ -97,16 +99,16 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_task_free(&tasks[t]);
         }
 
         taskIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = taskIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
                 ret = ABT_task_create(pools[s], update, (void *)&args[argsIdx],
                                       &tasks[taskIdx]);
                 HANDLE_ERROR(ret, "ABT_task_create");
@@ -115,7 +117,7 @@ static void run(void)
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_task_free(&tasks[t]);
         }
     }
@@ -128,19 +130,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -155,15 +157,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -179,26 +181,26 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
     run();
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -227,4 +229,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/examples/stencil_thread.c
+++ b/examples/stencil_thread.c
@@ -8,24 +8,24 @@
 #include <assert.h>
 #include <abt.h>
 
-#define N                       4
-#define NBLOCKS                 32
-#define NITER                   50
-#define DEFAULT_NUM_XSTREAMS    4
-#define PRINT                   0
+#define N 4
+#define NBLOCKS 32
+#define NITER 50
+#define DEFAULT_NUM_XSTREAMS 4
+#define PRINT 0
 
-#define HANDLE_ERROR(ret,msg)                       \
-  if (ret != ABT_SUCCESS) {                         \
-    fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);   \
-    exit(EXIT_FAILURE);                             \
-  }
+#define HANDLE_ERROR(ret, msg)                                                 \
+    if (ret != ABT_SUCCESS) {                                                  \
+        fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);                          \
+        exit(EXIT_FAILURE);                                                    \
+    }
 
-#define totalSize  (ncells+2)
-#define here(x,y)  ((x)*totalSize+y)
-#define left(x,y)  ((x-1)*totalSize+y)
-#define right(x,y) ((x+1)*totalSize+y)
-#define up(x,y)    ((x)*totalSize+y-1)
-#define down(x,y)  ((x)*totalSize+y+1)
+#define totalSize (ncells + 2)
+#define here(x, y) ((x)*totalSize + y)
+#define left(x, y) ((x - 1) * totalSize + y)
+#define right(x, y) ((x + 1) * totalSize + y)
+#define up(x, y) ((x)*totalSize + y - 1)
+#define down(x, y) ((x)*totalSize + y + 1)
 
 static void compute(void *args);
 static void update(void *args);
@@ -50,10 +50,12 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[x*totalSize+y] = (values[left(x,y)]+values[right(x,y)]
-                                     +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[x * totalSize + y] =
+                (values[left(x, y)] + values[right(x, y)] + values[up(x, y)] +
+                 values[down(x, y)]) /
+                4.0;
         }
     }
 }
@@ -65,17 +67,17 @@ static void update(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_thread *threads = malloc(nBlocks*nBlocks*sizeof(ABT_thread));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_thread *threads = malloc(nBlocks * nBlocks * sizeof(ABT_thread));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int threadIdx, argsIdx;
 
     int s = 0;
@@ -84,42 +86,42 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
-                ret = ABT_thread_create(pools[s], compute,
-                                        (void *)&args[argsIdx],
-                                        ABT_THREAD_ATTR_NULL,
-                                        &threads[threadIdx]);
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
+                ret =
+                    ABT_thread_create(pools[s], compute, (void *)&args[argsIdx],
+                                      ABT_THREAD_ATTR_NULL,
+                                      &threads[threadIdx]);
                 HANDLE_ERROR(ret, "ABT_thread_create");
                 threadIdx++;
                 s = (s + 1) % num_xstreams;
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_thread_free(&threads[t]);
         }
 
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
-                ret = ABT_thread_create(pools[s], update,
-                                        (void *)&args[argsIdx],
-                                        ABT_THREAD_ATTR_NULL,
-                                        &threads[threadIdx]);
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
+                ret =
+                    ABT_thread_create(pools[s], update, (void *)&args[argsIdx],
+                                      ABT_THREAD_ATTR_NULL,
+                                      &threads[threadIdx]);
                 HANDLE_ERROR(ret, "ABT_thread_create");
                 threadIdx++;
                 s = (s + 1) % num_xstreams;
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++)
+        for (t = 0; t < nBlocks * nBlocks; t++)
             ABT_thread_free(&threads[t]);
     }
 
@@ -131,19 +133,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -158,15 +160,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -182,26 +184,26 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
     run();
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -230,4 +232,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/examples/stencil_thread_cond.c
+++ b/examples/stencil_thread_cond.c
@@ -9,24 +9,24 @@
 #include <assert.h>
 #include <abt.h>
 
-#define N                       4
-#define NBLOCKS                 32
-#define NITER                   50
-#define DEFAULT_NUM_XSTREAMS    4
-#define PRINT                   0
+#define N 4
+#define NBLOCKS 32
+#define NITER 50
+#define DEFAULT_NUM_XSTREAMS 4
+#define PRINT 0
 
-#define HANDLE_ERROR(ret,msg)                       \
-  if (ret != ABT_SUCCESS) {                         \
-    fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);   \
-    exit(EXIT_FAILURE);                             \
-  }
+#define HANDLE_ERROR(ret, msg)                                                 \
+    if (ret != ABT_SUCCESS) {                                                  \
+        fprintf(stderr, "ERROR[%d]: %s\n", ret, msg);                          \
+        exit(EXIT_FAILURE);                                                    \
+    }
 
-#define totalSize  (ncells+2)
-#define here(x,y)  ((x)*totalSize+y)
-#define left(x,y)  ((x-1)*totalSize+y)
-#define right(x,y) ((x+1)*totalSize+y)
-#define up(x,y)    ((x)*totalSize+y-1)
-#define down(x,y)  ((x)*totalSize+y+1)
+#define totalSize (ncells + 2)
+#define here(x, y) ((x)*totalSize + y)
+#define left(x, y) ((x - 1) * totalSize + y)
+#define right(x, y) ((x + 1) * totalSize + y)
+#define up(x, y) ((x)*totalSize + y - 1)
+#define down(x, y) ((x)*totalSize + y + 1)
 
 static void compute(void *args);
 static void run(void);
@@ -53,10 +53,11 @@ static void compute(void *args)
     int firstX = intargs[0];
     int firstY = intargs[1];
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            results[here(x,y)] = (values[left(x,y)]+values[right(x,y)]
-                                 +values[up(x,y)]+values[down(x,y)])/4.0;
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            results[here(x, y)] = (values[left(x, y)] + values[right(x, y)] +
+                                   values[up(x, y)] + values[down(x, y)]) /
+                                  4.0;
         }
     }
 
@@ -64,8 +65,8 @@ static void compute(void *args)
     /* Left neighbour */
     x = firstX;
     if (x > 1) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = left(x,y)*4;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = left(x, y) * 4;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -74,10 +75,10 @@ static void compute(void *args)
     }
 
     /* Right neighbour */
-    x = firstX+blockSize-1;
+    x = firstX + blockSize - 1;
     if (x < ncells) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = right(x,y)*4+1;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = right(x, y) * 4 + 1;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -88,8 +89,8 @@ static void compute(void *args)
     /* Up neighbour */
     y = firstY;
     if (y > 1) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = up(x,y)*4+2;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = up(x, y) * 4 + 2;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -98,10 +99,10 @@ static void compute(void *args)
     }
 
     /* Down neighbour */
-    y = firstY+blockSize-1;
+    y = firstY + blockSize - 1;
     if (y < ncells) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = down(x,y)*4+3;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = down(x, y) * 4 + 3;
             ABT_mutex_lock(ready_mutex[coord]);
             ready[coord] = 1;
             ABT_cond_signal(ready_cond[coord]);
@@ -113,8 +114,8 @@ static void compute(void *args)
     /* From left neighbour */
     x = firstX;
     if (x > 1) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = here(x,y)*4+1;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = here(x, y) * 4 + 1;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -124,10 +125,10 @@ static void compute(void *args)
     }
 
     /* From right neighbour */
-    x = firstX+blockSize-1;
+    x = firstX + blockSize - 1;
     if (x < ncells) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            int coord = here(x,y)*4;
+        for (y = firstY; y < firstY + blockSize; y++) {
+            int coord = here(x, y) * 4;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -139,8 +140,8 @@ static void compute(void *args)
     /* From up neighbour */
     y = firstY;
     if (y > 1) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = here(x,y)*4+3;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = here(x, y) * 4 + 3;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -150,10 +151,10 @@ static void compute(void *args)
     }
 
     /* From down neighbour */
-    y = firstY+blockSize-1;
+    y = firstY + blockSize - 1;
     if (y < ncells) {
-        for (x = firstX; x < firstX+blockSize; x++) {
-            int coord = here(x,y)*4+2;
+        for (x = firstX; x < firstX + blockSize; x++) {
+            int coord = here(x, y) * 4 + 2;
             ABT_mutex_lock(ready_mutex[coord]);
             if (!ready[coord]) {
                 ABT_cond_wait(ready_cond[coord], ready_mutex[coord]);
@@ -162,17 +163,17 @@ static void compute(void *args)
         }
     }
 
-    for (x = firstX; x < firstX+blockSize; x++) {
-        for (y = firstY; y < firstY+blockSize; y++) {
-            values[here(x,y)] = results[here(x,y)];
+    for (x = firstX; x < firstX + blockSize; x++) {
+        for (y = firstY; y < firstY + blockSize; y++) {
+            values[here(x, y)] = results[here(x, y)];
         }
     }
 }
 
 static void run(void)
 {
-    ABT_thread *threads = malloc(nBlocks*nBlocks*sizeof(ABT_thread));
-    int *args = (int *)malloc(nBlocks*nBlocks*2*sizeof(int));
+    ABT_thread *threads = malloc(nBlocks * nBlocks * sizeof(ABT_thread));
+    int *args = (int *)malloc(nBlocks * nBlocks * 2 * sizeof(int));
     int threadIdx, argsIdx;
 
     int s = 0;
@@ -181,27 +182,27 @@ static void run(void)
 
     for (i = 0; i < niterations; i++) {
         threadIdx = 0;
-        for (x = 1; x < ncells+1; x += blockSize) {
-            for (y = 1; y < ncells+1; y += blockSize) {
+        for (x = 1; x < ncells + 1; x += blockSize) {
+            for (y = 1; y < ncells + 1; y += blockSize) {
                 argsIdx = threadIdx * 2;
-                args[argsIdx+0] = x;
-                args[argsIdx+1] = y;
-                ret = ABT_thread_create(pools[s], compute,
-                                        (void *)&args[argsIdx],
-                                        ABT_THREAD_ATTR_NULL,
-                                        &threads[threadIdx]);
+                args[argsIdx + 0] = x;
+                args[argsIdx + 1] = y;
+                ret =
+                    ABT_thread_create(pools[s], compute, (void *)&args[argsIdx],
+                                      ABT_THREAD_ATTR_NULL,
+                                      &threads[threadIdx]);
                 HANDLE_ERROR(ret, "ABT_thread_create");
                 threadIdx++;
                 s = (s + 1) % num_xstreams;
             }
         }
 
-        for (t = 0; t < nBlocks*nBlocks; t++) {
+        for (t = 0; t < nBlocks * nBlocks; t++) {
             ABT_thread_free(&threads[t]);
         }
 
         /* Reset the ready array */
-        memset(ready, 0, 4*(ncells+2)*(ncells+2)*sizeof(int));
+        memset(ready, 0, 4 * (ncells + 2) * (ncells + 2) * sizeof(int));
     }
 
     free(threads);
@@ -212,19 +213,19 @@ static int eq(double a, double b)
 {
     double e = 0.00001;
     if (a < b)
-        return (b-a < e);
+        return (b - a < e);
     else
-        return (a-b < e);
+        return (a - b < e);
 }
 
 static int check(double *results, int n)
 {
     int i, j;
-    for (i = 0; i < n/2; i++) {
-        for (j = 0; j < n/2; j++) {
-            if (!eq(results[i*n+j], results[i*n+(n-1-j)]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+j]) ||
-                !eq(results[i*n+j], results[(n-1-i)*n+(n-1-j)]))
+    for (i = 0; i < n / 2; i++) {
+        for (j = 0; j < n / 2; j++) {
+            if (!eq(results[i * n + j], results[i * n + (n - 1 - j)]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + j]) ||
+                !eq(results[i * n + j], results[(n - 1 - i) * n + (n - 1 - j)]))
                 return 0;
         }
     }
@@ -239,15 +240,15 @@ int main(int argc, char *argv[])
 
     ABT_init(argc, argv);
 
-    blockSize    = (argc > 1) ? atoi(argv[1]) : N;
-    nBlocks      = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
-    niterations  = (argc > 3) ? atoi(argv[3]) : NITER;
+    blockSize = (argc > 1) ? atoi(argv[1]) : N;
+    nBlocks = (argc > 2) ? atoi(argv[2]) : NBLOCKS;
+    niterations = (argc > 3) ? atoi(argv[3]) : NITER;
     num_xstreams = (argc > 4) ? atoi(argv[4]) : DEFAULT_NUM_XSTREAMS;
-    print        = (argc > 5) ? atoi(argv[5]) : PRINT;
+    print = (argc > 5) ? atoi(argv[5]) : PRINT;
 
     assert(blockSize > 0);
 
-    ncells = blockSize*nBlocks;
+    ncells = blockSize * nBlocks;
 
     /* ES creation */
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
@@ -263,21 +264,23 @@ int main(int argc, char *argv[])
         ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
     }
 
-    results = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    values = (double *)calloc((ncells+2)*(ncells+2), sizeof(double));
-    for (y = 1; y < ncells+1; y++) {
+    results = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    values = (double *)calloc((ncells + 2) * (ncells + 2), sizeof(double));
+    for (y = 1; y < ncells + 1; y++) {
         values[here(0, y)] = 1;
-        values[here(ncells+1, y)] = 1;
+        values[here(ncells + 1, y)] = 1;
     }
 
-    ready = (int *)calloc(4*(ncells+2)*(ncells+2), sizeof(int));
-    ready_cond = (ABT_cond *)malloc(4*(ncells+2)*(ncells+2)*sizeof(ABT_cond));
-    ready_mutex = (ABT_mutex *)malloc(4*(ncells+2)*(ncells+2)*sizeof(ABT_mutex));
-    for (x = 1; x < ncells+1; x++) {
-        for (y = 1; y < ncells+1; y++) {
+    ready = (int *)calloc(4 * (ncells + 2) * (ncells + 2), sizeof(int));
+    ready_cond =
+        (ABT_cond *)malloc(4 * (ncells + 2) * (ncells + 2) * sizeof(ABT_cond));
+    ready_mutex = (ABT_mutex *)malloc(4 * (ncells + 2) * (ncells + 2) *
+                                      sizeof(ABT_mutex));
+    for (x = 1; x < ncells + 1; x++) {
+        for (y = 1; y < ncells + 1; y++) {
             for (i = 0; i < 4; i++) {
-                ABT_cond_create(&ready_cond[here(x,y)*4+i]);
-                ABT_mutex_create(&ready_mutex[here(x,y)*4+i]);
+                ABT_cond_create(&ready_cond[here(x, y) * 4 + i]);
+                ABT_mutex_create(&ready_mutex[here(x, y) * 4 + i]);
             }
         }
     }
@@ -286,15 +289,15 @@ int main(int argc, char *argv[])
 
     /* Show results */
     if (print) {
-        for (x = 1; x < ncells+1; x++) {
-            for (y = 1; y < ncells+1; y++) {
-                printf("%5f ", results[here(x,y)]);
+        for (x = 1; x < ncells + 1; x++) {
+            for (y = 1; y < ncells + 1; y++) {
+                printf("%5f ", results[here(x, y)]);
             }
             printf("\n");
         }
     }
 
-    if (!check(results, ncells+2)) {
+    if (!check(results, ncells + 2)) {
         printf("Wrong result !!!!\n");
         return -1;
     } else {
@@ -319,11 +322,11 @@ int main(int argc, char *argv[])
     free(results);
     free(values);
 
-    for (x = 1; x < ncells+1; x++) {
-        for (y = 1; y < ncells+1; y++) {
+    for (x = 1; x < ncells + 1; x++) {
+        for (y = 1; y < ncells + 1; y++) {
             for (i = 0; i < 4; i++) {
-                ABT_cond_free(&ready_cond[here(x,y)*4+i]);
-                ABT_mutex_free(&ready_mutex[here(x,y)*4+i]);
+                ABT_cond_free(&ready_cond[here(x, y) * 4 + i]);
+                ABT_mutex_free(&ready_mutex[here(x, y) * 4 + i]);
             }
         }
     }
@@ -336,4 +339,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/maint/code-cleanup.sh
+++ b/maint/code-cleanup.sh
@@ -1,37 +1,50 @@
 #! /bin/bash
 
-if test ! -z "`which gindent`" ; then
-        indent=gindent
-else
-        indent=indent
+# clang-format-6.0 and above versions are recommended.
+# * clang-format < 3.9 cannot be used since SortIncludes is not supported.
+#   SortIncludes must be disabled since abti.h depends on the order of #include.
+
+indent_list="clang-format-9.0 clang-format-8.0 clang-format-7.0 \
+             clang-format-6.0 clang-format clang-format-5.0 clang-format-4.0 \
+             clang-format-3.9"
+
+is_find_indent=0
+for indent in $indent_list; do
+    if test ! -z "`which $indent`" ; then
+        is_find_indent=1
+        break
+    fi
+done
+if [ "is_find_indent" = "x0" ]; then
+    echo "clang-format is not found."
+    exit 1
 fi
 
 indent_code()
 {
     file=$1
-
-    $indent --k-and-r-style --line-length80 --else-endif-column1 --start-left-side-of-comments \
-	--break-after-boolean-operator --dont-cuddle-else --dont-format-comments \
-	--comment-indentation1 --indent-level4 --no-tabs --no-space-after-casts \
-    -T ABT_stream -T ABT_stream_state -T ABT_thread -T ABT_thread_state \
-    -T ABT_task -T ABT_task_state -T ABT_mutex -T ABT_condition \
-    -T ABT_scheduler -T ABT_unit_type -T ABT_unit -T ABT_pool \
-    -T ABT_scheduler_funcs \
-    -T ABTI_stream -T ABTI_stream_type -T ABTI_thread -T ABTI_thread_type \
-    -T ABTI_task -T ABTI_mutex -T ABTI_condition -T ABTI_scheduler \
-    -T ABTI_scheduler_type -T ABTI_unit -T ABTI_pool \
-    -T ABTI_stream_pool -T ABTI_task_pool -T ABTI_global -T ABTI_local \
-	${file}
-    rm -f ${file}~
-    cp ${file} /tmp/${USER}.__tmp__ && \
-	cat ${file} | sed -e 's/ *$//g' -e 's/( */(/g' -e 's/ *)/)/g' \
-	-e 's/if(/if (/g' -e 's/while(/while (/g' -e 's/do{/do {/g' -e 's/}while/} while/g' > \
-	/tmp/${USER}.__tmp__ && mv /tmp/${USER}.__tmp__ ${file}
+    if [[ "$file" == *"abt.h.in" ]]; then
+        return
+    fi
+    $indent --style="{BasedOnStyle: llvm, \
+                      BreakBeforeBraces: WebKit, \
+                      IndentWidth: 4, \
+                      Cpp11BracedListStyle: false, \
+                      IndentCaseLabels: true, \
+                      AlignAfterOpenBracket: Align, \
+                      SortIncludes: false, \
+                      AllowShortFunctionsOnASingleLine : None, \
+                      PenaltyBreakBeforeFirstCallParameter: 100000}" \
+                      -i ${file}
 }
 
 usage()
 {
     echo "Usage: $1 [filename | --all] {--recursive} {--debug}"
+    echo "Example 1: format a single file (e.g., src/thread.c)"
+    echo "  $1 src/thread.c"
+    echo "Example 2: recursively find all files and format them"
+    echo "  $1 --all --recursive"
 }
 
 # Check usage
@@ -49,43 +62,49 @@ ignore=0
 ignore_list="__I_WILL_NEVER_FIND_YOU__"
 for arg in $@; do
     if [ "$ignore" = "1" ] ; then
-	ignore_list="$ignore_list|$arg"
-	ignore=0
-	continue;
+        ignore_list="$ignore_list|$arg"
+        ignore=0
+    continue;
     fi
 
     if [ "$arg" = "--all" ]; then
-	all=1
+        all=1
     elif [ "$arg" = "--recursive" ]; then
-	recursive=1
+        recursive=1
     elif [ "$arg" = "--debug" ]; then
-	debug="echo"
+        debug="echo"
     elif [ "$arg" = "--ignore" ] ; then
-	ignore=1
+        ignore=1
     else
-	got_file=1
+        got_file=1
     fi
 done
+
 if [ "$recursive" = "1" -a "$all" = "0" ]; then
     echo "--recursive cannot be used without --all"
     usage $0
     exit
 fi
+
 if [ "$got_file" = "1" -a "$all" = "1" ]; then
     echo "--all cannot be used in conjunction with a specific file"
     usage $0
     exit
 fi
 
+if [ "x$debug" != "x" ]; then
+    echo "Use $indent (`$indent --version`)"
+fi
+
 if [ "$recursive" = "1" ]; then
     for i in `find . \! -type d | egrep '(\.c$|\.h$|\.c\.in$|\.h\.in$|\.cpp$|\.cpp.in$)' | \
-	egrep -v "($ignore_list)"` ; do
-	${debug} indent_code $i
+        egrep -v "($ignore_list)"` ; do
+        ${debug} indent_code $i
     done
 elif [ "$all" = "1" ]; then
     for i in `find . -maxdepth 1 \! -type d | egrep '(\.c$|\.h$|\.c\.in$|\.h\.in$|\.cpp$|\.cpp.in$)' | \
-	egrep -v "($ignore_list)"` ; do
-	${debug} indent_code $i
+        egrep -v "($ignore_list)"` ; do
+        ${debug} indent_code $i
     done
 else
     ${debug} indent_code $@

--- a/maint/template.c
+++ b/maint/template.c
@@ -18,9 +18,9 @@ int ABTI_template(ABTI_thread *p_thread, void *p_arg)
     /* Implementation */
     /* ... */
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     goto fn_exit;
 }

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -12,10 +12,9 @@
 #include <sys/cpuset.h>
 #include <pthread_np.h>
 
-typedef cpuset_t  cpu_set_t;
+typedef cpuset_t cpu_set_t;
 
-static inline
-int ABTD_CPU_COUNT(cpu_set_t *p_cpuset)
+static inline int ABTD_CPU_COUNT(cpu_set_t *p_cpuset)
 {
     int i, num_cpus = 0;
     for (i = 0; i < CPU_SETSIZE; i++) {
@@ -29,7 +28,7 @@ int ABTD_CPU_COUNT(cpu_set_t *p_cpuset)
 #else
 #define _GNU_SOURCE
 #include <sched.h>
-#define ABTD_CPU_COUNT  CPU_COUNT
+#define ABTD_CPU_COUNT CPU_COUNT
 #endif
 
 enum {
@@ -49,8 +48,9 @@ static inline cpu_set_t ABTD_affinity_get_cpuset_for_rank(int rank)
         int num_threads_per_socket = num_cores / 2;
         int rem = rank % 2;
         int socket_id = rank / num_threads_per_socket;
-        int target = (rank - num_threads_per_socket * socket_id - rem + socket_id)
-                   + num_threads_per_socket * rem;
+        int target =
+            (rank - num_threads_per_socket * socket_id - rem + socket_id) +
+            num_threads_per_socket * rem;
         return g_cpusets[target % num_cores];
 
     } else if (g_affinity_type == ABTI_ES_AFFINITY_KNC) {
@@ -109,7 +109,8 @@ void ABTD_affinity_init(void)
 
     /* affinity type */
     char *env = getenv("ABT_AFFINITY_TYPE");
-    if (env == NULL) env = getenv("ABT_ENV_AFFINITY_TYPE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_AFFINITY_TYPE");
     if (env != NULL) {
         if (strcmp(env, "chameleon") == 0) {
             g_affinity_type = ABTI_ES_AFFINITY_CHAMELEON;
@@ -145,10 +146,10 @@ int ABTD_affinity_set(ABTD_xstream_context *p_ctx, int rank)
         goto fn_fail;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -174,10 +175,10 @@ int ABTD_affinity_set_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
                                &cpuset);
     ABTI_CHECK_TRUE(!i, ABT_ERR_OTHER);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -215,14 +216,13 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
         *p_num_cpus = ABTD_CPU_COUNT(&cpuset);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
     return ABT_ERR_FEATURE_NA;
 #endif
 }
-

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -7,18 +7,17 @@
 #include <unistd.h>
 #include <strings.h>
 
-#define ABTD_KEY_TABLE_DEFAULT_SIZE     4
-#define ABTD_THREAD_DEFAULT_STACKSIZE   16384
-#define ABTD_SCHED_DEFAULT_STACKSIZE    (4*1024*1024)
-#define ABTD_SCHED_EVENT_FREQ           50
-#define ABTD_SCHED_SLEEP_NSEC           100
+#define ABTD_KEY_TABLE_DEFAULT_SIZE 4
+#define ABTD_THREAD_DEFAULT_STACKSIZE 16384
+#define ABTD_SCHED_DEFAULT_STACKSIZE (4 * 1024 * 1024)
+#define ABTD_SCHED_EVENT_FREQ 50
+#define ABTD_SCHED_SLEEP_NSEC 100
 
-#define ABTD_OS_PAGE_SIZE               (4*1024)
-#define ABTD_HUGE_PAGE_SIZE             (2*1024*1024)
-#define ABTD_MEM_PAGE_SIZE              (2*1024*1024)
-#define ABTD_MEM_STACK_PAGE_SIZE        (8*1024*1024)
-#define ABTD_MEM_MAX_NUM_STACKS         65536
-
+#define ABTD_OS_PAGE_SIZE (4 * 1024)
+#define ABTD_HUGE_PAGE_SIZE (2 * 1024 * 1024)
+#define ABTD_MEM_PAGE_SIZE (2 * 1024 * 1024)
+#define ABTD_MEM_STACK_PAGE_SIZE (8 * 1024 * 1024)
+#define ABTD_MEM_MAX_NUM_STACKS 65536
 
 void ABTD_env_init(ABTI_global *p_global)
 {
@@ -30,7 +29,8 @@ void ABTD_env_init(ABTI_global *p_global)
     /* By default, we use the CPU affinity */
     p_global->set_affinity = ABT_TRUE;
     env = getenv("ABT_SET_AFFINITY");
-    if (env == NULL) env = getenv("ABT_ENV_SET_AFFINITY");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SET_AFFINITY");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -52,7 +52,8 @@ void ABTD_env_init(ABTI_global *p_global)
     p_global->use_debug = ABT_FALSE;
 #endif
     env = getenv("ABT_USE_LOG");
-    if (env == NULL) env = getenv("ABT_ENV_USE_LOG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_USE_LOG");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -62,7 +63,8 @@ void ABTD_env_init(ABTI_global *p_global)
         }
     }
     env = getenv("ABT_USE_DEBUG");
-    if (env == NULL) env = getenv("ABT_ENV_USE_DEBUG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_USE_DEBUG");
     if (env != NULL) {
         if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
             strcasecmp(env, "no") == 0) {
@@ -74,7 +76,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Maximum size of the internal ES array */
     env = getenv("ABT_MAX_NUM_XSTREAMS");
-    if (env == NULL) env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
     if (env != NULL) {
         p_global->max_xstreams = atoi(env);
     } else {
@@ -83,7 +86,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default key table size */
     env = getenv("ABT_KEY_TABLE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_KEY_TABLE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_KEY_TABLE_SIZE");
     if (env != NULL) {
         p_global->key_table_size = (int)atoi(env);
     } else {
@@ -92,7 +96,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default stack size for ULT */
     env = getenv("ABT_THREAD_STACKSIZE");
-    if (env == NULL) env = getenv("ABT_ENV_THREAD_STACKSIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_THREAD_STACKSIZE");
     if (env != NULL) {
         p_global->thread_stacksize = (size_t)atol(env);
         ABTI_ASSERT(p_global->thread_stacksize >= 512);
@@ -102,7 +107,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default stack size for scheduler */
     env = getenv("ABT_SCHED_STACKSIZE");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_STACKSIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_STACKSIZE");
     if (env != NULL) {
         p_global->sched_stacksize = (size_t)atol(env);
         ABTI_ASSERT(p_global->sched_stacksize >= 512);
@@ -112,7 +118,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default frequency for event checking by the scheduler */
     env = getenv("ABT_SCHED_EVENT_FREQ");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_EVENT_FREQ");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_EVENT_FREQ");
     if (env != NULL) {
         p_global->sched_event_freq = (uint32_t)atol(env);
         ABTI_ASSERT(p_global->sched_event_freq >= 1);
@@ -122,7 +129,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Default nanoseconds for scheduler sleep */
     env = getenv("ABT_SCHED_SLEEP_NSEC");
-    if (env == NULL) env = getenv("ABT_ENV_SCHED_SLEEP_NSEC");
+    if (env == NULL)
+        env = getenv("ABT_ENV_SCHED_SLEEP_NSEC");
     if (env != NULL) {
         p_global->sched_sleep_nsec = atol(env);
         ABTI_ASSERT(p_global->sched_sleep_nsec >= 0);
@@ -132,7 +140,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Mutex attributes */
     env = getenv("ABT_MUTEX_MAX_HANDOVERS");
-    if (env == NULL) env = getenv("ABT_ENV_MUTEX_MAX_HANDOVERS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MUTEX_MAX_HANDOVERS");
     if (env != NULL) {
         p_global->mutex_max_handovers = (uint32_t)atoi(env);
         ABTI_ASSERT(p_global->mutex_max_handovers >= 1);
@@ -141,7 +150,8 @@ void ABTD_env_init(ABTI_global *p_global)
     }
 
     env = getenv("ABT_MUTEX_MAX_WAKEUPS");
-    if (env == NULL) env = getenv("ABT_ENV_MUTEX_MAX_WAKEUPS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MUTEX_MAX_WAKEUPS");
     if (env != NULL) {
         p_global->mutex_max_wakeups = (uint32_t)atoi(env);
         ABTI_ASSERT(p_global->mutex_max_wakeups >= 1);
@@ -151,7 +161,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* OS page size */
     env = getenv("ABT_OS_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_OS_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_OS_PAGE_SIZE");
     if (env != NULL) {
         p_global->os_page_size = (uint32_t)atol(env);
     } else {
@@ -160,7 +171,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Huge page size */
     env = getenv("ABT_HUGE_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
     if (env != NULL) {
         p_global->huge_page_size = (uint32_t)atol(env);
     } else {
@@ -170,7 +182,8 @@ void ABTD_env_init(ABTI_global *p_global)
 #ifdef ABT_CONFIG_USE_MEM_POOL
     /* Page size for memory allocation */
     env = getenv("ABT_MEM_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_PAGE_SIZE");
     if (env != NULL) {
         p_global->mem_page_size = (uint32_t)atol(env);
     } else {
@@ -179,7 +192,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Stack page size for memory allocation */
     env = getenv("ABT_MEM_STACK_PAGE_SIZE");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_STACK_PAGE_SIZE");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_STACK_PAGE_SIZE");
     if (env != NULL) {
         p_global->mem_sp_size = (size_t)atol(env);
     } else {
@@ -188,7 +202,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Maximum number of stacks that each ES can keep during execution */
     env = getenv("ABT_MEM_MAX_NUM_STACKS");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_MAX_NUM_STACKS");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_MAX_NUM_STACKS");
     if (env != NULL) {
         p_global->mem_max_stacks = (uint32_t)atol(env);
     } else {
@@ -199,7 +214,8 @@ void ABTD_env_init(ABTI_global *p_global)
      * pages and then to fall back to allocate regular pages using mmap() when
      * huge pages are run out of. */
     env = getenv("ABT_MEM_LP_ALLOC");
-    if (env == NULL) env = getenv("ABT_ENV_MEM_LP_ALLOC");
+    if (env == NULL)
+        env = getenv("ABT_ENV_MEM_LP_ALLOC");
 #if defined(HAVE_MAP_ANONYMOUS) || defined(HAVE_MAP_ANON)
 #if defined(__x86_64__)
     int lp_alloc = ABTI_MEM_LP_MMAP_HP_RP;
@@ -246,7 +262,8 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Whether to print the configuration on ABT_init() */
     env = getenv("ABT_PRINT_CONFIG");
-    if (env == NULL) env = getenv("ABT_ENV_PRINT_CONFIG");
+    if (env == NULL)
+        env = getenv("ABT_ENV_PRINT_CONFIG");
     if (env != NULL) {
         if (strcmp(env, "1") == 0 || strcasecmp(env, "yes") == 0 ||
             strcasecmp(env, "y") == 0) {
@@ -261,4 +278,3 @@ void ABTD_env_init(ABTI_global *p_global)
     /* Init timer */
     ABTD_time_init();
 }
-

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -34,8 +34,8 @@ static void *ABTDI_xstream_context_thread_func(void *arg)
             restart = ABT_FALSE;
         } else {
             /* ABTD_xstream_context_restart() restarts this thread */
-            ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING
-                        || p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN);
+            ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING ||
+                        p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN);
             restart = ABT_TRUE;
         }
         pthread_mutex_unlock(&p_ctx->state_lock);
@@ -119,4 +119,3 @@ int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx)
     p_ctx->native_thread = pthread_self();
     return abt_errno;
 }
-

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -62,8 +62,8 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
                                           ABT_bool is_sched)
 {
     ABTD_thread_context *p_ctx = &p_thread->ctx;
-    ABTD_thread_context *p_link = (ABTD_thread_context *)
-        ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
+    ABTD_thread_context *p_link =
+        (ABTD_thread_context *)ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
     if (p_link) {
         /* If p_link is set, it means that other ULT has called the join. */
         ABTI_thread *p_joiner = (ABTI_thread *)p_link;
@@ -105,14 +105,16 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
                                      ABTI_THREAD_REQ_TERMINATE);
         }
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+        uint32_t req =
+            ABTD_atomic_fetch_or_uint32(&p_thread->request,
+                                        ABTI_THREAD_REQ_JOIN |
+                                            ABTI_THREAD_REQ_TERMINATE);
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             do {
-                p_link = (ABTD_thread_context *)
-                    ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
+                p_link = (ABTD_thread_context *)ABTD_atomic_load_ptr(
+                    (void **)&p_ctx->p_link);
             } while (!p_link);
             ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
         }
@@ -182,12 +184,15 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
         ABTI_thread *p_joiner = (ABTI_thread *)p_ctx->p_link;
         ABTI_thread_set_ready(p_local, p_joiner);
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+        uint32_t req =
+            ABTD_atomic_fetch_or_uint32(&p_thread->request,
+                                        ABTI_THREAD_REQ_JOIN |
+                                            ABTI_THREAD_REQ_TERMINATE);
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
-            while (ABTD_atomic_load_ptr((void **)&p_ctx->p_link) == NULL);
+            while (ABTD_atomic_load_ptr((void **)&p_ctx->p_link) == NULL)
+                ;
             ABTI_thread *p_joiner = (ABTI_thread *)p_ctx->p_link;
             ABTI_thread_set_ready(p_local, p_joiner);
         }

--- a/src/arch/abtd_time.c
+++ b/src/arch/abtd_time.c
@@ -41,7 +41,8 @@ double ABTD_time_read_sec(ABTD_time *p_time)
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
     secs = ((double)p_time->tv_sec) + 1.0e-9 * ((double)p_time->tv_nsec);
 #elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
-    if (g_time_mult == 0.0) ABTD_time_init();
+    if (g_time_mult == 0.0)
+        ABTD_time_init();
     secs = *p_time * g_time_mult;
 #elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
     secs = ((double)p_time->tv_sec) + 1.0e-6 * ((double)p_time->tv_usec);
@@ -49,4 +50,3 @@ double ABTD_time_read_sec(ABTD_time *p_time)
 
     return secs;
 }
-

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup BARRIER Barrier
  * This group is for Barrier.
  */
@@ -82,10 +81,10 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
             (ABT_unit_type *)ABTU_malloc(num_waiters * sizeof(ABT_unit_type));
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("ABT_barrier_reinit", abt_errno);
     goto fn_exit;
 }
@@ -123,10 +122,10 @@ int ABT_barrier_free(ABT_barrier *barrier)
     /* Return value */
     *barrier = ABT_BARRIER_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("ABT_barrier_free", abt_errno);
     goto fn_exit;
 }
@@ -191,7 +190,8 @@ int ABT_barrier_wait(ABT_barrier barrier)
         } else {
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal));
+            while (!ABTD_atomic_load_int32(&ext_signal))
+                ;
         }
     } else {
         /* Signal all the waiting ULTs */
@@ -215,10 +215,10 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABTI_spinlock_release(&p_barrier->lock);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -244,11 +244,10 @@ int ABT_barrier_get_num_waiters(ABT_barrier barrier, uint32_t *num_waiters)
 
     *num_waiters = p_barrier->num_waiters;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("ABT_barrier_get_num_waiters", abt_errno);
     goto fn_exit;
 }
-

--- a/src/cond.c
+++ b/src/cond.c
@@ -6,7 +6,6 @@
 #include "abti.h"
 #include <sys/time.h>
 
-
 /** @defgroup COND Condition Variable
  * This group is for Condition Variable.
  */
@@ -65,10 +64,10 @@ int ABT_cond_free(ABT_cond *cond)
     /* Return value */
     *cond = ABT_COND_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -103,33 +102,31 @@ int ABT_cond_wait(ABT_cond cond, ABT_mutex mutex)
     if (abt_errno != ABT_SUCCESS)
         goto fn_fail;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-
-static inline
-double convert_timespec_to_sec(const struct timespec *p_ts)
+static inline double convert_timespec_to_sec(const struct timespec *p_ts)
 {
     double secs;
     secs = ((double)p_ts->tv_sec) + 1.0e-9 * ((double)p_ts->tv_nsec);
     return secs;
 }
 
-static inline
-void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
+static inline void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
 {
-    if (p_unit->p_next == NULL) return;
+    if (p_unit->p_next == NULL)
+        return;
 
     ABTI_spinlock_acquire(&p_cond->lock);
 
     if (p_unit->p_next == NULL) {
         ABTI_spinlock_release(&p_cond->lock);
-        return ;
+        return;
     }
 
     /* If p_unit is still in the queue, we have to remove it. */
@@ -249,14 +246,13 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     /* Lock the mutex again */
     ABTI_mutex_lock(&p_local, p_mutex);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup COND
@@ -313,10 +309,10 @@ int ABT_cond_signal(ABT_cond cond)
 
     ABTI_spinlock_release(&p_cond->lock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -343,11 +339,10 @@ int ABT_cond_broadcast(ABT_cond cond)
 
     ABTI_cond_broadcast(p_local, p_cond);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/error.c
+++ b/src/error.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup ERROR Error
  * This group is for error classes.
  */
@@ -27,73 +26,72 @@
  */
 int ABT_error_get_str(int err, char *str, size_t *len)
 {
-    static const char *err_str[] = {
-        "ABT_SUCCESS",
-        "ABT_ERR_UNINITIALIZED",
-        "ABT_ERR_MEM",
-        "ABT_ERR_OTHER",
-        "ABT_ERR_INV_XSTREAM",
-        "ABT_ERR_INV_XSTREAM_RANK",
-        "ABT_ERR_INV_XSTREAM_BARRIER",
-        "ABT_ERR_INV_SCHED",
-        "ABT_ERR_INV_SCHED_KIND",
-        "ABT_ERR_INV_SCHED_PREDEF",
-        "ABT_ERR_INV_SCHED_TYPE",
-        "ABT_ERR_INV_SCHED_CONFIG",
-        "ABT_ERR_INV_POOL",
-        "ABT_ERR_INV_POOL_KIND",
-        "ABT_ERR_INV_POOL_ACCESS",
-        "ABT_ERR_INV_UNIT",
-        "ABT_ERR_INV_THREAD",
-        "ABT_ERR_INV_THREAD_ATTR",
-        "ABT_ERR_INV_TASK",
-        "ABT_ERR_INV_KEY",
-        "ABT_ERR_INV_MUTEX",
-        "ABT_ERR_INV_MUTEX_ATTR",
-        "ABT_ERR_INV_COND",
-        "ABT_ERR_INV_RWLOCK",
-        "ABT_ERR_INV_EVENTUAL",
-        "ABT_ERR_INV_FUTURE",
-        "ABT_ERR_INV_BARRIER",
-        "ABT_ERR_INV_TIMER",
-        "ABT_ERR_INV_EVENT",
-        "ABT_ERR_XSTREAM",
-        "ABT_ERR_XSTREAM_STATE",
-        "ABT_ERR_XSTREAM_BARRIER",
-        "ABT_ERR_SCHED",
-        "ABT_ERR_SCHED_CONFIG",
-        "ABT_ERR_POOL",
-        "ABT_ERR_UNIT",
-        "ABT_ERR_THREAD",
-        "ABT_ERR_TASK",
-        "ABT_ERR_KEY",
-        "ABT_ERR_MUTEX",
-        "ABT_ERR_MUTEX_LOCKED",
-        "ABT_ERR_COND",
-        "ABT_ERR_COND_TIMEDOUT",
-        "ABT_ERR_RWLOCK",
-        "ABT_ERR_EVENTUAL",
-        "ABT_ERR_FUTURE",
-        "ABT_ERR_BARRIER",
-        "ABT_ERR_TIMER",
-        "ABT_ERR_EVENT",
-        "ABT_ERR_MIGRATION_TARGET",
-        "ABT_ERR_MIGRATION_NA",
-        "ABT_ERR_MISSING_JOIN",
-        "ABT_ERR_FEATURE_NA"
-    };
+    static const char *err_str[] = { "ABT_SUCCESS",
+                                     "ABT_ERR_UNINITIALIZED",
+                                     "ABT_ERR_MEM",
+                                     "ABT_ERR_OTHER",
+                                     "ABT_ERR_INV_XSTREAM",
+                                     "ABT_ERR_INV_XSTREAM_RANK",
+                                     "ABT_ERR_INV_XSTREAM_BARRIER",
+                                     "ABT_ERR_INV_SCHED",
+                                     "ABT_ERR_INV_SCHED_KIND",
+                                     "ABT_ERR_INV_SCHED_PREDEF",
+                                     "ABT_ERR_INV_SCHED_TYPE",
+                                     "ABT_ERR_INV_SCHED_CONFIG",
+                                     "ABT_ERR_INV_POOL",
+                                     "ABT_ERR_INV_POOL_KIND",
+                                     "ABT_ERR_INV_POOL_ACCESS",
+                                     "ABT_ERR_INV_UNIT",
+                                     "ABT_ERR_INV_THREAD",
+                                     "ABT_ERR_INV_THREAD_ATTR",
+                                     "ABT_ERR_INV_TASK",
+                                     "ABT_ERR_INV_KEY",
+                                     "ABT_ERR_INV_MUTEX",
+                                     "ABT_ERR_INV_MUTEX_ATTR",
+                                     "ABT_ERR_INV_COND",
+                                     "ABT_ERR_INV_RWLOCK",
+                                     "ABT_ERR_INV_EVENTUAL",
+                                     "ABT_ERR_INV_FUTURE",
+                                     "ABT_ERR_INV_BARRIER",
+                                     "ABT_ERR_INV_TIMER",
+                                     "ABT_ERR_INV_EVENT",
+                                     "ABT_ERR_XSTREAM",
+                                     "ABT_ERR_XSTREAM_STATE",
+                                     "ABT_ERR_XSTREAM_BARRIER",
+                                     "ABT_ERR_SCHED",
+                                     "ABT_ERR_SCHED_CONFIG",
+                                     "ABT_ERR_POOL",
+                                     "ABT_ERR_UNIT",
+                                     "ABT_ERR_THREAD",
+                                     "ABT_ERR_TASK",
+                                     "ABT_ERR_KEY",
+                                     "ABT_ERR_MUTEX",
+                                     "ABT_ERR_MUTEX_LOCKED",
+                                     "ABT_ERR_COND",
+                                     "ABT_ERR_COND_TIMEDOUT",
+                                     "ABT_ERR_RWLOCK",
+                                     "ABT_ERR_EVENTUAL",
+                                     "ABT_ERR_FUTURE",
+                                     "ABT_ERR_BARRIER",
+                                     "ABT_ERR_TIMER",
+                                     "ABT_ERR_EVENT",
+                                     "ABT_ERR_MIGRATION_TARGET",
+                                     "ABT_ERR_MIGRATION_NA",
+                                     "ABT_ERR_MISSING_JOIN",
+                                     "ABT_ERR_FEATURE_NA" };
 
     int abt_errno = ABT_SUCCESS;
     ABTI_CHECK_TRUE(err >= ABT_SUCCESS && err <= ABT_ERR_FEATURE_NA,
                     ABT_ERR_OTHER);
-    if (str) ABTU_strcpy(str, err_str[err]);
-    if (len) *len = strlen(err_str[err]);
+    if (str)
+        ABTU_strcpy(str, err_str[err]);
+    if (len)
+        *len = strlen(err_str[err]);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup EVENTUAL Eventual
  * In Argobots, an \a eventual corresponds to the traditional behavior of
  * the future concept (refer to \ref FUTURE "Future"). A ULT creates an
@@ -71,15 +70,16 @@ int ABT_eventual_free(ABT_eventual *eventual)
      * freed here. */
     ABTI_spinlock_acquire(&p_eventual->lock);
 
-    if (p_eventual->value) ABTU_free(p_eventual->value);
+    if (p_eventual->value)
+        ABTU_free(p_eventual->value);
     ABTU_free(p_eventual);
 
     *eventual = ABT_EVENTUAL_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -153,18 +153,20 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal));
+            while (!ABTD_atomic_load_int32(&ext_signal))
+                ;
             ABTU_free(p_unit);
         }
     } else {
         ABTI_spinlock_release(&p_eventual->lock);
     }
-    if (value) *value = p_eventual->value;
+    if (value)
+        *value = p_eventual->value;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -193,21 +195,21 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
 
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready != ABT_FALSE) {
-        if (value) *value = p_eventual->value;
+        if (value)
+            *value = p_eventual->value;
         flag = ABT_TRUE;
     }
     ABTI_spinlock_release(&p_eventual->lock);
 
-   *is_ready = flag;
+    *is_ready = flag;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup EVENTUAL
@@ -237,7 +239,8 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     ABTI_spinlock_acquire(&p_eventual->lock);
 
     p_eventual->ready = ABT_TRUE;
-    if (p_eventual->value) memcpy(p_eventual->value, value, nbytes);
+    if (p_eventual->value)
+        memcpy(p_eventual->value, value, nbytes);
 
     if (p_eventual->p_head == NULL) {
         ABTI_spinlock_release(&p_eventual->lock);
@@ -275,10 +278,10 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 
     ABTI_spinlock_release(&p_eventual->lock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -305,11 +308,10 @@ int ABT_eventual_reset(ABT_eventual eventual)
     p_eventual->ready = ABT_FALSE;
     ABTI_spinlock_release(&p_eventual->lock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/futures.c
+++ b/src/futures.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup FUTURE Future
  * A future, an eventual, or a \a promise, is a mechanism for passing a value
  * between threads, allowing a thread to wait for a value that is set
@@ -103,10 +102,10 @@ int ABT_future_free(ABT_future *future)
 
     *future = ABT_FUTURE_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -178,17 +177,18 @@ int ABT_future_wait(ABT_future future)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal));
+            while (!ABTD_atomic_load_int32(&ext_signal))
+                ;
             ABTU_free(p_unit);
         }
     } else {
         ABTI_spinlock_release(&p_future->lock);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -213,10 +213,10 @@ int ABT_future_test(ABT_future future, ABT_bool *flag)
 
     *flag = p_future->ready;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -294,10 +294,10 @@ int ABT_future_set(ABT_future future, void *value)
 
     ABTI_spinlock_release(&p_future->lock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -324,10 +324,10 @@ int ABT_future_reset(ABT_future future)
     p_future->ready = ABT_FALSE;
     ABTI_spinlock_release(&p_future->lock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -38,7 +38,8 @@ static uint32_t g_ABTI_initialized = 0;
  */
 int ABT_init(int argc, char **argv)
 {
-    ABTI_UNUSED(argc); ABTI_UNUSED(argv);
+    ABTI_UNUSED(argc);
+    ABTI_UNUSED(argv);
     int abt_errno = ABT_SUCCESS;
 
     /* First, take a global lock protecting the initialization/finalization
@@ -64,8 +65,9 @@ int ABT_init(int argc, char **argv)
     ABTI_pool_reset_id();
 
     /* Initialize the ES array */
-    gp_ABTI_global->p_xstreams = (ABTI_xstream **)ABTU_calloc(
-            gp_ABTI_global->max_xstreams, sizeof(ABTI_xstream *));
+    gp_ABTI_global->p_xstreams =
+        (ABTI_xstream **)ABTU_calloc(gp_ABTI_global->max_xstreams,
+                                     sizeof(ABTI_xstream *));
     gp_ABTI_global->num_xstreams = 0;
 
     /* Initialize a spinlock */
@@ -93,8 +95,8 @@ int ABT_init(int argc, char **argv)
     p_local->p_thread = p_main_thread;
 
     /* Start the primary ES */
-    abt_errno = ABTI_xstream_start_primary(&p_local, p_newxstream,
-                                           p_main_thread);
+    abt_errno =
+        ABTI_xstream_start_primary(&p_local, p_newxstream, p_main_thread);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_start_primary");
 
     if (gp_ABTI_global->print_config == ABT_TRUE) {
@@ -102,12 +104,12 @@ int ABT_init(int argc, char **argv)
     }
     ABTD_atomic_store_uint32(&g_ABTI_initialized, 1);
 
-  fn_exit:
+fn_exit:
     /* Unlock a global lock */
     ABTI_spinlock_release(&g_ABTI_init_lock);
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -171,7 +173,8 @@ int ABT_finalize(void)
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch to the top scheduler */
-        ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
+        ABTI_sched *p_sched =
+            ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
         ABTI_thread_context_switch_thread_to_sched(&p_local, p_thread, p_sched);
 
         /* Back to the original thread */
@@ -208,12 +211,12 @@ int ABT_finalize(void)
     gp_ABTI_global = NULL;
     ABTD_atomic_store_uint32(&g_ABTI_initialized, 0);
 
-  fn_exit:
+fn_exit:
     /* Unlock a global lock */
     ABTI_spinlock_release(&g_ABTI_init_lock);
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -248,7 +251,8 @@ void ABTI_global_update_max_xstreams(int new_size)
 {
     int i, cur_size;
 
-    if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams) return;
+    if (new_size != 0 && new_size < gp_ABTI_global->max_xstreams)
+        return;
 
     ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
 
@@ -275,9 +279,10 @@ void ABTI_global_update_max_xstreams(int new_size)
     cur_size = gp_ABTI_global->max_xstreams;
     new_size = (new_size > 0) ? new_size : cur_size * 2;
     gp_ABTI_global->max_xstreams = new_size;
-    gp_ABTI_global->p_xstreams = (ABTI_xstream **)ABTU_realloc(
-            gp_ABTI_global->p_xstreams, cur_size * sizeof(ABTI_xstream *),
-            new_size * sizeof(ABTI_xstream *));
+    gp_ABTI_global->p_xstreams =
+        (ABTI_xstream **)ABTU_realloc(gp_ABTI_global->p_xstreams,
+                                      cur_size * sizeof(ABTI_xstream *),
+                                      new_size * sizeof(ABTI_xstream *));
 
     for (i = gp_ABTI_global->num_xstreams; i < new_size; i++) {
         gp_ABTI_global->p_xstreams[i] = NULL;
@@ -285,4 +290,3 @@ void ABTI_global_update_max_xstreams(int new_size)
 
     ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
-

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -28,15 +28,15 @@ typedef struct ABTD_xstream_context {
     pthread_mutex_t state_lock;
     pthread_cond_t state_cond;
 } ABTD_xstream_context;
-typedef pthread_mutex_t     ABTD_xstream_mutex;
+typedef pthread_mutex_t ABTD_xstream_mutex;
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-typedef pthread_barrier_t   ABTD_xstream_barrier;
+typedef pthread_barrier_t ABTD_xstream_barrier;
 #else
-typedef void *              ABTD_xstream_barrier;
+typedef void *ABTD_xstream_barrier;
 #endif
 
 /* ES Storage Qualifier */
-#define ABTD_XSTREAM_LOCAL  __thread
+#define ABTD_XSTREAM_LOCAL __thread
 
 /* Environment */
 void ABTD_env_init(ABTI_global *p_global);
@@ -79,8 +79,8 @@ typedef struct timeval ABTD_time;
 
 #endif
 
-void   ABTD_time_init(void);
-int    ABTD_time_get(ABTD_time *p_time);
+void ABTD_time_init(void);
+int ABTD_time_get(ABTD_time *p_time);
 double ABTD_time_read_sec(ABTD_time *p_time);
 
 #endif /* ABTD_H_INCLUDED */

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,9 +8,8 @@
 
 #include <stdint.h>
 
-static inline
-int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
-                                   int weak)
+static inline int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv,
+                                                 int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int32_t tmp_oldv = oldv;
@@ -22,9 +21,8 @@ int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
 #endif
 }
 
-static inline
-uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
-                                     uint32_t newv, int weak)
+static inline uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
+                                                   uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint32_t tmp_oldv = oldv;
@@ -36,9 +34,8 @@ uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
 #endif
 }
 
-static inline
-int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
-                                   int weak)
+static inline int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv,
+                                                 int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int64_t tmp_oldv = oldv;
@@ -50,9 +47,8 @@ int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
 #endif
 }
 
-static inline
-uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
-                                     uint64_t newv, int weak)
+static inline uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
+                                                   uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint64_t tmp_oldv = oldv;
@@ -64,8 +60,8 @@ uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
 #endif
 }
 
-static inline
-void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+static inline void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv,
+                                             int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     void *tmp_oldv = oldv;
@@ -77,197 +73,182 @@ void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv, int32_t newv,
-                                int weak)
+static inline int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv,
+                                              int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
-                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(ptr, oldv, newv);
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv,
-                                 int weak)
+static inline int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv,
+                                               uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
-                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(ptr, oldv, newv);
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv, int64_t newv,
-                                int weak)
+static inline int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv,
+                                              int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
-                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(ptr, oldv, newv);
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv,
-                                 int weak)
+static inline int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv,
+                                               uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
-                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(ptr, oldv, newv);
 #endif
 }
 
-static inline
-int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv, int weak)
+static inline int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv,
+                                            int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
-                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(ptr, oldv, newv);
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv,
+                                                     int32_t newv)
 {
-   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline
-uint32_t ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
-                                         uint32_t newv)
+static inline uint32_t
+ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
 {
-   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline
-int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv,
+                                                     int64_t newv)
 {
-   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline
-uint64_t ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
-                                         uint64_t newv)
+static inline uint64_t
+ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
 {
-   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline
-void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+static inline void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv,
+                                                 void *newv)
 {
-   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
+    return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline
-int32_t ABTD_atomic_val_cas_strong_int32(int32_t *ptr, int32_t oldv,
-                                         int32_t newv)
+static inline int32_t
+ABTD_atomic_val_cas_strong_int32(int32_t *ptr, int32_t oldv, int32_t newv)
 {
-   return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
 }
 
-static inline
-uint32_t ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
-                                           uint32_t newv)
+static inline uint32_t
+ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
 {
-   return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline
-int64_t ABTD_atomic_val_cas_strong_int64(int64_t *ptr, int64_t oldv,
-                                         int64_t newv)
+static inline int64_t
+ABTD_atomic_val_cas_strong_int64(int64_t *ptr, int64_t oldv, int64_t newv)
 {
-   return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
 }
 
-static inline
-uint64_t ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
-                                           uint64_t newv)
+static inline uint64_t
+ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
 {
-   return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline
-void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+static inline void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv,
+                                                   void *newv)
 {
-   return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
+    return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv,
+                                                  int32_t newv)
 {
-   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
-                                     uint32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
+                                                   uint32_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv,
+                                                  int64_t newv)
 {
-   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
-                                     uint64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
+                                                   uint64_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv, void *newv)
+static inline int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv,
+                                                void *newv)
 {
-   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
+    return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv,
+                                                    int32_t newv)
 {
-   return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr, uint32_t oldv,
-                                       uint32_t newv)
+static inline int
+ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv,
+                                                    int64_t newv)
 {
-   return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr, uint64_t oldv,
-                                       uint64_t newv)
+static inline int
+ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
 {
-   return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline
-int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv, void *newv)
+static inline int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv,
+                                                  void *newv)
 {
-   return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
+    return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline
-int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -276,8 +257,7 @@ int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -286,8 +266,7 @@ uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -296,8 +275,7 @@ int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -306,8 +284,7 @@ uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-double ABTD_atomic_fetch_add_double(double *ptr, double v)
+static inline double ABTD_atomic_fetch_add_double(double *ptr, double v)
 {
     union value {
         double d_val;
@@ -323,8 +300,7 @@ double ABTD_atomic_fetch_add_double(double *ptr, double v)
     return oldv.d_val;
 }
 
-static inline
-int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -333,8 +309,7 @@ int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -343,8 +318,7 @@ uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -353,8 +327,7 @@ int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -363,14 +336,12 @@ uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-double ABTD_atomic_fetch_sub_double(double *ptr, double v)
+static inline double ABTD_atomic_fetch_sub_double(double *ptr, double v)
 {
     return ABTD_atomic_fetch_add_double(ptr, -v);
 }
 
-static inline
-int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -379,8 +350,7 @@ int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -389,8 +359,7 @@ uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -399,8 +368,7 @@ int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -409,8 +377,7 @@ uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -419,8 +386,7 @@ int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -429,8 +395,7 @@ uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -439,8 +404,7 @@ int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -449,8 +413,7 @@ uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -459,8 +422,7 @@ int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -469,8 +431,7 @@ uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -479,8 +440,7 @@ int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -489,8 +449,7 @@ uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -500,8 +459,7 @@ uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-void ABTD_atomic_clear_uint8(uint8_t *ptr)
+static inline void ABTD_atomic_clear_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELEASE);
@@ -510,8 +468,7 @@ void ABTD_atomic_clear_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -523,8 +480,7 @@ uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_load_int32(int32_t *ptr)
+static inline int32_t ABTD_atomic_load_int32(int32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -536,8 +492,7 @@ int32_t ABTD_atomic_load_int32(int32_t *ptr)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
+static inline uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -549,8 +504,7 @@ uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_load_int64(int64_t *ptr)
+static inline int64_t ABTD_atomic_load_int64(int64_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -562,8 +516,7 @@ int64_t ABTD_atomic_load_int64(int64_t *ptr)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
+static inline uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -576,22 +529,20 @@ uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
 #endif
 }
 
-static inline
-void *ABTD_atomic_load_ptr(void **ptr)
+static inline void *ABTD_atomic_load_ptr(void **ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    void *val = *(void * volatile *)ptr;
+    void *val = *(void *volatile *)ptr;
     __sync_synchronize();
     return val;
 #endif
 }
 
-static inline
-void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
+static inline void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -602,8 +553,7 @@ void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
+static inline void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -614,8 +564,7 @@ void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
+static inline void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -626,8 +575,7 @@ void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
+static inline void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -638,20 +586,18 @@ void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
 #endif
 }
 
-static inline
-void ABTD_atomic_store_ptr(void **ptr, void *val)
+static inline void ABTD_atomic_store_ptr(void **ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(void * volatile *)ptr = val;
+    *(void *volatile *)ptr = val;
     __sync_synchronize();
 #endif
 }
 
-static inline
-int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -664,8 +610,7 @@ int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline
-uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -678,8 +623,7 @@ uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline
-int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -692,8 +636,7 @@ int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline
-uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -706,8 +649,7 @@ uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline
-void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
+static inline void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -720,8 +662,7 @@ void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
 #endif
 }
 
-static inline
-void ABTD_atomic_mem_barrier(void)
+static inline void ABTD_atomic_mem_barrier(void)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_thread_fence(__ATOMIC_ACQ_REL);
@@ -730,17 +671,15 @@ void ABTD_atomic_mem_barrier(void)
 #endif
 }
 
-static inline
-void ABTD_compiler_barrier(void)
+static inline void ABTD_compiler_barrier(void)
 {
-    __asm__ __volatile__ ( "" ::: "memory" );
+    __asm__ __volatile__("" ::: "memory");
 }
 
-static inline
-void ABTD_atomic_pause(void)
+static inline void ABTD_atomic_pause(void)
 {
 #ifdef __x86_64__
-    __asm__ __volatile__ ( "pause" ::: "memory" );
+    __asm__ __volatile__("pause" ::: "memory");
 #endif
 }
 

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -14,15 +14,15 @@
 #endif
 
 typedef struct ABTD_thread_context {
-    void *                 p_ctx;        /* actual context of fcontext, or a
-                                          * pointer to uctx */
-    void (*f_thread)(void *);            /* ULT function */
-    void *                 p_arg;        /* ULT function argument */
-    struct ABTD_thread_context *p_link;  /* pointer to scheduler context */
+    void *p_ctx;                        /* actual context of fcontext, or a
+                                         * pointer to uctx */
+    void (*f_thread)(void *);           /* ULT function */
+    void *p_arg;                        /* ULT function argument */
+    struct ABTD_thread_context *p_link; /* pointer to scheduler context */
 #ifndef ABT_CONFIG_USE_FCONTEXT
-    ucontext_t             uctx;         /* ucontext entity pointed by p_ctx */
-    void (*f_uctx_thread)(void *);       /* root function called by ucontext */
-    void *                 p_uctx_arg;   /* argument for root function */
+    ucontext_t uctx;               /* ucontext entity pointed by p_ctx */
+    void (*f_uctx_thread)(void *); /* root function called by ucontext */
+    void *p_uctx_arg;              /* argument for root function */
 #endif
 } ABTD_thread_context;
 

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -9,13 +9,13 @@
 typedef void *fcontext_t;
 
 #if defined(ABT_C_HAVE_VISIBILITY)
-#define ABT_API_PRIVATE     __attribute__((visibility ("hidden")))
+#define ABT_API_PRIVATE __attribute__((visibility("hidden")))
 #else
 #define ABT_API_PRIVATE
 #endif
 
-fcontext_t make_fcontext(void *sp, size_t size, void (*thread_func)(void *))
-                         ABT_API_PRIVATE;
+fcontext_t make_fcontext(void *sp, size_t size,
+                         void (*thread_func)(void *)) ABT_API_PRIVATE;
 void *jump_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
 void *take_fcontext(fcontext_t *old, fcontext_t new, void *arg) ABT_API_PRIVATE;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -23,31 +23,31 @@ void init_and_call_fcontext(void *p_arg, void (*f_thread)(void *),
                             void *p_stacktop, fcontext_t *old);
 #endif
 
-static inline
-void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
-                              void (*thread_func)(void *))
+static inline void ABTD_thread_context_make(ABTD_thread_context *p_ctx,
+                                            void *sp, size_t size,
+                                            void (*thread_func)(void *))
 {
     p_ctx->p_ctx = make_fcontext(sp, size, thread_func);
 }
 
-static inline
-void ABTD_thread_context_jump(ABTD_thread_context *p_old,
-                              ABTD_thread_context *p_new, void *arg)
+static inline void ABTD_thread_context_jump(ABTD_thread_context *p_old,
+                                            ABTD_thread_context *p_new,
+                                            void *arg)
 {
     jump_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
 }
 
-static inline
-void ABTD_thread_context_take(ABTD_thread_context *p_old,
-                              ABTD_thread_context *p_new, void *arg)
+static inline void ABTD_thread_context_take(ABTD_thread_context *p_old,
+                                            ABTD_thread_context *p_new,
+                                            void *arg)
 {
     take_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx, void *sp,
-                                       void (*thread_func)(void *), void *arg)
+static inline void
+ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx, void *sp,
+                                  void (*thread_func)(void *), void *arg)
 {
     init_and_call_fcontext(arg, thread_func, sp, &p_ctx->p_ctx);
 }

--- a/src/include/abtd_stream.h
+++ b/src/include/abtd_stream.h
@@ -7,23 +7,20 @@
 #define ABTD_STREAM_H_INCLUDED
 
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-static inline
-int ABTD_xstream_barrier_init(uint32_t num_waiters,
-                              ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_init(uint32_t num_waiters,
+                                            ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_init(p_barrier, NULL, num_waiters);
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
 }
 
-static inline
-int ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_destroy(p_barrier);
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
 }
 
-static inline
-int ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
+static inline int ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
 {
     return pthread_barrier_wait(p_barrier);
 }

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -7,7 +7,7 @@
 #define ABTD_THREAD_H_INCLUDED
 
 #if defined(ABT_C_HAVE_VISIBILITY)
-#define ABT_API_PRIVATE     __attribute__((visibility ("hidden")))
+#define ABT_API_PRIVATE __attribute__((visibility("hidden")))
 #else
 #define ABT_API_PRIVATE
 #endif
@@ -18,12 +18,12 @@ void ABTD_thread_func_wrapper_sched(void *p_arg);
 void ABTD_thread_terminate_thread_no_arg();
 #endif
 
-static inline
-int ABTDI_thread_context_create(ABTD_thread_context *p_link,
-                               void (*f_wrapper)(void *),
-                               void (*f_thread)(void *), void *p_arg,
-                               size_t stacksize, void *p_stack,
-                               ABTD_thread_context *p_newctx)
+static inline int ABTDI_thread_context_create(ABTD_thread_context *p_link,
+                                              void (*f_wrapper)(void *),
+                                              void (*f_thread)(void *),
+                                              void *p_arg, size_t stacksize,
+                                              void *p_stack,
+                                              ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
     void *p_stacktop;
@@ -40,30 +40,25 @@ int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     return abt_errno;
 }
 
-static inline
-int ABTD_thread_context_create_thread(ABTD_thread_context *p_link,
-                                      void (*f_thread)(void *), void *p_arg,
-                                      size_t stacksize, void *p_stack,
-                                      ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_create_thread(
+    ABTD_thread_context *p_link, void (*f_thread)(void *), void *p_arg,
+    size_t stacksize, void *p_stack, ABTD_thread_context *p_newctx)
 {
     return ABTDI_thread_context_create(p_link, ABTD_thread_func_wrapper_thread,
                                        f_thread, p_arg, stacksize, p_stack,
                                        p_newctx);
 }
 
-static inline
-int ABTD_thread_context_create_sched(ABTD_thread_context *p_link,
-                                     void (*f_thread)(void *), void *p_arg,
-                                     size_t stacksize, void *p_stack,
-                                     ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_create_sched(
+    ABTD_thread_context *p_link, void (*f_thread)(void *), void *p_arg,
+    size_t stacksize, void *p_stack, ABTD_thread_context *p_newctx)
 {
     return ABTDI_thread_context_create(p_link, ABTD_thread_func_wrapper_sched,
                                        f_thread, p_arg, stacksize, p_stack,
                                        p_newctx);
 }
 
-static inline
-int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -80,10 +75,10 @@ int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-int ABTD_thread_context_init(ABTD_thread_context *p_link,
-                             void (*f_thread)(void *), void *p_arg,
-                             ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_init(ABTD_thread_context *p_link,
+                                           void (*f_thread)(void *),
+                                           void *p_arg,
+                                           ABTD_thread_context *p_newctx)
 {
     int abt_errno = ABT_SUCCESS;
     p_newctx->p_ctx = NULL;
@@ -93,9 +88,9 @@ int ABTD_thread_context_init(ABTD_thread_context *p_link,
     return abt_errno;
 }
 
-static inline
-int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
-                                   ABTD_thread_context *p_newctx)
+static inline int ABTD_thread_context_arm_thread(size_t stacksize,
+                                                 void *p_stack,
+                                                 ABTD_thread_context *p_newctx)
 {
     /* This function *arms* the dynamic promotion thread (initialized by
      * ABTD_thread_context_init) as if it were created by
@@ -114,49 +109,46 @@ int ABTD_thread_context_arm_thread(size_t stacksize, void *p_stack,
 /* Currently, nothing to do */
 #define ABTD_thread_context_free(p_ctx)
 
-static inline
-void ABTD_thread_context_switch(ABTD_thread_context *p_old,
-                                ABTD_thread_context *p_new)
+static inline void ABTD_thread_context_switch(ABTD_thread_context *p_old,
+                                              ABTD_thread_context *p_new)
 {
     ABTD_thread_context_jump(p_old, p_new, p_new);
 }
 
-static inline
-void ABTD_thread_finish_context(ABTD_thread_context *p_old,
-                                ABTD_thread_context *p_new)
+static inline void ABTD_thread_finish_context(ABTD_thread_context *p_old,
+                                              ABTD_thread_context *p_new)
 {
     ABTD_thread_context_take(p_old, p_new, p_new);
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-void ABTD_thread_context_make_and_call(ABTD_thread_context *p_old,
-                                       void (*f_thread)(void *), void *p_arg,
-                                       void *p_stacktop)
+static inline void ABTD_thread_context_make_and_call(ABTD_thread_context *p_old,
+                                                     void (*f_thread)(void *),
+                                                     void *p_arg,
+                                                     void *p_stacktop)
 {
     ABTD_thread_context_init_and_call(p_old, p_stacktop, f_thread, p_arg);
 }
 
-static inline
-ABT_bool ABTD_thread_context_is_dynamic_promoted(ABTD_thread_context *p_ctx)
+static inline ABT_bool
+ABTD_thread_context_is_dynamic_promoted(ABTD_thread_context *p_ctx)
 {
     /* Check if the ULT has been dynamically promoted; internally, it checks if
      * the context is NULL. */
     return p_ctx->p_ctx ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline
-void ABTDI_thread_context_dynamic_promote(void *p_stacktop, void *jump_f)
+static inline void ABTDI_thread_context_dynamic_promote(void *p_stacktop,
+                                                        void *jump_f)
 {
     /* Perform dynamic promotion */
-    void **p_return_address = (void **)(((char *) p_stacktop) - 0x10);
-    void ***p_stack_pointer = (void ***)(((char *) p_stacktop) - 0x08);
+    void **p_return_address = (void **)(((char *)p_stacktop) - 0x10);
+    void ***p_stack_pointer = (void ***)(((char *)p_stacktop) - 0x08);
     *p_stack_pointer = p_return_address;
     *p_return_address = jump_f;
 }
 
-static inline
-void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
+static inline void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
 {
     union fp_conv {
         void (*f)(void *);
@@ -168,21 +160,19 @@ void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
 }
 #endif
 
-static inline
-void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
-                                     ABTD_thread_context *p_link)
+static inline void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
+                                                   ABTD_thread_context *p_link)
 {
     ABTD_atomic_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
 }
 
-static inline
-void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx, void *arg)
+static inline void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx,
+                                               void *arg)
 {
     p_ctx->p_arg = arg;
 }
 
-static inline
-void *ABTD_thread_context_get_arg(ABTD_thread_context *p_ctx)
+static inline void *ABTD_thread_context_get_arg(ABTD_thread_context *p_ctx)
 {
     return p_ctx->p_arg;
 }

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -23,9 +23,9 @@ static void ABTD_ucontext_wrapper(int arg1, int arg2)
     ABTI_ASSERT(0);
 }
 
-static inline
-void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
-                              void (*thread_func)(void *))
+static inline void ABTD_thread_context_make(ABTD_thread_context *p_ctx,
+                                            void *sp, size_t size,
+                                            void (*thread_func)(void *))
 {
     getcontext(&p_ctx->uctx);
     p_ctx->p_ctx = &p_ctx->uctx;
@@ -49,17 +49,17 @@ void ABTD_thread_context_make(ABTD_thread_context *p_ctx, void *sp, size_t size,
 #endif
 }
 
-static inline
-void ABTD_thread_context_jump(ABTD_thread_context *p_old,
-                              ABTD_thread_context *p_new, void *arg)
+static inline void ABTD_thread_context_jump(ABTD_thread_context *p_old,
+                                            ABTD_thread_context *p_new,
+                                            void *arg)
 {
     p_new->p_uctx_arg = arg;
     swapcontext(&p_old->uctx, &p_new->uctx);
 }
 
-static inline
-void ABTD_thread_context_take(ABTD_thread_context *p_old,
-                              ABTD_thread_context *p_new, void *arg)
+static inline void ABTD_thread_context_take(ABTD_thread_context *p_old,
+                                            ABTD_thread_context *p_new,
+                                            void *arg)
 {
     p_new->p_uctx_arg = arg;
     setcontext(&p_new->uctx);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -19,43 +19,40 @@
 #include "abti_error.h"
 #include "abti_valgrind.h"
 
-
 /* Constants */
-#define ABTI_SCHED_NUM_PRIO         3
+#define ABTI_SCHED_NUM_PRIO 3
 
-#define ABTI_XSTREAM_REQ_JOIN       (1 << 0)
-#define ABTI_XSTREAM_REQ_EXIT       (1 << 1)
-#define ABTI_XSTREAM_REQ_CANCEL     (1 << 2)
-#define ABTI_XSTREAM_REQ_STOP       (1 << 3)
+#define ABTI_XSTREAM_REQ_JOIN (1 << 0)
+#define ABTI_XSTREAM_REQ_EXIT (1 << 1)
+#define ABTI_XSTREAM_REQ_CANCEL (1 << 2)
+#define ABTI_XSTREAM_REQ_STOP (1 << 3)
 
-#define ABTI_SCHED_REQ_FINISH       (1 << 0)
-#define ABTI_SCHED_REQ_EXIT         (1 << 1)
+#define ABTI_SCHED_REQ_FINISH (1 << 0)
+#define ABTI_SCHED_REQ_EXIT (1 << 1)
 
-#define ABTI_THREAD_REQ_JOIN        (1 << 0)
-#define ABTI_THREAD_REQ_EXIT        (1 << 1)
-#define ABTI_THREAD_REQ_CANCEL      (1 << 2)
-#define ABTI_THREAD_REQ_MIGRATE     (1 << 3)
-#define ABTI_THREAD_REQ_TERMINATE   (1 << 4)
-#define ABTI_THREAD_REQ_BLOCK       (1 << 5)
-#define ABTI_THREAD_REQ_ORPHAN      (1 << 6)
-#define ABTI_THREAD_REQ_NOPUSH      (1 << 7)
-#define ABTI_THREAD_REQ_STOP        \
-    (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_TERMINATE)
-#define ABTI_THREAD_REQ_NON_YIELD   \
-    (ABTI_THREAD_REQ_EXIT    | ABTI_THREAD_REQ_CANCEL |        \
-     ABTI_THREAD_REQ_MIGRATE | ABTI_THREAD_REQ_TERMINATE |     \
-     ABTI_THREAD_REQ_BLOCK   | ABTI_THREAD_REQ_ORPHAN |        \
-     ABTI_THREAD_REQ_NOPUSH)
+#define ABTI_THREAD_REQ_JOIN (1 << 0)
+#define ABTI_THREAD_REQ_EXIT (1 << 1)
+#define ABTI_THREAD_REQ_CANCEL (1 << 2)
+#define ABTI_THREAD_REQ_MIGRATE (1 << 3)
+#define ABTI_THREAD_REQ_TERMINATE (1 << 4)
+#define ABTI_THREAD_REQ_BLOCK (1 << 5)
+#define ABTI_THREAD_REQ_ORPHAN (1 << 6)
+#define ABTI_THREAD_REQ_NOPUSH (1 << 7)
+#define ABTI_THREAD_REQ_STOP (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_TERMINATE)
+#define ABTI_THREAD_REQ_NON_YIELD                                              \
+    (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_CANCEL | ABTI_THREAD_REQ_MIGRATE | \
+     ABTI_THREAD_REQ_TERMINATE | ABTI_THREAD_REQ_BLOCK |                       \
+     ABTI_THREAD_REQ_ORPHAN | ABTI_THREAD_REQ_NOPUSH)
 
-#define ABTI_TASK_REQ_CANCEL        (1 << 0)
+#define ABTI_TASK_REQ_CANCEL (1 << 0)
 
-#define ABTI_THREAD_INIT_ID         0xFFFFFFFFFFFFFFFF
-#define ABTI_TASK_INIT_ID           0xFFFFFFFFFFFFFFFF
+#define ABTI_THREAD_INIT_ID 0xFFFFFFFFFFFFFFFF
+#define ABTI_TASK_INIT_ID 0xFFFFFFFFFFFFFFFF
 
-#define ABTI_INDENT                 4
+#define ABTI_INDENT 4
 
-#define ABT_THREAD_TYPE_FULLY_FLEDGED      0
-#define ABT_THREAD_TYPE_DYNAMIC_PROMOTION  1
+#define ABT_THREAD_TYPE_FULLY_FLEDGED 0
+#define ABT_THREAD_TYPE_DYNAMIC_PROMOTION 1
 
 enum ABTI_xstream_type {
     ABTI_XSTREAM_TYPE_PRIMARY,
@@ -87,47 +84,46 @@ enum ABTI_stack_type {
 };
 
 /* Macro functions */
-#define ABTI_UNUSED(a)              (void)(a)
-
+#define ABTI_UNUSED(a) (void)(a)
 
 /* Data Types */
-typedef struct ABTI_global          ABTI_global;
-typedef struct ABTI_local           ABTI_local;
-typedef struct ABTI_local_func      ABTI_local_func;
-typedef struct ABTI_xstream         ABTI_xstream;
-typedef enum ABTI_xstream_type      ABTI_xstream_type;
-typedef struct ABTI_sched           ABTI_sched;
-typedef char *                      ABTI_sched_config;
-typedef enum ABTI_sched_used        ABTI_sched_used;
-typedef void *                      ABTI_sched_id;      /* Scheduler id */
-typedef uintptr_t                   ABTI_sched_kind;    /* Scheduler kind */
-typedef struct ABTI_pool            ABTI_pool;
-typedef struct ABTI_unit            ABTI_unit;
-typedef struct ABTI_thread_attr     ABTI_thread_attr;
-typedef struct ABTI_thread          ABTI_thread;
-typedef enum ABTI_thread_type       ABTI_thread_type;
-typedef enum ABTI_stack_type        ABTI_stack_type;
-typedef struct ABTI_thread_req_arg  ABTI_thread_req_arg;
-typedef struct ABTI_thread_list     ABTI_thread_list;
-typedef struct ABTI_thread_entry    ABTI_thread_entry;
-typedef struct ABTI_thread_htable   ABTI_thread_htable;
-typedef struct ABTI_thread_queue    ABTI_thread_queue;
-typedef struct ABTI_task            ABTI_task;
-typedef struct ABTI_key             ABTI_key;
-typedef struct ABTI_ktelem          ABTI_ktelem;
-typedef struct ABTI_ktable          ABTI_ktable;
-typedef struct ABTI_mutex_attr      ABTI_mutex_attr;
-typedef struct ABTI_mutex           ABTI_mutex;
-typedef struct ABTI_cond            ABTI_cond;
-typedef struct ABTI_rwlock          ABTI_rwlock;
-typedef struct ABTI_eventual        ABTI_eventual;
-typedef struct ABTI_future          ABTI_future;
-typedef struct ABTI_barrier         ABTI_barrier;
-typedef struct ABTI_timer           ABTI_timer;
+typedef struct ABTI_global ABTI_global;
+typedef struct ABTI_local ABTI_local;
+typedef struct ABTI_local_func ABTI_local_func;
+typedef struct ABTI_xstream ABTI_xstream;
+typedef enum ABTI_xstream_type ABTI_xstream_type;
+typedef struct ABTI_sched ABTI_sched;
+typedef char *ABTI_sched_config;
+typedef enum ABTI_sched_used ABTI_sched_used;
+typedef void *ABTI_sched_id;       /* Scheduler id */
+typedef uintptr_t ABTI_sched_kind; /* Scheduler kind */
+typedef struct ABTI_pool ABTI_pool;
+typedef struct ABTI_unit ABTI_unit;
+typedef struct ABTI_thread_attr ABTI_thread_attr;
+typedef struct ABTI_thread ABTI_thread;
+typedef enum ABTI_thread_type ABTI_thread_type;
+typedef enum ABTI_stack_type ABTI_stack_type;
+typedef struct ABTI_thread_req_arg ABTI_thread_req_arg;
+typedef struct ABTI_thread_list ABTI_thread_list;
+typedef struct ABTI_thread_entry ABTI_thread_entry;
+typedef struct ABTI_thread_htable ABTI_thread_htable;
+typedef struct ABTI_thread_queue ABTI_thread_queue;
+typedef struct ABTI_task ABTI_task;
+typedef struct ABTI_key ABTI_key;
+typedef struct ABTI_ktelem ABTI_ktelem;
+typedef struct ABTI_ktable ABTI_ktable;
+typedef struct ABTI_mutex_attr ABTI_mutex_attr;
+typedef struct ABTI_mutex ABTI_mutex;
+typedef struct ABTI_cond ABTI_cond;
+typedef struct ABTI_rwlock ABTI_rwlock;
+typedef struct ABTI_eventual ABTI_eventual;
+typedef struct ABTI_future ABTI_future;
+typedef struct ABTI_barrier ABTI_barrier;
+typedef struct ABTI_timer ABTI_timer;
 #ifdef ABT_CONFIG_USE_MEM_POOL
-typedef struct ABTI_stack_header    ABTI_stack_header;
-typedef struct ABTI_page_header     ABTI_page_header;
-typedef struct ABTI_sp_header       ABTI_sp_header;
+typedef struct ABTI_stack_header ABTI_stack_header;
+typedef struct ABTI_page_header ABTI_page_header;
+typedef struct ABTI_sp_header ABTI_sp_header;
 #endif
 /* ID associated with native thread (e.g, Pthreads), which can distinguish
  * execution streams and external threads */
@@ -137,31 +133,28 @@ typedef struct ABTI_native_thread_id_opaque *ABTI_native_thread_id;
 struct ABTI_unit_id_opaque;
 typedef struct ABTI_unit_id_opaque *ABTI_unit_id;
 
-
 /* Architecture-Dependent Definitions */
 #include "abtd.h"
 
-
 /* Spinlock */
-typedef struct ABTI_spinlock        ABTI_spinlock;
+typedef struct ABTI_spinlock ABTI_spinlock;
 #include "abti_spinlock.h"
-
 
 /* Definitions */
 struct ABTI_mutex_attr {
-    uint32_t attrs;             /* bit-or'ed attributes */
-    uint32_t nesting_cnt;       /* nesting count */
-    ABTI_unit_id owner_id;      /* owner's ID */
-    uint32_t max_handovers;     /* max. # of handovers */
-    uint32_t max_wakeups;       /* max. # of wakeups */
+    uint32_t attrs;         /* bit-or'ed attributes */
+    uint32_t nesting_cnt;   /* nesting count */
+    ABTI_unit_id owner_id;  /* owner's ID */
+    uint32_t max_handovers; /* max. # of handovers */
+    uint32_t max_wakeups;   /* max. # of wakeups */
 };
 
 struct ABTI_mutex {
-    uint32_t val;                   /* 0: unlocked, 1: locked */
-    ABTI_mutex_attr attr;           /* attributes */
-    ABTI_thread_htable *p_htable;   /* a set of queues */
-    ABTI_thread *p_handover;        /* next ULT for the mutex handover */
-    ABTI_thread *p_giver;           /* current ULT that hands over the mutex */
+    uint32_t val;                 /* 0: unlocked, 1: locked */
+    ABTI_mutex_attr attr;         /* attributes */
+    ABTI_thread_htable *p_htable; /* a set of queues */
+    ABTI_thread *p_handover;      /* next ULT for the mutex handover */
+    ABTI_thread *p_giver;         /* current ULT that hands over the mutex */
 };
 
 struct ABTI_global {
@@ -183,22 +176,22 @@ struct ABTI_global {
     long sched_sleep_nsec;      /* Default nanoseconds for scheduler sleep */
     ABTI_thread *p_thread_main; /* ULT of the main function */
 
-    uint32_t mutex_max_handovers;      /* Default max. # of local handovers */
-    uint32_t mutex_max_wakeups;        /* Default max. # of wakeups */
-    uint32_t os_page_size;             /* OS page size */
-    uint32_t huge_page_size;           /* Huge page size */
+    uint32_t mutex_max_handovers; /* Default max. # of local handovers */
+    uint32_t mutex_max_wakeups;   /* Default max. # of wakeups */
+    uint32_t os_page_size;        /* OS page size */
+    uint32_t huge_page_size;      /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    ABTI_spinlock mem_task_lock;       /* Spinlock protecting p_mem_task */
-    uint32_t mem_page_size;            /* Page size for memory allocation */
-    uint32_t mem_sp_size;              /* Stack page size */
-    uint32_t mem_max_stacks;           /* Max. # of stacks kept in each ES */
-    int mem_lp_alloc;                  /* How to allocate large pages */
-    ABTI_stack_header *p_mem_stack;    /* List of ULT stack */
-    ABTI_page_header *p_mem_task;      /* List of task block pages */
-    ABTI_sp_header *p_mem_sph;         /* List of stack pages */
+    ABTI_spinlock mem_task_lock;    /* Spinlock protecting p_mem_task */
+    uint32_t mem_page_size;         /* Page size for memory allocation */
+    uint32_t mem_sp_size;           /* Stack page size */
+    uint32_t mem_max_stacks;        /* Max. # of stacks kept in each ES */
+    int mem_lp_alloc;               /* How to allocate large pages */
+    ABTI_stack_header *p_mem_stack; /* List of ULT stack */
+    ABTI_page_header *p_mem_task;   /* List of task block pages */
+    ABTI_sp_header *p_mem_sph;      /* List of stack pages */
 #endif
 
-    ABT_bool print_config;      /* Whether to print config on ABT_init */
+    ABT_bool print_config; /* Whether to print config on ABT_init */
 };
 
 struct ABTI_local_func {
@@ -210,33 +203,32 @@ struct ABTI_local_func {
 };
 
 struct ABTI_local {
-    ABTI_xstream *p_xstream;    /* Current ES */
-    ABTI_thread *p_thread;      /* Current running ULT */
-    ABTI_task *p_task;          /* Current running tasklet */
+    ABTI_xstream *p_xstream; /* Current ES */
+    ABTI_thread *p_thread;   /* Current running ULT */
+    ABTI_task *p_task;       /* Current running tasklet */
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    uint32_t num_stacks;                /* Current # of stacks */
-    ABTI_stack_header *p_mem_stack;     /* Free stack list */
-    ABTI_page_header *p_mem_task_head;  /* Head of page list */
-    ABTI_page_header *p_mem_task_tail;  /* Tail of page list */
+    uint32_t num_stacks;               /* Current # of stacks */
+    ABTI_stack_header *p_mem_stack;    /* Free stack list */
+    ABTI_page_header *p_mem_task_head; /* Head of page list */
+    ABTI_page_header *p_mem_task_tail; /* Tail of page list */
 #endif
 };
 
 struct ABTI_xstream {
-    int rank;                   /* Rank */
-    ABTI_xstream_type type;     /* Type */
-    volatile
-    ABT_xstream_state state;    /* State */
-    ABTI_sched **scheds;        /* Stack of running schedulers */
-    int max_scheds;             /* Allocation size of the array scheds */
-    int num_scheds;             /* Number of scheds */
-    ABTI_spinlock sched_lock;   /* Lock for the scheduler management */
+    int rank;                         /* Rank */
+    ABTI_xstream_type type;           /* Type */
+    volatile ABT_xstream_state state; /* State */
+    ABTI_sched **scheds;              /* Stack of running schedulers */
+    int max_scheds;                   /* Allocation size of the array scheds */
+    int num_scheds;                   /* Number of scheds */
+    ABTI_spinlock sched_lock;         /* Lock for the scheduler management */
 
-    uint32_t request;           /* Request */
-    void *p_req_arg;            /* Request argument */
-    ABTI_sched *p_main_sched;   /* Main scheduler */
+    uint32_t request;         /* Request */
+    void *p_req_arg;          /* Request argument */
+    ABTI_sched *p_main_sched; /* Main scheduler */
 
-    ABTD_xstream_context ctx;   /* ES context */
+    ABTD_xstream_context ctx; /* ES context */
 };
 
 struct ABTI_sched {
@@ -255,49 +247,49 @@ struct ABTI_sched {
 
     /* Scheduler functions */
     ABT_sched_init_fn init;
-    ABT_sched_run_fn  run;
+    ABT_sched_run_fn run;
     ABT_sched_free_fn free;
     ABT_sched_get_migr_pool_fn get_migr_pool;
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-    uint64_t id;                /* ID */
+    uint64_t id; /* ID */
 #endif
 };
 
 struct ABTI_pool {
-    ABT_pool_access access;  /* Access mode */
-    ABT_bool automatic;      /* To know if automatic data free */
-    int32_t num_scheds;      /* Number of associated schedulers */
-                             /* NOTE: int32_t to check if still positive */
+    ABT_pool_access access; /* Access mode */
+    ABT_bool automatic;     /* To know if automatic data free */
+    int32_t num_scheds;     /* Number of associated schedulers */
+                            /* NOTE: int32_t to check if still positive */
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     ABTI_native_thread_id consumer_id; /* Associated consumer ID */
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
     ABTI_native_thread_id producer_id; /* Associated producer ID */
 #endif
-    uint32_t num_blocked;    /* Number of blocked ULTs */
-    int32_t num_migrations;  /* Number of migrating ULTs */
-    void *data;              /* Specific data */
-    uint64_t id;             /* ID */
+    uint32_t num_blocked;   /* Number of blocked ULTs */
+    int32_t num_migrations; /* Number of migrating ULTs */
+    void *data;             /* Specific data */
+    uint64_t id;            /* ID */
 
     /* Functions to manage units */
-    ABT_unit_get_type_fn           u_get_type;
-    ABT_unit_get_thread_fn         u_get_thread;
-    ABT_unit_get_task_fn           u_get_task;
-    ABT_unit_is_in_pool_fn         u_is_in_pool;
+    ABT_unit_get_type_fn u_get_type;
+    ABT_unit_get_thread_fn u_get_thread;
+    ABT_unit_get_task_fn u_get_task;
+    ABT_unit_is_in_pool_fn u_is_in_pool;
     ABT_unit_create_from_thread_fn u_create_from_thread;
-    ABT_unit_create_from_task_fn   u_create_from_task;
-    ABT_unit_free_fn               u_free;
+    ABT_unit_create_from_task_fn u_create_from_task;
+    ABT_unit_free_fn u_free;
 
     /* Functions to manage the pool */
-    ABT_pool_init_fn               p_init;
-    ABT_pool_get_size_fn           p_get_size;
-    ABT_pool_push_fn               p_push;
-    ABT_pool_pop_fn                p_pop;
-    ABT_pool_pop_timedwait_fn      p_pop_timedwait;
-    ABT_pool_remove_fn             p_remove;
-    ABT_pool_free_fn               p_free;
-    ABT_pool_print_all_fn          p_print_all;
+    ABT_pool_init_fn p_init;
+    ABT_pool_get_size_fn p_get_size;
+    ABT_pool_push_fn p_push;
+    ABT_pool_pop_fn p_pop;
+    ABT_pool_pop_timedwait_fn p_pop_timedwait;
+    ABT_pool_remove_fn p_remove;
+    ABT_pool_free_fn p_free;
+    ABT_pool_print_all_fn p_print_all;
 };
 
 struct ABTI_unit {
@@ -306,42 +298,42 @@ struct ABTI_unit {
     ABT_pool pool;
     union {
         ABT_thread thread;
-        ABT_task   task;
+        ABT_task task;
     } handle;
     ABT_unit_type type;
 };
 
 struct ABTI_thread_attr {
-    void *p_stack;                      /* Stack address */
-    size_t stacksize;                   /* Stack size (in bytes) */
-    ABTI_stack_type stacktype;          /* Stack type */
+    void *p_stack;             /* Stack address */
+    size_t stacksize;          /* Stack size (in bytes) */
+    ABTI_stack_type stacktype; /* Stack type */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABT_bool migratable;                /* Migratability */
-    void (*f_cb)(ABT_thread, void *);   /* Callback function */
-    void *p_cb_arg;                     /* Callback function argument */
+    ABT_bool migratable;              /* Migratability */
+    void (*f_cb)(ABT_thread, void *); /* Callback function */
+    void *p_cb_arg;                   /* Callback function argument */
 #endif
 };
 
 struct ABTI_thread {
-    ABTD_thread_context ctx;        /* Context */
-    ABTI_unit unit_def;             /* Internal unit definition */
-    ABT_thread_state state;         /* State */
-    uint32_t request;               /* Request */
-    ABTI_xstream *p_last_xstream;   /* Last ES where it ran */
+    ABTD_thread_context ctx;      /* Context */
+    ABTI_unit unit_def;           /* Internal unit definition */
+    ABT_thread_state state;       /* State */
+    uint32_t request;             /* Request */
+    ABTI_xstream *p_last_xstream; /* Last ES where it ran */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched;           /* If it is a scheduler, its ptr */
+    ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
 #endif
-    ABT_unit unit;                  /* Unit enclosing this thread */
-    ABTI_pool *p_pool;              /* Associated pool */
-    uint32_t refcount;              /* Reference count */
-    ABTI_thread_type type;          /* Type */
+    ABT_unit unit;         /* Unit enclosing this thread */
+    ABTI_pool *p_pool;     /* Associated pool */
+    uint32_t refcount;     /* Reference count */
+    ABTI_thread_type type; /* Type */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_req_arg *p_req_arg; /* Request argument */
     ABTI_spinlock lock;             /* Spinlock */
 #endif
-    ABTI_ktable *p_keytable;        /* ULT-specific data */
-    ABTI_thread_attr attr;          /* Attributes */
-    ABT_thread_id id;               /* ID */
+    ABTI_ktable *p_keytable; /* ULT-specific data */
+    ABTI_thread_attr attr;   /* Attributes */
+    ABT_thread_id id;        /* ID */
 };
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -364,30 +356,30 @@ struct ABTI_thread_entry {
 };
 
 struct ABTI_task {
-    ABTI_xstream *p_xstream;   /* Associated ES */
-    ABT_task_state state;      /* State */
-    uint32_t request;          /* Request */
-    void (*f_task)(void *);    /* Task function */
-    void *p_arg;               /* Task arguments */
+    ABTI_xstream *p_xstream; /* Associated ES */
+    ABT_task_state state;    /* State */
+    uint32_t request;        /* Request */
+    void (*f_task)(void *);  /* Task function */
+    void *p_arg;             /* Task arguments */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched;      /* If it is a scheduler, its ptr */
+    ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
 #endif
-    ABTI_pool *p_pool;         /* Associated pool */
-    ABT_unit unit;             /* Unit enclosing this task */
-    ABTI_unit unit_def;        /* Internal unit definition */
-    uint32_t refcount;         /* Reference count */
-    ABTI_ktable *p_keytable;   /* Tasklet-specific data */
+    ABTI_pool *p_pool;       /* Associated pool */
+    ABT_unit unit;           /* Unit enclosing this task */
+    ABTI_unit unit_def;      /* Internal unit definition */
+    uint32_t refcount;       /* Reference count */
+    ABTI_ktable *p_keytable; /* Tasklet-specific data */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABT_bool migratable;       /* Migratability */
+    ABT_bool migratable; /* Migratability */
 #endif
-    uint64_t id;               /* ID */
+    uint64_t id; /* ID */
 };
 
 struct ABTI_key {
     void (*f_destructor)(void *value);
     uint32_t id;
-    uint32_t refcount;          /* Reference count */
-    ABT_bool freed;             /* TRUE: freed, FALSE: not */
+    uint32_t refcount; /* Reference count */
+    ABT_bool freed;    /* TRUE: freed, FALSE: not */
 };
 
 struct ABTI_ktelem {
@@ -397,22 +389,22 @@ struct ABTI_ktelem {
 };
 
 struct ABTI_ktable {
-    int size;                   /* size of the table */
-    int num;                    /* number of elements stored */
-    ABTI_ktelem **p_elems;      /* element array */
+    int size;              /* size of the table */
+    int num;               /* number of elements stored */
+    ABTI_ktelem **p_elems; /* element array */
 };
 
 struct ABTI_cond {
     ABTI_spinlock lock;
     ABTI_mutex *p_waiter_mutex;
     size_t num_waiters;
-    ABTI_unit *p_head;          /* Head of waiters */
-    ABTI_unit *p_tail;          /* Tail of waiters */
+    ABTI_unit *p_head; /* Head of waiters */
+    ABTI_unit *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_rwlock {
     ABTI_mutex mutex;
-    ABTI_cond  cond;
+    ABTI_cond cond;
     size_t reader_count;
     int write_flag;
 };
@@ -422,8 +414,8 @@ struct ABTI_eventual {
     ABT_bool ready;
     void *value;
     int nbytes;
-    ABTI_unit *p_head;          /* Head of waiters */
-    ABTI_unit *p_tail;          /* Tail of waiters */
+    ABTI_unit *p_head; /* Head of waiters */
+    ABTI_unit *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_future {
@@ -433,8 +425,8 @@ struct ABTI_future {
     uint32_t compartments;
     void **array;
     void (*p_callback)(void **arg);
-    ABTI_unit *p_head;          /* Head of waiters */
-    ABTI_unit *p_tail;          /* Tail of waiters */
+    ABTI_unit *p_head; /* Head of waiters */
+    ABTI_unit *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_barrier {
@@ -449,7 +441,6 @@ struct ABTI_timer {
     ABTD_time start;
     ABTD_time end;
 };
-
 
 /* Global Data */
 extern ABTI_global *gp_ABTI_global;
@@ -468,7 +459,8 @@ int ABTI_local_finalize(ABTI_local **pp_local);
 /* Execution Stream (ES) */
 int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
                         ABTI_xstream **pp_xstream);
-int ABTI_xstream_create_primary(ABTI_local **pp_local, ABTI_xstream **pp_xstream);
+int ABTI_xstream_create_primary(ABTI_local **pp_local,
+                                ABTI_xstream **pp_xstream);
 int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream);
 int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream,
                                ABTI_thread *p_thread);
@@ -477,8 +469,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream);
 void ABTI_xstream_schedule(void *p_arg);
 int ABTI_xstream_run_unit(ABTI_local **pp_local, ABTI_xstream *p_xstream,
                           ABT_unit unit, ABTI_pool *p_pool);
-int ABTI_xstream_schedule_thread(ABTI_local **pp_local,
-                                 ABTI_xstream *p_xstream,
+int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
                                  ABTI_thread *p_thread);
 void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
                                 ABTI_task *p_task);
@@ -546,33 +537,32 @@ void ABTI_pool_reset_id(void);
 void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 
 /* User-level Thread (ULT)  */
-int   ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
-                                  ABTI_pool *p_pool);
-int   ABTI_thread_create(ABTI_local *p_local, ABTI_pool *p_pool,
-                         void (*thread_func)(void *), void *arg,
-                         ABTI_thread_attr *p_attr, ABTI_thread **pp_newthread);
-int   ABTI_thread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                              ABTI_thread **p_thread);
-int   ABTI_thread_create_main_sched(ABTI_local *p_local,
-                                    ABTI_xstream *p_xstream,
-                                    ABTI_sched *p_sched);
-int   ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
-                               ABTI_sched *p_sched);
-void  ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
-void  ABTI_thread_free_main(ABTI_local *p_local, ABTI_thread *p_thread);
-void  ABTI_thread_free_main_sched(ABTI_local *p_local, ABTI_thread *p_thread);
-int   ABTI_thread_set_blocked(ABTI_thread *p_thread);
-void  ABTI_thread_suspend(ABTI_local **pp_local, ABTI_thread *p_thread);
-int   ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread);
-void  ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
-int   ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
+int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
+                                ABTI_pool *p_pool);
+int ABTI_thread_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                       void (*thread_func)(void *), void *arg,
+                       ABTI_thread_attr *p_attr, ABTI_thread **pp_newthread);
+int ABTI_thread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                            ABTI_thread **p_thread);
+int ABTI_thread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                                  ABTI_sched *p_sched);
+int ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
+                             ABTI_sched *p_sched);
+void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
+void ABTI_thread_free_main(ABTI_local *p_local, ABTI_thread *p_thread);
+void ABTI_thread_free_main_sched(ABTI_local *p_local, ABTI_thread *p_thread);
+int ABTI_thread_set_blocked(ABTI_thread *p_thread);
+void ABTI_thread_suspend(ABTI_local **pp_local, ABTI_thread *p_thread);
+int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread);
+void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
+int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-void  ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
+void ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
 void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);
 #endif
-void  ABTI_thread_retain(ABTI_thread *p_thread);
-void  ABTI_thread_release(ABTI_thread *p_thread);
-void  ABTI_thread_reset_id(void);
+void ABTI_thread_retain(ABTI_thread *p_thread);
+void ABTI_thread_release(ABTI_thread *p_thread);
+void ABTI_thread_reset_id(void);
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread);
 ABT_thread_id ABTI_thread_self_id(ABTI_local *p_local);
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread);
@@ -591,7 +581,7 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
 ABT_bool ABTI_thread_htable_add(ABTI_thread_htable *p_htable, int idx,
                                 ABTI_thread *p_thread);
 void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
-                             ABTI_thread *p_thread);
+                                 ABTI_thread *p_thread);
 ABT_bool ABTI_thread_htable_add_low(ABTI_thread_htable *p_htable, int idx,
                                     ABTI_thread *p_thread);
 ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,

--- a/src/include/abti_barrier.h
+++ b/src/include/abti_barrier.h
@@ -9,8 +9,7 @@
 /* Inlined functions for Barrier */
 
 /* Barrier */
-static inline
-ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
+static inline ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_barrier *p_barrier;
@@ -25,8 +24,7 @@ ABTI_barrier *ABTI_barrier_get_ptr(ABT_barrier barrier)
 #endif
 }
 
-static inline
-ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
+static inline ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_barrier h_barrier;
@@ -42,4 +40,3 @@ ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
 }
 
 #endif /* ABTI_BARRIER_H_INCLUDED */
-

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -10,18 +10,16 @@
 
 /* Inlined functions for Condition Variable  */
 
-static inline
-void ABTI_cond_init(ABTI_cond *p_cond)
+static inline void ABTI_cond_init(ABTI_cond *p_cond)
 {
     ABTI_spinlock_clear(&p_cond->lock);
     p_cond->p_waiter_mutex = NULL;
-    p_cond->num_waiters  = 0;
+    p_cond->num_waiters = 0;
     p_cond->p_head = NULL;
     p_cond->p_tail = NULL;
 }
 
-static inline
-void ABTI_cond_fini(ABTI_cond *p_cond)
+static inline void ABTI_cond_fini(ABTI_cond *p_cond)
 {
     /* The lock needs to be acquired to safely free the condition structure.
      * However, we do not have to unlock it because the entire structure is
@@ -29,8 +27,7 @@ void ABTI_cond_fini(ABTI_cond *p_cond)
     ABTI_spinlock_acquire(&p_cond->lock);
 }
 
-static inline
-ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
+static inline ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_cond *p_cond;
@@ -45,8 +42,7 @@ ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
 #endif
 }
 
-static inline
-ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
+static inline ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_cond h_cond;
@@ -61,9 +57,8 @@ ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 #endif
 }
 
-static inline
-int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
-                   ABTI_mutex *p_mutex)
+static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
+                                 ABTI_mutex *p_mutex)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -138,23 +133,23 @@ int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
 
         /* External thread is waiting here polling ext_signal. */
         /* FIXME: need a better implementation */
-        while (!ABTD_atomic_load_int32(&ext_signal));
+        while (!ABTD_atomic_load_int32(&ext_signal))
+            ;
         ABTU_free(p_unit);
     }
 
     /* Lock the mutex again */
     ABTI_mutex_lock(pp_local, p_mutex);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-static inline
-void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
+static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
 {
     ABTI_spinlock_acquire(&p_cond->lock);
 
@@ -198,4 +193,3 @@ void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
 }
 
 #endif /* ABTI_COND_H_INCLUDED */
-

--- a/src/include/abti_config.h
+++ b/src/include/abti_config.h
@@ -8,8 +8,8 @@
 
 /* Inlined functions for Config */
 
-static inline
-ABTI_sched_config *ABTI_sched_config_get_ptr(ABT_sched_config config)
+static inline ABTI_sched_config *
+ABTI_sched_config_get_ptr(ABT_sched_config config)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_sched_config *p_config;
@@ -24,8 +24,8 @@ ABTI_sched_config *ABTI_sched_config_get_ptr(ABT_sched_config config)
 #endif
 }
 
-static inline
-ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
+static inline ABT_sched_config
+ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_sched_config h_config;
@@ -41,4 +41,3 @@ ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
 }
 
 #endif /* ABTI_CONFIG_H_INCLUDED */
-

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -9,208 +9,207 @@
 #include <assert.h>
 #include <abt_config.h>
 
-
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
 #define ABTI_IS_ERROR_CHECK_ENABLED 1
 #else
 #define ABTI_IS_ERROR_CHECK_ENABLED 0
 #endif
 
-#define ABTI_ASSERT(cond)                  \
-    do {                                   \
-        if (ABTI_IS_ERROR_CHECK_ENABLED) { \
-            assert(cond);                  \
-        }                                  \
-    } while(0)
-
-#define ABTI_STATIC_ASSERT(cond)                \
-    do {                                        \
-        ((void)sizeof(char[2 * !!(cond) - 1])); \
-    } while(0)
-
-#define ABTI_CHECK_INITIALIZED()                                     \
-    do {                                                             \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && gp_ABTI_global == NULL) { \
-            abt_errno = ABT_ERR_UNINITIALIZED;                       \
-            goto fn_fail;                                            \
-        }                                                            \
-    } while(0)
-
-#define ABTI_CHECK_ERROR(abt_errno)                                    \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) { \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_ERROR_MSG(abt_errno, msg)                           \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) { \
-            HANDLE_ERROR(msg);                                         \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_TRUE(cond, val)                                     \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                  \
-            abt_errno = (val);                                         \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_TRUE_RET(cond, val)                                 \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                  \
-            return (val);                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_TRUE_MSG(cond, val, msg)           \
-    do {                                              \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) { \
-            abt_errno = (val);                        \
-            HANDLE_ERROR(msg);                        \
-            goto fn_fail;                             \
-        }                                             \
-    } while(0)
-
-#define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)         \
-    do {                                              \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) { \
-            HANDLE_ERROR(msg);                        \
-            return (val);                             \
-        }                                             \
-    } while(0)
-
-#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                  \
-    do {                                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_xstream *)NULL) { \
-            abt_errno = ABT_ERR_INV_XSTREAM;                            \
-            goto fn_fail;                                               \
-        }                                                               \
-    } while(0)
-
-#define ABTI_CHECK_NULL_POOL_PTR(p)                                  \
-    do {                                                             \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_pool *)NULL) { \
-            abt_errno = ABT_ERR_INV_POOL;                            \
-            goto fn_fail;                                            \
-        }                                                            \
-    } while(0)
-
-#define ABTI_CHECK_NULL_SCHED_PTR(p)                                  \
-    do {                                                              \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_sched *)NULL) { \
-            abt_errno = ABT_ERR_INV_SCHED;                            \
-            goto fn_fail;                                             \
-        }                                                             \
-    } while(0)
-
-#define ABTI_CHECK_NULL_THREAD_PTR(p)                                  \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) { \
-            abt_errno = ABT_ERR_INV_THREAD;                            \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                  \
-    do {                                                                    \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread_attr *)NULL) { \
-            abt_errno = ABT_ERR_INV_THREAD_ATTR;                            \
-            goto fn_fail;                                                   \
-        }                                                                   \
-    } while(0)
-
-#define ABTI_CHECK_NULL_TASK_PTR(p)                                  \
-    do {                                                             \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_task *)NULL) { \
-            abt_errno = ABT_ERR_INV_TASK;                            \
-            goto fn_fail;                                            \
-        }                                                            \
-    } while(0)
-
-#define ABTI_CHECK_NULL_KEY_PTR(p)                                  \
-    do {                                                            \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_key *)NULL) { \
-            abt_errno = ABT_ERR_INV_KEY;                            \
-            goto fn_fail;                                           \
-        }                                                           \
-    } while(0)
-
-#define ABTI_CHECK_NULL_MUTEX_PTR(p)                                  \
-    do {                                                              \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex *)NULL) { \
-            abt_errno = ABT_ERR_INV_MUTEX;                            \
-            goto fn_fail;                                             \
-        }                                                             \
-    } while(0)
-
-#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                  \
-    do {                                                                   \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex_attr *)NULL) { \
-            abt_errno = ABT_ERR_INV_MUTEX_ATTR;                            \
-            goto fn_fail;                                                  \
-        }                                                                  \
-    } while(0)
-
-#define ABTI_CHECK_NULL_COND_PTR(p)                                  \
-    do {                                                             \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_cond *)NULL) { \
-            abt_errno = ABT_ERR_INV_COND;                            \
-            goto fn_fail;                                            \
-        }                                                            \
-    } while(0)
-
-#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                  \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_rwlock *)NULL) { \
-            abt_errno = ABT_ERR_INV_RWLOCK;                            \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_NULL_FUTURE_PTR(p)                                  \
-    do {                                                               \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_future *)NULL) { \
-            abt_errno = ABT_ERR_INV_FUTURE;                            \
-            goto fn_fail;                                              \
-        }                                                              \
-    } while(0)
-
-#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                  \
-    do {                                                                 \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_eventual *)NULL) { \
-            abt_errno = ABT_ERR_INV_EVENTUAL;                            \
-            goto fn_fail;                                                \
-        }                                                                \
-    } while(0)
-
-#define ABTI_CHECK_NULL_BARRIER_PTR(p)                                  \
-    do {                                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_barrier *)NULL) { \
-            abt_errno = ABT_ERR_INV_BARRIER;                            \
-            goto fn_fail;                                               \
-        }                                                               \
+#define ABTI_ASSERT(cond)                                                      \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED) {                                     \
+            assert(cond);                                                      \
+        }                                                                      \
     } while (0)
 
-#define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)      \
-    do {                                            \
-        if (ABTI_IS_ERROR_CHECK_ENABLED             \
-            && p == (ABTI_xstream_barrier *)NULL) { \
-            abt_errno = ABT_ERR_INV_BARRIER;        \
-            goto fn_fail;                           \
-        }                                           \
+#define ABTI_STATIC_ASSERT(cond)                                               \
+    do {                                                                       \
+        ((void)sizeof(char[2 * !!(cond)-1]));                                  \
     } while (0)
 
-#define ABTI_CHECK_NULL_TIMER_PTR(p)                                  \
-    do {                                                              \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_timer *)NULL) { \
-            abt_errno = ABT_ERR_INV_TIMER;                            \
-            goto fn_fail;                                             \
-        }                                                             \
-    } while(0)
+#define ABTI_CHECK_INITIALIZED()                                               \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && gp_ABTI_global == NULL) {           \
+            abt_errno = ABT_ERR_UNINITIALIZED;                                 \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_ERROR(abt_errno)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_ERROR_MSG(abt_errno, msg)                                   \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+            HANDLE_ERROR(msg);                                                 \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_TRUE(cond, val)                                             \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+            abt_errno = (val);                                                 \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_TRUE_RET(cond, val)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+            return (val);                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_TRUE_MSG(cond, val, msg)                                    \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+            abt_errno = (val);                                                 \
+            HANDLE_ERROR(msg);                                                 \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_TRUE_MSG_RET(cond, val, msg)                                \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+            HANDLE_ERROR(msg);                                                 \
+            return (val);                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_xstream *)NULL) {        \
+            abt_errno = ABT_ERR_INV_XSTREAM;                                   \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_POOL_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_pool *)NULL) {           \
+            abt_errno = ABT_ERR_INV_POOL;                                      \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_SCHED_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_sched *)NULL) {          \
+            abt_errno = ABT_ERR_INV_SCHED;                                     \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
+            abt_errno = ABT_ERR_INV_THREAD;                                    \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                     \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread_attr *)NULL) {    \
+            abt_errno = ABT_ERR_INV_THREAD_ATTR;                               \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_task *)NULL) {           \
+            abt_errno = ABT_ERR_INV_TASK;                                      \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_KEY_PTR(p)                                             \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_key *)NULL) {            \
+            abt_errno = ABT_ERR_INV_KEY;                                       \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_MUTEX_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex *)NULL) {          \
+            abt_errno = ABT_ERR_INV_MUTEX;                                     \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                      \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex_attr *)NULL) {     \
+            abt_errno = ABT_ERR_INV_MUTEX_ATTR;                                \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_COND_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_cond *)NULL) {           \
+            abt_errno = ABT_ERR_INV_COND;                                      \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_rwlock *)NULL) {         \
+            abt_errno = ABT_ERR_INV_RWLOCK;                                    \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_FUTURE_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_future *)NULL) {         \
+            abt_errno = ABT_ERR_INV_FUTURE;                                    \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                        \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_eventual *)NULL) {       \
+            abt_errno = ABT_ERR_INV_EVENTUAL;                                  \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_BARRIER_PTR(p)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_barrier *)NULL) {        \
+            abt_errno = ABT_ERR_INV_BARRIER;                                   \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)                                 \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            p == (ABTI_xstream_barrier *)NULL) {                               \
+            abt_errno = ABT_ERR_INV_BARRIER;                                   \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_TIMER_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_timer *)NULL) {          \
+            abt_errno = ABT_ERR_INV_TIMER;                                     \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
 
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
 #define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 1
@@ -218,26 +217,26 @@
 #define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 0
 #endif
 
-#define HANDLE_WARNING(msg)                                           \
-    do {                                                              \
-        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                        \
-            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); \
-        }                                                             \
-    } while(0)
+#define HANDLE_WARNING(msg)                                                    \
+    do {                                                                       \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                                 \
+            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg);          \
+        }                                                                      \
+    } while (0)
 
-#define HANDLE_ERROR(msg)                                             \
-    do {                                                              \
-        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                        \
-            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); \
-        }                                                             \
-    } while(0)
+#define HANDLE_ERROR(msg)                                                      \
+    do {                                                                       \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                                 \
+            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg);          \
+        }                                                                      \
+    } while (0)
 
-#define HANDLE_ERROR_WITH_CODE(msg, n)                                       \
-    do {                                                                     \
-        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                               \
-            fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n); \
-        }                                                                    \
-    } while(0)
+#define HANDLE_ERROR_WITH_CODE(msg, n)                                         \
+    do {                                                                       \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                                 \
+            fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n);   \
+        }                                                                      \
+    } while (0)
 
 #define HANDLE_ERROR_FUNC_WITH_CODE(n)                                         \
     do {                                                                       \
@@ -245,6 +244,6 @@
             fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__,  \
                     n);                                                        \
         }                                                                      \
-    } while(0)
+    } while (0)
 
 #endif /* ABTI_ERROR_H_INCLUDED */

--- a/src/include/abti_eventual.h
+++ b/src/include/abti_eventual.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Eventual */
 
-static inline
-ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
+static inline ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_eventual *p_eventual;
@@ -24,8 +23,7 @@ ABTI_eventual *ABTI_eventual_get_ptr(ABT_eventual eventual)
 #endif
 }
 
-static inline
-ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
+static inline ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_eventual h_eventual;
@@ -41,4 +39,3 @@ ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
 }
 
 #endif /* ABTI_EVENTUAL_H_INCLUDED */
-

--- a/src/include/abti_future.h
+++ b/src/include/abti_future.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Future */
 
-static inline
-ABTI_future *ABTI_future_get_ptr(ABT_future future)
+static inline ABTI_future *ABTI_future_get_ptr(ABT_future future)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_future *p_future;
@@ -24,8 +23,7 @@ ABTI_future *ABTI_future_get_ptr(ABT_future future)
 #endif
 }
 
-static inline
-ABT_future ABTI_future_get_handle(ABTI_future *p_future)
+static inline ABT_future ABTI_future_get_handle(ABTI_future *p_future)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_future h_future;
@@ -41,4 +39,3 @@ ABT_future ABTI_future_get_handle(ABTI_future *p_future)
 }
 
 #endif /* ABTI_FUTURE_H_INCLUDED */
-

--- a/src/include/abti_global.h
+++ b/src/include/abti_global.h
@@ -8,47 +8,39 @@
 
 /* Inlined functions for Global Data */
 
-static inline
-size_t ABTI_global_get_thread_stacksize(void)
+static inline size_t ABTI_global_get_thread_stacksize(void)
 {
     return gp_ABTI_global->thread_stacksize;
 }
 
-static inline
-size_t ABTI_global_get_sched_stacksize(void)
+static inline size_t ABTI_global_get_sched_stacksize(void)
 {
     return gp_ABTI_global->sched_stacksize;
 }
 
-static inline
-size_t ABTI_global_get_sched_event_freq(void)
+static inline size_t ABTI_global_get_sched_event_freq(void)
 {
     return gp_ABTI_global->sched_event_freq;
 }
 
-static inline
-long ABTI_global_get_sched_sleep_nsec(void)
+static inline long ABTI_global_get_sched_sleep_nsec(void)
 {
     return gp_ABTI_global->sched_sleep_nsec;
 }
 
-static inline
-ABTI_thread *ABTI_global_get_main(void)
+static inline ABTI_thread *ABTI_global_get_main(void)
 {
     return gp_ABTI_global->p_thread_main;
 }
 
-static inline
-uint32_t ABTI_global_get_mutex_max_handovers(void)
+static inline uint32_t ABTI_global_get_mutex_max_handovers(void)
 {
     return gp_ABTI_global->mutex_max_handovers;
 }
 
-static inline
-uint32_t ABTI_global_get_mutex_max_wakeups(void)
+static inline uint32_t ABTI_global_get_mutex_max_wakeups(void)
 {
     return gp_ABTI_global->mutex_max_wakeups;
 }
 
 #endif /* ABTI_GLOBAL_H_INCLUDED */
-

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Work unit-specific data key */
 
-static inline
-ABTI_key *ABTI_key_get_ptr(ABT_key key)
+static inline ABTI_key *ABTI_key_get_ptr(ABT_key key)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_key *p_key;
@@ -24,8 +23,7 @@ ABTI_key *ABTI_key_get_ptr(ABT_key key)
 #endif
 }
 
-static inline
-ABT_key ABTI_key_get_handle(ABTI_key *p_key)
+static inline ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_key h_key;
@@ -41,4 +39,3 @@ ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 }
 
 #endif /* ABTI_KEY_H_INCLUDED */
-

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -68,8 +68,7 @@ static inline void ABTI_local_set_local(ABTI_local *p_local)
  */
 static inline void *ABTI_local_get_local_ptr(void)
 {
-	return gp_ABTI_local_func.get_local_ptr_f();
+    return gp_ABTI_local_func.get_local_ptr_f();
 }
 
 #endif /* ABTI_LOCAL_H_INCLUDED */
-

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -36,20 +36,19 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
     return lp_ABTI_log->p_sched;
 }
 
-#define ABTI_LOG_INIT()             ABTI_log_init()
-#define ABTI_LOG_FINALIZE()         ABTI_log_finalize()
-#define ABTI_LOG_SET_SCHED(s)       ABTI_log_set_sched(s)
-#define ABTI_LOG_GET_SCHED(ret)     ret = ABTI_log_get_sched()
-#define LOG_EVENT(fmt,...)          ABTI_log_event(stderr,fmt,__VA_ARGS__)
-#define LOG_DEBUG(fmt,...)          \
-    ABTI_log_debug(stderr,__FILE__,__LINE__,fmt,__VA_ARGS__)
+#define ABTI_LOG_INIT() ABTI_log_init()
+#define ABTI_LOG_FINALIZE() ABTI_log_finalize()
+#define ABTI_LOG_SET_SCHED(s) ABTI_log_set_sched(s)
+#define ABTI_LOG_GET_SCHED(ret) ret = ABTI_log_get_sched()
+#define LOG_EVENT(fmt, ...) ABTI_log_event(stderr, fmt, __VA_ARGS__)
+#define LOG_DEBUG(fmt, ...)                                                    \
+    ABTI_log_debug(stderr, __FILE__, __LINE__, fmt, __VA_ARGS__)
 
-#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)    \
+#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)                          \
     ABTI_log_pool_push(p_pool, unit, produer_id)
-#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id) \
+#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id)                       \
     ABTI_log_pool_remove(p_pool, unit, consumer_id)
-#define LOG_EVENT_POOL_POP(p_pool, unit) \
-    ABTI_log_pool_pop(p_pool, unit)
+#define LOG_EVENT_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
 
 #else
 
@@ -58,8 +57,8 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
 #define ABTI_LOG_SET_SCHED(s)
 #define ABTI_LOG_GET_SCHED(ret)
 
-#define LOG_EVENT(fmt,...)
-#define LOG_DEBUG(fmt,...)
+#define LOG_EVENT(fmt, ...)
+#define LOG_DEBUG(fmt, ...)
 
 #define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)
 #define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id)

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -9,13 +9,14 @@
 /* Memory allocation */
 
 /* Header size should be a multiple of cache line size. It is constant. */
-#define ABTI_MEM_SH_SIZE (((sizeof(ABTI_thread) + sizeof(ABTI_stack_header) \
-                            + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) \
-                           / ABT_CONFIG_STATIC_CACHELINE_SIZE) \
-                          * ABT_CONFIG_STATIC_CACHELINE_SIZE)
+#define ABTI_MEM_SH_SIZE                                                       \
+    (((sizeof(ABTI_thread) + sizeof(ABTI_stack_header) +                       \
+       ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) /                                 \
+      ABT_CONFIG_STATIC_CACHELINE_SIZE) *                                      \
+     ABT_CONFIG_STATIC_CACHELINE_SIZE)
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-typedef struct ABTI_blk_header  ABTI_blk_header;
+typedef struct ABTI_blk_header ABTI_blk_header;
 
 enum {
     ABTI_MEM_LP_MALLOC = 0,
@@ -26,13 +27,13 @@ enum {
 };
 
 struct ABTI_sp_header {
-    uint32_t num_total_stacks;  /* Number of total stacks */
-    uint32_t num_empty_stacks;  /* Number of empty stacks */
-    size_t stacksize;           /* Stack size */
-    uint64_t id;                /* ID */
-    ABT_bool is_mmapped;        /* ABT_TRUE if it is mmapped */
-    void *p_sp;                 /* Pointer to the allocated stack page */
-    ABTI_sp_header *p_next;     /* Next stack page header */
+    uint32_t num_total_stacks; /* Number of total stacks */
+    uint32_t num_empty_stacks; /* Number of empty stacks */
+    size_t stacksize;          /* Stack size */
+    uint64_t id;               /* ID */
+    ABT_bool is_mmapped;       /* ABT_TRUE if it is mmapped */
+    void *p_sp;                /* Pointer to the allocated stack page */
+    ABTI_sp_header *p_next;    /* Next stack page header */
 };
 
 struct ABTI_stack_header {
@@ -42,21 +43,21 @@ struct ABTI_stack_header {
 };
 
 struct ABTI_page_header {
-    uint32_t blk_size;          /* Block size in bytes */
-    uint32_t num_total_blks;    /* Number of total blocks */
-    uint32_t num_empty_blks;    /* Number of empty blocks */
-    uint32_t num_remote_free;   /* Number of remote free blocks */
-    ABTI_blk_header *p_head;    /* First empty block */
-    ABTI_blk_header *p_free;    /* For remote free */
+    uint32_t blk_size;              /* Block size in bytes */
+    uint32_t num_total_blks;        /* Number of total blocks */
+    uint32_t num_empty_blks;        /* Number of empty blocks */
+    uint32_t num_remote_free;       /* Number of remote free blocks */
+    ABTI_blk_header *p_head;        /* First empty block */
+    ABTI_blk_header *p_free;        /* For remote free */
     ABTI_native_thread_id owner_id; /* Owner's ID */
-    ABTI_page_header *p_prev;   /* Prev page header */
-    ABTI_page_header *p_next;   /* Next page header */
-    ABT_bool is_mmapped;        /* ABT_TRUE if it is mmapped */
+    ABTI_page_header *p_prev;       /* Prev page header */
+    ABTI_page_header *p_next;       /* Next page header */
+    ABT_bool is_mmapped;            /* ABT_TRUE if it is mmapped */
 };
 
 struct ABTI_blk_header {
-    ABTI_page_header *p_ph;     /* Page header */
-    ABTI_blk_header *p_next;    /* Next block header */
+    ABTI_page_header *p_ph;  /* Page header */
+    ABTI_blk_header *p_next; /* Next block header */
 };
 
 void ABTI_mem_init(ABTI_global *p_global);
@@ -74,7 +75,6 @@ void ABTI_mem_free_remote(ABTI_page_header *p_ph, ABTI_blk_header *p_bh);
 ABTI_page_header *ABTI_mem_take_global_page(ABTI_local *p_local);
 
 char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize);
-
 
 /******************************************************************************
  * Unless the stack is given by the user, we allocate a stack first and then
@@ -94,9 +94,8 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize);
  *****************************************************************************/
 
 /* Inline functions */
-static inline
-ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
-                                                  ABTI_thread_attr *p_attr)
+static inline ABTI_thread *
+ABTI_mem_alloc_thread_with_stacksize(size_t stacksize, ABTI_thread_attr *p_attr)
 {
     size_t actual_stacksize;
     char *p_blk;
@@ -131,9 +130,8 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
-                                   ABTI_thread_attr *p_attr)
+static inline ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
+                                                 ABTI_thread_attr *p_attr)
 {
     /* Basic idea: allocate a memory for stack and use the first some memory as
      * ABTI_stack_header and ABTI_thread. So, the effective stack area is
@@ -212,7 +210,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
 
     /* Get the ABTI_thread pointer and stack pointer */
     p_thread = (ABTI_thread *)p_blk;
-    p_stack  = p_sh->p_stack;
+    p_stack = p_sh->p_stack;
 
     /* Set attributes */
     if (p_attr == NULL) {
@@ -229,8 +227,8 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
     return p_thread;
 }
 
-static inline
-void ABTI_mem_free_thread(ABTI_local *p_local, ABTI_thread *p_thread)
+static inline void ABTI_mem_free_thread(ABTI_local *p_local,
+                                        ABTI_thread *p_thread)
 {
     ABTI_stack_header *p_sh;
     ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
@@ -259,8 +257,7 @@ void ABTI_mem_free_thread(ABTI_local *p_local, ABTI_thread *p_thread)
     }
 }
 
-static inline
-ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
+static inline ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
 {
     ABTI_task *p_task = NULL;
     const size_t blk_size = sizeof(ABTI_blk_header) + sizeof(ABTI_task);
@@ -279,7 +276,8 @@ ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
     /* Find the page that has an empty block */
     ABTI_page_header *p_ph = p_local->p_mem_task_head;
     while (p_ph) {
-        if (p_ph->p_head) break;
+        if (p_ph->p_head)
+            break;
         if (p_ph->p_free) {
             ABTI_mem_take_free(p_ph);
             break;
@@ -315,8 +313,7 @@ ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
     return p_task;
 }
 
-static inline
-void ABTI_mem_free_task(ABTI_local *p_local, ABTI_task *p_task)
+static inline void ABTI_mem_free_task(ABTI_local *p_local, ABTI_task *p_task)
 {
     ABTI_blk_header *p_head;
     ABTI_page_header *p_ph;
@@ -357,8 +354,8 @@ void ABTI_mem_free_task(ABTI_local *p_local, ABTI_task *p_task)
 #define ABTI_mem_finalize(p)
 #define ABTI_mem_finalize_local(p)
 
-static inline
-ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
+static inline ABTI_thread *
+ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
 {
     size_t stacksize, actual_stacksize;
     char *p_blk;
@@ -384,8 +381,8 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t *p_stacksize)
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
+static inline ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr,
+                                                 size_t *p_stacksize)
 {
     ABTI_thread *p_thread;
 
@@ -418,8 +415,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABT_thread_attr attr, size_t *p_stacksize)
     return p_thread;
 }
 
-static inline
-ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
+static inline ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
 {
     ABTI_thread *p_thread;
 
@@ -433,21 +429,18 @@ ABTI_thread *ABTI_mem_alloc_main_thread(ABT_thread_attr attr)
     return p_thread;
 }
 
-static inline
-void ABTI_mem_free_thread(ABTI_thread *p_thread)
+static inline void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
     ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
     ABTU_free(p_thread);
 }
 
-static inline
-ABTI_task *ABTI_mem_alloc_task(void)
+static inline ABTI_task *ABTI_mem_alloc_task(void)
 {
     return (ABTI_task *)ABTU_malloc(sizeof(ABTI_task));
 }
 
-static inline
-void ABTI_mem_free_task(ABTI_task *p_task)
+static inline void ABTI_mem_free_task(ABTI_task *p_task)
 {
     ABTU_free(p_task);
 }
@@ -455,4 +448,3 @@ void ABTI_mem_free_task(ABTI_task *p_task)
 #endif /* ABT_CONFIG_USE_MEM_POOL */
 
 #endif /* ABTI_MEM_H_INCLUDED */
-

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -6,8 +6,7 @@
 #ifndef ABTI_MUTEX_H_INCLUDED
 #define ABTI_MUTEX_H_INCLUDED
 
-static inline
-ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
+static inline ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_mutex *p_mutex;
@@ -22,8 +21,7 @@ ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
 #endif
 }
 
-static inline
-ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
+static inline ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_mutex h_mutex;
@@ -38,8 +36,7 @@ ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline
-void ABTI_mutex_init(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_init(ABTI_mutex *p_mutex)
 {
     p_mutex->val = 0;
     p_mutex->attr.attrs = ABTI_MUTEX_ATTR_NONE;
@@ -55,26 +52,24 @@ void ABTI_mutex_init(ABTI_mutex *p_mutex)
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
 #define ABTI_mutex_fini(p_mutex)
 #else
-static inline
-void ABTI_mutex_fini(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_fini(ABTI_mutex *p_mutex)
 {
     ABTI_thread_htable_free(p_mutex->p_htable);
 }
 #endif
 
-static inline
-void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
 {
     /* ABTI_spinlock_ functions cannot be used since p_mutex->val can take
      * other values (i.e., not UNLOCKED nor LOCKED.) */
     while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-        while (ABTD_atomic_load_uint32(&p_mutex->val) != 0);
+        while (ABTD_atomic_load_uint32(&p_mutex->val) != 0)
+            ;
     }
     LOG_EVENT("%p: spinlock\n", p_mutex);
 }
 
-static inline
-void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTI_local *p_local = *pp_local;
@@ -118,7 +113,8 @@ void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                         ABTI_thread *p_giver = p_mutex->p_giver;
                         p_giver->state = ABT_THREAD_STATE_READY;
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
-                            ABTI_self_get_native_thread_id(*pp_local));
+                                       ABTI_self_get_native_thread_id(
+                                           *pp_local));
                         break;
                     }
                 }
@@ -131,17 +127,16 @@ void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
         ABTI_mutex_spinlock(p_mutex);
     }
 
-  fn_exit:
-    return ;
+fn_exit:
+    return;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
 }
 
-static inline
-int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
+static inline int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
 {
     if (!ABTD_atomic_bool_cas_strong_uint32(&p_mutex->val, 0, 1)) {
         return ABT_ERR_MUTEX_LOCKED;
@@ -149,8 +144,7 @@ int ABTI_mutex_trylock(ABTI_mutex *p_mutex)
     return ABT_SUCCESS;
 }
 
-static inline
-void ABTI_mutex_unlock(ABTI_local *p_local, ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_unlock(ABTI_local *p_local, ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTD_atomic_mem_barrier();
@@ -167,11 +161,10 @@ void ABTI_mutex_unlock(ABTI_local *p_local, ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline
-ABT_bool ABTI_mutex_equal(ABTI_mutex *p_mutex1, ABTI_mutex *p_mutex2)
+static inline ABT_bool ABTI_mutex_equal(ABTI_mutex *p_mutex1,
+                                        ABTI_mutex *p_mutex2)
 {
     return (p_mutex1 == p_mutex2) ? ABT_TRUE : ABT_FALSE;
 }
 
 #endif /* ABTI_MUTEX_H_INCLUDED */
-

--- a/src/include/abti_mutex_attr.h
+++ b/src/include/abti_mutex_attr.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for mutex attributes */
 
-static inline
-ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
+static inline ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_mutex_attr *p_attr;
@@ -24,8 +23,7 @@ ABTI_mutex_attr *ABTI_mutex_attr_get_ptr(ABT_mutex_attr attr)
 #endif
 }
 
-static inline
-ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
+static inline ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_mutex_attr h_attr;
@@ -40,8 +38,7 @@ ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
 #endif
 }
 
-#define ABTI_mutex_attr_copy(p_dest,p_src)              \
+#define ABTI_mutex_attr_copy(p_dest, p_src)                                    \
     memcpy(p_dest, p_src, sizeof(ABTI_mutex_attr))
 
 #endif /* ABTI_MUTEX_ATTR_H_INCLUDED */
-

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Pool */
 
-static inline
-ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
+static inline ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_pool *p_pool;
@@ -24,8 +23,7 @@ ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
 #endif
 }
 
-static inline
-ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
+static inline ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_pool h_pool;
@@ -41,46 +39,40 @@ ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
 }
 
 /* A ULT is blocked and is waiting for going back to this pool */
-static inline
-void ABTI_pool_inc_num_blocked(ABTI_pool *p_pool)
+static inline void ABTI_pool_inc_num_blocked(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_uint32(&p_pool->num_blocked, 1);
 }
 
 /* A blocked ULT is back in the pool */
-static inline
-void ABTI_pool_dec_num_blocked(ABTI_pool *p_pool)
+static inline void ABTI_pool_dec_num_blocked(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_sub_uint32(&p_pool->num_blocked, 1);
 }
 
 /* The pool will receive a migrated ULT */
-static inline
-void ABTI_pool_inc_num_migrations(ABTI_pool *p_pool)
+static inline void ABTI_pool_inc_num_migrations(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_int32(&p_pool->num_migrations, 1);
 }
 
 /* The pool has received a migrated ULT */
-static inline
-void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
+static inline void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_sub_int32(&p_pool->num_migrations, 1);
 }
 
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-static inline
-void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
+static inline void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 {
     LOG_EVENT_POOL_PUSH(p_pool, unit,
-        ABTI_self_get_native_thread_id(ABTI_local_get_local()));
+                        ABTI_self_get_native_thread_id(ABTI_local_get_local()));
 
     /* Push unit into pool */
     p_pool->p_push(ABTI_pool_get_handle(p_pool), unit);
 }
 
-static inline
-void ABTI_pool_add_thread(ABTI_thread *p_thread)
+static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
 {
     /* Set the ULT's state as READY */
     p_thread->state = ABT_THREAD_STATE_READY;
@@ -89,16 +81,15 @@ void ABTI_pool_add_thread(ABTI_thread *p_thread)
     ABTI_pool_push(p_thread->p_pool, p_thread->unit);
 }
 
-#define ABTI_POOL_PUSH(p_pool,unit,p_producer)      \
-    ABTI_pool_push(p_pool, unit)
+#define ABTI_POOL_PUSH(p_pool, unit, p_producer) ABTI_pool_push(p_pool, unit)
 
-#define ABTI_POOL_ADD_THREAD(p_thread,p_producer)   \
+#define ABTI_POOL_ADD_THREAD(p_thread, p_producer)                             \
     ABTI_pool_add_thread(p_thread)
 
 #else /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
 
-static inline
-int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit, ABTI_native_thread_id producer_id)
+static inline int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit,
+                                 ABTI_native_thread_id producer_id)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -111,16 +102,16 @@ int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit, ABTI_native_thread_id produ
     /* Push unit into pool */
     p_pool->p_push(ABTI_pool_get_handle(p_pool), unit);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-static inline
-int ABTI_pool_add_thread(ABTI_thread *p_thread, ABTI_native_thread_id producer_id)
+static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
+                                       ABTI_native_thread_id producer_id)
 {
     int abt_errno;
 
@@ -131,57 +122,56 @@ int ABTI_pool_add_thread(ABTI_thread *p_thread, ABTI_native_thread_id producer_i
     abt_errno = ABTI_pool_push(p_thread->p_pool, p_thread->unit, producer_id);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-#define ABTI_POOL_PUSH(p_pool,unit,producer_id)                  \
-    do {                                                         \
-        abt_errno = ABTI_pool_push(p_pool, unit, producer_id);   \
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_pool_push");       \
-    } while(0)
+#define ABTI_POOL_PUSH(p_pool, unit, producer_id)                              \
+    do {                                                                       \
+        abt_errno = ABTI_pool_push(p_pool, unit, producer_id);                 \
+        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_pool_push");                     \
+    } while (0)
 
-#define ABTI_POOL_ADD_THREAD(p_thread,producer_id)               \
-    do {                                                         \
-        abt_errno = ABTI_pool_add_thread(p_thread, producer_id); \
-        ABTI_CHECK_ERROR(abt_errno);                             \
-    } while(0)
+#define ABTI_POOL_ADD_THREAD(p_thread, producer_id)                            \
+    do {                                                                       \
+        abt_errno = ABTI_pool_add_thread(p_thread, producer_id);               \
+        ABTI_CHECK_ERROR(abt_errno);                                           \
+    } while (0)
 
 #endif /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
 
 #ifdef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-static inline
-int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
+static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 {
     int abt_errno = ABT_SUCCESS;
 
     LOG_EVENT_POOL_REMOVE(p_pool, unit,
-        ABTI_self_get_native_thread_id(ABTI_local_get_local()));
+                          ABTI_self_get_native_thread_id(
+                              ABTI_local_get_local()));
 
     abt_errno = p_pool->p_remove(ABTI_pool_get_handle(p_pool), unit);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-#define ABTI_POOL_REMOVE(p_pool,unit,consumer_id)    \
+#define ABTI_POOL_REMOVE(p_pool, unit, consumer_id)                            \
     ABTI_pool_remove(p_pool, unit)
-#define ABTI_POOL_SET_CONSUMER(p_pool,consumer_id)
+#define ABTI_POOL_SET_CONSUMER(p_pool, consumer_id)
 
 #else /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
-static inline
-int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                     ABTI_native_thread_id consumer_id)
+static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
+                                   ABTI_native_thread_id consumer_id)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -193,26 +183,26 @@ int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
     abt_errno = p_pool->p_remove(ABTI_pool_get_handle(p_pool), unit);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-#define ABTI_POOL_REMOVE(p_pool,unit,consumer_id)                \
+#define ABTI_POOL_REMOVE(p_pool, unit, consumer_id)                            \
     ABTI_pool_remove(p_pool, unit, consumer_id)
-#define ABTI_POOL_SET_CONSUMER(p_pool,consumer_id)               \
-    do {                                                         \
-        abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id); \
-        ABTI_CHECK_ERROR(abt_errno);                             \
-    } while(0)
+#define ABTI_POOL_SET_CONSUMER(p_pool, consumer_id)                            \
+    do {                                                                       \
+        abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);               \
+        ABTI_CHECK_ERROR(abt_errno);                                           \
+    } while (0)
 
 #endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
-static inline
-ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs)
+static inline ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool,
+                                               double abstime_secs)
 {
     ABT_unit unit;
 
@@ -222,8 +212,7 @@ ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs)
     return unit;
 }
 
-static inline
-ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
+static inline ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
 {
     ABT_unit unit;
 
@@ -235,29 +224,25 @@ ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
 
 /* Increase num_scheds to mark the pool as having another scheduler. If the
  * pool is not available, it returns ABT_ERR_INV_POOL_ACCESS.  */
-static inline
-void ABTI_pool_retain(ABTI_pool *p_pool)
+static inline void ABTI_pool_retain(ABTI_pool *p_pool)
 {
     ABTD_atomic_fetch_add_int32(&p_pool->num_scheds, 1);
 }
 
 /* Decrease the num_scheds to release this pool from a scheduler. Call when
  * the pool is removed from a scheduler or when it stops. */
-static inline
-int32_t ABTI_pool_release(ABTI_pool *p_pool)
+static inline int32_t ABTI_pool_release(ABTI_pool *p_pool)
 {
     ABTI_ASSERT(p_pool->num_scheds > 0);
     return ABTD_atomic_fetch_sub_int32(&p_pool->num_scheds, 1) - 1;
 }
 
-static inline
-size_t ABTI_pool_get_size(ABTI_pool *p_pool)
+static inline size_t ABTI_pool_get_size(ABTI_pool *p_pool)
 {
     return p_pool->p_get_size(ABTI_pool_get_handle(p_pool));
 }
 
-static inline
-size_t ABTI_pool_get_total_size(ABTI_pool *p_pool)
+static inline size_t ABTI_pool_get_total_size(ABTI_pool *p_pool)
 {
     size_t total_size;
     total_size = ABTI_pool_get_size(p_pool);
@@ -267,4 +252,3 @@ size_t ABTI_pool_get_total_size(ABTI_pool *p_pool)
 }
 
 #endif /* ABTI_POOL_H_INCLUDED */
-

--- a/src/include/abti_rwlock.h
+++ b/src/include/abti_rwlock.h
@@ -11,8 +11,7 @@
 
 /* Inlined functions for RWLock */
 
-static inline
-ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
+static inline ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_rwlock *p_rwlock;
@@ -27,8 +26,7 @@ ABTI_rwlock *ABTI_rwlock_get_ptr(ABT_rwlock rwlock)
 #endif
 }
 
-static inline
-ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
+static inline ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_rwlock h_rwlock;
@@ -43,8 +41,7 @@ ABT_rwlock ABTI_rwlock_get_handle(ABTI_rwlock *p_rwlock)
 #endif
 }
 
-static inline
-void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_init(&p_rwlock->mutex);
     ABTI_cond_init(&p_rwlock->cond);
@@ -52,15 +49,14 @@ void ABTI_rwlock_init(ABTI_rwlock *p_rwlock)
     p_rwlock->write_flag = 0;
 }
 
-static inline
-void ABTI_rwlock_fini(ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_fini(ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_fini(&p_rwlock->mutex);
     ABTI_cond_fini(&p_rwlock->cond);
 }
 
-static inline
-int ABTI_rwlock_rdlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
+static inline int ABTI_rwlock_rdlock(ABTI_local **pp_local,
+                                     ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -78,14 +74,14 @@ int ABTI_rwlock_rdlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
     return abt_errno;
 }
 
-static inline
-int ABTI_rwlock_wrlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
+static inline int ABTI_rwlock_wrlock(ABTI_local **pp_local,
+                                     ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_mutex_lock(pp_local, &p_rwlock->mutex);
 
-    while ((p_rwlock->write_flag || p_rwlock->reader_count)
-            && abt_errno == ABT_SUCCESS) {
+    while ((p_rwlock->write_flag || p_rwlock->reader_count) &&
+           abt_errno == ABT_SUCCESS) {
         abt_errno = ABTI_cond_wait(pp_local, &p_rwlock->cond, &p_rwlock->mutex);
     }
 
@@ -97,15 +93,14 @@ int ABTI_rwlock_wrlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
     return abt_errno;
 }
 
-static inline
-void ABTI_rwlock_unlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
+static inline void ABTI_rwlock_unlock(ABTI_local **pp_local,
+                                      ABTI_rwlock *p_rwlock)
 {
     ABTI_mutex_lock(pp_local, &p_rwlock->mutex);
 
     if (p_rwlock->write_flag) {
         p_rwlock->write_flag = 0;
-    }
-    else {
+    } else {
         p_rwlock->reader_count--;
     }
 
@@ -117,4 +112,3 @@ void ABTI_rwlock_unlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
 }
 
 #endif /* ABTI_RWLOCK_H_INCLUDED */
-

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Scheduler */
 
-static inline
-ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
+static inline ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_sched *p_sched;
@@ -24,8 +23,7 @@ ABTI_sched *ABTI_sched_get_ptr(ABT_sched sched)
 #endif
 }
 
-static inline
-ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
+static inline ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_sched h_sched;
@@ -42,8 +40,8 @@ ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 
 /* Set `used` of p_sched to NOT_USED and free p_sched if its `automatic` is
  * ABT_TRUE, which means it is safe to free p_sched inside the runtime. */
-static inline
-int ABTI_sched_discard_and_free(ABTI_local *p_local, ABTI_sched *p_sched)
+static inline int ABTI_sched_discard_and_free(ABTI_local *p_local,
+                                              ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     p_sched->used = ABTI_SCHED_NOT_USED;
@@ -53,20 +51,17 @@ int ABTI_sched_discard_and_free(ABTI_local *p_local, ABTI_sched *p_sched)
     return abt_errno;
 }
 
-static inline
-void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)
+static inline void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_sched->request, req);
 }
 
-static inline
-void ABTI_sched_unset_request(ABTI_sched *p_sched, uint32_t req)
+static inline void ABTI_sched_unset_request(ABTI_sched *p_sched, uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_sched->request, ~req);
 }
 
-static inline
-ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
+static inline ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
 {
     int p;
     size_t s;
@@ -75,23 +70,25 @@ ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
         ABT_pool pool = p_sched->pools[p];
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
         s = ABTI_pool_get_size(p_pool);
-        if (s > 0) return ABT_TRUE;
+        if (s > 0)
+            return ABT_TRUE;
     }
 
     return ABT_FALSE;
 }
 
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
-#define CNT_DECL(c)         int c
-#define CNT_INIT(c,v)       c = v
-#define CNT_INC(c)          c++
-#define SCHED_SLEEP(c,t)    if (c == 0) nanosleep(&(t), NULL)
+#define CNT_DECL(c) int c
+#define CNT_INIT(c, v) c = v
+#define CNT_INC(c) c++
+#define SCHED_SLEEP(c, t)                                                      \
+    if (c == 0)                                                                \
+    nanosleep(&(t), NULL)
 #else
 #define CNT_DECL(c)
-#define CNT_INIT(c,v)
+#define CNT_INIT(c, v)
 #define CNT_INC(c)
-#define SCHED_SLEEP(c,t)
+#define SCHED_SLEEP(c, t)
 #endif
 
 #endif /* ABTI_SCHED_H_INCLUDED */
-

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -6,8 +6,8 @@
 #ifndef ABTI_SELF_H_INCLUDED
 #define ABTI_SELF_H_INCLUDED
 
-static inline
-ABTI_native_thread_id ABTI_self_get_native_thread_id(ABTI_local *p_local)
+static inline ABTI_native_thread_id
+ABTI_self_get_native_thread_id(ABTI_local *p_local)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
@@ -20,8 +20,7 @@ ABTI_native_thread_id ABTI_self_get_native_thread_id(ABTI_local *p_local)
     return (ABTI_native_thread_id)p_local->p_xstream;
 }
 
-static inline
-ABTI_unit_id ABTI_self_get_unit_id(ABTI_local *p_local)
+static inline ABTI_unit_id ABTI_self_get_unit_id(ABTI_local *p_local)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
@@ -44,8 +43,7 @@ ABTI_unit_id ABTI_self_get_unit_id(ABTI_local *p_local)
     return id;
 }
 
-static inline
-ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
+static inline ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
@@ -67,4 +65,3 @@ ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
 }
 
 #endif /* ABTI_SELF_H_INCLUDED */
-

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -10,7 +10,10 @@ struct ABTI_spinlock {
     uint8_t val;
 };
 
-#define ABTI_SPINLOCK_STATIC_INITIALIZER() {0}
+#define ABTI_SPINLOCK_STATIC_INITIALIZER()                                     \
+    {                                                                          \
+        0                                                                      \
+    }
 
 static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 {
@@ -20,7 +23,8 @@ static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_lock->val)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_lock->val) != 0);
+        while (ABTD_atomic_load_uint8((uint8_t *)&p_lock->val) != 0)
+            ;
     }
 }
 

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Execution Stream (ES) */
 
-static inline
-ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
+static inline ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_xstream *p_xstream;
@@ -24,8 +23,7 @@ ABTI_xstream *ABTI_xstream_get_ptr(ABT_xstream xstream)
 #endif
 }
 
-static inline
-ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
+static inline ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_xstream h_xstream;
@@ -40,44 +38,41 @@ ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
 #endif
 }
 
-static inline
-void ABTI_xstream_set_request(ABTI_xstream *p_xstream, uint32_t req)
+static inline void ABTI_xstream_set_request(ABTI_xstream *p_xstream,
+                                            uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_xstream->request, req);
 }
 
-static inline
-void ABTI_xstream_unset_request(ABTI_xstream *p_xstream, uint32_t req)
+static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
+                                              uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_xstream->request, ~req);
 }
 
 /* Get the top scheduler from the sched stack (field scheds) */
-static inline
-ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
+static inline ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
 {
-    return p_xstream->scheds[p_xstream->num_scheds-1];
+    return p_xstream->scheds[p_xstream->num_scheds - 1];
 }
 
 /* Get the parent scheduler of the current scheduler */
-static inline
-ABTI_sched *ABTI_xstream_get_parent_sched(ABTI_xstream *p_xstream)
+static inline ABTI_sched *ABTI_xstream_get_parent_sched(ABTI_xstream *p_xstream)
 {
     ABTI_ASSERT(p_xstream->num_scheds >= 2);
-    return p_xstream->scheds[p_xstream->num_scheds-2];
+    return p_xstream->scheds[p_xstream->num_scheds - 2];
 }
 
 /* Get the scheduling context */
-static inline
-ABTD_thread_context *ABTI_xstream_get_sched_ctx(ABTI_xstream *p_xstream)
+static inline ABTD_thread_context *
+ABTI_xstream_get_sched_ctx(ABTI_xstream *p_xstream)
 {
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_xstream);
     return p_sched->p_ctx;
 }
 
 /* Remove the top scheduler from the sched stack (field scheds) */
-static inline
-void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
+static inline void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
 {
     p_xstream->num_scheds--;
     ABTI_ASSERT(p_xstream->num_scheds >= 0);
@@ -85,15 +80,15 @@ void ABTI_xstream_pop_sched(ABTI_xstream *p_xstream)
 
 /* Replace the top scheduler of the sched stack (field scheds) with the target
  * scheduler */
-static inline
-void ABTI_xstream_replace_top_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
+static inline void ABTI_xstream_replace_top_sched(ABTI_xstream *p_xstream,
+                                                  ABTI_sched *p_sched)
 {
-    p_xstream->scheds[p_xstream->num_scheds-1] = p_sched;
+    p_xstream->scheds[p_xstream->num_scheds - 1] = p_sched;
 }
 
 /* Add the specified scheduler to the sched stack (field scheds) */
-static inline
-void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
+static inline void ABTI_xstream_push_sched(ABTI_xstream *p_xstream,
+                                           ABTI_sched *p_sched)
 {
     if (p_xstream->num_scheds == p_xstream->max_scheds) {
         int cur_size = p_xstream->max_scheds;
@@ -109,18 +104,17 @@ void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 }
 
 /* Get the first pool of the main scheduler. */
-static inline
-ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
+static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 {
     ABT_pool pool = p_xstream->p_main_sched->pools[0];
     return ABTI_pool_get_ptr(pool);
 }
 
-static inline
-void ABTI_xstream_terminate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
+static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
+                                                 ABTI_thread *p_thread)
 {
-    LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
         ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
@@ -142,11 +136,11 @@ void ABTI_xstream_terminate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
     }
 }
 
-static inline
-void ABTI_xstream_terminate_task(ABTI_local *p_local, ABTI_task *p_task)
+static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
+                                               ABTI_task *p_task)
 {
-    LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n",
-              ABTI_task_get_id(p_task), p_task->p_xstream->rank);
+    LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
+              p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
         ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
@@ -169,8 +163,8 @@ void ABTI_xstream_terminate_task(ABTI_local *p_local, ABTI_task *p_task)
 }
 
 /* Get the native thread id associated with the target xstream. */
-static inline
-ABTI_native_thread_id ABTI_xstream_get_native_thread_id(ABTI_xstream *p_xstream)
+static inline ABTI_native_thread_id
+ABTI_xstream_get_native_thread_id(ABTI_xstream *p_xstream)
 {
     return (ABTI_native_thread_id)p_xstream;
 }

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for Tasklet  */
 
-static inline
-ABTI_task *ABTI_task_get_ptr(ABT_task task)
+static inline ABTI_task *ABTI_task_get_ptr(ABT_task task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_task *p_task;
@@ -24,8 +23,7 @@ ABTI_task *ABTI_task_get_ptr(ABT_task task)
 #endif
 }
 
-static inline
-ABT_task ABTI_task_get_handle(ABTI_task *p_task)
+static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_task h_task;
@@ -40,17 +38,14 @@ ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 #endif
 }
 
-static inline
-void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_task->request, req);
 }
 
-static inline
-void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }
 
 #endif /* ABTI_TASK_H_INCLUDED */
-

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -8,8 +8,7 @@
 
 /* Inlined functions for User-level Thread (ULT) */
 
-static inline
-ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
+static inline ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_thread *p_thread;
@@ -24,8 +23,7 @@ ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
 #endif
 }
 
-static inline
-ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
+static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_thread h_thread;
@@ -41,8 +39,7 @@ ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline
-ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
+static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
 {
     /*
      * Create a context and switch to it. The flow of the dynamic promotion
@@ -126,8 +123,7 @@ ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
     return ABTD_thread_context_is_dynamic_promoted(&p_thread->ctx);
 }
 
-static inline
-void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
+static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 {
     LOG_EVENT("[U%" PRIu64 "] dynamic-promote ULT\n",
               ABTI_thread_get_id(p_thread));
@@ -138,11 +134,9 @@ void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 }
 #endif
 
-static inline
-void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_local *p_local,
-                                                          ABTI_thread *p_old,
-                                                          ABTI_thread *p_new,
-                                                          ABT_bool is_finish)
+static inline void ABTI_thread_context_switch_thread_to_thread_internal(
+    ABTI_local *p_local, ABTI_thread *p_old, ABTI_thread *p_new,
+    ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
@@ -166,10 +160,8 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_local *p_local,
     }
 }
 
-static inline
-void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
-                                                         ABTI_sched *p_new,
-                                                         ABT_bool is_finish)
+static inline void ABTI_thread_context_switch_thread_to_sched_internal(
+    ABTI_thread *p_old, ABTI_sched *p_new, ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched);
@@ -180,8 +172,8 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old))
         ABTI_thread_dynamic_promote_thread(p_old);
     /* Schedulers' contexts must be eagerly initialized. */
-    ABTI_ASSERT(!p_new->p_thread
-                || ABTI_thread_is_dynamic_promoted(p_new->p_thread));
+    ABTI_ASSERT(!p_new->p_thread ||
+                ABTI_thread_is_dynamic_promoted(p_new->p_thread));
 #endif
     if (is_finish) {
         ABTD_thread_finish_context(&p_old->ctx, p_new->p_ctx);
@@ -190,11 +182,9 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
     }
 }
 
-static inline
-void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
-                                                         ABTI_sched *p_old,
-                                                         ABTI_thread *p_new,
-                                                         ABT_bool is_finish)
+static inline void ABTI_thread_context_switch_sched_to_thread_internal(
+    ABTI_local *p_local, ABTI_sched *p_old, ABTI_thread *p_new,
+    ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->is_sched);
@@ -204,11 +194,11 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
     p_local->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be eagerly initialized. */
-    ABTI_ASSERT(!p_old->p_thread
-                || ABTI_thread_is_dynamic_promoted(p_old->p_thread));
+    ABTI_ASSERT(!p_old->p_thread ||
+                ABTI_thread_is_dynamic_promoted(p_old->p_thread));
     if (!ABTI_thread_is_dynamic_promoted(p_new)) {
-        void *p_stacktop = ((char *)p_new->attr.p_stack) +
-                            p_new->attr.stacksize;
+        void *p_stacktop =
+            ((char *)p_new->attr.p_stack) + p_new->attr.stacksize;
         LOG_EVENT("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
                   ABTI_thread_get_id(p_new));
         ABTD_thread_context_make_and_call(p_old->p_ctx, p_new->ctx.f_thread,
@@ -223,8 +213,9 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
             /* See ABTDI_thread_terminate for details.
              * TODO: avoid making a copy of the code. */
             ABTD_thread_context *p_ctx = &p_prev->ctx;
-            ABTD_thread_context *p_link = (ABTD_thread_context *)
-                ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
+            ABTD_thread_context *p_link =
+                (ABTD_thread_context *)ABTD_atomic_load_ptr(
+                    (void **)&p_ctx->p_link);
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
                  * join. */
@@ -238,15 +229,17 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
                 ABTD_atomic_store_uint32(&p_prev->request,
                                          ABTI_THREAD_REQ_TERMINATE);
             } else {
-                uint32_t req = ABTD_atomic_fetch_or_uint32(&p_prev->request,
-                        ABTI_THREAD_REQ_JOIN | ABTI_THREAD_REQ_TERMINATE);
+                uint32_t req =
+                    ABTD_atomic_fetch_or_uint32(&p_prev->request,
+                                                ABTI_THREAD_REQ_JOIN |
+                                                    ABTI_THREAD_REQ_TERMINATE);
                 if (req & ABTI_THREAD_REQ_JOIN) {
                     /* This case means there has been a join request and the
                      * joiner has blocked.  We have to wake up the joiner ULT.
                      */
                     do {
-                        p_link = (ABTD_thread_context *)
-                            ABTD_atomic_load_ptr((void **)&p_ctx->p_link);
+                        p_link = (ABTD_thread_context *)ABTD_atomic_load_ptr(
+                            (void **)&p_ctx->p_link);
                     } while (!p_link);
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }
@@ -262,18 +255,16 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
     }
 }
 
-static inline
-void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
-                                                        ABTI_sched *p_new,
-                                                        ABT_bool is_finish)
+static inline void ABTI_thread_context_switch_sched_to_sched_internal(
+    ABTI_sched *p_old, ABTI_sched *p_new, ABT_bool is_finish)
 {
     ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be initialized eagerly. */
-    ABTI_ASSERT(!p_old->p_thread
-                || ABTI_thread_is_dynamic_promoted(p_old->p_thread));
-    ABTI_ASSERT(!p_new->p_thread
-                || ABTI_thread_is_dynamic_promoted(p_new->p_thread));
+    ABTI_ASSERT(!p_old->p_thread ||
+                ABTI_thread_is_dynamic_promoted(p_old->p_thread));
+    ABTI_ASSERT(!p_new->p_thread ||
+                ABTI_thread_is_dynamic_promoted(p_new->p_thread));
 #endif
     if (is_finish) {
         ABTD_thread_finish_context(p_old->p_ctx, p_new->p_ctx);
@@ -282,97 +273,83 @@ void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
     }
 }
 
-static inline
-void ABTI_thread_context_switch_thread_to_thread(ABTI_local **pp_local,
-                                                 ABTI_thread *p_old,
-                                                 ABTI_thread *p_new)
+static inline void ABTI_thread_context_switch_thread_to_thread(
+    ABTI_local **pp_local, ABTI_thread *p_old, ABTI_thread *p_new)
 {
-    ABTI_thread_context_switch_thread_to_thread_internal(*pp_local,
-                                                         p_old, p_new,
-                                                         ABT_FALSE);
+    ABTI_thread_context_switch_thread_to_thread_internal(*pp_local, p_old,
+                                                         p_new, ABT_FALSE);
     *pp_local = ABTI_local_get_local_uninlined();
 }
 
-static inline
-void ABTI_thread_context_switch_thread_to_sched(ABTI_local **pp_local,
-                                                ABTI_thread *p_old,
-                                                ABTI_sched *p_new)
+static inline void ABTI_thread_context_switch_thread_to_sched(
+    ABTI_local **pp_local, ABTI_thread *p_old, ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new,
                                                         ABT_FALSE);
     *pp_local = ABTI_local_get_local_uninlined();
 }
 
-static inline
-void ABTI_thread_context_switch_sched_to_thread(ABTI_local **pp_local,
-                                                ABTI_sched *p_old,
-                                                ABTI_thread *p_new)
+static inline void ABTI_thread_context_switch_sched_to_thread(
+    ABTI_local **pp_local, ABTI_sched *p_old, ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_sched_to_thread_internal(*pp_local, p_old, p_new,
                                                         ABT_FALSE);
     *pp_local = ABTI_local_get_local_uninlined();
 }
 
-static inline
-void ABTI_thread_context_switch_sched_to_sched(ABTI_local **pp_local,
-                                               ABTI_sched *p_old,
-                                               ABTI_sched *p_new)
+static inline void
+ABTI_thread_context_switch_sched_to_sched(ABTI_local **pp_local,
+                                          ABTI_sched *p_old, ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_FALSE);
     *pp_local = ABTI_local_get_local_uninlined();
 }
 
-static inline
-void ABTI_thread_finish_context_thread_to_thread(ABTI_local *p_local,
-                                                 ABTI_thread *p_old,
-                                                 ABTI_thread *p_new)
+static inline void ABTI_thread_finish_context_thread_to_thread(
+    ABTI_local *p_local, ABTI_thread *p_old, ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_thread_to_thread_internal(p_local, p_old, p_new,
                                                          ABT_TRUE);
 }
 
-static inline
-void ABTI_thread_finish_context_thread_to_sched(ABTI_thread *p_old,
-                                                ABTI_sched *p_new)
+static inline void
+ABTI_thread_finish_context_thread_to_sched(ABTI_thread *p_old,
+                                           ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new, ABT_TRUE);
 }
 
-static inline
-void ABTI_thread_finish_context_sched_to_thread(ABTI_local *p_local,
-                                                ABTI_sched *p_old,
-                                                ABTI_thread *p_new)
+static inline void ABTI_thread_finish_context_sched_to_thread(
+    ABTI_local *p_local, ABTI_sched *p_old, ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_sched_to_thread_internal(p_local, p_old, p_new,
                                                         ABT_TRUE);
 }
 
-static inline
-void ABTI_thread_finish_context_sched_to_sched(ABTI_sched *p_old,
-                                               ABTI_sched *p_new)
+static inline void ABTI_thread_finish_context_sched_to_sched(ABTI_sched *p_old,
+                                                             ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_TRUE);
 }
 
-static inline
-void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
+static inline void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_thread->request, req);
 }
 
-static inline
-void ABTI_thread_unset_request(ABTI_thread *p_thread, uint32_t req)
+static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
+                                             uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_thread->request, ~req);
 }
 
-static inline
-void ABTI_thread_yield(ABTI_local **pp_local, ABTI_thread *p_thread)
+static inline void ABTI_thread_yield(ABTI_local **pp_local,
+                                     ABTI_thread *p_thread)
 {
     ABTI_sched *p_sched;
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] yield\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 
     /* Change the state of current running thread */
     p_thread->state = ABT_THREAD_STATE_READY;
@@ -387,4 +364,3 @@ void ABTI_thread_yield(ABTI_local **pp_local, ABTI_thread *p_thread)
 }
 
 #endif /* ABTI_THREAD_H_INCLUDED */
-

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -19,8 +19,7 @@
  * @param[in] attr  handle to the ULT attribute
  * @return ABTI_thread_attr pointer
  */
-static inline
-ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
+static inline ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_thread_attr *p_attr;
@@ -46,8 +45,8 @@ ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
  * @param[in] p_attr  pointer to ABTI_thread_attr
  * @return ABT_thread_attr handle
  */
-static inline
-ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
+static inline ABT_thread_attr
+ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_thread_attr h_attr;
@@ -63,34 +62,32 @@ ABT_thread_attr ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static inline
-void ABTI_thread_attr_init_migration(ABTI_thread_attr *p_attr,
-                                     ABT_bool migratable)
+static inline void ABTI_thread_attr_init_migration(ABTI_thread_attr *p_attr,
+                                                   ABT_bool migratable)
 {
     p_attr->migratable = migratable;
-    p_attr->f_cb       = NULL;
-    p_attr->p_cb_arg   = NULL;
+    p_attr->f_cb = NULL;
+    p_attr->p_cb_arg = NULL;
 }
 #endif
 
-static inline
-void ABTI_thread_attr_init(ABTI_thread_attr *p_attr, void *p_stack,
-                           size_t stacksize, ABTI_stack_type stacktype,
-                           ABT_bool migratable)
+static inline void ABTI_thread_attr_init(ABTI_thread_attr *p_attr,
+                                         void *p_stack, size_t stacksize,
+                                         ABTI_stack_type stacktype,
+                                         ABT_bool migratable)
 {
-    p_attr->p_stack    = p_stack;
-    p_attr->stacksize  = stacksize;
-    p_attr->stacktype  = stacktype;
+    p_attr->p_stack = p_stack;
+    p_attr->stacksize = stacksize;
+    p_attr->stacktype = stacktype;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_attr_init_migration(p_attr, migratable);
 #endif
 }
 
-static inline
-void ABTI_thread_attr_copy(ABTI_thread_attr *p_dest, ABTI_thread_attr *p_src)
+static inline void ABTI_thread_attr_copy(ABTI_thread_attr *p_dest,
+                                         ABTI_thread_attr *p_src)
 {
     memcpy(p_dest, p_src, sizeof(ABTI_thread_attr));
 }
 
 #endif /* ABTI_THREAD_ATTR_H_INCLUDED */
-

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -48,57 +48,60 @@ struct ABTI_thread_htable {
 #elif defined(USE_PTHREAD_MUTEX)
     pthread_mutex_t mutex;
 #else
-    ABTI_spinlock mutex;          /* To protect table */
+    ABTI_spinlock mutex; /* To protect table */
 #endif
     uint32_t num_elems;
     uint32_t num_rows;
     ABTI_thread_queue *queue;
 
-    ABTI_thread_queue *h_list;  /* list of non-empty high prio. queues */
-    ABTI_thread_queue *l_list;  /* list of non-empty low prio. queues */
+    ABTI_thread_queue *h_list; /* list of non-empty high prio. queues */
+    ABTI_thread_queue *l_list; /* list of non-empty low prio. queues */
 };
 
 #if defined(HAVE_LH_LOCK_H)
-#define ABTI_THREAD_HTABLE_LOCK(m)      lh_acquire_lock(&m)
-#define ABTI_THREAD_HTABLE_UNLOCK(m)    lh_release_lock(&m)
+#define ABTI_THREAD_HTABLE_LOCK(m) lh_acquire_lock(&m)
+#define ABTI_THREAD_HTABLE_UNLOCK(m) lh_release_lock(&m)
 #elif defined(HAVE_CLH_H)
-#define ABTI_THREAD_HTABLE_LOCK(m)      clh_acquire(&m)
-#define ABTI_THREAD_HTABLE_UNLOCK(m)    clh_release(&m)
+#define ABTI_THREAD_HTABLE_LOCK(m) clh_acquire(&m)
+#define ABTI_THREAD_HTABLE_UNLOCK(m) clh_release(&m)
 #elif defined(USE_PTHREAD_MUTEX)
-#define ABTI_THREAD_HTABLE_LOCK(m)      pthread_mutex_lock(&m)
-#define ABTI_THREAD_HTABLE_UNLOCK(m)    pthread_mutex_unlock(&m)
+#define ABTI_THREAD_HTABLE_LOCK(m) pthread_mutex_lock(&m)
+#define ABTI_THREAD_HTABLE_UNLOCK(m) pthread_mutex_unlock(&m)
 #else
-#define ABTI_THREAD_HTABLE_LOCK(m)      ABTI_spinlock_acquire(&m)
-#define ABTI_THREAD_HTABLE_UNLOCK(m)    ABTI_spinlock_release(&m)
+#define ABTI_THREAD_HTABLE_LOCK(m) ABTI_spinlock_acquire(&m)
+#define ABTI_THREAD_HTABLE_UNLOCK(m) ABTI_spinlock_release(&m)
 #endif
 
-static inline
-void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue) {
+static inline void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue)
+{
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->mutex)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->mutex) != 0);
+        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->mutex) != 0)
+            ;
     }
 }
 
-static inline
-void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue) {
+static inline void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue)
+{
     ABTD_atomic_clear_uint8((uint8_t *)&p_queue->mutex);
 }
 
-static inline
-void ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue) {
+static inline void
+ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
+{
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->low_mutex)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->low_mutex) != 0);
+        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->low_mutex) != 0)
+            ;
     }
 }
 
-static inline
-void ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue) {
+static inline void
+ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue)
+{
     ABTD_atomic_clear_uint8((uint8_t *)&p_queue->low_mutex);
 }
 
-static inline
-void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
-                                   ABTI_thread_queue *p_node)
+static inline void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
+                                                 ABTI_thread_queue *p_node)
 {
     ABTI_thread_queue *p_curr = p_htable->h_list;
     if (!p_curr) {
@@ -113,8 +116,7 @@ void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,
     }
 }
 
-static inline
-void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
+static inline void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
 {
     ABTI_thread_queue *p_prev, *p_next;
     ABTI_thread_queue *p_node = p_htable->h_list;
@@ -134,9 +136,8 @@ void ABTI_thread_htable_del_h_head(ABTI_thread_htable *p_htable)
     }
 }
 
-static inline
-void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
-                                   ABTI_thread_queue *p_node)
+static inline void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
+                                                 ABTI_thread_queue *p_node)
 {
     ABTI_thread_queue *p_curr = p_htable->l_list;
     if (!p_curr) {
@@ -151,8 +152,7 @@ void ABTI_thread_htable_add_l_node(ABTI_thread_htable *p_htable,
     }
 }
 
-static inline
-void ABTI_thread_htable_del_l_head(ABTI_thread_htable *p_htable)
+static inline void ABTI_thread_htable_del_l_head(ABTI_thread_htable *p_htable)
 {
     ABTI_thread_queue *p_prev, *p_next;
     ABTI_thread_queue *p_node = p_htable->l_list;

--- a/src/include/abti_timer.h
+++ b/src/include/abti_timer.h
@@ -8,16 +8,14 @@
 
 /* Inlined functions for Timer */
 
-static inline
-double ABTI_get_wtime(void)
+static inline double ABTI_get_wtime(void)
 {
     ABTD_time t;
     ABTD_time_get(&t);
     return ABTD_time_read_sec(&t);
 }
 
-static inline
-ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
+static inline ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_timer *p_timer;
@@ -32,8 +30,7 @@ ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
 #endif
 }
 
-static inline
-ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
+static inline ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_timer h_timer;
@@ -49,4 +46,3 @@ ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
 }
 
 #endif /* ABTI_TIMER_H_INCLUDED */
-

--- a/src/include/abti_valgrind.h
+++ b/src/include/abti_valgrind.h
@@ -13,24 +13,28 @@
 
 void ABTI_valgrind_register_stack(const void *p_stack, size_t size);
 void ABTI_valgrind_unregister_stack(const void *p_stack);
-#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)         \
-        do {                                                \
-            if (!RUNNING_ON_VALGRIND)                       \
-                break;                                      \
-            ABTI_valgrind_register_stack  (p_stack, size);  \
-        } while (0)
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)                            \
+    do {                                                                       \
+        if (!RUNNING_ON_VALGRIND)                                              \
+            break;                                                             \
+        ABTI_valgrind_register_stack(p_stack, size);                           \
+    } while (0)
 
-#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)         \
-        do {                                            \
-            if (!RUNNING_ON_VALGRIND)                   \
-                break;                                  \
-            ABTI_valgrind_unregister_stack(p_stack);    \
-        } while (0)
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)                                \
+    do {                                                                       \
+        if (!RUNNING_ON_VALGRIND)                                              \
+            break;                                                             \
+        ABTI_valgrind_unregister_stack(p_stack);                               \
+    } while (0)
 
 #else
 
-#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)   do { } while(0)
-#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)       do { } while(0)
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)                            \
+    do {                                                                       \
+    } while (0)
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)                                \
+    do {                                                                       \
+    } while (0)
 
 #endif /* HAVE_VALGRIND_SUPPORT */
 

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -13,52 +13,47 @@
 
 /* Utility feature */
 #ifdef ABT_CONFIG_HAVE___BUILTIN_EXPECT
-#define ABTU_likely(cond)       __builtin_expect(!!(cond), 1)
-#define ABTU_unlikely(cond)     __builtin_expect(!!(cond), 0)
+#define ABTU_likely(cond) __builtin_expect(!!(cond), 1)
+#define ABTU_unlikely(cond) __builtin_expect(!!(cond), 0)
 #else
-#define ABTU_likely(cond)       (cond)
-#define ABTU_unlikely(cond)     (cond)
+#define ABTU_likely(cond) (cond)
+#define ABTU_unlikely(cond) (cond)
 #endif
 
 /* Utility Functions */
 
-static inline
-void *ABTU_memalign(size_t alignment, size_t size)
+static inline void *ABTU_memalign(size_t alignment, size_t size)
 {
     void *p_ptr;
     int ret = posix_memalign(&p_ptr, alignment, size);
     assert(ret == 0);
     return p_ptr;
 }
-static inline
-void ABTU_free(void *ptr)
+static inline void ABTU_free(void *ptr)
 {
     free(ptr);
 }
 
 #ifdef ABT_CONFIG_USE_ALIGNED_ALLOC
 
-static inline
-void *ABTU_malloc(size_t size)
+static inline void *ABTU_malloc(size_t size)
 {
     /* Round up to the smallest multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE
      * which is greater than or equal to size in order to avoid any
      * false-sharing. */
-    size = (size + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)
-           & (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+    size = (size + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
+           (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
     return ABTU_memalign(ABT_CONFIG_STATIC_CACHELINE_SIZE, size);
 }
 
-static inline
-void *ABTU_calloc(size_t num, size_t size)
+static inline void *ABTU_calloc(size_t num, size_t size)
 {
     void *ptr = ABTU_malloc(num * size);
     memset(ptr, 0, num * size);
     return ptr;
 }
 
-static inline
-void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
+static inline void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 {
     void *new_ptr = ABTU_malloc(new_size);
     memcpy(new_ptr, ptr, (old_size < new_size) ? old_size : new_size);
@@ -68,20 +63,17 @@ void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 
 #else /* ABT_CONFIG_USE_ALIGNED_ALLOC */
 
-static inline
-void *ABTU_malloc(size_t size)
+static inline void *ABTU_malloc(size_t size)
 {
     return malloc(size);
 }
 
-static inline
-void *ABTU_calloc(size_t num, size_t size)
+static inline void *ABTU_calloc(size_t num, size_t size)
 {
     return calloc(num, size);
 }
 
-static inline
-void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
+static inline void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 {
     (void)old_size;
     return realloc(ptr, new_size);
@@ -89,8 +81,8 @@ void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 
 #endif /* !ABT_CONFIG_USE_ALIGNED_ALLOC */
 
-#define ABTU_strcpy(d,s)        strcpy(d,s)
-#define ABTU_strncpy(d,s,n)     strncpy(d,s,n)
+#define ABTU_strcpy(d, s) strcpy(d, s)
+#define ABTU_strncpy(d, s, n) strncpy(d, s, n)
 
 /* The caller should free the memory returned. */
 char *ABTU_get_indent_str(int indent);

--- a/src/info.c
+++ b/src/info.c
@@ -10,7 +10,6 @@
  * routines in this group are meant for debugging and diagnosing Argobots.
  */
 
-
 /**
  * @ingroup INFO
  * @brief   Get the configuration information associated with \c query_kind.
@@ -229,14 +228,13 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             break;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -254,7 +252,6 @@ int ABT_info_print_config(FILE *fp)
 {
     return ABTI_info_print_config(fp);
 }
-
 
 /**
  * @ingroup INFO
@@ -290,14 +287,13 @@ int ABT_info_print_all_xstreams(FILE *fp)
 
     fflush(fp);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -319,14 +315,13 @@ int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 
     ABTI_xstream_print(p_xstream, fp, 0, ABT_FALSE);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -348,14 +343,13 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 
     ABTI_sched_print(p_sched, fp, 0, ABT_FALSE);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -369,7 +363,7 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_pool(FILE* fp, ABT_pool pool)
+int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -377,14 +371,13 @@ int ABT_info_print_pool(FILE* fp, ABT_pool pool)
 
     ABTI_pool_print(p_pool, fp, 0);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -398,7 +391,7 @@ int ABT_info_print_pool(FILE* fp, ABT_pool pool)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_thread(FILE* fp, ABT_thread thread)
+int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
@@ -406,14 +399,13 @@ int ABT_info_print_thread(FILE* fp, ABT_thread thread)
 
     ABTI_thread_print(p_thread, fp, 0);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -428,7 +420,7 @@ int ABT_info_print_thread(FILE* fp, ABT_thread thread)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr)
+int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
@@ -436,14 +428,13 @@ int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr)
 
     ABTI_thread_attr_print(p_attr, fp, 0);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup INFO
@@ -457,7 +448,7 @@ int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr)
  * @return Error code
  * @retval ABT_SUCCESS  on success
  */
-int ABT_info_print_task(FILE* fp, ABT_task task)
+int ABT_info_print_task(FILE *fp, ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_task *p_task = ABTI_task_get_ptr(task);
@@ -465,10 +456,10 @@ int ABT_info_print_task(FILE* fp, ABT_task task)
 
     ABTI_task_print(p_task, fp, 0);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -493,10 +484,10 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 
     abt_errno = ABTI_thread_print_stack(p_thread, fp);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -522,15 +513,15 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
         ABT_thread thread = p_pool->u_get_thread(unit);
         ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
         ABT_thread_id thread_id = ABTI_thread_get_id(p_thread);
-        fprintf(fp, "id        : %" PRIu64 "\n"
-                    "ctx       : %p\n",
-                    (uint64_t)thread_id,
-                    (void *)&p_thread->ctx);
+        fprintf(fp,
+                "id        : %" PRIu64 "\n"
+                "ctx       : %p\n",
+                (uint64_t)thread_id, (void *)&p_thread->ctx);
         ABTD_thread_print_context(p_thread, fp, 2);
-        fprintf(fp, "stack     : %p\n"
-                    "stacksize : %" PRIu64 "\n",
-                    p_thread->attr.p_stack,
-                    (uint64_t)p_thread->attr.stacksize);
+        fprintf(fp,
+                "stack     : %p\n"
+                "stacksize : %" PRIu64 "\n",
+                p_thread->attr.p_stack, (uint64_t)p_thread->attr.stacksize);
         int abt_errno = ABTI_thread_print_stack(p_thread, fp);
         if (abt_errno != ABT_SUCCESS)
             fprintf(fp, "Failed to print stack.\n");
@@ -565,10 +556,10 @@ int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
     abt_errno = ABTI_info_print_thread_stacks_in_pool(fp, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -588,10 +579,10 @@ int ABTI_info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool)
     arg.pool = pool;
     p_pool->p_print_all(pool, &arg, ABTI_info_print_unit);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -602,8 +593,8 @@ struct ABTI_info_pool_set_t {
     size_t len;
 };
 
-static inline
-void ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
+static inline void
+ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
 {
     size_t default_len = 16;
     p_set->pools = (ABT_pool *)ABTU_malloc(sizeof(ABT_pool) * default_len);
@@ -611,14 +602,14 @@ void ABTI_info_initialize_pool_set(struct ABTI_info_pool_set_t *p_set)
     p_set->len = default_len;
 }
 
-static inline
-void ABTI_info_finalize_pool_set(struct ABTI_info_pool_set_t *p_set)
+static inline void
+ABTI_info_finalize_pool_set(struct ABTI_info_pool_set_t *p_set)
 {
     ABTU_free(p_set->pools);
 }
 
-static inline
-void ABTI_info_add_pool_set(ABT_pool pool, struct ABTI_info_pool_set_t *p_set)
+static inline void ABTI_info_add_pool_set(ABT_pool pool,
+                                          struct ABTI_info_pool_set_t *p_set)
 {
     size_t i;
     for (i = 0; i < p_set->num; i++) {
@@ -636,10 +627,10 @@ void ABTI_info_add_pool_set(ABT_pool pool, struct ABTI_info_pool_set_t *p_set)
     p_set->pools[p_set->num++] = pool;
 }
 
-#define PRINT_STACK_FLAG_UNSET      0
+#define PRINT_STACK_FLAG_UNSET 0
 #define PRINT_STACK_FLAG_INITIALIZE 1
-#define PRINT_STACK_FLAG_WAIT       2
-#define PRINT_STACK_FLAG_FINALIZE   3
+#define PRINT_STACK_FLAG_WAIT 2
+#define PRINT_STACK_FLAG_FINALIZE 3
 
 static uint32_t print_stack_flag = PRINT_STACK_FLAG_UNSET;
 static FILE *print_stack_fp = NULL;
@@ -653,9 +644,9 @@ static uint32_t print_stack_barrier = 0;
  * @brief   Dump stacks of threads in pools existing in Argobots.
  *
  * \c ABT_info_trigger_print_all_thread_stacks() tries to dump call stacks of
- * all threads stored in pools in the Argobots runtime. This function itself does
- * not print stacks; it immediately returns after updating a flag. Stacks are
- * printed when all execution streams stop in \c ABT_xstream_check_events().
+ * all threads stored in pools in the Argobots runtime. This function itself
+ * does not print stacks; it immediately returns after updating a flag. Stacks
+ * are printed when all execution streams stop in \c ABT_xstream_check_events().
  *
  * If some execution streams do not stop within a certain time period, one of
  * the stopped execution streams starts to print stack information. In this
@@ -665,10 +656,10 @@ static uint32_t print_stack_barrier = 0;
  *
  * \c cb_func is called after completing stack dump unless it is NULL. The first
  * argument is set to \c ABT_TRUE if not all the execution streams stop within
- * \c timeout. Otherwise, \c ABT_FALSE is set. The second argument is user-defined
- * data \c arg. Since \c cb_func is not called by a thread or an execution
- * stream, \c ABT_self_...() functions in \c cb_func return undefined values.
- * Neither signal-safety nor thread-safety is required for \c cb_func.
+ * \c timeout. Otherwise, \c ABT_FALSE is set. The second argument is
+ * user-defined data \c arg. Since \c cb_func is not called by a thread or an
+ * execution stream, \c ABT_self_...() functions in \c cb_func return undefined
+ * values. Neither signal-safety nor thread-safety is required for \c cb_func.
  *
  * In Argobots, \c ABT_info_trigger_print_all_thread_stacks is exceptionally
  * signal-safe; it can be safely called in a signal handler.
@@ -723,12 +714,12 @@ void ABTI_info_check_print_all_thread_stacks(void)
          * printing data. */
         ABTI_spinlock_acquire(&gp_ABTI_global->xstreams_lock);
         while (1) {
-            if (ABTD_atomic_load_uint32(&print_stack_barrier)
-                >= gp_ABTI_global->num_xstreams) {
+            if (ABTD_atomic_load_uint32(&print_stack_barrier) >=
+                gp_ABTI_global->num_xstreams) {
                 break;
             }
-            if (print_stack_timeout >= 0.0
-                && (ABTI_get_wtime() - start_time) >= print_stack_timeout) {
+            if (print_stack_timeout >= 0.0 &&
+                (ABTI_get_wtime() - start_time) >= print_stack_timeout) {
                 force_print = ABT_TRUE;
                 break;
             }
@@ -744,9 +735,10 @@ void ABTI_info_check_print_all_thread_stacks(void)
         ABTI_info_initialize_pool_set(&pool_set);
         FILE *fp = print_stack_fp;
         if (force_print) {
-            fprintf(fp, "ABT_info_trigger_print_all_thread_stacks: "
-                        "timeout (only %d ESs stop)\n",
-                        (int)print_stack_barrier);
+            fprintf(fp,
+                    "ABT_info_trigger_print_all_thread_stacks: "
+                    "timeout (only %d ESs stop)\n",
+                    (int)print_stack_barrier);
         }
         for (i = 0; i < gp_ABTI_global->num_xstreams; i++) {
             ABTI_xstream *p_xstream = gp_ABTI_global->p_xstreams[i];
@@ -758,7 +750,8 @@ void ABTI_info_check_print_all_thread_stacks(void)
             for (j = 0; j < p_main_sched->num_pools; j++) {
                 ABT_pool pool = p_main_sched->pools[j];
                 ABTI_ASSERT(pool != ABT_POOL_NULL);
-                fprintf(fp, "  pools[%d] : %p\n", j, (void *)ABTI_pool_get_ptr(pool));
+                fprintf(fp, "  pools[%d] : %p\n", j,
+                        (void *)ABTI_pool_get_ptr(pool));
                 ABTI_info_add_pool_set(pool, &pool_set);
             }
         }
@@ -779,12 +772,12 @@ void ABTI_info_check_print_all_thread_stacks(void)
         ABTD_atomic_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_FINALIZE);
     } else {
         /* Wait for the master's work. */
-        while (ABTD_atomic_load_uint32(&print_stack_flag)
-               != PRINT_STACK_FLAG_FINALIZE)
+        while (ABTD_atomic_load_uint32(&print_stack_flag) !=
+               PRINT_STACK_FLAG_FINALIZE)
             ABTD_atomic_pause();
     }
-    ABTI_ASSERT(ABTD_atomic_load_uint32(&print_stack_flag)
-                == PRINT_STACK_FLAG_FINALIZE);
+    ABTI_ASSERT(ABTD_atomic_load_uint32(&print_stack_flag) ==
+                PRINT_STACK_FLAG_FINALIZE);
 
     /* Decrement the barrier value. */
     uint32_t dec_value = ABTD_atomic_fetch_sub_uint32(&print_stack_barrier, 1);
@@ -809,18 +802,18 @@ int ABTI_info_print_config(FILE *fp)
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
     fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
     fprintf(fp, " - ES affinity: %s\n",
-                (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
+            (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - logging: %s\n",
-                (p_global->use_logging == ABT_TRUE) ? "on" : "off");
+            (p_global->use_logging == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - debug output: %s\n",
-                (p_global->use_debug == ABT_TRUE) ? "on" : "off");
+            (p_global->use_debug == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - key table entries: %d\n", p_global->key_table_size);
     fprintf(fp, " - ULT stack size: %u KB\n",
-                (unsigned)(p_global->thread_stacksize / 1024));
+            (unsigned)(p_global->thread_stacksize / 1024));
     fprintf(fp, " - scheduler stack size: %u KB\n",
-                (unsigned)(p_global->sched_stacksize / 1024));
+            (unsigned)(p_global->sched_stacksize / 1024));
     fprintf(fp, " - scheduler event check frequency: %u\n",
-                p_global->sched_event_freq);
+            p_global->sched_event_freq);
 
     fprintf(fp, " - timer function: "
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
@@ -835,7 +828,7 @@ int ABTI_info_print_config(FILE *fp)
 #ifdef ABT_CONFIG_USE_MEM_POOL
     fprintf(fp, "Memory Pool:\n");
     fprintf(fp, " - page size for allocation: %u KB\n",
-                p_global->mem_page_size / 1024);
+            p_global->mem_page_size / 1024);
     fprintf(fp, " - stack page size: %u KB\n", p_global->mem_sp_size / 1024);
     fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
     switch (p_global->mem_lp_alloc) {
@@ -860,10 +853,10 @@ int ABTI_info_print_config(FILE *fp)
 
     fflush(fp);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/key.c
+++ b/src/key.c
@@ -91,10 +91,10 @@ int ABT_key_free(ABT_key *key)
     /* Return value */
     *key = ABT_KEY_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -147,10 +147,10 @@ int ABT_key_set(ABT_key key, void *value)
     /* Save the value in the key-value table */
     ABTI_ktable_set(p_ktable, p_key, value);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -206,10 +206,10 @@ int ABT_key_get(ABT_key key, void **value)
 
     *value = keyval;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -221,7 +221,8 @@ ABTI_ktable *ABTI_ktable_alloc(int size)
     p_ktable = (ABTI_ktable *)ABTU_malloc(sizeof(ABTI_ktable));
     p_ktable->size = size;
     p_ktable->num = 0;
-    p_ktable->p_elems = (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
+    p_ktable->p_elems =
+        (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
 
     return p_ktable;
 }
@@ -331,4 +332,3 @@ void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key)
         p_elem = p_elem->p_next;
     }
 }
-

--- a/src/local.c
+++ b/src/local.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/
@@ -25,13 +24,11 @@ static void *ABTI_local_get_local_ptr_internal(void)
     return (void *)&lp_ABTI_local;
 }
 
-ABTI_local_func gp_ABTI_local_func = {
-    {0},
-    ABTI_local_get_local_internal,
-    ABTI_local_set_local_internal,
-    ABTI_local_get_local_ptr_internal,
-    {0}
-};
+ABTI_local_func gp_ABTI_local_func = { { 0 },
+                                       ABTI_local_get_local_internal,
+                                       ABTI_local_set_local_internal,
+                                       ABTI_local_get_local_ptr_internal,
+                                       { 0 } };
 /* ES Local Data */
 ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local = NULL;
 
@@ -51,10 +48,10 @@ int ABTI_local_init(ABTI_local **pp_local)
     ABTI_LOG_INIT();
     *pp_local = p_local;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -72,11 +69,10 @@ int ABTI_local_finalize(ABTI_local **pp_local)
 
     ABTI_LOG_FINALIZE();
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-

--- a/src/log.c
+++ b/src/log.c
@@ -24,7 +24,8 @@ void ABTI_log_finalize(void)
 
 void ABTI_log_print(FILE *fh, const char *format, ...)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     va_list list;
     va_start(list, format);
@@ -35,7 +36,8 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
 
 void ABTI_log_event(FILE *fh, const char *format, ...)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
     ABTI_local *p_local = ABTI_local_get_local_uninlined();
 
     ABT_unit_type type = ABTI_self_get_type(p_local);
@@ -121,7 +123,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
 
 void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
 {
-    if (gp_ABTI_global->use_debug == ABT_FALSE) return;
+    if (gp_ABTI_global->use_debug == ABT_FALSE)
+        return;
 
     int line_len;
     size_t newfmt_len;
@@ -144,7 +147,8 @@ void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                         ABTI_native_thread_id producer_id)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -155,14 +159,12 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                 LOG_EVENT("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->p_last_xstream->rank,
-                          p_pool->id,
+                          p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
-                          ABTI_thread_get_id(p_thread),
-                          p_pool->id,
+                          ABTI_thread_get_id(p_thread), p_pool->id,
                           (void *)producer_id);
             }
             break;
@@ -172,15 +174,12 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
             if (p_task->p_xstream) {
                 LOG_EVENT("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
-                          ABTI_task_get_id(p_task),
-                          p_task->p_xstream->rank,
-                          p_pool->id,
-                          (void *)producer_id);
+                          ABTI_task_get_id(p_task), p_task->p_xstream->rank,
+                          p_pool->id, (void *)producer_id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
-                          ABTI_task_get_id(p_task),
-                          p_pool->id,
+                          ABTI_task_get_id(p_task), p_pool->id,
                           (void *)producer_id);
             }
             break;
@@ -194,7 +193,8 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           ABTI_native_thread_id consumer_id)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -205,14 +205,12 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                 LOG_EVENT("[U%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->p_last_xstream->rank,
-                          p_pool->id,
+                          p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: NT %p)\n",
-                          ABTI_thread_get_id(p_thread),
-                          p_pool->id,
+                          ABTI_thread_get_id(p_thread), p_pool->id,
                           (void *)consumer_id);
             }
             break;
@@ -222,15 +220,12 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
             if (p_task->p_xstream) {
                 LOG_EVENT("[T%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
-                          ABTI_task_get_id(p_task),
-                          p_task->p_xstream->rank,
-                          p_pool->id,
-                          (void *)consumer_id);
+                          ABTI_task_get_id(p_task), p_task->p_xstream->rank,
+                          p_pool->id, (void *)consumer_id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: NT %p)\n",
-                          ABTI_task_get_id(p_task),
-                          p_pool->id,
+                          ABTI_task_get_id(p_task), p_pool->id,
                           (void *)consumer_id);
             }
             break;
@@ -243,8 +238,10 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
 
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE) return;
-    if (unit == ABT_UNIT_NULL) return;
+    if (gp_ABTI_global->use_logging == ABT_FALSE)
+        return;
+    if (unit == ABT_UNIT_NULL)
+        return;
 
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -255,12 +252,10 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
                 LOG_EVENT("[U%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->p_last_xstream->rank,
-                          p_pool->id);
+                          p_thread->p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_thread),
-                          p_pool->id);
+                          ABTI_thread_get_id(p_thread), p_pool->id);
             }
             break;
 
@@ -269,13 +264,11 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
             if (p_task->p_xstream) {
                 LOG_EVENT("[T%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
-                          ABTI_task_get_id(p_task),
-                          p_task->p_xstream->rank,
+                          ABTI_task_get_id(p_task), p_task->p_xstream->rank,
                           p_pool->id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_task_get_id(p_task),
-                          p_pool->id);
+                          ABTI_task_get_id(p_task), p_pool->id);
             }
             break;
 

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -29,17 +29,18 @@ ABTI_valgrind_id_list *gp_valgrind_id_list_tail = NULL;
 
 #include <valgrind/valgrind.h>
 
-void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
+void ABTI_valgrind_register_stack(const void *p_stack, size_t size)
+{
     if (p_stack == 0)
         return;
 
     const void *p_start = (char *)(p_stack);
-    const void *p_end   = (char *)(p_stack) + size;
+    const void *p_end = (char *)(p_stack) + size;
 
     ABTI_spinlock_acquire(&g_valgrind_id_list_lock);
     ABTI_valgrind_id valgrind_id = VALGRIND_STACK_REGISTER(p_start, p_end);
     ABTI_valgrind_id_list *p_valgrind_id_list =
-                 (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
+        (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
     p_valgrind_id_list->p_stack = p_stack;
     p_valgrind_id_list->valgrind_id = valgrind_id;
     p_valgrind_id_list->p_next = 0;
@@ -50,12 +51,13 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
         gp_valgrind_id_list_tail->p_next = p_valgrind_id_list;
         gp_valgrind_id_list_tail = p_valgrind_id_list;
     }
-    LOG_DEBUG("valgrind : register stack %p (id = %d)\n",
-              p_stack, (int) valgrind_id);
+    LOG_DEBUG("valgrind : register stack %p (id = %d)\n", p_stack,
+              (int)valgrind_id);
     ABTI_spinlock_release(&g_valgrind_id_list_lock);
 }
 
-void ABTI_valgrind_unregister_stack(const void *p_stack) {
+void ABTI_valgrind_unregister_stack(const void *p_stack)
+{
     if (p_stack == 0)
         return;
 
@@ -69,13 +71,13 @@ void ABTI_valgrind_unregister_stack(const void *p_stack) {
             gp_valgrind_id_list_tail = NULL;
     } else {
         /* Do linear search to find the corresponding valgrind_id. */
-        ABTI_valgrind_id_list *p_prev    = gp_valgrind_id_list_head;
+        ABTI_valgrind_id_list *p_prev = gp_valgrind_id_list_head;
         ABTI_valgrind_id_list *p_current = gp_valgrind_id_list_head->p_next;
         ABT_bool deregister_flag = ABT_FALSE;
         while (p_current) {
             if (p_current->p_stack == p_stack) {
-                LOG_DEBUG("valgrind : deregister stack %p (id = %d)\n",
-                          p_stack, (int) p_current->valgrind_id);
+                LOG_DEBUG("valgrind : deregister stack %p (id = %d)\n", p_stack,
+                          (int)p_current->valgrind_id);
                 VALGRIND_STACK_DEREGISTER(p_current->valgrind_id);
                 p_prev->p_next = p_current->p_next;
                 if (!p_prev->p_next)
@@ -84,7 +86,7 @@ void ABTI_valgrind_unregister_stack(const void *p_stack) {
                 deregister_flag = ABT_TRUE;
                 break;
             }
-            p_prev    = p_current;
+            p_prev = p_current;
             p_current = p_current->p_next;
         }
         ABTI_ASSERT(deregister_flag);

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -6,7 +6,6 @@
 #include "abti.h"
 #include "abti_thread_htable.h"
 
-
 /** @defgroup MUTEX Mutex
  * Mutex is a synchronization method to support mutual exclusion between ULTs.
  * When more than one ULT competes for locking the same mutex, only one ULT is
@@ -77,10 +76,10 @@ int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
     /* Return value */
     *newmutex = ABTI_mutex_get_handle(p_newmutex);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -113,10 +112,10 @@ int ABT_mutex_free(ABT_mutex *mutex)
     /* Return value */
     *mutex = ABT_MUTEX_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -166,16 +165,16 @@ int ABT_mutex_lock(ABT_mutex mutex)
         ABTI_mutex_lock(&p_local, p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-static inline
-void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
+static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
+                                       ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTI_local *p_local = *pp_local;
@@ -225,7 +224,7 @@ void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
             while (c != 0) {
                 ABTI_mutex_wait_low(pp_local, p_mutex, 2);
 
-  check_handover:
+            check_handover:
                 /* If the mutex has been handed over to the current ULT from
                  * other ULT on the same ES, we don't need to change the mutex
                  * state. */
@@ -238,7 +237,8 @@ void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                         ABTI_thread *p_giver = p_mutex->p_giver;
                         p_giver->state = ABT_THREAD_STATE_READY;
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
-                            ABTI_self_get_native_thread_id(*pp_local));
+                                       ABTI_self_get_native_thread_id(
+                                           *pp_local));
                         break;
                     }
                 }
@@ -251,10 +251,10 @@ void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
         ABTI_mutex_spinlock(p_mutex);
     }
 
-  fn_exit:
-    return ;
+fn_exit:
+    return;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
@@ -300,10 +300,10 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
         ABTI_mutex_lock_low(&p_local, p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -360,10 +360,10 @@ int ABT_mutex_trylock(ABT_mutex mutex)
         abt_errno = ABTI_mutex_trylock(p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -409,10 +409,10 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
         ABTI_mutex_spinlock(p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -442,8 +442,9 @@ int ABT_mutex_unlock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local)
-                        == p_mutex->attr.owner_id, ABT_ERR_INV_THREAD);
+        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local) ==
+                            p_mutex->attr.owner_id,
+                        ABT_ERR_INV_THREAD);
         if (p_mutex->attr.nesting_cnt == 0) {
             p_mutex->attr.owner_id = 0;
             ABTI_mutex_unlock(p_local, p_mutex);
@@ -456,17 +457,17 @@ int ABT_mutex_unlock(ABT_mutex mutex)
         ABTI_mutex_unlock(p_local, p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
 /* Hand over the mutex to other ULT on the same ES */
-static inline
-int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
+static inline int ABTI_mutex_unlock_se(ABTI_local **pp_local,
+                                       ABTI_mutex *p_mutex)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -510,7 +511,7 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
     i = (int)p_xstream->rank;
     p_queue = &p_htable->queue[i];
 
- check_cond:
+check_cond:
     /* Check whether the mutex handover is possible */
     if (p_queue->num_handovers >= p_mutex->attr.max_handovers) {
         ABTD_atomic_store_uint32(&p_mutex->val, 0); /* Unlock */
@@ -523,7 +524,7 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
 
     /* Hand over the mutex to high-priority ULTs */
     if (p_queue->num_threads <= 1) {
-        if(p_htable->h_list != NULL) {
+        if (p_htable->h_list != NULL) {
             ABTD_atomic_store_uint32(&p_mutex->val, 0); /* Unlock */
             LOG_EVENT("%p: unlock_se\n", p_mutex);
             ABTI_mutex_wake_de(*pp_local, p_mutex);
@@ -532,8 +533,10 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
         }
     } else {
         p_next = ABTI_thread_htable_pop(p_htable, p_queue);
-        if (p_next == NULL) goto check_cond;
-        else goto handover;
+        if (p_next == NULL)
+            goto check_cond;
+        else
+            goto handover;
     }
 
     /* When we don't have high-priority ULTs and other ESs don't either,
@@ -546,10 +549,11 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
         return abt_errno;
     } else {
         p_next = ABTI_thread_htable_pop_low(p_htable, p_queue);
-        if (p_next == NULL) goto check_cond;
+        if (p_next == NULL)
+            goto check_cond;
     }
 
-  handover:
+handover:
     /* We don't push p_thread to the pool. Instead, we will yield_to p_thread
      * directly at the end of this function. */
     p_queue->num_handovers++;
@@ -558,11 +562,12 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
     p_mutex->p_handover = p_next;
     p_mutex->p_giver = p_thread;
 
-    LOG_EVENT("%p: handover -> U%" PRIu64 "\n",
-              p_mutex, ABTI_thread_get_id(p_next));
+    LOG_EVENT("%p: handover -> U%" PRIu64 "\n", p_mutex,
+              ABTI_thread_get_id(p_next));
 
     /* yield_to the next ULT */
-    while (ABTD_atomic_load_uint32(&p_next->request) & ABTI_THREAD_REQ_BLOCK);
+    while (ABTD_atomic_load_uint32(&p_next->request) & ABTI_THREAD_REQ_BLOCK)
+        ;
     ABTI_pool_dec_num_blocked(p_next->p_pool);
     p_next->state = ABT_THREAD_STATE_RUNNING;
     ABTI_thread_context_switch_thread_to_thread(pp_local, p_thread, p_next);
@@ -601,8 +606,9 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local)
-                        == p_mutex->attr.owner_id, ABT_ERR_INV_THREAD);
+        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local) ==
+                            p_mutex->attr.owner_id,
+                        ABT_ERR_INV_THREAD);
         if (p_mutex->attr.nesting_cnt == 0) {
             p_mutex->attr.owner_id = 0;
             ABTI_mutex_unlock_se(&p_local, p_mutex);
@@ -615,10 +621,10 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
         ABTI_mutex_unlock_se(&p_local, p_mutex);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -632,10 +638,10 @@ int ABT_mutex_unlock_de(ABT_mutex mutex)
 
     ABTI_mutex_unlock(p_local, p_mutex);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -662,7 +668,6 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
     *result = ABTI_mutex_equal(p_mutex1, p_mutex2);
     return ABT_SUCCESS;
 }
-
 
 void ABTI_mutex_wait(ABTI_local **pp_local, ABTI_mutex *p_mutex, int val)
 {
@@ -755,30 +760,34 @@ void ABTI_mutex_wake_de(ABTI_local *p_local, ABTI_mutex *p_mutex)
 
         /* Wake up the high-priority ULTs */
         p_start = p_htable->h_list;
-        for (p_curr = p_start; p_curr; ) {
+        for (p_curr = p_start; p_curr;) {
             p_thread = ABTI_thread_htable_pop(p_htable, p_curr);
             if (p_curr->num_threads == 0) {
                 ABTI_thread_htable_del_h_head(p_htable);
             } else {
                 p_htable->h_list = p_curr->p_h_next;
             }
-            if (p_thread != NULL) goto done;
+            if (p_thread != NULL)
+                goto done;
             p_curr = p_htable->h_list;
-            if (p_curr == p_start) break;
+            if (p_curr == p_start)
+                break;
         }
 
         /* Wake up the low-priority ULTs */
         p_start = p_htable->l_list;
-        for (p_curr = p_start; p_curr; ) {
+        for (p_curr = p_start; p_curr;) {
             p_thread = ABTI_thread_htable_pop_low(p_htable, p_curr);
             if (p_curr->low_num_threads == 0) {
                 ABTI_thread_htable_del_l_head(p_htable);
             } else {
                 p_htable->l_list = p_curr->p_l_next;
             }
-            if (p_thread != NULL) goto done;
+            if (p_thread != NULL)
+                goto done;
             p_curr = p_htable->l_list;
-            if (p_curr == p_start) break;
+            if (p_curr == p_start)
+                break;
         }
 
         /* Nothing to wake up */
@@ -786,7 +795,7 @@ void ABTI_mutex_wake_de(ABTI_local *p_local, ABTI_mutex *p_mutex)
         LOG_EVENT("%p: nothing to wake up\n", p_mutex);
         break;
 
-  done:
+    done:
         ABTI_THREAD_HTABLE_UNLOCK(p_htable->mutex);
 
         /* Push p_thread to the scheduler's pool */
@@ -796,4 +805,3 @@ void ABTI_mutex_wake_de(ABTI_local *p_local, ABTI_mutex *p_mutex)
         ABTI_thread_set_ready(p_local, p_thread);
     }
 }
-

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup MUTEX_ATTR Mutex Attributes
  * Attributes are used to specify mutex behavior that is different from the
  * default.  When a mutex is created with \c ABT_mutex_create_with_attr(),
@@ -69,10 +68,10 @@ int ABT_mutex_attr_free(ABT_mutex_attr *attr)
     /* Return value */
     *attr = ABT_MUTEX_ATTR_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -103,14 +102,13 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
         p_attr->attrs &= ~ABTI_MUTEX_ATTR_RECURSIVE;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /*****************************************************************************/
 /* Private APIs                                                              */
@@ -135,15 +133,10 @@ void ABTI_mutex_attr_get_str(ABTI_mutex_attr *p_attr, char *p_buf)
     }
 
     sprintf(p_buf,
-        "["
-        "attrs:%x "
-        "nesting_cnt:%u "
-        "owner_id:%p "
-        "]",
-        p_attr->attrs,
-        p_attr->nesting_cnt,
-        (void *)p_attr->owner_id
-    );
+            "["
+            "attrs:%x "
+            "nesting_cnt:%u "
+            "owner_id:%p "
+            "]",
+            p_attr->attrs, p_attr->nesting_cnt, (void *)p_attr->owner_id);
 }
-
-

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -6,8 +6,7 @@
 #include "abti.h"
 #include <time.h>
 
-static inline
-double get_cur_time(void)
+static inline double get_cur_time(void)
 {
 #if defined(HAVE_CLOCK_GETTIME)
     struct timespec ts;
@@ -25,18 +24,18 @@ double get_cur_time(void)
 
 /* FIFO pool implementation */
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push_shared(ABT_pool pool, ABT_unit unit);
-static void     pool_push_private(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push_shared(ABT_pool pool, ABT_unit unit);
+static void pool_push_private(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop_shared(ABT_pool pool);
 static ABT_unit pool_pop_private(ABT_pool pool);
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
-static int      pool_remove_shared(ABT_pool pool, ABT_unit unit);
-static int      pool_remove_private(ABT_pool pool, ABT_unit unit);
-static int      pool_print_all(ABT_pool pool, void *arg,
-                               void (*print_fn)(void *, ABT_unit));
+static int pool_remove_shared(ABT_pool pool, ABT_unit unit);
+static int pool_remove_private(ABT_pool pool, ABT_unit unit);
+static int pool_print_all(ABT_pool pool, void *arg,
+                          void (*print_fn)(void *, ABT_unit));
 
 typedef ABTI_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -60,7 +59,6 @@ static inline data_t *pool_get_data_ptr(void *p_data)
     return (data_t *)p_data;
 }
 
-
 /* Obtain the FIFO pool definition according to the access type */
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
 {
@@ -70,8 +68,8 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     /* FIXME: need better implementation, e.g., lock-free one */
     switch (access) {
         case ABT_POOL_ACCESS_PRIV:
-            p_def->p_push   = pool_push_private;
-            p_def->p_pop    = pool_pop_private;
+            p_def->p_push = pool_push_private;
+            p_def->p_pop = pool_pop_private;
             p_def->p_remove = pool_remove_private;
             break;
 
@@ -79,8 +77,8 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
         case ABT_POOL_ACCESS_MPSC:
         case ABT_POOL_ACCESS_SPMC:
         case ABT_POOL_ACCESS_MPMC:
-            p_def->p_push   = pool_push_shared;
-            p_def->p_pop    = pool_pop_shared;
+            p_def->p_push = pool_push_shared;
+            p_def->p_pop = pool_pop_shared;
             p_def->p_remove = pool_remove_shared;
             break;
 
@@ -89,28 +87,27 @@ int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
     }
 
     /* Common definitions regardless of the access type */
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->p_pop_timedwait      = pool_pop_timedwait;
-    p_def->p_print_all          = pool_print_all;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->p_pop_timedwait = pool_pop_timedwait;
+    p_def->p_print_all = pool_print_all;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /* Pool functions */
 
@@ -242,14 +239,14 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
             ABTI_spinlock_release(&p_data->mutex);
             /* Sleep. */
             const int sleep_nsecs = 100;
-            struct timespec ts = {0, sleep_nsecs};
+            struct timespec ts = { 0, sleep_nsecs };
             nanosleep(&ts, NULL);
 
             double elapsed = get_cur_time() - time_start;
             if (elapsed > abstime_secs)
                 break;
         }
-    } while(h_unit == ABT_UNIT_NULL);
+    } while (h_unit == ABT_UNIT_NULL);
 
     return h_unit;
 }
@@ -379,9 +376,9 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
     return ABT_SUCCESS;
 }
 
-
 static int pool_print_all(ABT_pool pool, void *arg,
-                          void (*print_fn)(void *, ABT_unit)) {
+                          void (*print_fn)(void *, ABT_unit))
+{
     ABT_pool_access access;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
@@ -407,13 +404,12 @@ static int pool_print_all(ABT_pool pool, void *arg,
     return ABT_SUCCESS;
 }
 
-
 /* Unit functions */
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -452,9 +448,9 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->handle.thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -465,9 +461,9 @@ static ABT_unit unit_create_from_task(ABT_task task)
     unit_t *p_unit = &p_task->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->handle.task = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }
@@ -476,4 +472,3 @@ static void unit_free(ABT_unit *unit)
 {
     *unit = ABT_UNIT_NULL;
 }
-

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -7,15 +7,15 @@
 
 /* FIFO_WAIT pool implementation */
 
-static int      pool_init(ABT_pool pool, ABT_pool_config config);
-static int      pool_free(ABT_pool pool);
-static size_t   pool_get_size(ABT_pool pool);
-static void     pool_push(ABT_pool pool, ABT_unit unit);
+static int pool_init(ABT_pool pool, ABT_pool_config config);
+static int pool_free(ABT_pool pool);
+static size_t pool_get_size(ABT_pool pool);
+static void pool_push(ABT_pool pool, ABT_unit unit);
 static ABT_unit pool_pop(ABT_pool pool);
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
-static int      pool_remove(ABT_pool pool, ABT_unit unit);
-static int      pool_print_all(ABT_pool pool, void *arg,
-                               void (*print_fn)(void *, ABT_unit));
+static int pool_remove(ABT_pool pool, ABT_unit unit);
+static int pool_print_all(ABT_pool pool, void *arg,
+                          void (*print_fn)(void *, ABT_unit));
 
 typedef ABTI_unit unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
@@ -42,26 +42,25 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 
 int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def)
 {
-    p_def->access               = access;
-    p_def->p_init               = pool_init;
-    p_def->p_free               = pool_free;
-    p_def->p_get_size           = pool_get_size;
-    p_def->p_push               = pool_push;
-    p_def->p_pop                = pool_pop;
-    p_def->p_pop_timedwait      = pool_pop_timedwait;
-    p_def->p_remove             = pool_remove;
-    p_def->p_print_all          = pool_print_all;
-    p_def->u_get_type           = unit_get_type;
-    p_def->u_get_thread         = unit_get_thread;
-    p_def->u_get_task           = unit_get_task;
-    p_def->u_is_in_pool         = unit_is_in_pool;
+    p_def->access = access;
+    p_def->p_init = pool_init;
+    p_def->p_free = pool_free;
+    p_def->p_get_size = pool_get_size;
+    p_def->p_push = pool_push;
+    p_def->p_pop = pool_pop;
+    p_def->p_pop_timedwait = pool_pop_timedwait;
+    p_def->p_remove = pool_remove;
+    p_def->p_print_all = pool_print_all;
+    p_def->u_get_type = unit_get_type;
+    p_def->u_get_thread = unit_get_thread;
+    p_def->u_get_task = unit_get_task;
+    p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task   = unit_create_from_task;
-    p_def->u_free               = unit_free;
+    p_def->u_create_from_task = unit_create_from_task;
+    p_def->u_free = unit_free;
 
     return ABT_SUCCESS;
 }
-
 
 /* Pool functions */
 
@@ -134,10 +133,10 @@ static void pool_push(ABT_pool pool, ABT_unit unit)
 }
 
 static inline void convert_double_sec_to_timespec(struct timespec *ts_out,
-    double seconds)
+                                                  double seconds)
 {
     ts_out->tv_sec = (time_t)seconds;
-    ts_out->tv_nsec = (long)((seconds-ts_out->tv_sec) * 1000000000.0);
+    ts_out->tv_nsec = (long)((seconds - ts_out->tv_sec) * 1000000000.0);
 }
 
 static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
@@ -149,8 +148,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
 
     pthread_mutex_lock(&p_data->mutex);
 
-    if(!p_data->num_units)
-    {
+    if (!p_data->num_units) {
         struct timespec ts;
         convert_double_sec_to_timespec(&ts, abstime_secs);
         pthread_cond_timedwait(&p_data->cond, &p_data->mutex, &ts);
@@ -245,7 +243,8 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
 }
 
 static int pool_print_all(ABT_pool pool, void *arg,
-                          void (*print_fn)(void *, ABT_unit)) {
+                          void (*print_fn)(void *, ABT_unit))
+{
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
 
@@ -269,8 +268,8 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
-   unit_t *p_unit = (unit_t *)unit;
-   return p_unit->type;
+    unit_t *p_unit = (unit_t *)unit;
+    return p_unit->type;
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
@@ -309,9 +308,9 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->handle.thread = thread;
-    p_unit->type   = ABT_UNIT_TYPE_THREAD;
+    p_unit->type = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
 }
@@ -322,9 +321,9 @@ static ABT_unit unit_create_from_task(ABT_task task)
     unit_t *p_unit = &p_task->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool   = ABT_POOL_NULL;
+    p_unit->pool = ABT_POOL_NULL;
     p_unit->handle.task = task;
-    p_unit->type   = ABT_UNIT_TYPE_TASK;
+    p_unit->type = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;
 }

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -7,7 +7,6 @@
 
 static inline uint64_t ABTI_pool_get_new_id(void);
 
-
 /** @defgroup POOL Pool
  * This group is for Pool.
  */
@@ -38,10 +37,10 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     ABTI_CHECK_ERROR(abt_errno);
     *newpool = ABTI_pool_get_handle(p_newpool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *newpool = ABT_POOL_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -70,10 +69,10 @@ int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
     ABTI_CHECK_ERROR(abt_errno);
     *newpool = ABTI_pool_get_handle(p_newpool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     *newpool = ABT_POOL_NULL;
     goto fn_exit;
@@ -94,15 +93,16 @@ int ABT_pool_free(ABT_pool *pool)
     ABT_pool h_pool = *pool;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(h_pool);
 
-    ABTI_CHECK_TRUE(p_pool != NULL && h_pool != ABT_POOL_NULL, ABT_ERR_INV_POOL);
+    ABTI_CHECK_TRUE(p_pool != NULL && h_pool != ABT_POOL_NULL,
+                    ABT_ERR_INV_POOL);
     ABTI_pool_free(p_pool);
 
     *pool = ABT_POOL_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -124,10 +124,10 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 
     *access = p_pool->access;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -154,14 +154,13 @@ int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 
     *size = ABTI_pool_get_total_size(p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup POOL
@@ -184,10 +183,10 @@ int ABT_pool_get_size(ABT_pool pool, size_t *size)
 
     *size = ABTI_pool_get_size(p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -214,11 +213,11 @@ int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 
     unit = ABTI_pool_pop(p_pool);
 
-  fn_exit:
+fn_exit:
     *p_unit = unit;
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     unit = ABT_UNIT_NULL;
     goto fn_exit;
@@ -237,11 +236,11 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 
     unit = ABTI_pool_pop_timedwait(p_pool, abstime_secs);
 
-  fn_exit:
+fn_exit:
     *p_unit = unit;
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     unit = ABT_UNIT_NULL;
     goto fn_exit;
@@ -269,15 +268,16 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
     ABTI_pool_push(p_pool, unit);
 #else
     /* Save the producer ES information in the pool */
-    abt_errno = ABTI_pool_push(p_pool, unit,
-        ABTI_self_get_native_thread_id(ABTI_local_get_local()));
+    abt_errno =
+        ABTI_pool_push(p_pool, unit,
+                       ABTI_self_get_native_thread_id(ABTI_local_get_local()));
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -302,13 +302,14 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     abt_errno = ABTI_POOL_REMOVE(p_pool, unit,
-        ABTI_self_get_native_thread_id(ABTI_local_get_local()));
+                                 ABTI_self_get_native_thread_id(
+                                     ABTI_local_get_local()));
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -333,7 +334,8 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
  * @retval ABT_SUCCESS on success
  */
 int ABT_pool_print_all(ABT_pool pool, void *arg,
-                       void (*print_fn)(void *, ABT_unit)) {
+                       void (*print_fn)(void *, ABT_unit))
+{
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -402,10 +404,10 @@ int ABT_pool_get_data(ABT_pool pool, void **data)
 
     *data = p_pool->data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -457,8 +459,9 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
              * a pool with another associated pool, and set the right value if
              * it is okay  */
             for (p = 0; p < p_sched->num_pools; p++) {
-                abt_errno = ABTI_pool_set_consumer(
-                    ABTI_pool_get_ptr(p_sched->pools[p]), p_pool->consumer_id);
+                abt_errno =
+                    ABTI_pool_set_consumer(ABTI_pool_get_ptr(p_sched->pools[p]),
+                                           p_pool->consumer_id);
                 ABTI_CHECK_ERROR(abt_errno);
             }
             break;
@@ -470,8 +473,10 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
             for (p = 0; p < p_sched->num_pools; p++) {
                 ABTI_pool *p_local_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
                 ABTI_CHECK_TRUE(p_local_pool->access != ABT_POOL_ACCESS_PRIV &&
-                                p_local_pool->access != ABT_POOL_ACCESS_SPSC &&
-                                p_local_pool->access != ABT_POOL_ACCESS_MPSC,
+                                    p_local_pool->access !=
+                                        ABT_POOL_ACCESS_SPSC &&
+                                    p_local_pool->access !=
+                                        ABT_POOL_ACCESS_MPSC,
                                 ABT_ERR_POOL);
             }
             break;
@@ -488,7 +493,7 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         abt_errno = ABTI_thread_create_sched(p_local, p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-    } else if (p_sched->type == ABT_SCHED_TYPE_TASK){
+    } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
         abt_errno = ABTI_task_create_sched(p_local, p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
@@ -524,10 +529,10 @@ int ABT_pool_get_id(ABT_pool pool, int *id)
 
     *id = (int)p_pool->id;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -543,36 +548,36 @@ int ABTI_pool_create(ABT_pool_def *def, ABT_pool_config config,
     ABTI_pool *p_pool;
 
     p_pool = (ABTI_pool *)ABTU_malloc(sizeof(ABTI_pool));
-    p_pool->access               = def->access;
-    p_pool->automatic            = automatic;
-    p_pool->num_scheds           = 0;
+    p_pool->access = def->access;
+    p_pool->automatic = automatic;
+    p_pool->num_scheds = 0;
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    p_pool->consumer_id          = 0;
+    p_pool->consumer_id = 0;
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    p_pool->producer_id          = 0;
+    p_pool->producer_id = 0;
 #endif
-    p_pool->num_blocked          = 0;
-    p_pool->num_migrations       = 0;
-    p_pool->data                 = NULL;
+    p_pool->num_blocked = 0;
+    p_pool->num_migrations = 0;
+    p_pool->data = NULL;
 
     /* Set up the pool functions from def */
-    p_pool->u_get_type           = def->u_get_type;
-    p_pool->u_get_thread         = def->u_get_thread;
-    p_pool->u_get_task           = def->u_get_task;
-    p_pool->u_is_in_pool         = def->u_is_in_pool;
+    p_pool->u_get_type = def->u_get_type;
+    p_pool->u_get_thread = def->u_get_thread;
+    p_pool->u_get_task = def->u_get_task;
+    p_pool->u_is_in_pool = def->u_is_in_pool;
     p_pool->u_create_from_thread = def->u_create_from_thread;
-    p_pool->u_create_from_task   = def->u_create_from_task;
-    p_pool->u_free               = def->u_free;
-    p_pool->p_init               = def->p_init;
-    p_pool->p_get_size           = def->p_get_size;
-    p_pool->p_push               = def->p_push;
-    p_pool->p_pop                = def->p_pop;
-    p_pool->p_pop_timedwait      = def->p_pop_timedwait;
-    p_pool->p_remove             = def->p_remove;
-    p_pool->p_free               = def->p_free;
-    p_pool->p_print_all          = def->p_print_all;
-    p_pool->id                   = ABTI_pool_get_new_id();
+    p_pool->u_create_from_task = def->u_create_from_task;
+    p_pool->u_free = def->u_free;
+    p_pool->p_init = def->p_init;
+    p_pool->p_get_size = def->p_get_size;
+    p_pool->p_push = def->p_push;
+    p_pool->p_pop = def->p_pop;
+    p_pool->p_pop_timedwait = def->p_pop_timedwait;
+    p_pool->p_remove = def->p_remove;
+    p_pool->p_free = def->p_free;
+    p_pool->p_print_all = def->p_print_all;
+    p_pool->id = ABTI_pool_get_new_id();
     LOG_EVENT("[P%" PRIu64 "] created\n", p_pool->id);
 
     /* Configure the pool */
@@ -585,10 +590,10 @@ int ABTI_pool_create(ABT_pool_def *def, ABT_pool_config config,
     }
     *pp_newpool = p_pool;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -612,14 +617,14 @@ int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
     }
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABTI_pool_create(&def, ABT_POOL_CONFIG_NULL, automatic,
-                                 pp_newpool);
+    abt_errno =
+        ABTI_pool_create(&def, ABT_POOL_CONFIG_NULL, automatic, pp_newpool);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -644,57 +649,64 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
     char *access;
 
     switch (p_pool->access) {
-        case ABT_POOL_ACCESS_PRIV: access = "PRIV"; break;
-        case ABT_POOL_ACCESS_SPSC: access = "SPSC"; break;
-        case ABT_POOL_ACCESS_MPSC: access = "MPSC"; break;
-        case ABT_POOL_ACCESS_SPMC: access = "SPMC"; break;
-        case ABT_POOL_ACCESS_MPMC: access = "MPMC"; break;
-        default:                   access = "UNKNOWN"; break;
+        case ABT_POOL_ACCESS_PRIV:
+            access = "PRIV";
+            break;
+        case ABT_POOL_ACCESS_SPSC:
+            access = "SPSC";
+            break;
+        case ABT_POOL_ACCESS_MPSC:
+            access = "MPSC";
+            break;
+        case ABT_POOL_ACCESS_SPMC:
+            access = "SPMC";
+            break;
+        case ABT_POOL_ACCESS_MPMC:
+            access = "MPMC";
+            break;
+        default:
+            access = "UNKNOWN";
+            break;
     }
 
     fprintf(p_os,
-        "%s== POOL (%p) ==\n"
-        "%sid            : %" PRIu64 "\n"
-        "%saccess        : %s\n"
-        "%sautomatic     : %s\n"
-        "%snum_scheds    : %d\n"
+            "%s== POOL (%p) ==\n"
+            "%sid            : %" PRIu64 "\n"
+            "%saccess        : %s\n"
+            "%sautomatic     : %s\n"
+            "%snum_scheds    : %d\n"
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        "%sconsumer ID   : %p\n"
+            "%sconsumer ID   : %p\n"
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-        "%sproducer ID   : %p\n"
+            "%sproducer ID   : %p\n"
 #endif
-        "%ssize          : %zu\n"
-        "%snum_blocked   : %u\n"
-        "%snum_migrations: %d\n"
-        "%sdata          : %p\n",
-        prefix, (void *)p_pool,
-        prefix, p_pool->id,
-        prefix, access,
-        prefix, (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
-        prefix, p_pool->num_scheds,
+            "%ssize          : %zu\n"
+            "%snum_blocked   : %u\n"
+            "%snum_migrations: %d\n"
+            "%sdata          : %p\n",
+            prefix, (void *)p_pool, prefix, p_pool->id, prefix, access, prefix,
+            (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE", prefix,
+            p_pool->num_scheds,
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        prefix, (void *)p_pool->consumer_id,
+            prefix, (void *)p_pool->consumer_id,
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-        prefix, (void *)p_pool->producer_id,
+            prefix, (void *)p_pool->producer_id,
 #endif
-        prefix, ABTI_pool_get_size(p_pool),
-        prefix, p_pool->num_blocked,
-        prefix, p_pool->num_migrations,
-        prefix, p_pool->data
-    );
+            prefix, ABTI_pool_get_size(p_pool), prefix, p_pool->num_blocked,
+            prefix, p_pool->num_migrations, prefix, p_pool->data);
 
-  fn_exit:
+fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-/* Set the associated consumer ES of a pool. This function has no effect on pools
- * of shared-read access mode.
- * If a pool is private-read to an ES, we check that the previous value of
- * "consumer_id" is the same as the argument of the function "consumer_id"
+/* Set the associated consumer ES of a pool. This function has no effect on
+ * pools of shared-read access mode. If a pool is private-read to an ES, we
+ * check that the previous value of "consumer_id" is the same as the argument of
+ * the function "consumer_id"
  * */
 int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_native_thread_id consumer_id)
 {
@@ -708,11 +720,11 @@ int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_native_thread_id consumer_id)
         case ABT_POOL_ACCESS_PRIV:
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
             ABTI_CHECK_TRUE(!p_pool->producer_id ||
-                            p_pool->producer_id == consumer_id,
+                                p_pool->producer_id == consumer_id,
                             ABT_ERR_INV_POOL_ACCESS);
 #endif
             ABTI_CHECK_TRUE(!p_pool->consumer_id ||
-                            p_pool->consumer_id == consumer_id,
+                                p_pool->consumer_id == consumer_id,
                             ABT_ERR_INV_POOL_ACCESS);
             p_pool->consumer_id = consumer_id;
             break;
@@ -720,7 +732,7 @@ int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_native_thread_id consumer_id)
         case ABT_POOL_ACCESS_SPSC:
         case ABT_POOL_ACCESS_MPSC:
             ABTI_CHECK_TRUE(!p_pool->consumer_id ||
-                            p_pool->consumer_id == consumer_id,
+                                p_pool->consumer_id == consumer_id,
                             ABT_ERR_INV_POOL_ACCESS);
             /* NB: as we do not want to use a mutex, the function can be wrong
              * here */
@@ -747,10 +759,10 @@ fn_fail:
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-/* Set the associated producer ES of a pool. This function has no effect on pools
- * of shared-write access mode.
- * If a pool is private-write to an ES, we check that the previous value of
- * "producer_id" is the same as the argument of the function "producer_id"
+/* Set the associated producer ES of a pool. This function has no effect on
+ * pools of shared-write access mode. If a pool is private-write to an ES, we
+ * check that the previous value of "producer_id" is the same as the argument of
+ * the function "producer_id"
  * */
 int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_native_thread_id producer_id)
 {
@@ -764,11 +776,11 @@ int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_native_thread_id producer_id)
         case ABT_POOL_ACCESS_PRIV:
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
             ABTI_CHECK_TRUE(!p_pool->consumer_id ||
-                            p_pool->consumer_id == producer_id,
+                                p_pool->consumer_id == producer_id,
                             ABT_ERR_INV_POOL_ACCESS);
 #endif
             ABTI_CHECK_TRUE(!p_pool->producer_id ||
-                            p_pool->producer_id == producer_id,
+                                p_pool->producer_id == producer_id,
                             ABT_ERR_INV_POOL_ACCESS);
             p_pool->producer_id = producer_id;
             break;
@@ -776,7 +788,7 @@ int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_native_thread_id producer_id)
         case ABT_POOL_ACCESS_SPSC:
         case ABT_POOL_ACCESS_SPMC:
             ABTI_CHECK_TRUE(!p_pool->producer_id ||
-                            p_pool->producer_id == producer_id,
+                                p_pool->producer_id == producer_id,
                             ABT_ERR_INV_POOL_ACCESS);
             /* NB: as we do not want to use a mutex, the function can be wrong
              * here */
@@ -807,10 +819,9 @@ fn_fail:
  * ES */
 int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source)
 {
-#if !defined(ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK) && \
+#if !defined(ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK) &&                        \
     !defined(ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK)
-    switch (p_pool->access)
-    {
+    switch (p_pool->access) {
         /* Need producer in the same ES */
         case ABT_POOL_ACCESS_PRIV:
         case ABT_POOL_ACCESS_SPSC:
@@ -829,7 +840,6 @@ int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source)
     return ABT_TRUE;
 #endif
 }
-
 
 static uint64_t g_pool_id = 0;
 void ABTI_pool_reset_id(void)

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -31,8 +31,7 @@ int ABT_rwlock_create(ABT_rwlock *newrwlock)
     p_newrwlock = (ABTI_rwlock *)ABTU_malloc(sizeof(ABTI_rwlock));
     if (p_newrwlock == NULL) {
         abt_errno = ABT_ERR_MEM;
-    }
-    else {
+    } else {
         ABTI_rwlock_init(p_newrwlock);
     }
 
@@ -70,10 +69,10 @@ int ABT_rwlock_free(ABT_rwlock *rwlock)
     /* Return value */
     *rwlock = ABT_RWLOCK_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -105,10 +104,10 @@ int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 
     ABTI_rwlock_rdlock(&p_local, p_rwlock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -139,10 +138,10 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 
     ABTI_rwlock_wrlock(&p_local, p_rwlock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -152,9 +151,9 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
  * @brief Unlock the rwlock
  *
  * \c ABT_rwlock_unlock unlocks the rwlock \c rwlock.
- * If the caller ULT locked the rwlock, this routine unlocks the rwlock. However,
- * if the caller ULT did not lock the rwlock, this routine may result in
- * undefined behavior.
+ * If the caller ULT locked the rwlock, this routine unlocks the rwlock.
+ * However, if the caller ULT did not lock the rwlock, this routine may result
+ * in undefined behavior.
  *
  * @param[in] rwlock  handle to the rwlock
  * @return Error code
@@ -169,10 +168,10 @@ int ABT_rwlock_unlock(ABT_rwlock rwlock)
 
     ABTI_rwlock_unlock(&p_local, p_rwlock);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -9,9 +9,9 @@
  * This group is for the basic scheduler.
  */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_def = {
@@ -31,10 +31,8 @@ typedef struct {
 #endif
 } sched_data;
 
-ABT_sched_config_var ABT_sched_basic_freq = {
-    .idx = 0,
-    .type = ABT_SCHED_CONFIG_INT
-};
+ABT_sched_config_var ABT_sched_basic_freq = { .idx = 0,
+                                              .type = ABT_SCHED_CONFIG_INT };
 
 ABT_sched_def *ABTI_sched_get_basic_def(void)
 {
@@ -80,10 +78,10 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     p_sched->data = p_data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("basic: sched_init", abt_errno);
     goto fn_exit;
 }
@@ -105,8 +103,8 @@ static void sched_run(ABT_sched sched)
 
     p_data = sched_data_get_ptr(p_sched->data);
     event_freq = p_data->event_freq;
-    num_pools  = p_data->num_pools;
-    pools      = p_data->pools;
+    num_pools = p_data->num_pools;
+    pools = p_data->pools;
 
     while (1) {
         for (i = 0; i < num_pools; i++) {
@@ -120,8 +118,8 @@ static void sched_run(ABT_sched sched)
         /* if we attempted event_freq pops, check for events */
         if (pop_count >= event_freq) {
             ABTI_xstream_check_events(p_xstream, sched);
-            if (ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream)
-                == ABT_TRUE)
+            if (ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream) ==
+                ABT_TRUE)
                 break;
             SCHED_SLEEP(unit != ABT_UNIT_NULL, p_data->sleep_time);
             pop_count = 0;
@@ -147,12 +145,20 @@ static int pool_get_access_num(ABT_pool *p_pool)
 
     access = ABTI_pool_get_ptr(*p_pool)->access;
     switch (access) {
-        case ABT_POOL_ACCESS_PRIV: num = 0; break;
+        case ABT_POOL_ACCESS_PRIV:
+            num = 0;
+            break;
         case ABT_POOL_ACCESS_SPSC:
-        case ABT_POOL_ACCESS_MPSC: num = 1; break;
+        case ABT_POOL_ACCESS_MPSC:
+            num = 1;
+            break;
         case ABT_POOL_ACCESS_SPMC:
-        case ABT_POOL_ACCESS_MPMC: num = 2; break;
-        default: ABTI_ASSERT(0); break;
+        case ABT_POOL_ACCESS_MPMC:
+            num = 2;
+            break;
+        default:
+            ABTI_ASSERT(0);
+            break;
     }
 
     return num;
@@ -178,4 +184,3 @@ static void sched_sort_pools(int num_pools, ABT_pool *pools)
 {
     qsort(pools, num_pools, sizeof(ABT_pool), sched_cmp_pools);
 }
-

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -9,9 +9,9 @@
  * This group is for the basic waiting scheduler.
  */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_wait_def = {
@@ -28,10 +28,9 @@ typedef struct {
     ABT_pool *pools;
 } sched_data;
 
-ABT_sched_config_var ABT_sched_basic_wait_freq = {
-    .idx = 0,
-    .type = ABT_SCHED_CONFIG_INT
-};
+ABT_sched_config_var ABT_sched_basic_wait_freq = { .idx = 0,
+                                                   .type =
+                                                       ABT_SCHED_CONFIG_INT };
 
 ABT_sched_def *ABTI_sched_get_basic_wait_def(void)
 {
@@ -73,10 +72,10 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     p_sched->data = p_data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("basic_wait: sched_init", abt_errno);
     goto fn_exit;
 }
@@ -98,8 +97,8 @@ static void sched_run(ABT_sched sched)
 
     p_data = sched_data_get_ptr(p_sched->data);
     event_freq = p_data->event_freq;
-    num_pools  = p_data->num_pools;
-    pools      = p_data->pools;
+    num_pools = p_data->num_pools;
+    pools = p_data->pools;
 
     while (1) {
         run_cnt_nowait = 0;
@@ -120,14 +119,14 @@ static void sched_run(ABT_sched sched)
         /* Block briefly on pop_timedwait() if we didn't find work to do in
          * main loop above.
          */
-        if(!run_cnt_nowait) {
+        if (!run_cnt_nowait) {
             double abstime = ABTI_get_wtime();
             abstime += 0.1;
-            ABT_unit unit = ABTI_pool_pop_timedwait(
-                ABTI_pool_get_ptr(pools[0]), abstime);
+            ABT_unit unit =
+                ABTI_pool_pop_timedwait(ABTI_pool_get_ptr(pools[0]), abstime);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_xstream_run_unit(&p_local, p_xstream, unit,
-                    ABTI_pool_get_ptr(pools[0]));
+                                      ABTI_pool_get_ptr(pools[0]));
                 break;
             }
         }
@@ -140,8 +139,8 @@ static void sched_run(ABT_sched sched)
          */
         if (!run_cnt_nowait || (++work_count >= event_freq)) {
             ABTI_xstream_check_events(p_xstream, sched);
-            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
-                                                   p_xstream);
+            ABT_bool stop =
+                ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream);
             if (stop == ABT_TRUE)
                 break;
             work_count = 0;
@@ -167,12 +166,20 @@ static int pool_get_access_num(ABT_pool *p_pool)
 
     access = ABTI_pool_get_ptr(*p_pool)->access;
     switch (access) {
-        case ABT_POOL_ACCESS_PRIV: num = 0; break;
+        case ABT_POOL_ACCESS_PRIV:
+            num = 0;
+            break;
         case ABT_POOL_ACCESS_SPSC:
-        case ABT_POOL_ACCESS_MPSC: num = 1; break;
+        case ABT_POOL_ACCESS_MPSC:
+            num = 1;
+            break;
         case ABT_POOL_ACCESS_SPMC:
-        case ABT_POOL_ACCESS_MPMC: num = 2; break;
-        default: ABTI_ASSERT(0); break;
+        case ABT_POOL_ACCESS_MPMC:
+            num = 2;
+            break;
+        default:
+            ABTI_ASSERT(0);
+            break;
     }
 
     return num;

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
@@ -15,21 +14,16 @@
  */
 
 /* Global configurable parameters */
-ABT_sched_config_var ABT_sched_config_var_end = {
-    .idx = -1,
-    .type = ABT_SCHED_CONFIG_INT
-};
+ABT_sched_config_var ABT_sched_config_var_end = { .idx = -1,
+                                                  .type =
+                                                      ABT_SCHED_CONFIG_INT };
 
-ABT_sched_config_var ABT_sched_config_access = {
-    .idx = -2,
-    .type = ABT_SCHED_CONFIG_INT
-};
+ABT_sched_config_var ABT_sched_config_access = { .idx = -2,
+                                                 .type = ABT_SCHED_CONFIG_INT };
 
-ABT_sched_config_var ABT_sched_config_automatic = {
-    .idx = -3,
-    .type = ABT_SCHED_CONFIG_INT
-};
-
+ABT_sched_config_var ABT_sched_config_automatic = { .idx = -3,
+                                                    .type =
+                                                        ABT_SCHED_CONFIG_INT };
 
 /**
  * @ingroup SCHED_CONFIG
@@ -54,7 +48,8 @@ ABT_sched_config_var ABT_sched_config_automatic = {
  *
  * For example, if you want to configure the basic scheduler to have a
  * frequency for checking events equal to 5, you will have this call:
- * ABT_sched_config_create(&config, ABT_sched_basic_freq, 5, ABT_sched_config_var_end);
+ * ABT_sched_config_create(&config, ABT_sched_basic_freq, 5,
+ * ABT_sched_config_var_end);
  *
  * @param[out] config   configuration to create
  * @param[in]  ...      list of arguments
@@ -67,7 +62,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
     ABTI_sched_config *p_config;
 
     char *buffer = NULL;
-    size_t alloc_size = 8*sizeof(size_t);
+    size_t alloc_size = 8 * sizeof(size_t);
 
     int num_params = 0;
     size_t offset = sizeof(num_params);
@@ -78,7 +73,8 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
     va_list varg_list;
     va_start(varg_list, config);
 
-    /* We read each couple (var, value) until we find ABT_sched_config_var_end */
+    /* We read each couple (var, value) until we find ABT_sched_config_var_end
+     */
     while (1) {
         ABT_sched_config_var var = va_arg(varg_list, ABT_sched_config_var);
         if (var.idx == ABT_sched_config_var_end.idx)
@@ -89,17 +85,17 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
         num_params++;
 
         size_t size = ABTI_sched_config_type_size(type);
-        if (offset+sizeof(param)+sizeof(type)+size > buffer_size) {
+        if (offset + sizeof(param) + sizeof(type) + size > buffer_size) {
             size_t cur_buffer_size = buffer_size;
             buffer_size += alloc_size;
             buffer = ABTU_realloc(buffer, cur_buffer_size, buffer_size);
         }
         /* Copy the parameter index */
-        memcpy(buffer+offset, (void *)&param, sizeof(param));
+        memcpy(buffer + offset, (void *)&param, sizeof(param));
         offset += sizeof(param);
 
         /* Copy the size of the argument */
-        memcpy(buffer+offset, (void *)&size, sizeof(size));
+        memcpy(buffer + offset, (void *)&size, sizeof(size));
         offset += sizeof(size);
 
         /* Copy the argument */
@@ -125,7 +121,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 goto fn_fail;
         }
 
-        memcpy(buffer+offset, ptr, size);
+        memcpy(buffer + offset, ptr, size);
         offset += size;
     }
     va_end(varg_list);
@@ -140,10 +136,10 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
     p_config = (ABTI_sched_config *)buffer;
     *config = ABTI_sched_config_get_handle(p_config);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -169,7 +165,7 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
     int v;
 
     /* We read all the variables and save the addresses */
-    void **variables = (void *)ABTU_malloc(num_vars*sizeof(void *));
+    void **variables = (void *)ABTU_malloc(num_vars * sizeof(void *));
     va_list varg_list;
     va_start(varg_list, num_vars);
     for (v = 0; v < num_vars; v++) {
@@ -182,10 +178,10 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
 
     ABTU_free(variables);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -240,13 +236,15 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
     ABTU_free(variables);
     ABTI_CHECK_ERROR(abt_errno);
 
-    if (access_i != -1) *access = (ABT_pool_access)access_i;
-    if (automatic_i != -1) *automatic = (ABT_bool)automatic_i;
+    if (access_i != -1)
+        *access = (ABT_pool_access)access_i;
+    if (automatic_i != -1)
+        *automatic = (ABT_bool)automatic_i;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -272,16 +270,15 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
 
     /* Copy the data from buffer to the right variables */
     int p;
-    for (p = 0; p < num_params; p++)
-    {
+    for (p = 0; p < num_params; p++) {
         int var_idx;
         size_t size;
 
         /* Get the variable index of the next parameter */
-        memcpy(&var_idx, buffer+offset, sizeof(var_idx));
+        memcpy(&var_idx, buffer + offset, sizeof(var_idx));
         offset += sizeof(var_idx);
         /* Get the size of the next parameter */
-        memcpy(&size, buffer+offset, sizeof(size));
+        memcpy(&size, buffer + offset, sizeof(size));
         offset += sizeof(size);
         /* Get the next argument */
         /* We save it only if
@@ -290,18 +287,19 @@ int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
          */
         if (type == 0) {
             if (var_idx < 0) {
-                var_idx = (var_idx+2)*-1;
-                if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                var_idx = (var_idx + 2) * -1;
+                if (var_idx >= num_vars)
+                    return ABT_ERR_INV_SCHED_CONFIG;
+                memcpy(variables[var_idx], buffer + offset, size);
             }
         } else {
             if (var_idx >= 0) {
-                if (var_idx >= num_vars) return ABT_ERR_INV_SCHED_CONFIG;
-                memcpy(variables[var_idx], buffer+offset, size);
+                if (var_idx >= num_vars)
+                    return ABT_ERR_INV_SCHED_CONFIG;
+                memcpy(variables[var_idx], buffer + offset, size);
             }
         }
         offset += size;
     }
     return ABT_SUCCESS;
 }
-

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -5,20 +5,17 @@
 
 #include "abti.h"
 
-
 /* Priority Scheduler Implementation */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 
-static ABT_sched_def sched_prio_def = {
-    .type = ABT_SCHED_TYPE_TASK,
-    .init = sched_init,
-    .run = sched_run,
-    .free = sched_free,
-    .get_migr_pool = NULL
-};
+static ABT_sched_def sched_prio_def = { .type = ABT_SCHED_TYPE_TASK,
+                                        .init = sched_init,
+                                        .run = sched_run,
+                                        .free = sched_free,
+                                        .get_migr_pool = NULL };
 
 typedef struct {
     uint32_t event_freq;
@@ -26,7 +23,6 @@ typedef struct {
     struct timespec sleep_time;
 #endif
 } sched_data;
-
 
 ABT_sched_def *ABTI_sched_get_prio_def(void)
 {
@@ -59,10 +55,10 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     p_sched->data = p_data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("prio: sched_init", abt_errno);
     goto fn_exit;
 }
@@ -107,9 +103,10 @@ static void sched_run(ABT_sched sched)
         }
 
         if (++work_count >= event_freq) {
-            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
-                                                   p_xstream);
-            if (stop == ABT_TRUE) break;
+            ABT_bool stop =
+                ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream);
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);
             SCHED_SLEEP(run_cnt, p_data->sleep_time);
@@ -129,4 +126,3 @@ static int sched_free(ABT_sched sched)
 
     return ABT_SUCCESS;
 }
-

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -7,9 +7,9 @@
 
 /* Random Work-stealing Scheduler Implementation */
 
-static int  sched_init(ABT_sched sched, ABT_sched_config config);
+static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
-static int  sched_free(ABT_sched);
+static int sched_free(ABT_sched);
 
 static ABT_sched_def sched_randws_def = {
     .type = ABT_SCHED_TYPE_TASK,
@@ -52,10 +52,10 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     p_sched->data = p_data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_WITH_CODE("randws: sched_init", abt_errno);
     goto fn_exit;
 }
@@ -93,7 +93,8 @@ static void sched_run(ABT_sched sched)
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             pool = p_pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
             unit = ABTI_pool_pop(p_pool);
@@ -106,9 +107,10 @@ static void sched_run(ABT_sched sched)
         }
 
         if (++work_count >= p_data->event_freq) {
-            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
-                                                   p_xstream);
-            if (stop == ABT_TRUE) break;
+            ABT_bool stop =
+                ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream);
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);
             SCHED_SLEEP(run_cnt, p_data->sleep_time);
@@ -128,4 +130,3 @@ static int sched_free(ABT_sched sched)
 
     return ABT_SUCCESS;
 }
-

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -9,7 +9,6 @@
 static inline uint64_t ABTI_sched_get_new_id(void);
 #endif
 
-
 /** @defgroup SCHED Scheduler
  * This group is for Scheduler.
  */
@@ -51,10 +50,10 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     /* Return value */
     *newsched = ABTI_sched_get_handle(p_sched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *newsched = ABT_SCHED_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -97,15 +96,15 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_newsched;
-    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools, config,
-                                        &p_newsched);
+    abt_errno =
+        ABTI_sched_create_basic(predef, num_pools, pools, config, &p_newsched);
     ABTI_CHECK_ERROR(abt_errno);
     *newsched = ABTI_sched_get_handle(p_newsched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     *newsched = ABT_SCHED_NULL;
     goto fn_exit;
@@ -139,10 +138,10 @@ int ABT_sched_free(ABT_sched *sched)
     /* Return value */
     *sched = ABT_SCHED_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -169,10 +168,10 @@ int ABT_sched_get_num_pools(ABT_sched sched, int *num_pools)
 
     *num_pools = p_sched->num_pools;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -196,17 +195,17 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    ABTI_CHECK_TRUE(idx+max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE(idx + max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
 
     int p;
-    for (p = idx; p < idx+max_pools; p++) {
-        pools[p-idx] = p_sched->pools[p];
+    for (p = idx; p < idx + max_pools; p++) {
+        pools[p - idx] = p_sched->pools[p];
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -230,10 +229,10 @@ int ABT_sched_finish(ABT_sched sched)
 
     ABTI_sched_finish(p_sched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -243,7 +242,8 @@ int ABT_sched_finish(ABT_sched sched)
  * @brief   Ask a scheduler to stop as soon as possible
  *
  * The scheduler will stop even if its pools are not empty. It is the user's
- * responsibility to ensure that the left work will be done by another scheduler.
+ * responsibility to ensure that the left work will be done by another
+ * scheduler.
  *
  * @param[in] sched  handle to the target scheduler
  * @return Error code
@@ -257,10 +257,10 @@ int ABT_sched_exit(ABT_sched sched)
 
     ABTI_sched_exit(p_sched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -302,10 +302,10 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 
     *stop = ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -356,7 +356,7 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched,
         }
     }
 
-  fn_exit:
+fn_exit:
     return stop;
 }
 
@@ -379,10 +379,10 @@ int ABT_sched_set_data(ABT_sched sched, void *data)
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
     p_sched->data = data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -408,10 +408,10 @@ int ABT_sched_get_data(ABT_sched sched, void **data)
 
     *data = p_sched->data;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -437,11 +437,11 @@ int ABT_sched_get_size(ABT_sched sched, size_t *size)
 
     pool_size = ABTI_sched_get_size(p_sched);
 
-  fn_exit:
+fn_exit:
     *size = pool_size;
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -480,11 +480,11 @@ int ABT_sched_get_total_size(ABT_sched sched, size_t *size)
 
     pool_size = ABTI_sched_get_total_size(p_sched);
 
-  fn_exit:
+fn_exit:
     *size = pool_size;
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -539,13 +539,13 @@ size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
                 }
 #endif
                 break;
-            default: break;
+            default:
+                break;
         }
     }
 
     return pool_size;
 }
-
 
 /*****************************************************************************/
 /* Private APIs                                                              */
@@ -573,13 +573,13 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 
     /* Copy of the contents of pools */
     ABT_pool *pool_list;
-    pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+    pool_list = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
     for (p = 0; p < num_pools; p++) {
         if (pools[p] == ABT_POOL_NULL) {
             ABTI_pool *p_newpool;
-            abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
-                                              ABT_POOL_ACCESS_MPSC,
-                                              ABT_TRUE, &p_newpool);
+            abt_errno =
+                ABTI_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPSC,
+                                       ABT_TRUE, &p_newpool);
             ABTI_CHECK_ERROR(abt_errno);
             pool_list[p] = ABTI_pool_get_handle(p_newpool);
         } else {
@@ -592,25 +592,25 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
         ABTI_pool_retain(ABTI_pool_get_ptr(pool_list[p]));
     }
 
-    p_sched->used          = ABTI_SCHED_NOT_USED;
-    p_sched->automatic     = automatic;
-    p_sched->kind          = ABTI_sched_get_kind(def);
-    p_sched->state         = ABT_SCHED_STATE_READY;
-    p_sched->request       = 0;
-    p_sched->pools         = pool_list;
-    p_sched->num_pools     = num_pools;
-    p_sched->type          = def->type;
-    p_sched->p_thread      = NULL;
-    p_sched->p_task        = NULL;
-    p_sched->p_ctx         = NULL;
+    p_sched->used = ABTI_SCHED_NOT_USED;
+    p_sched->automatic = automatic;
+    p_sched->kind = ABTI_sched_get_kind(def);
+    p_sched->state = ABT_SCHED_STATE_READY;
+    p_sched->request = 0;
+    p_sched->pools = pool_list;
+    p_sched->num_pools = num_pools;
+    p_sched->type = def->type;
+    p_sched->p_thread = NULL;
+    p_sched->p_task = NULL;
+    p_sched->p_ctx = NULL;
 
-    p_sched->init          = def->init;
-    p_sched->run           = def->run;
-    p_sched->free          = def->free;
+    p_sched->init = def->init;
+    p_sched->run = def->run;
+    p_sched->free = def->free;
     p_sched->get_migr_pool = def->get_migr_pool;
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-    p_sched->id            = ABTI_sched_get_new_id();
+    p_sched->id = ABTI_sched_get_new_id();
 #endif
     LOG_EVENT("[S%" PRIu64 "] created\n", p_sched->id);
 
@@ -621,10 +621,10 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     p_sched->init(newsched, config);
     *pp_newsched = p_sched;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -651,7 +651,7 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     if (pools != NULL) {
         /* Copy of the contents of pools */
         ABT_pool *pool_list;
-        pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+        pool_list = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
         int p;
         for (p = 0; p < num_pools; p++) {
             if (pools[p] == ABT_POOL_NULL) {
@@ -669,28 +669,28 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         switch (predef) {
             case ABT_SCHED_DEFAULT:
             case ABT_SCHED_BASIC:
-                abt_errno = ABTI_sched_create(ABTI_sched_get_basic_def(),
-                                              num_pools, pool_list,
-                                              ABT_SCHED_CONFIG_NULL,
-                                              automatic, pp_newsched);
+                abt_errno =
+                    ABTI_sched_create(ABTI_sched_get_basic_def(), num_pools,
+                                      pool_list, ABT_SCHED_CONFIG_NULL,
+                                      automatic, pp_newsched);
                 break;
             case ABT_SCHED_BASIC_WAIT:
                 abt_errno = ABTI_sched_create(ABTI_sched_get_basic_wait_def(),
                                               num_pools, pool_list,
-                                              ABT_SCHED_CONFIG_NULL,
-                                              automatic, pp_newsched);
+                                              ABT_SCHED_CONFIG_NULL, automatic,
+                                              pp_newsched);
                 break;
             case ABT_SCHED_PRIO:
-                abt_errno = ABTI_sched_create(ABTI_sched_get_prio_def(),
-                                              num_pools, pool_list,
-                                              ABT_SCHED_CONFIG_NULL,
-                                              automatic, pp_newsched);
+                abt_errno =
+                    ABTI_sched_create(ABTI_sched_get_prio_def(), num_pools,
+                                      pool_list, ABT_SCHED_CONFIG_NULL,
+                                      automatic, pp_newsched);
                 break;
             case ABT_SCHED_RANDWS:
-                abt_errno = ABTI_sched_create(ABTI_sched_get_randws_def(),
-                                              num_pools, pool_list,
-                                              ABT_SCHED_CONFIG_NULL,
-                                              automatic, pp_newsched);
+                abt_errno =
+                    ABTI_sched_create(ABTI_sched_get_randws_def(), num_pools,
+                                      pool_list, ABT_SCHED_CONFIG_NULL,
+                                      automatic, pp_newsched);
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
@@ -731,8 +731,8 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         int p;
         for (p = 0; p < num_pools; p++) {
             ABTI_pool *p_newpool;
-            abt_errno = ABTI_pool_create_basic(kind, access, ABT_TRUE,
-                                               &p_newpool);
+            abt_errno =
+                ABTI_pool_create_basic(kind, access, ABT_TRUE, &p_newpool);
             ABTI_CHECK_ERROR(abt_errno);
             pool_list[p] = ABTI_pool_get_handle(p_newpool);
         }
@@ -742,23 +742,23 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
             case ABT_SCHED_DEFAULT:
             case ABT_SCHED_BASIC:
                 abt_errno = ABTI_sched_create(ABTI_sched_get_basic_def(),
-                                              num_pools, pool_list,
-                                              config, automatic, pp_newsched);
+                                              num_pools, pool_list, config,
+                                              automatic, pp_newsched);
                 break;
             case ABT_SCHED_BASIC_WAIT:
                 abt_errno = ABTI_sched_create(ABTI_sched_get_basic_wait_def(),
-                                              num_pools, pool_list,
-                                              config, automatic, pp_newsched);
+                                              num_pools, pool_list, config,
+                                              automatic, pp_newsched);
                 break;
             case ABT_SCHED_PRIO:
                 abt_errno = ABTI_sched_create(ABTI_sched_get_prio_def(),
-                                              num_pools, pool_list,
-                                              config, automatic, pp_newsched);
+                                              num_pools, pool_list, config,
+                                              automatic, pp_newsched);
                 break;
             case ABT_SCHED_RANDWS:
                 abt_errno = ABTI_sched_create(ABTI_sched_get_randws_def(),
-                                              num_pools, pool_list,
-                                              config, automatic, pp_newsched);
+                                              num_pools, pool_list, config,
+                                              automatic, pp_newsched);
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
@@ -768,10 +768,10 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     }
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -821,10 +821,10 @@ int ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched)
 
     ABTU_free(p_sched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -847,22 +847,20 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
             p_pool = NULL;
         else
             p_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
-    }
-    else
+    } else
         p_pool = ABTI_pool_get_ptr(p_sched->get_migr_pool(sched));
 
     /* Check the pool */
     if (ABTI_pool_accept_migration(p_pool, source_pool) == ABT_TRUE) {
         *pp_pool = p_pool;
-    }
-    else {
+    } else {
         ABTI_CHECK_TRUE(0, ABT_ERR_INV_POOL_ACCESS);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *pp_pool = NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -870,7 +868,7 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
 
 ABTI_sched_kind ABTI_sched_get_kind(ABT_sched_def *def)
 {
-  return (ABTI_sched_kind)def;
+    return (ABTI_sched_kind)def;
 }
 
 void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
@@ -901,22 +899,46 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     }
 
     switch (p_sched->type) {
-        case ABT_SCHED_TYPE_ULT:  type = "ULT"; break;
-        case ABT_SCHED_TYPE_TASK: type = "TASKLET"; break;
-        default:                  type = "UNKNOWN"; break;
+        case ABT_SCHED_TYPE_ULT:
+            type = "ULT";
+            break;
+        case ABT_SCHED_TYPE_TASK:
+            type = "TASKLET";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_sched->state) {
-        case ABT_SCHED_STATE_READY:      state = "READY"; break;
-        case ABT_SCHED_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_SCHED_STATE_STOPPED:    state = "STOPPED"; break;
-        case ABT_SCHED_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                         state = "UNKNOWN"; break;
+        case ABT_SCHED_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_SCHED_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_SCHED_STATE_STOPPED:
+            state = "STOPPED";
+            break;
+        case ABT_SCHED_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
     switch (p_sched->used) {
-        case ABTI_SCHED_NOT_USED: used = "NOT_USED"; break;
-        case ABTI_SCHED_MAIN:     used = "MAIN"; break;
-        case ABTI_SCHED_IN_POOL:  used = "IN_POOL"; break;
-        default:                  used = "UNKNOWN"; break;
+        case ABTI_SCHED_NOT_USED:
+            used = "NOT_USED";
+            break;
+        case ABTI_SCHED_MAIN:
+            used = "MAIN";
+            break;
+        case ABTI_SCHED_IN_POOL:
+            used = "IN_POOL";
+            break;
+        default:
+            used = "UNKNOWN";
+            break;
     }
 
     size = sizeof(char) * (p_sched->num_pools * 20 + 4);
@@ -932,37 +954,31 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     pools_str[pos] = ']';
 
     fprintf(p_os,
-        "%s== SCHED (%p) ==\n"
+            "%s== SCHED (%p) ==\n"
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-        "%sid       : %" PRIu64 "\n"
+            "%sid       : %" PRIu64 "\n"
 #endif
-        "%skind     : %" PRIxPTR " (%s)\n"
-        "%stype     : %s\n"
-        "%sstate    : %s\n"
-        "%sused     : %s\n"
-        "%sautomatic: %s\n"
-        "%srequest  : 0x%x\n"
-        "%snum_pools: %d\n"
-        "%spools    : %s\n"
-        "%ssize     : %zu\n"
-        "%stot_size : %zu\n"
-        "%sdata     : %p\n",
-        prefix, (void *)p_sched,
+            "%skind     : %" PRIxPTR " (%s)\n"
+            "%stype     : %s\n"
+            "%sstate    : %s\n"
+            "%sused     : %s\n"
+            "%sautomatic: %s\n"
+            "%srequest  : 0x%x\n"
+            "%snum_pools: %d\n"
+            "%spools    : %s\n"
+            "%ssize     : %zu\n"
+            "%stot_size : %zu\n"
+            "%sdata     : %p\n",
+            prefix, (void *)p_sched,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-        prefix, p_sched->id,
+            prefix, p_sched->id,
 #endif
-        prefix, p_sched->kind, kind_str,
-        prefix, type,
-        prefix, state,
-        prefix, used,
-        prefix, (p_sched->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
-        prefix, p_sched->request,
-        prefix, p_sched->num_pools,
-        prefix, pools_str,
-        prefix, ABTI_sched_get_size(p_sched),
-        prefix, ABTI_sched_get_total_size(p_sched),
-        prefix, p_sched->data
-    );
+            prefix, p_sched->kind, kind_str, prefix, type, prefix, state,
+            prefix, used, prefix,
+            (p_sched->automatic == ABT_TRUE) ? "TRUE" : "FALSE", prefix,
+            p_sched->request, prefix, p_sched->num_pools, prefix, pools_str,
+            prefix, ABTI_sched_get_size(p_sched), prefix,
+            ABTI_sched_get_total_size(p_sched), prefix, p_sched->data);
     ABTU_free(pools_str);
 
     if (print_sub == ABT_TRUE) {
@@ -972,7 +988,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
         }
     }
 
-  fn_exit:
+fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }

--- a/src/self.c
+++ b/src/self.c
@@ -5,11 +5,9 @@
 
 #include "abti.h"
 
-
 /** @defgroup SELF Self
  * This group is for the self wok unit.
  */
-
 
 /**
  * @ingroup SELF
@@ -50,7 +48,7 @@ int ABT_self_get_type(ABT_unit_type *type)
     }
 #endif
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 }
 
@@ -95,14 +93,14 @@ int ABT_self_is_primary(ABT_bool *flag)
 
     p_thread = p_local->p_thread;
     if (p_thread) {
-        *flag = (p_thread->type == ABTI_THREAD_TYPE_MAIN)
-              ? ABT_TRUE : ABT_FALSE;
+        *flag =
+            (p_thread->type == ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
     } else {
         abt_errno = ABT_ERR_INV_THREAD;
         *flag = ABT_FALSE;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 }
 
@@ -147,13 +145,13 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
-    *flag = (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
-          ? ABT_TRUE : ABT_FALSE;
+    *flag =
+        (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) ? ABT_TRUE : ABT_FALSE;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -210,7 +208,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
         *pool_id = -1;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 }
 
@@ -254,10 +252,10 @@ int ABT_self_suspend(void)
 
     ABTI_thread_suspend(&p_local, p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -301,10 +299,10 @@ int ABT_self_set_arg(void *arg)
         goto fn_fail;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -356,10 +354,10 @@ int ABT_self_get_arg(void **arg)
         goto fn_fail;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -9,7 +9,6 @@ static void ABTI_xstream_set_new_rank(ABTI_xstream *);
 static ABT_bool ABTI_xstream_take_rank(ABTI_xstream *, int);
 static void ABTI_xstream_return_rank(ABTI_xstream *);
 
-
 /** @defgroup ES Execution Stream (ES)
  * This group is for Execution Stream.
  */
@@ -52,10 +51,10 @@ int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
     /* Return value */
     *newxstream = ABTI_xstream_get_handle(p_newxstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *newxstream = ABT_XSTREAM_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -71,13 +70,13 @@ int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
 
     ABTI_xstream_set_new_rank(p_newxstream);
 
-    p_newxstream->type         = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state        = ABT_XSTREAM_STATE_RUNNING;
-    p_newxstream->scheds       = NULL;
-    p_newxstream->num_scheds   = 0;
-    p_newxstream->max_scheds   = 0;
-    p_newxstream->request      = 0;
-    p_newxstream->p_req_arg    = NULL;
+    p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
+    p_newxstream->state = ABT_XSTREAM_STATE_RUNNING;
+    p_newxstream->scheds = NULL;
+    p_newxstream->num_scheds = 0;
+    p_newxstream->max_scheds = 0;
+    p_newxstream->request = 0;
+    p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
     /* Initialize the spinlock */
@@ -92,10 +91,10 @@ int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
     /* Return value */
     *pp_xstream = p_newxstream;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -119,10 +118,10 @@ int ABTI_xstream_create_primary(ABTI_local **pp_local,
 
     *pp_xstream = p_newxstream;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -152,8 +151,8 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
     ABTI_xstream *p_newxstream;
 
     ABTI_sched *p_sched;
-    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools,
-                                        config, &p_sched);
+    abt_errno =
+        ABTI_sched_create_basic(predef, num_pools, pools, config, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno = ABTI_xstream_create(&p_local, p_sched, &p_newxstream);
@@ -165,10 +164,10 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
 
     *newxstream = ABTI_xstream_get_handle(p_newxstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -215,13 +214,13 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
                         ABT_ERR_INV_SCHED);
     }
 
-    p_newxstream->type         = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state        = ABT_XSTREAM_STATE_RUNNING;
-    p_newxstream->scheds       = NULL;
-    p_newxstream->num_scheds   = 0;
-    p_newxstream->max_scheds   = 0;
-    p_newxstream->request      = 0;
-    p_newxstream->p_req_arg    = NULL;
+    p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
+    p_newxstream->state = ABT_XSTREAM_STATE_RUNNING;
+    p_newxstream->scheds = NULL;
+    p_newxstream->num_scheds = 0;
+    p_newxstream->max_scheds = 0;
+    p_newxstream->request = 0;
+    p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
     /* Initialize the spinlock */
@@ -240,10 +239,10 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     /* Return value */
     *newxstream = ABTI_xstream_get_handle(p_newxstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *newxstream = ABT_XSTREAM_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -272,10 +271,10 @@ int ABT_xstream_start(ABT_xstream xstream)
     abt_errno = ABTI_xstream_start(p_local, p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -304,9 +303,9 @@ int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
 
     } else {
         /* Start the main scheduler on a different ES */
-        abt_errno = ABTD_xstream_context_create(
-                ABTI_xstream_launch_main_sched, (void *)p_xstream,
-                &p_xstream->ctx);
+        abt_errno =
+            ABTD_xstream_context_create(ABTI_xstream_launch_main_sched,
+                                        (void *)p_xstream, &p_xstream->ctx);
         ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_create");
     }
 
@@ -315,10 +314,10 @@ int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
         ABTD_affinity_set(&p_xstream->ctx, p_xstream->rank);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -337,16 +336,16 @@ int ABT_xstream_revive(ABT_xstream xstream)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    p_xstream->state        = ABT_XSTREAM_STATE_RUNNING;
-    p_xstream->request      = 0;
-    p_xstream->p_req_arg    = NULL;
+    p_xstream->state = ABT_XSTREAM_STATE_RUNNING;
+    p_xstream->request = 0;
+    p_xstream->p_req_arg = NULL;
     abt_errno = ABTD_xstream_context_revive(&p_xstream->ctx);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -355,7 +354,8 @@ int ABT_xstream_revive(ABT_xstream xstream)
  * [in] p_xstream  the primary ES
  * [in] p_thread   the main ULT
  */
-int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream, ABTI_thread *p_thread)
+int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream,
+                               ABTI_thread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -382,18 +382,18 @@ int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream, A
     p_sched->p_thread->p_last_xstream = p_xstream;
 
     /* Start the scheduler by context switching to it */
-    LOG_EVENT("[U%" PRIu64 ":E%d] yield\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
     ABTI_thread_context_switch_thread_to_sched(pp_local, p_thread, p_sched);
 
     /* Back to the main ULT */
-    LOG_EVENT("[U%" PRIu64 ":E%d] resume\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] resume\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -419,12 +419,12 @@ int ABT_xstream_free(ABT_xstream *xstream)
     ABT_xstream h_xstream = *xstream;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(h_xstream);
-    if (p_xstream == NULL) goto fn_exit;
+    if (p_xstream == NULL)
+        goto fn_exit;
 
     /* We first need to check whether p_local is NULL because this
      * routine might be called by external threads. */
-    ABTI_CHECK_TRUE_MSG(p_local == NULL ||
-                          p_xstream != p_local->p_xstream,
+    ABTI_CHECK_TRUE_MSG(p_local == NULL || p_xstream != p_local->p_xstream,
                         ABT_ERR_INV_XSTREAM,
                         "The current xstream cannot be freed.");
 
@@ -445,10 +445,10 @@ int ABT_xstream_free(ABT_xstream *xstream)
     /* Return value */
     *xstream = ABT_XSTREAM_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -476,10 +476,10 @@ int ABT_xstream_join(ABT_xstream xstream)
     abt_errno = ABTI_xstream_join(&p_local, p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -528,13 +528,13 @@ int ABT_xstream_exit(void)
         }
 #endif
         ABTI_thread_yield(&p_local, p_local->p_thread);
-    } while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state)
-             != ABT_XSTREAM_STATE_TERMINATED);
+    } while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) !=
+             ABT_XSTREAM_STATE_TERMINATED);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -559,10 +559,10 @@ int ABT_xstream_cancel(ABT_xstream xstream)
     /* Set the cancel request */
     ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_CANCEL);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     goto fn_exit;
 }
 
@@ -605,10 +605,10 @@ int ABT_xstream_self(ABT_xstream *xstream)
     /* Return value */
     *xstream = ABTI_xstream_get_handle(p_xstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -646,10 +646,10 @@ int ABT_xstream_self_rank(int *rank)
     /* Return value */
     *rank = (int)p_xstream->rank;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -676,10 +676,10 @@ int ABT_xstream_set_rank(ABT_xstream xstream, const int rank)
         ABTD_affinity_set(&p_xstream->ctx, p_xstream->rank);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -700,10 +700,10 @@ int ABT_xstream_get_rank(ABT_xstream xstream, int *rank)
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
     *rank = (int)p_xstream->rank;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -763,12 +763,13 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
         }
     }
 
-    /* TODO: permit to change the scheduler even when having work units in pools */
+    /* TODO: permit to change the scheduler even when having work units in pools
+     */
     if (p_xstream->p_main_sched) {
         /* We only allow to change the main scheduler when the current main
          * scheduler of p_xstream has no work unit in its associated pools. */
-        if (ABTI_sched_get_effective_size(p_local,
-                                          p_xstream->p_main_sched) > 0) {
+        if (ABTI_sched_get_effective_size(p_local, p_xstream->p_main_sched) >
+            0) {
             abt_errno = ABT_ERR_XSTREAM;
             goto fn_fail;
         }
@@ -787,10 +788,10 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
     abt_errno = ABTI_xstream_set_main_sched(&p_local, p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -809,7 +810,8 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
  * @retval ABT_SUCCESS on success
  */
 int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
-        ABT_sched_predef predef, int num_pools, ABT_pool *pools)
+                                     ABT_sched_predef predef, int num_pools,
+                                     ABT_pool *pools)
 {
     ABTI_local *p_local = ABTI_local_get_local();
     int abt_errno = ABT_SUCCESS;
@@ -825,10 +827,10 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
     abt_errno = ABTI_xstream_set_main_sched(&p_local, p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -854,10 +856,10 @@ int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched)
 
     *sched = ABTI_sched_get_handle(p_xstream->p_main_sched);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -886,10 +888,10 @@ int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
     max_pools = p_sched->num_pools > max_pools ? max_pools : p_sched->num_pools;
     memcpy(pools, p_sched->pools, sizeof(ABT_pool) * max_pools);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -913,10 +915,10 @@ int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state)
     /* Return value */
     *state = p_xstream->state;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -971,7 +973,7 @@ int ABT_xstream_get_num(int *num_xstreams)
 
     *num_xstreams = gp_ABTI_global->num_xstreams;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 }
 
@@ -998,13 +1000,13 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *flag)
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
-    *flag = (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
-          ? ABT_TRUE : ABT_FALSE;
+    *flag =
+        (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) ? ABT_TRUE : ABT_FALSE;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1031,10 +1033,10 @@ int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
     abt_errno = ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1064,10 +1066,10 @@ int ABTI_xstream_run_unit(ABTI_local **pp_local, ABTI_xstream *p_xstream,
         ABTI_CHECK_TRUE(0, ABT_ERR_INV_UNIT);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1105,10 +1107,10 @@ int ABT_xstream_check_events(ABT_sched sched)
     abt_errno = ABTI_xstream_check_events(p_xstream, sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1130,14 +1132,13 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
         ABTI_sched_exit(p_sched);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /**
  * @ingroup ES
@@ -1161,10 +1162,10 @@ int ABT_xstream_set_cpubind(ABT_xstream xstream, int cpuid)
     abt_errno = ABTD_affinity_set_cpuset(&p_xstream->ctx, 1, &cpuid);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1191,10 +1192,10 @@ int ABT_xstream_get_cpubind(ABT_xstream xstream, int *cpuid)
     abt_errno = ABTD_affinity_get_cpuset(&p_xstream->ctx, 1, cpuid, NULL);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1222,10 +1223,10 @@ int ABT_xstream_set_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset)
     abt_errno = ABTD_affinity_set_cpuset(&p_xstream->ctx, cpuset_size, cpuset);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1265,14 +1266,13 @@ int ABT_xstream_get_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset,
                                          num_cpus);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /*****************************************************************************/
 /* Private APIs                                                              */
@@ -1310,8 +1310,8 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-    if (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state)
-        == ABT_XSTREAM_STATE_TERMINATED) {
+    if (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) ==
+        ABT_XSTREAM_STATE_TERMINATED) {
         goto fn_join;
     }
 
@@ -1333,8 +1333,8 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         /* Set the join request */
         ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state)
-               != ABT_XSTREAM_STATE_TERMINATED) {
+        while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) !=
+               ABT_XSTREAM_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
             if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
                 ABTD_atomic_pause();
@@ -1346,15 +1346,15 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-  fn_join:
+fn_join:
     /* Normal join request */
     abt_errno = ABTD_xstream_context_join(&p_xstream->ctx);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_join");
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     goto fn_exit;
 }
 
@@ -1387,10 +1387,10 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream)
 
     ABTU_free(p_xstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1430,9 +1430,10 @@ void ABTI_xstream_schedule(void *p_arg)
         /* When join is requested, the ES terminates after finishing
          * execution of all work units. */
         if (request & ABTI_XSTREAM_REQ_JOIN) {
-            if (ABTI_sched_get_effective_size(p_local, p_xstream->p_main_sched)
-                == 0) {
-                /* If a ULT has been blocked on the join call, we make it ready */
+            if (ABTI_sched_get_effective_size(p_local,
+                                              p_xstream->p_main_sched) == 0) {
+                /* If a ULT has been blocked on the join call, we make it ready
+                 */
                 if (p_xstream->p_req_arg) {
                     ABTI_thread_set_ready(p_local,
                                           (ABTI_thread *)p_xstream->p_req_arg);
@@ -1457,8 +1458,8 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
     if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
-        LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n",
-                  ABTI_thread_get_id(p_thread), p_xstream->rank);
+        LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
+                  p_xstream->rank);
         ABTD_thread_cancel(p_local, p_thread);
         ABTI_xstream_terminate_thread(p_local, p_thread);
         goto fn_exit;
@@ -1513,8 +1514,8 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 #endif
 
     p_xstream = p_thread->p_last_xstream;
-    LOG_EVENT("[U%" PRIu64 ":E%d] stopped\n",
-              ABTI_thread_get_id(p_thread), p_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] stopped\n", ABTI_thread_get_id(p_thread),
+              p_xstream->rank);
 
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Delete the last scheduler if the ULT was a scheduler */
@@ -1533,16 +1534,18 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
      * be delayed. */
     if (p_thread->request & ABTI_THREAD_REQ_STOP) {
         /* The ULT has completed its execution or it called the exit request. */
-        LOG_EVENT("[U%" PRIu64 ":E%d] %s\n",
-                  ABTI_thread_get_id(p_thread), p_xstream->rank,
-                  (p_thread->request & ABTI_THREAD_REQ_TERMINATE ? "finished" :
-                  ((p_thread->request & ABTI_THREAD_REQ_EXIT) ? "exit called" :
-                  "UNKNOWN")));
+        LOG_EVENT("[U%" PRIu64 ":E%d] %s\n", ABTI_thread_get_id(p_thread),
+                  p_xstream->rank,
+                  (p_thread->request & ABTI_THREAD_REQ_TERMINATE
+                       ? "finished"
+                       : ((p_thread->request & ABTI_THREAD_REQ_EXIT)
+                              ? "exit called"
+                              : "UNKNOWN")));
         ABTI_xstream_terminate_thread(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
     } else if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
-        LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n",
-                  ABTI_thread_get_id(p_thread), p_xstream->rank);
+        LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
+                  p_xstream->rank);
         ABTD_thread_cancel(p_local, p_thread);
         ABTI_xstream_terminate_thread(p_local, p_thread);
 #endif
@@ -1564,8 +1567,8 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     } else if (p_thread->request & ABTI_THREAD_REQ_ORPHAN) {
         /* The ULT is not pushed back to the pool and is disconnected from any
          * pool. */
-        LOG_EVENT("[U%" PRIu64 ":E%d] orphaned\n",
-                  ABTI_thread_get_id(p_thread), p_xstream->rank);
+        LOG_EVENT("[U%" PRIu64 ":E%d] orphaned\n", ABTI_thread_get_id(p_thread),
+                  p_xstream->rank);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
         p_thread->p_pool->u_free(&p_thread->unit);
         p_thread->p_pool = NULL;
@@ -1579,10 +1582,10 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
         goto fn_fail;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1609,8 +1612,8 @@ void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
 
 #ifdef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Execute the task function */
-    LOG_EVENT("[T%" PRIu64 ":E%d] running\n",
-              ABTI_task_get_id(p_task), p_xstream->rank);
+    LOG_EVENT("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
+              p_xstream->rank);
     ABTI_LOG_SET_SCHED(NULL);
     p_task->f_task(p_task->p_arg);
 #else
@@ -1628,8 +1631,8 @@ void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
     }
 
     /* Execute the task function */
-    LOG_EVENT("[T%" PRIu64 ":E%d] running\n",
-              ABTI_task_get_id(p_task), p_xstream->rank);
+    LOG_EVENT("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
+              p_xstream->rank);
     ABTI_LOG_SET_SCHED(p_task->is_sched ? p_task->is_sched : NULL);
 
     p_task->f_task(p_task->p_arg);
@@ -1647,8 +1650,8 @@ void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
 #endif
 
     ABTI_LOG_SET_SCHED(ABTI_xstream_get_top_sched(p_xstream));
-    LOG_EVENT("[T%" PRIu64 ":E%d] stopped\n",
-              ABTI_task_get_id(p_task), p_xstream->rank);
+    LOG_EVENT("[T%" PRIu64 ":E%d] stopped\n", ABTI_task_get_id(p_task),
+              p_xstream->rank);
 
     /* Terminate the tasklet */
     ABTI_xstream_terminate_task(p_local, p_task);
@@ -1671,13 +1674,14 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
     ABTI_spinlock_acquire(&p_thread->lock); // TODO: mutex useful?
     {
         /* extracting argument in migration request */
-        p_pool = (ABTI_pool *)ABTI_thread_extract_req_arg(p_thread,
-                ABTI_THREAD_REQ_MIGRATE);
+        p_pool =
+            (ABTI_pool *)ABTI_thread_extract_req_arg(p_thread,
+                                                     ABTI_THREAD_REQ_MIGRATE);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
         LOG_EVENT("[U%" PRIu64 "] migration: E%d -> NT %p\n",
-                ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
-                (void *)p_pool->consumer_id);
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
+                  (void *)p_pool->consumer_id);
 
         /* Change the associated pool */
         p_thread->p_pool = p_pool;
@@ -1693,10 +1697,10 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
     /* Check the push */
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
@@ -1714,8 +1718,8 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     /* We check that from the pool set of the scheduler we do not find a pool
      * with another associated pool, and set the right value if it is okay  */
-    ABTI_native_thread_id consumer_id
-        = ABTI_xstream_get_native_thread_id(p_xstream);
+    ABTI_native_thread_id consumer_id =
+        ABTI_xstream_get_native_thread_id(p_xstream);
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);
@@ -1757,7 +1761,8 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_thread->type == ABTI_THREAD_TYPE_MAIN, ABT_ERR_THREAD);
+        ABTI_CHECK_TRUE(p_thread->type == ABTI_THREAD_TYPE_MAIN,
+                        ABT_ERR_THREAD);
 
         /* Free the current main scheduler */
         abt_errno = ABTI_sched_discard_and_free(*pp_local, p_main_sched);
@@ -1814,10 +1819,10 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
         ABTI_CHECK_ERROR(abt_errno);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1838,16 +1843,32 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     size_t size, pos;
 
     switch (p_xstream->type) {
-        case ABTI_XSTREAM_TYPE_PRIMARY:   type = "PRIMARY"; break;
-        case ABTI_XSTREAM_TYPE_SECONDARY: type = "SECONDARY"; break;
-        default:                          type = "UNKNOWN"; break;
+        case ABTI_XSTREAM_TYPE_PRIMARY:
+            type = "PRIMARY";
+            break;
+        case ABTI_XSTREAM_TYPE_SECONDARY:
+            type = "SECONDARY";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_xstream->state) {
-        case ABT_XSTREAM_STATE_CREATED:    state = "CREATED"; break;
-        case ABT_XSTREAM_STATE_READY:      state = "READY"; break;
-        case ABT_XSTREAM_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_XSTREAM_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                           state = "UNKNOWN"; break;
+        case ABT_XSTREAM_STATE_CREATED:
+            state = "CREATED";
+            break;
+        case ABT_XSTREAM_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_XSTREAM_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_XSTREAM_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
 
     size = sizeof(char) * (p_xstream->num_scheds * 20 + 4);
@@ -1862,25 +1883,19 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     scheds_str[pos] = ']';
 
     fprintf(p_os,
-        "%s== ES (%p) ==\n"
-        "%srank      : %d\n"
-        "%stype      : %s\n"
-        "%sstate     : %s\n"
-        "%srequest   : 0x%x\n"
-        "%smax_scheds: %d\n"
-        "%snum_scheds: %d\n"
-        "%sscheds    : %s\n"
-        "%smain_sched: %p\n",
-        prefix, (void *)p_xstream,
-        prefix, p_xstream->rank,
-        prefix, type,
-        prefix, state,
-        prefix, p_xstream->request,
-        prefix, p_xstream->max_scheds,
-        prefix, p_xstream->num_scheds,
-        prefix, scheds_str,
-        prefix, (void *)p_xstream->p_main_sched
-    );
+            "%s== ES (%p) ==\n"
+            "%srank      : %d\n"
+            "%stype      : %s\n"
+            "%sstate     : %s\n"
+            "%srequest   : 0x%x\n"
+            "%smax_scheds: %d\n"
+            "%snum_scheds: %d\n"
+            "%sscheds    : %s\n"
+            "%smain_sched: %p\n",
+            prefix, (void *)p_xstream, prefix, p_xstream->rank, prefix, type,
+            prefix, state, prefix, p_xstream->request, prefix,
+            p_xstream->max_scheds, prefix, p_xstream->num_scheds, prefix,
+            scheds_str, prefix, (void *)p_xstream->p_main_sched);
     ABTU_free(scheds_str);
 
     if (print_sub == ABT_TRUE) {
@@ -1888,7 +1903,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                          ABT_TRUE);
     }
 
-  fn_exit:
+fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }
@@ -1924,14 +1939,13 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     /* Reset the current ES and its local info. */
     ABTI_local_finalize(&p_local);
 
-  fn_exit:
+fn_exit:
     return NULL;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /*****************************************************************************/
 /* Internal static functions                                                 */
@@ -2002,4 +2016,3 @@ static void ABTI_xstream_return_rank(ABTI_xstream *p_xstream)
     gp_ABTI_global->num_xstreams--;
     ABTI_spinlock_release(&gp_ABTI_global->xstreams_lock);
 }
-

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup ES_BARRIER ES barrier
  * This group is for ES barrier.
  */
@@ -15,10 +14,9 @@ typedef struct {
     ABTD_xstream_barrier bar;
 } ABTI_xstream_barrier;
 
-
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-static inline
-ABTI_xstream_barrier *ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
+static inline ABTI_xstream_barrier *
+ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_xstream_barrier *p_barrier;
@@ -33,8 +31,8 @@ ABTI_xstream_barrier *ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
 #endif
 }
 
-static inline
-ABT_xstream_barrier ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barrier)
+static inline ABT_xstream_barrier
+ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barrier)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_xstream_barrier h_barrier;
@@ -50,7 +48,6 @@ ABT_xstream_barrier ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barr
 }
 #endif
 
-
 /**
  * @ingroup ES_BARRIER
  * @brief   Create a new ES barrier.
@@ -65,13 +62,15 @@ ABT_xstream_barrier ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barr
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_xstream_barrier_create(uint32_t num_waiters, ABT_xstream_barrier *newbarrier)
+int ABT_xstream_barrier_create(uint32_t num_waiters,
+                               ABT_xstream_barrier *newbarrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream_barrier *p_newbarrier;
 
-    p_newbarrier = (ABTI_xstream_barrier *)ABTU_malloc(sizeof(ABTI_xstream_barrier));
+    p_newbarrier =
+        (ABTI_xstream_barrier *)ABTU_malloc(sizeof(ABTI_xstream_barrier));
 
     p_newbarrier->num_waiters = num_waiters;
     abt_errno = ABTD_xstream_barrier_init(num_waiters, &p_newbarrier->bar);
@@ -80,10 +79,10 @@ int ABT_xstream_barrier_create(uint32_t num_waiters, ABT_xstream_barrier *newbar
     /* Return value */
     *newbarrier = ABTI_xstream_barrier_get_handle(p_newbarrier);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -119,10 +118,10 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
     /* Return value */
     *barrier = ABT_XSTREAM_BARRIER_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -152,14 +151,13 @@ int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
         ABTD_xstream_barrier_wait(&p_barrier->bar);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
     return ABT_ERR_FEATURE_NA;
 #endif
 }
-

--- a/src/task.c
+++ b/src/task.c
@@ -14,7 +14,6 @@ static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                             ABTI_task *p_task);
 static inline uint64_t ABTI_task_get_new_id(void);
 
-
 /** @defgroup TASK Tasklet
  * This group is for Tasklet.
  */
@@ -42,8 +41,7 @@ static inline uint64_t ABTI_task_get_new_id(void);
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_task_create(ABT_pool pool,
-                    void (*task_func)(void *), void *arg,
+int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
                     ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
@@ -62,11 +60,12 @@ int ABT_task_create(ABT_pool pool,
         *newtask = ABTI_task_get_handle(p_newtask);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
-    if (newtask) *newtask = ABT_TASK_NULL;
+fn_fail:
+    if (newtask)
+        *newtask = ABT_TASK_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -81,23 +80,23 @@ int ABTI_task_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     void *arg = (void *)ABTI_sched_get_handle(p_sched);
     /* If p_sched is reused, ABTI_task_revive() can be used. */
     if (p_sched->p_task) {
-        abt_errno = ABTI_task_revive(p_local, p_pool,
-                                     (void (*)(void *))p_sched->run, arg,
-                                     p_sched->p_task);
+        abt_errno =
+            ABTI_task_revive(p_local, p_pool, (void (*)(void *))p_sched->run,
+                             arg, p_sched->p_task);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
     }
 
     /* Allocate a task object */
-    abt_errno = ABTI_task_create(p_local, p_pool,
-                                 (void (*)(void *))p_sched->run, arg, p_sched,
-                                 1, &p_newtask);
+    abt_errno =
+        ABTI_task_create(p_local, p_pool, (void (*)(void *))p_sched->run, arg,
+                         p_sched, 1, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -154,11 +153,12 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     if (newtask)
         *newtask = ABTI_task_get_handle(p_newtask);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
-    if (newtask) *newtask = ABT_TASK_NULL;
+fn_fail:
+    if (newtask)
+        *newtask = ABT_TASK_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -196,10 +196,10 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
     abt_errno = ABTI_task_revive(p_local, p_pool, task_func, arg, p_task);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -226,8 +226,8 @@ int ABT_task_free(ABT_task *task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* Wait until the task terminates */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
-           != ABT_TASK_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state) !=
+           ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
             ABTD_atomic_pause();
@@ -243,10 +243,10 @@ int ABT_task_free(ABT_task *task)
     /* Return value */
     *task = ABT_TASK_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -272,8 +272,8 @@ int ABT_task_join(ABT_task task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* TODO: better implementation */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
-           != ABT_TASK_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state) !=
+           ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
             ABTD_atomic_pause();
@@ -283,10 +283,10 @@ int ABT_task_join(ABT_task task)
         ABTI_thread_yield(&p_local, p_local->p_thread);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -311,10 +311,10 @@ int ABT_task_cancel(ABT_task task)
     /* Set the cancel request */
     ABTI_task_set_request(p_task, ABTI_TASK_REQ_CANCEL);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
@@ -430,10 +430,10 @@ int ABT_task_get_xstream(ABT_task task, ABT_xstream *xstream)
     /* Return value */
     *xstream = ABTI_xstream_get_handle(p_task->p_xstream);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -457,10 +457,10 @@ int ABT_task_get_state(ABT_task task, ABT_task_state *state)
     /* Return value */
     *state = p_task->state;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -487,10 +487,10 @@ int ABT_task_get_last_pool(ABT_task task, ABT_pool *pool)
     /* Return value */
     *pool = ABTI_pool_get_handle(p_task->p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -519,10 +519,10 @@ int ABT_task_get_last_pool_id(ABT_task task, int *id)
     ABTI_ASSERT(p_task->p_pool);
     *id = (int)(p_task->p_pool->id);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -552,10 +552,10 @@ int ABT_task_set_migratable(ABT_task task, ABT_bool flag)
 
     p_task->migratable = flag;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -586,10 +586,10 @@ int ABT_task_is_migratable(ABT_task task, ABT_bool *flag)
 
     *flag = p_task->migratable;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -640,10 +640,10 @@ int ABT_task_retain(ABT_task task)
 
     ABTI_task_retain(p_task);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -668,10 +668,10 @@ int ABT_task_release(ABT_task task)
 
     ABTI_task_release(p_task);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -696,10 +696,10 @@ int ABT_task_get_id(ABT_task task, uint64_t *task_id)
 
     *task_id = ABTI_task_get_id(p_task);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -725,14 +725,13 @@ int ABT_task_get_arg(ABT_task task, void **arg)
 
     *arg = p_task->p_arg;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
-
 
 /*****************************************************************************/
 /* Private APIs                                                              */
@@ -751,21 +750,21 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Allocate a task object */
     p_newtask = ABTI_mem_alloc_task(p_local);
 
-    p_newtask->p_xstream  = NULL;
-    p_newtask->state      = ABT_TASK_STATE_READY;
-    p_newtask->request    = 0;
-    p_newtask->f_task     = task_func;
-    p_newtask->p_arg      = arg;
+    p_newtask->p_xstream = NULL;
+    p_newtask->state = ABT_TASK_STATE_READY;
+    p_newtask->request = 0;
+    p_newtask->f_task = task_func;
+    p_newtask->p_arg = arg;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched   = p_sched;
+    p_newtask->is_sched = p_sched;
 #endif
-    p_newtask->p_pool     = p_pool;
-    p_newtask->refcount   = refcount;
+    p_newtask->p_pool = p_pool;
+    p_newtask->refcount = refcount;
     p_newtask->p_keytable = NULL;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     p_newtask->migratable = ABT_TRUE;
 #endif
-    p_newtask->id         = ABTI_TASK_INIT_ID;
+    p_newtask->id = ABTI_TASK_INIT_ID;
 
     /* Create a wrapper work unit */
     h_newtask = ABTI_task_get_handle(p_newtask);
@@ -788,10 +787,10 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Return value */
     *pp_newtask = p_newtask;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -805,12 +804,12 @@ static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_CHECK_TRUE(p_task->state == ABT_TASK_STATE_TERMINATED,
                     ABT_ERR_INV_TASK);
 
-    p_task->p_xstream  = NULL;
-    p_task->state      = ABT_TASK_STATE_READY;
-    p_task->request    = 0;
-    p_task->f_task     = task_func;
-    p_task->p_arg      = arg;
-    p_task->refcount   = 1;
+    p_task->p_xstream = NULL;
+    p_task->state = ABT_TASK_STATE_READY;
+    p_task->request = 0;
+    p_task->f_task = task_func;
+    p_task->p_arg = arg;
+    p_task->refcount = 1;
     p_task->p_keytable = NULL;
 
     if (p_task->p_pool != p_pool) {
@@ -836,10 +835,10 @@ static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -872,46 +871,48 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
     int xstream_rank = p_xstream ? p_xstream->rank : 0;
     char *state;
     switch (p_task->state) {
-        case ABT_TASK_STATE_READY:      state = "READY"; break;
-        case ABT_TASK_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_TASK_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                        state = "UNKNOWN";
+        case ABT_TASK_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_TASK_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_TASK_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
     }
 
     fprintf(p_os,
-        "%s== TASKLET (%p) ==\n"
-        "%sid        : %" PRIu64 "\n"
-        "%sstate     : %s\n"
-        "%sES        : %p (%d)\n"
+            "%s== TASKLET (%p) ==\n"
+            "%sid        : %" PRIu64 "\n"
+            "%sstate     : %s\n"
+            "%sES        : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        "%sis_sched  : %p\n"
+            "%sis_sched  : %p\n"
 #endif
-        "%spool      : %p\n"
+            "%spool      : %p\n"
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        "%smigratable: %s\n"
+            "%smigratable: %s\n"
 #endif
-        "%srefcount  : %u\n"
-        "%srequest   : 0x%x\n"
-        "%sp_arg     : %p\n"
-        "%skeytable  : %p\n",
-        prefix, (void *)p_task,
-        prefix, ABTI_task_get_id(p_task),
-        prefix, state,
-        prefix, (void *)p_task->p_xstream, xstream_rank,
+            "%srefcount  : %u\n"
+            "%srequest   : 0x%x\n"
+            "%sp_arg     : %p\n"
+            "%skeytable  : %p\n",
+            prefix, (void *)p_task, prefix, ABTI_task_get_id(p_task), prefix,
+            state, prefix, (void *)p_task->p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, (void *)p_task->is_sched,
+            prefix, (void *)p_task->is_sched,
 #endif
-        prefix, (void *)p_task->p_pool,
+            prefix, (void *)p_task->p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
+            prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
 #endif
-        prefix, p_task->refcount,
-        prefix, p_task->request,
-        prefix, p_task->p_arg,
-        prefix, (void *)p_task->p_keytable
-    );
+            prefix, p_task->refcount, prefix, p_task->request, prefix,
+            p_task->p_arg, prefix, (void *)p_task->p_keytable);
 
-  fn_exit:
+fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }
@@ -954,4 +955,3 @@ static inline uint64_t ABTI_task_get_new_id(void)
 {
     return ABTD_atomic_fetch_add_uint64(&g_task_id, 1);
 }
-

--- a/src/thread.c
+++ b/src/thread.c
@@ -5,11 +5,11 @@
 
 #include "abti.h"
 
-static inline int ABTI_thread_create_internal(ABTI_local *p_local,
-    ABTI_pool *p_pool, void (*thread_func)(void *), void *arg,
-    ABTI_thread_attr *p_attr, ABTI_thread_type thread_type, ABTI_sched *p_sched,
-    int refcount, ABTI_xstream *p_parent_xstream, ABT_bool push_pool,
-    ABTI_thread **pp_newthread);
+static inline int ABTI_thread_create_internal(
+    ABTI_local *p_local, ABTI_pool *p_pool, void (*thread_func)(void *),
+    void *arg, ABTI_thread_attr *p_attr, ABTI_thread_type thread_type,
+    ABTI_sched *p_sched, int refcount, ABTI_xstream *p_parent_xstream,
+    ABT_bool push_pool, ABTI_thread **pp_newthread);
 static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                               void (*thread_func)(void *), void *arg,
                               ABTI_thread *p_thread);
@@ -23,7 +23,6 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
 static inline ABT_bool ABTI_thread_is_ready(ABTI_thread *p_thread);
 static inline void ABTI_thread_free_internal(ABTI_thread *p_thread);
 static inline ABT_thread_id ABTI_thread_get_new_id(void);
-
 
 /** @defgroup ULT User-level Thread (ULT)
  * This group is for User-level Thread (ULT).
@@ -51,9 +50,8 @@ static inline ABT_thread_id ABTI_thread_get_new_id(void);
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
-                      void *arg, ABT_thread_attr attr,
-                      ABT_thread *newthread)
+int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
+                      ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
@@ -63,20 +61,22 @@ int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     int refcount = (newthread != NULL) ? 1 : 0;
-    abt_errno = ABTI_thread_create_internal(p_local, p_pool, thread_func, arg,
-                                            ABTI_thread_attr_get_ptr(attr),
-                                            ABTI_THREAD_TYPE_USER, NULL,
-                                            refcount, NULL, ABT_TRUE,
-                                            &p_newthread);
+    abt_errno =
+        ABTI_thread_create_internal(p_local, p_pool, thread_func, arg,
+                                    ABTI_thread_attr_get_ptr(attr),
+                                    ABTI_THREAD_TYPE_USER, NULL, refcount, NULL,
+                                    ABT_TRUE, &p_newthread);
 
     /* Return value */
-    if (newthread) *newthread = ABTI_thread_get_handle(p_newthread);
+    if (newthread)
+        *newthread = ABTI_thread_get_handle(p_newthread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
-    if (newthread) *newthread = ABT_THREAD_NULL;
+fn_fail:
+    if (newthread)
+        *newthread = ABT_THREAD_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -122,8 +122,8 @@ int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_create_on_xstream(ABT_xstream xstream,
-                      void (*thread_func)(void *), void *arg,
-                      ABT_thread_attr attr, ABT_thread *newthread)
+                                 void (*thread_func)(void *), void *arg,
+                                 ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
@@ -135,21 +135,23 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
     /* TODO: need to consider the access type of target pool */
     ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newthread != NULL) ? 1 : 0;
-    abt_errno = ABTI_thread_create_internal(p_local, p_pool, thread_func, arg,
-                                            ABTI_thread_attr_get_ptr(attr),
-                                            ABTI_THREAD_TYPE_USER, NULL,
-                                            refcount, NULL, ABT_TRUE,
-                                            &p_newthread);
+    abt_errno =
+        ABTI_thread_create_internal(p_local, p_pool, thread_func, arg,
+                                    ABTI_thread_attr_get_ptr(attr),
+                                    ABTI_THREAD_TYPE_USER, NULL, refcount, NULL,
+                                    ABT_TRUE, &p_newthread);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
-    if (newthread) *newthread = ABTI_thread_get_handle(p_newthread);
+    if (newthread)
+        *newthread = ABTI_thread_get_handle(p_newthread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
-    if (newthread) *newthread = ABT_THREAD_NULL;
+fn_fail:
+    if (newthread)
+        *newthread = ABT_THREAD_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -200,9 +202,11 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
 
             void (*thread_f)(void *) = thread_func_list[i];
             void *arg = arg_list ? arg_list[i] : NULL;
-            abt_errno = ABTI_thread_create_internal(p_local, p_pool, thread_f,
-                arg, ABTI_thread_attr_get_ptr(attr), ABTI_THREAD_TYPE_USER,
-                NULL, 0, NULL, ABT_TRUE, NULL);
+            abt_errno =
+                ABTI_thread_create_internal(p_local, p_pool, thread_f, arg,
+                                            ABTI_thread_attr_get_ptr(attr),
+                                            ABTI_THREAD_TYPE_USER, NULL, 0,
+                                            NULL, ABT_TRUE, NULL);
             ABTI_CHECK_ERROR(abt_errno);
         }
     } else {
@@ -214,19 +218,21 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
 
             void (*thread_f)(void *) = thread_func_list[i];
             void *arg = arg_list ? arg_list[i] : NULL;
-            abt_errno = ABTI_thread_create_internal(p_local, p_pool, thread_f,
-                arg, ABTI_thread_attr_get_ptr(attr), ABTI_THREAD_TYPE_USER,
-                NULL, 1, NULL, ABT_TRUE, &p_newthread);
+            abt_errno =
+                ABTI_thread_create_internal(p_local, p_pool, thread_f, arg,
+                                            ABTI_thread_attr_get_ptr(attr),
+                                            ABTI_THREAD_TYPE_USER, NULL, 1,
+                                            NULL, ABT_TRUE, &p_newthread);
             newthread_list[i] = ABTI_thread_get_handle(p_newthread);
             /* TODO: Release threads that have been already created. */
             ABTI_CHECK_ERROR(abt_errno);
         }
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -250,7 +256,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
+int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
                       ABT_thread *thread)
 {
     int abt_errno = ABT_SUCCESS;
@@ -265,10 +271,10 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
     abt_errno = ABTI_thread_revive(p_local, p_pool, thread_func, arg, p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -297,13 +303,12 @@ int ABT_thread_free(ABT_thread *thread)
 
     /* We first need to check whether p_local is NULL because external
      * threads might call this routine. */
-    ABTI_CHECK_TRUE_MSG(p_local == NULL ||
-                          p_thread != p_local->p_thread,
+    ABTI_CHECK_TRUE_MSG(p_local == NULL || p_thread != p_local->p_thread,
                         ABT_ERR_INV_THREAD,
                         "The current thread cannot be freed.");
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                            p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be freed explicitly.");
 
@@ -318,10 +323,10 @@ int ABT_thread_free(ABT_thread *thread)
     /* Return value */
     *thread = ABT_THREAD_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -371,10 +376,10 @@ int ABT_thread_join(ABT_thread thread)
     abt_errno = ABTI_thread_join(&p_local, p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -397,15 +402,15 @@ int ABT_thread_join_many(int num_threads, ABT_thread *thread_list)
     ABTI_local *p_local = ABTI_local_get_local();
     int i;
     for (i = 0; i < num_threads; i++) {
-        abt_errno = ABTI_thread_join(&p_local,
-                                     ABTI_thread_get_ptr(thread_list[i]));
+        abt_errno =
+            ABTI_thread_join(&p_local, ABTI_thread_get_ptr(thread_list[i]));
         ABTI_CHECK_ERROR(abt_errno);
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -447,10 +452,10 @@ int ABT_thread_exit(void)
     /* Terminate this ULT */
     ABTD_thread_exit(p_local, p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -473,17 +478,17 @@ int ABT_thread_cancel(ABT_thread thread)
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                            p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be canceled.");
 
     /* Set the cancel request */
     ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_CANCEL);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #endif
@@ -598,10 +603,10 @@ int ABT_thread_get_state(ABT_thread thread, ABT_thread_state *state)
     /* Return value */
     *state = p_thread->state;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -628,10 +633,10 @@ int ABT_thread_get_last_pool(ABT_thread thread, ABT_pool *pool)
     /* Return value */
     *pool = ABTI_pool_get_handle(p_thread->p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -660,10 +665,10 @@ int ABT_thread_get_last_pool_id(ABT_thread thread, int *id)
     ABTI_ASSERT(p_thread->p_pool);
     *id = (int)(p_thread->p_pool->id);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -696,10 +701,10 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
 
     p_thread->p_pool = p_pool;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -729,7 +734,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     if (p_local != NULL) {
         p_cur_thread = p_local->p_thread;
     }
-    if (p_cur_thread == NULL) goto fn_exit;
+    if (p_cur_thread == NULL)
+        goto fn_exit;
 #endif
 
     ABTI_xstream *p_xstream = p_local->p_xstream;
@@ -794,10 +800,10 @@ int ABT_thread_yield_to(ABT_thread thread)
     ABTI_thread_context_switch_thread_to_thread(&p_local, p_cur_thread,
                                                 p_tar_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -826,7 +832,8 @@ int ABT_thread_yield(void)
     if (p_local != NULL) {
         p_thread = p_local->p_thread;
     }
-    if (p_thread == NULL) goto fn_exit;
+    if (p_thread == NULL)
+        goto fn_exit;
 #endif
 
     ABTI_CHECK_TRUE(p_thread->p_last_xstream == p_local->p_xstream,
@@ -834,10 +841,10 @@ int ABT_thread_yield(void)
 
     ABTI_thread_yield(&p_local, p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -870,10 +877,10 @@ int ABT_thread_resume(ABT_thread thread)
     abt_errno = ABTI_thread_set_ready(p_local, p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -909,10 +916,10 @@ int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
     abt_errno = ABTI_thread_migrate_to_xstream(&p_local, p_thread, p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -952,7 +959,7 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
     ABTI_CHECK_TRUE(p_sched->state == ABT_SCHED_STATE_RUNNING,
                     ABT_ERR_INV_XSTREAM);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -967,10 +974,10 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
 
     ABTI_pool_inc_num_migrations(p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1008,10 +1015,10 @@ int ABT_thread_migrate_to_pool(ABT_thread thread, ABT_pool pool)
 
     ABTI_pool_inc_num_migrations(p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1066,7 +1073,7 @@ int ABT_thread_migrate(ABT_thread thread)
                 abt_errno = ABTI_thread_migrate_to_xstream(&p_local, p_thread,
                                                            p_xstream);
                 if (abt_errno != ABT_ERR_INV_XSTREAM &&
-                        abt_errno != ABT_ERR_MIGRATION_TARGET) {
+                    abt_errno != ABT_ERR_MIGRATION_TARGET) {
                     ABTI_CHECK_ERROR(abt_errno);
                     break;
                 }
@@ -1074,10 +1081,10 @@ int ABT_thread_migrate(ABT_thread thread)
         }
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1099,7 +1106,7 @@ int ABT_thread_migrate(ABT_thread thread)
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_set_callback(ABT_thread thread,
-                            void(*cb_func)(ABT_thread thread, void *cb_arg),
+                            void (*cb_func)(ABT_thread thread, void *cb_arg),
                             void *cb_arg)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -1107,13 +1114,13 @@ int ABT_thread_set_callback(ABT_thread thread,
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    p_thread->attr.f_cb     = cb_func;
+    p_thread->attr.f_cb = cb_func;
     p_thread->attr.p_cb_arg = cb_arg;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1147,10 +1154,10 @@ int ABT_thread_set_migratable(ABT_thread thread, ABT_bool flag)
         p_thread->attr.migratable = flag;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1181,10 +1188,10 @@ int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *flag)
 
     *flag = p_thread->attr.migratable;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1218,10 +1225,10 @@ int ABT_thread_is_primary(ABT_thread thread, ABT_bool *flag)
 
     *flag = (p_thread->type == ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1269,10 +1276,10 @@ int ABT_thread_retain(ABT_thread thread)
 
     ABTI_thread_retain(p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1296,10 +1303,10 @@ int ABT_thread_release(ABT_thread thread)
 
     ABTI_thread_release(p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1325,10 +1332,10 @@ int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize)
     /* Return value */
     *stacksize = p_thread->attr.stacksize;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1353,10 +1360,10 @@ int ABT_thread_get_id(ABT_thread thread, ABT_thread_id *thread_id)
 
     *thread_id = ABTI_thread_get_id(p_thread);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1381,10 +1388,10 @@ int ABT_thread_set_arg(ABT_thread thread, void *arg)
 
     ABTD_thread_context_set_arg(&p_thread->ctx, arg);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1411,10 +1418,10 @@ int ABT_thread_get_arg(ABT_thread thread, void **arg)
 
     *arg = ABTD_thread_context_get_arg(&p_thread->ctx);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1446,10 +1453,10 @@ int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
 
     *attr = ABTI_thread_attr_get_handle(p_attr);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1458,14 +1465,11 @@ int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-static inline
-int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
-                                void (*thread_func)(void *),
-                                void *arg, ABTI_thread_attr *p_attr,
-                                ABTI_thread_type thread_type,
-                                ABTI_sched *p_sched, int refcount,
-                                ABTI_xstream *p_parent_xstream,
-                                ABT_bool push_pool, ABTI_thread **pp_newthread)
+static inline int ABTI_thread_create_internal(
+    ABTI_local *p_local, ABTI_pool *p_pool, void (*thread_func)(void *),
+    void *arg, ABTI_thread_attr *p_attr, ABTI_thread_type thread_type,
+    ABTI_sched *p_sched, int refcount, ABTI_xstream *p_parent_xstream,
+    ABT_bool push_pool, ABTI_thread **pp_newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newthread;
@@ -1474,8 +1478,8 @@ int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Allocate a ULT object and its stack, then create a thread context. */
     p_newthread = ABTI_mem_alloc_thread(p_local, p_attr);
     if ((thread_type == ABTI_THREAD_TYPE_MAIN ||
-         thread_type == ABTI_THREAD_TYPE_MAIN_SCHED)
-         && p_newthread->attr.p_stack == NULL) {
+         thread_type == ABTI_THREAD_TYPE_MAIN_SCHED) &&
+        p_newthread->attr.p_stack == NULL) {
         /* We don't need to initialize the context of 1. the main thread, and
          * 2. the main scheduler thread which runs on OS-level threads
          * (p_stack == NULL). Invalidate the context here. */
@@ -1489,32 +1493,32 @@ int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
                                                       &p_newthread->ctx);
 #else
         /* The context is not fully created now. */
-        abt_errno = ABTD_thread_context_init(NULL, thread_func, arg,
-                                             &p_newthread->ctx);
+        abt_errno =
+            ABTD_thread_context_init(NULL, thread_func, arg, &p_newthread->ctx);
 #endif
     } else {
         size_t stack_size = p_newthread->attr.stacksize;
         void *p_stack = p_newthread->attr.p_stack;
-        abt_errno = ABTD_thread_context_create_sched(NULL, thread_func, arg,
-                                                     stack_size, p_stack,
-                                                     &p_newthread->ctx);
+        abt_errno =
+            ABTD_thread_context_create_sched(NULL, thread_func, arg, stack_size,
+                                             p_stack, &p_newthread->ctx);
     }
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_newthread->state          = ABT_THREAD_STATE_READY;
-    p_newthread->request        = 0;
+    p_newthread->state = ABT_THREAD_STATE_READY;
+    p_newthread->request = 0;
     p_newthread->p_last_xstream = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newthread->is_sched       = p_sched;
+    p_newthread->is_sched = p_sched;
 #endif
-    p_newthread->p_pool         = p_pool;
-    p_newthread->refcount       = refcount;
-    p_newthread->type           = thread_type;
+    p_newthread->p_pool = p_pool;
+    p_newthread->refcount = refcount;
+    p_newthread->type = thread_type;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_newthread->p_req_arg      = NULL;
+    p_newthread->p_req_arg = NULL;
 #endif
-    p_newthread->p_keytable     = NULL;
-    p_newthread->id             = ABTI_THREAD_INIT_ID;
+    p_newthread->p_keytable = NULL;
+    p_newthread->id = ABTI_THREAD_INIT_ID;
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* Initialize a spinlock */
@@ -1562,10 +1566,10 @@ int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Return value */
     *pp_newthread = p_newthread;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *pp_newthread = NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -1577,10 +1581,10 @@ int ABTI_thread_create(ABTI_local *p_local, ABTI_pool *p_pool,
 {
     int abt_errno = ABT_SUCCESS;
     int refcount = (pp_newthread != NULL) ? 1 : 0;
-    abt_errno = ABTI_thread_create_internal(p_local, p_pool, thread_func, arg,
-                                            p_attr, ABTI_THREAD_TYPE_USER, NULL,
-                                            refcount, NULL, ABT_TRUE,
-                                            pp_newthread);
+    abt_errno =
+        ABTI_thread_create_internal(p_local, p_pool, thread_func, arg, p_attr,
+                                    ABTI_THREAD_TYPE_USER, NULL, refcount, NULL,
+                                    ABT_TRUE, pp_newthread);
     return abt_errno;
 }
 
@@ -1592,11 +1596,11 @@ int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
     ABTI_local *p_local = *pp_local;
 
     /* checking for cases when migration is not allowed */
-    ABTI_CHECK_TRUE(ABTI_pool_accept_migration(p_pool, p_thread->p_pool)
-                      == ABT_TRUE,
+    ABTI_CHECK_TRUE(ABTI_pool_accept_migration(p_pool, p_thread->p_pool) ==
+                        ABT_TRUE,
                     ABT_ERR_INV_POOL);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -1616,10 +1620,10 @@ int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
     }
     goto fn_exit;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -1655,10 +1659,10 @@ int ABTI_thread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
     /* Return value */
     *p_thread = p_newthread;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *p_thread = NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -1678,12 +1682,11 @@ int ABTI_thread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
         ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                               ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
         ABTI_thread *p_main_thread = ABTI_global_get_main();
-        abt_errno = ABTI_thread_create_internal(p_local, NULL,
-                                                ABTI_xstream_schedule,
-                                                (void *)p_xstream, &attr,
-                                                ABTI_THREAD_TYPE_MAIN_SCHED,
-                                                p_sched, 0, p_xstream,
-                                                ABT_FALSE, &p_newthread);
+        abt_errno =
+            ABTI_thread_create_internal(p_local, NULL, ABTI_xstream_schedule,
+                                        (void *)p_xstream, &attr,
+                                        ABTI_THREAD_TYPE_MAIN_SCHED, p_sched, 0,
+                                        p_xstream, ABT_FALSE, &p_newthread);
         ABTI_CHECK_ERROR(abt_errno);
         /* When the main scheduler is terminated, the control will jump to the
          * primary ULT. */
@@ -1693,12 +1696,11 @@ int ABTI_thread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
          * scheduler's ULT. */
         ABTI_thread_attr attr;
         ABTI_thread_attr_init(&attr, NULL, 0, ABTI_STACK_TYPE_MAIN, ABT_FALSE);
-        abt_errno = ABTI_thread_create_internal(p_local, NULL,
-                                                ABTI_xstream_schedule,
-                                                (void *)p_xstream, &attr,
-                                                ABTI_THREAD_TYPE_MAIN_SCHED,
-                                                p_sched, 0, p_xstream,
-                                                ABT_FALSE, &p_newthread);
+        abt_errno =
+            ABTI_thread_create_internal(p_local, NULL, ABTI_xstream_schedule,
+                                        (void *)p_xstream, &attr,
+                                        ABTI_THREAD_TYPE_MAIN_SCHED, p_sched, 0,
+                                        p_xstream, ABT_FALSE, &p_newthread);
         ABTI_CHECK_ERROR(abt_errno);
     }
 
@@ -1706,10 +1708,10 @@ int ABTI_thread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
     p_sched->p_thread = p_newthread;
     p_sched->p_ctx = &p_newthread->ctx;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1722,13 +1724,12 @@ int ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_thread *p_newthread;
     ABTI_thread_attr attr;
 
-
     /* If p_sched is reused, ABTI_thread_revive() can be used. */
     if (p_sched->p_thread) {
         ABT_sched h_sched = ABTI_sched_get_handle(p_sched);
-        abt_errno = ABTI_thread_revive(p_local, p_pool,
-                                       (void (*)(void *))p_sched->run,
-                                       (void *)h_sched, p_sched->p_thread);
+        abt_errno =
+            ABTI_thread_revive(p_local, p_pool, (void (*)(void *))p_sched->run,
+                               (void *)h_sched, p_sched->p_thread);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
     }
@@ -1736,22 +1737,24 @@ int ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
     /* Allocate a ULT object and its stack */
     ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                           ABTI_STACK_TYPE_MALLOC, ABT_FALSE);
-    abt_errno = ABTI_thread_create_internal(p_local, p_pool,
-        (void (*)(void *))p_sched->run, (void *)ABTI_sched_get_handle(p_sched),
-        &attr, ABTI_THREAD_TYPE_USER, p_sched, 1, NULL, ABT_TRUE, &p_newthread);
+    abt_errno =
+        ABTI_thread_create_internal(p_local, p_pool,
+                                    (void (*)(void *))p_sched->run,
+                                    (void *)ABTI_sched_get_handle(p_sched),
+                                    &attr, ABTI_THREAD_TYPE_USER, p_sched, 1,
+                                    NULL, ABT_TRUE, &p_newthread);
     ABTI_CHECK_ERROR(abt_errno);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     p_sched->p_thread = NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
 
-static inline
-void ABTI_thread_free_internal(ABTI_thread *p_thread)
+static inline void ABTI_thread_free_internal(ABTI_thread *p_thread)
 {
     /* Free the unit */
     p_thread->p_pool->u_free(&p_thread->unit);
@@ -1773,8 +1776,8 @@ void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread)
     ABTI_spinlock_acquire(&p_thread->lock);
 #endif
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] freed\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] freed\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 
     ABTI_thread_free_internal(p_thread);
 
@@ -1829,13 +1832,13 @@ int ABTI_thread_set_blocked(ABTI_thread *p_thread)
     ABTI_pool *p_pool = p_thread->p_pool;
     ABTI_pool_inc_num_blocked(p_pool);
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] blocked\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] blocked\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1850,13 +1853,13 @@ void ABTI_thread_suspend(ABTI_local **pp_local, ABTI_thread *p_thread)
     /* Switch to the scheduler, i.e., suspend p_thread  */
     ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_xstream);
-    LOG_EVENT("[U%" PRIu64 ":E%d] suspended\n",
-              ABTI_thread_get_id(p_thread), p_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] suspended\n", ABTI_thread_get_id(p_thread),
+              p_xstream->rank);
     ABTI_thread_context_switch_thread_to_sched(pp_local, p_thread, p_sched);
 
     /* The suspended ULT resumes its execution from here. */
-    LOG_EVENT("[U%" PRIu64 ":E%d] resumed\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] resumed\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 }
 
 int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
@@ -1864,16 +1867,18 @@ int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
     int abt_errno = ABT_SUCCESS;
 
     /* The ULT should be in BLOCKED state. */
-    ABTI_CHECK_TRUE(p_thread->state == ABT_THREAD_STATE_BLOCKED, ABT_ERR_THREAD);
+    ABTI_CHECK_TRUE(p_thread->state == ABT_THREAD_STATE_BLOCKED,
+                    ABT_ERR_THREAD);
 
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
      * request. Otherwise, the ULT can be pushed to a pool here and be
      * scheduled by another scheduler if it is pushed to a shared pool. */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->request)
-           & ABTI_THREAD_REQ_BLOCK);
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->request) &
+           ABTI_THREAD_REQ_BLOCK)
+        ;
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n",
-              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
+    LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n", ABTI_thread_get_id(p_thread),
+              p_thread->p_last_xstream->rank);
 
     /* p_thread->p_pool is loaded before ABTI_POOL_ADD_THREAD to keep
      * num_blocked consistent. Otherwise, other threads might pop p_thread
@@ -1887,10 +1892,10 @@ int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
     /* Decrease the number of blocked threads */
     ABTI_pool_dec_num_blocked(p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -1925,56 +1930,69 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
     char attr[100];
 
     switch (p_thread->type) {
-        case ABTI_THREAD_TYPE_MAIN:       type = "MAIN"; break;
-        case ABTI_THREAD_TYPE_MAIN_SCHED: type = "MAIN_SCHED"; break;
-        case ABTI_THREAD_TYPE_USER:       type = "USER"; break;
-        default:                          type = "UNKNOWN"; break;
+        case ABTI_THREAD_TYPE_MAIN:
+            type = "MAIN";
+            break;
+        case ABTI_THREAD_TYPE_MAIN_SCHED:
+            type = "MAIN_SCHED";
+            break;
+        case ABTI_THREAD_TYPE_USER:
+            type = "USER";
+            break;
+        default:
+            type = "UNKNOWN";
+            break;
     }
     switch (p_thread->state) {
-        case ABT_THREAD_STATE_READY:      state = "READY"; break;
-        case ABT_THREAD_STATE_RUNNING:    state = "RUNNING"; break;
-        case ABT_THREAD_STATE_BLOCKED:    state = "BLOCKED"; break;
-        case ABT_THREAD_STATE_TERMINATED: state = "TERMINATED"; break;
-        default:                          state = "UNKNOWN"; break;
+        case ABT_THREAD_STATE_READY:
+            state = "READY";
+            break;
+        case ABT_THREAD_STATE_RUNNING:
+            state = "RUNNING";
+            break;
+        case ABT_THREAD_STATE_BLOCKED:
+            state = "BLOCKED";
+            break;
+        case ABT_THREAD_STATE_TERMINATED:
+            state = "TERMINATED";
+            break;
+        default:
+            state = "UNKNOWN";
+            break;
     }
     ABTI_thread_attr_get_str(&p_thread->attr, attr);
 
     fprintf(p_os,
-        "%s== ULT (%p) ==\n"
-        "%sid      : %" PRIu64 "\n"
-        "%stype    : %s\n"
-        "%sstate   : %s\n"
-        "%slast_ES : %p (%d)\n"
+            "%s== ULT (%p) ==\n"
+            "%sid      : %" PRIu64 "\n"
+            "%stype    : %s\n"
+            "%sstate   : %s\n"
+            "%slast_ES : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        "%sis_sched: %p\n"
+            "%sis_sched: %p\n"
 #endif
-        "%spool    : %p\n"
-        "%srefcount: %u\n"
-        "%srequest : 0x%x\n"
+            "%spool    : %p\n"
+            "%srefcount: %u\n"
+            "%srequest : 0x%x\n"
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        "%sreq_arg : %p\n"
+            "%sreq_arg : %p\n"
 #endif
-        "%skeytable: %p\n"
-        "%sattr    : %s\n",
-        prefix, (void *)p_thread,
-        prefix, ABTI_thread_get_id(p_thread),
-        prefix, type,
-        prefix, state,
-        prefix, (void *)p_xstream, xstream_rank,
+            "%skeytable: %p\n"
+            "%sattr    : %s\n",
+            prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
+            prefix, type, prefix, state, prefix, (void *)p_xstream,
+            xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, (void *)p_thread->is_sched,
+            prefix, (void *)p_thread->is_sched,
 #endif
-        prefix, (void *)p_thread->p_pool,
-        prefix, p_thread->refcount,
-        prefix, p_thread->request,
+            prefix, (void *)p_thread->p_pool, prefix, p_thread->refcount,
+            prefix, p_thread->request,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-        prefix, (void *)p_thread->p_req_arg,
+            prefix, (void *)p_thread->p_req_arg,
 #endif
-        prefix, (void *)p_thread->p_keytable,
-        prefix, attr
-    );
+            prefix, (void *)p_thread->p_keytable, prefix, attr);
 
-  fn_exit:
+fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }
@@ -2003,8 +2021,7 @@ int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os)
         fprintf(p_os, "%016" PRIxPTR ":",
                 (uintptr_t)(&((uint8_t *)p_stack)[i]));
 #elif SIZEOF_VOID_P == 4
-        fprintf(p_os, "%08" PRIxPTR ":",
-                (uintptr_t)(&((uint8_t *)p_stack)[i]));
+        fprintf(p_os, "%08" PRIxPTR ":", (uintptr_t)(&((uint8_t *)p_stack)[i]));
 #else
 #error "unknown pointer size"
 #endif
@@ -2149,7 +2166,8 @@ void ABTI_thread_reset_id(void)
 
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread)
 {
-    if (p_thread == NULL) return ABTI_THREAD_INIT_ID;
+    if (p_thread == NULL)
+        return ABTI_THREAD_INIT_ID;
 
     if (p_thread->id == ABTI_THREAD_INIT_ID) {
         p_thread->id = ABTI_thread_get_new_id();
@@ -2160,13 +2178,15 @@ ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread)
 ABT_thread_id ABTI_thread_self_id(ABTI_local *p_local)
 {
     ABTI_thread *p_self = NULL;
-    if (p_local) p_self = p_local->p_thread;
+    if (p_local)
+        p_self = p_local->p_thread;
     return ABTI_thread_get_id(p_self);
 }
 
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread)
 {
-    if (p_thread == NULL) return -1;
+    if (p_thread == NULL)
+        return -1;
 
     if (p_thread->p_last_xstream) {
         return p_thread->p_last_xstream->rank;
@@ -2178,7 +2198,8 @@ int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread)
 int ABTI_thread_self_xstream_rank(ABTI_local *p_local)
 {
     ABTI_thread *p_self = NULL;
-    if (p_local) p_self = p_local->p_thread;
+    if (p_local)
+        p_self = p_local->p_thread;
     return ABTI_thread_get_xstream_rank(p_self);
 }
 
@@ -2200,24 +2221,26 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     stacksize = p_thread->attr.stacksize;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_thread->is_sched) {
-        abt_errno = ABTD_thread_context_create_sched(NULL, thread_func, arg,
-                                           stacksize, p_thread->attr.p_stack,
-                                           &p_thread->ctx);
+        abt_errno =
+            ABTD_thread_context_create_sched(NULL, thread_func, arg, stacksize,
+                                             p_thread->attr.p_stack,
+                                             &p_thread->ctx);
     } else {
 #endif
-        abt_errno = ABTD_thread_context_create_thread(NULL, thread_func, arg,
-                                           stacksize, p_thread->attr.p_stack,
-                                           &p_thread->ctx);
+        abt_errno =
+            ABTD_thread_context_create_thread(NULL, thread_func, arg, stacksize,
+                                              p_thread->attr.p_stack,
+                                              &p_thread->ctx);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_thread->state          = ABT_THREAD_STATE_READY;
-    p_thread->request        = 0;
+    p_thread->state = ABT_THREAD_STATE_READY;
+    p_thread->request = 0;
     p_thread->p_last_xstream = NULL;
-    p_thread->refcount       = 1;
-    p_thread->type           = ABTI_THREAD_TYPE_USER;
+    p_thread->refcount = 1;
+    p_thread->type = ABTI_THREAD_TYPE_USER;
 
     if (p_thread->p_pool != p_pool) {
         /* Free the unit for the old pool */
@@ -2242,10 +2265,10 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -2254,17 +2277,18 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
 
-    if (p_thread->state == ABT_THREAD_STATE_TERMINATED) return abt_errno;
+    if (p_thread->state == ABT_THREAD_STATE_TERMINATED)
+        return abt_errno;
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                          p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
-                        ABT_ERR_INV_THREAD,
-                        "The main ULT cannot be joined.");
+                            p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        ABT_ERR_INV_THREAD, "The main ULT cannot be joined.");
 
     ABTI_local *p_local = *pp_local;
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     ABT_unit_type type = ABTI_self_get_type(p_local);
-    if (type != ABT_UNIT_TYPE_THREAD) goto busywait_based;
+    if (type != ABT_UNIT_TYPE_THREAD)
+        goto busywait_based;
 #endif
 
     ABTI_CHECK_TRUE_MSG(p_thread != p_local->p_thread, ABT_ERR_INV_THREAD,
@@ -2274,8 +2298,7 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
     ABT_pool_access access = p_self->p_pool->access;
 
     if ((p_self->p_pool == p_thread->p_pool) &&
-        (access == ABT_POOL_ACCESS_PRIV ||
-         access == ABT_POOL_ACCESS_MPSC ||
+        (access == ABT_POOL_ACCESS_PRIV || access == ABT_POOL_ACCESS_MPSC ||
          access == ABT_POOL_ACCESS_SPSC) &&
         (p_thread->state == ABT_THREAD_STATE_READY)) {
 
@@ -2286,7 +2309,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
          * changes the state first followed by pushing p_thread to the pool.
          * Therefore, we have to check whether p_thread is in the pool, and if
          * not, we need to wait until it is added. */
-        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {}
+        while (p_thread->p_pool->u_is_in_pool(p_thread->unit) != ABT_TRUE) {
+        }
 
         /* Increase the number of blocked units.  Be sure to execute
          * ABTI_pool_inc_num_blocked before ABTI_POOL_REMOVE in order not to
@@ -2330,7 +2354,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
          * We can't block p_self in this case. */
         uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
                                                    ABTI_THREAD_REQ_JOIN);
-        if (req & ABTI_THREAD_REQ_JOIN) goto yield_based;
+        if (req & ABTI_THREAD_REQ_JOIN)
+            goto yield_based;
 
         ABTI_thread_set_blocked(p_self);
         LOG_EVENT("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
@@ -2359,26 +2384,26 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
         return abt_errno;
     }
 
-  yield_based:
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state)
-           != ABT_THREAD_STATE_TERMINATED) {
+yield_based:
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state) !=
+           ABT_THREAD_STATE_TERMINATED) {
         ABTI_thread_yield(pp_local, p_local->p_thread);
         p_local = *pp_local;
     }
     goto fn_exit;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-  busywait_based:
+busywait_based:
 #endif
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state)
-           != ABT_THREAD_STATE_TERMINATED) {
+    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state) !=
+           ABT_THREAD_STATE_TERMINATED) {
         ABTD_atomic_pause();
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -2394,7 +2419,7 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
     ABTI_CHECK_TRUE(p_xstream->state != ABT_XSTREAM_STATE_TERMINATED,
                     ABT_ERR_INV_XSTREAM);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
-                      p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
+                        p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(p_thread->state != ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
@@ -2444,10 +2469,10 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
         goto fn_fail;
     }
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -2457,4 +2482,3 @@ static inline ABT_thread_id ABTI_thread_get_new_id(void)
 {
     return (ABT_thread_id)ABTD_atomic_fetch_add_uint64(&g_thread_id, 1);
 }
-

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup ULT_ATTR ULT Attributes
  * Attributes are used to specify ULT behavior that is different from the
  * default. When a ULT is created with \c ABT_thread_create(), attributes
@@ -66,10 +65,10 @@ int ABT_thread_attr_free(ABT_thread_attr *attr)
     /* Return value */
     *attr = ABT_THREAD_ATTR_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -107,17 +106,17 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
             abt_errno = ABT_ERR_OTHER;
             goto fn_fail;
         }
-        p_attr->p_stack   = stackaddr;
+        p_attr->p_stack = stackaddr;
         p_attr->stacktype = ABTI_STACK_TYPE_USER;
     } else {
         p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;
     }
     p_attr->stacksize = stacksize;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -148,10 +147,10 @@ int ABT_thread_attr_get_stack(ABT_thread_attr attr, void **stackaddr,
     *stackaddr = p_attr->p_stack;
     *stacksize = p_attr->stacksize;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -177,10 +176,10 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
     /* Set the value */
     p_attr->stacksize = stacksize;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -205,10 +204,10 @@ int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
 
     *stacksize = p_attr->stacksize;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -227,7 +226,9 @@ int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
  * @retval ABT_SUCCESS on success
  */
 int ABT_thread_attr_set_callback(ABT_thread_attr attr,
-        void(*cb_func)(ABT_thread thread, void *cb_arg), void *cb_arg)
+                                 void (*cb_func)(ABT_thread thread,
+                                                 void *cb_arg),
+                                 void *cb_arg)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
@@ -235,13 +236,13 @@ int ABT_thread_attr_set_callback(ABT_thread_attr attr,
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     /* Set the value */
-    p_attr->f_cb     = cb_func;
+    p_attr->f_cb = cb_func;
     p_attr->p_cb_arg = cb_arg;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
@@ -275,17 +276,16 @@ int ABT_thread_attr_set_migratable(ABT_thread_attr attr, ABT_bool flag)
     /* Set the value */
     p_attr->migratable = flag;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
     return ABT_ERR_FEATURE_NA;
 #endif
 }
-
 
 /*****************************************************************************/
 /* Private APIs                                                              */
@@ -328,39 +328,43 @@ void ABTI_thread_attr_get_str(ABTI_thread_attr *p_attr, char *p_buf)
 
     char *stacktype;
     switch (p_attr->stacktype) {
-        case ABTI_STACK_TYPE_MEMPOOL: stacktype = "MEMPOOL"; break;
-        case ABTI_STACK_TYPE_MALLOC:  stacktype = "MALLOC"; break;
-        case ABTI_STACK_TYPE_USER:    stacktype = "USER"; break;
-        case ABTI_STACK_TYPE_MAIN:    stacktype = "MAIN"; break;
-        default:                      stacktype = "UNKNOWN"; break;
+        case ABTI_STACK_TYPE_MEMPOOL:
+            stacktype = "MEMPOOL";
+            break;
+        case ABTI_STACK_TYPE_MALLOC:
+            stacktype = "MALLOC";
+            break;
+        case ABTI_STACK_TYPE_USER:
+            stacktype = "USER";
+            break;
+        case ABTI_STACK_TYPE_MAIN:
+            stacktype = "MAIN";
+            break;
+        default:
+            stacktype = "UNKNOWN";
+            break;
     }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     sprintf(p_buf,
-        "["
-        "stack:%p "
-        "stacksize:%zu "
-        "stacktype:%s "
-        "migratable:%s "
-        "cb_arg:%p"
-        "]",
-        p_attr->p_stack,
-        p_attr->stacksize,
-        stacktype,
-        (p_attr->migratable == ABT_TRUE ? "TRUE" : "FALSE"),
-        p_attr->p_cb_arg
-    );
+            "["
+            "stack:%p "
+            "stacksize:%zu "
+            "stacktype:%s "
+            "migratable:%s "
+            "cb_arg:%p"
+            "]",
+            p_attr->p_stack, p_attr->stacksize, stacktype,
+            (p_attr->migratable == ABT_TRUE ? "TRUE" : "FALSE"),
+            p_attr->p_cb_arg);
 #else
     sprintf(p_buf,
-        "["
-        "stack:%p "
-        "stacksize:%zu "
-        "stacktype:%s "
-        "]",
-        p_attr->p_stack,
-        p_attr->stacksize,
-        stacktype
-    );
+            "["
+            "stack:%p "
+            "stacksize:%zu "
+            "stacktype:%s "
+            "]",
+            p_attr->p_stack, p_attr->stacksize, stacktype);
 #endif
 }
 
@@ -373,4 +377,3 @@ ABTI_thread_attr *ABTI_thread_attr_dup(ABTI_thread_attr *p_attr)
 
     return p_dupattr;
 }
-

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -63,11 +63,11 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
         uint32_t cur_size, new_size;
         cur_size = p_htable->num_rows;
         new_size = (idx / cur_size + 1) * cur_size;
-        p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
-                new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[cur_size], 0, (new_size - cur_size)
-                                              * sizeof(ABTI_thread_queue));
+        p_htable->queue = (ABTI_thread_queue *)
+            ABTU_realloc(p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
+                         new_size * sizeof(ABTI_thread_queue));
+        memset(&p_htable->queue[cur_size], 0,
+               (new_size - cur_size) * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 
@@ -124,11 +124,11 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
         uint32_t cur_size, new_size;
         cur_size = p_htable->num_rows;
         new_size = (idx / cur_size + 1) * cur_size;
-        p_htable->queue = (ABTI_thread_queue *)ABTU_realloc(
-                p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
-                new_size * sizeof(ABTI_thread_queue));
-        memset(&p_htable->queue[cur_size], 0, (new_size - cur_size)
-                                              * sizeof(ABTI_thread_queue));
+        p_htable->queue = (ABTI_thread_queue *)
+            ABTU_realloc(p_htable->queue, cur_size * sizeof(ABTI_thread_queue),
+                         new_size * sizeof(ABTI_thread_queue));
+        memset(&p_htable->queue[cur_size], 0,
+               (new_size - cur_size) * sizeof(ABTI_thread_queue));
         p_htable->num_rows = new_size;
     }
 
@@ -259,4 +259,3 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_local **pp_local,
         return ABT_FALSE;
     }
 }
-

--- a/src/timer.c
+++ b/src/timer.c
@@ -11,7 +11,6 @@ int ABTI_timer_create(ABTI_timer **pp_newtimer);
  * This group is for Timer.
  */
 
-
 /**
  * @ingroup TIMER
  * @brief   Get elapsed wall clock time.
@@ -50,10 +49,10 @@ int ABT_timer_create(ABT_timer *newtimer)
 
     *newtimer = ABTI_timer_get_handle(p_newtimer);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     *newtimer = ABT_TIMER_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
@@ -89,10 +88,10 @@ int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
 
     *newtimer = ABTI_timer_get_handle(p_newtimer);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -124,10 +123,10 @@ int ABT_timer_free(ABT_timer *timer)
     free(p_timer);
     *timer = ABT_TIMER_NULL;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -152,10 +151,10 @@ int ABT_timer_start(ABT_timer timer)
 
     ABTD_time_get(&p_timer->start);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -180,10 +179,10 @@ int ABT_timer_stop(ABT_timer timer)
 
     ABTD_time_get(&p_timer->end);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -211,14 +210,14 @@ int ABT_timer_read(ABT_timer timer, double *secs)
     double start, end;
 
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -230,7 +229,7 @@ int ABT_timer_read(ABT_timer timer, double *secs)
  * \c ABT_timer_stop_and_read() stops the timer and returns the time difference
  * in seconds between the start time of \c timer (when \c ABT_timer_start() was
  * called) and the end time of \c timer (when this routine was called) through
-  *\c secs.
+ *\c secs.
  * The resolution of elapsed time is at least a unit of microsecond.
  *
  * @param[in]  timer  handle to the timer
@@ -248,14 +247,14 @@ int ABT_timer_stop_and_read(ABT_timer timer, double *secs)
 
     ABTD_time_get(&p_timer->end);
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -285,14 +284,14 @@ int ABT_timer_stop_and_add(ABT_timer timer, double *secs)
 
     ABTD_time_get(&p_timer->end);
     start = ABTD_time_read_sec(&p_timer->start);
-    end   = ABTD_time_read_sec(&p_timer->end);
+    end = ABTD_time_read_sec(&p_timer->end);
 
     *secs += (end - start);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -333,10 +332,10 @@ int ABT_timer_get_overhead(double *overhead)
 
     *overhead = sum / iter;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -358,10 +357,10 @@ int ABTI_timer_create(ABTI_timer **pp_newtimer)
 
     *pp_newtimer = p_newtimer;
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/unit.c
+++ b/src/unit.c
@@ -5,7 +5,6 @@
 
 #include "abti.h"
 
-
 /** @defgroup UNIT  Work Unit
  * This group is for work units.
  */
@@ -34,10 +33,10 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
 
     ABTI_unit_set_associated_pool(unit, p_pool);
 
-  fn_exit:
+fn_exit:
     return abt_errno;
 
-  fn_fail:
+fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -7,14 +7,14 @@
 #include <math.h>
 #include <ctype.h>
 
-
 /* \c ABTU_get_indent_str() returns a white-space string with the length of
  * \c indent.  The caller should free the memory returned. */
 char *ABTU_get_indent_str(int indent)
 {
     char *space;
     space = (char *)ABTU_malloc(sizeof(char) * (indent + 1));
-    if (indent > 0) memset(space, ' ', indent);
+    if (indent > 0)
+        memset(space, ' ', indent);
     space[indent] = '\0';
     return space;
 }

--- a/test/basic/barrier.c
+++ b/test/basic/barrier.c
@@ -23,17 +23,19 @@ void run(void *args)
 
     assert(values[i] == i);
     ABT_barrier_wait(row_barrier[i]);
-    if (!j) values[i] = i+N;
+    if (!j)
+        values[i] = i + N;
 
     ABT_barrier_wait(row_barrier[i]);
-    assert(values[i] == i+N);
+    assert(values[i] == i + N);
 
     ABT_barrier_wait(global_barrier);
     ABT_barrier_wait(global_barrier);
-    if (!i) values[j] = j+2*N;
+    if (!i)
+        values[j] = j + 2 * N;
 
     ABT_barrier_wait(col_barrier[j]);
-    assert(values[j] == j+2*N);
+    assert(values[j] == j + 2 * N);
 }
 
 int main(int argc, char *argv[])
@@ -106,10 +108,12 @@ int main(int argc, char *argv[])
         }
         for (i = 0; i < N; i++) {
             for (j = 0; j < N; j++) {
-                args[2*(i*N+j)] = i;
-                args[2*(i*N+j)+1] = j;
-                ret = ABT_thread_create(pools[es], run, (void *)&args[2*(i*N+j)],
-                                        ABT_THREAD_ATTR_NULL, &threads[i*N+j]);
+                args[2 * (i * N + j)] = i;
+                args[2 * (i * N + j) + 1] = j;
+                ret = ABT_thread_create(pools[es], run,
+                                        (void *)&args[2 * (i * N + j)],
+                                        ABT_THREAD_ATTR_NULL,
+                                        &threads[i * N + j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 es = (es + 1) % num_xstreams;
             }
@@ -118,7 +122,7 @@ int main(int argc, char *argv[])
         /* Join and free ULTs */
         for (i = 0; i < N; i++) {
             for (j = 0; j < N; j++) {
-                ret = ABT_thread_free(&threads[i*N+j]);
+                ret = ABT_thread_free(&threads[i * N + j]);
                 ATS_ERROR(ret, "ABT_thread_free");
             }
         }
@@ -159,4 +163,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_join.c
+++ b/test/basic/cond_join.c
@@ -8,13 +8,13 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define NUM_THREADS     2
-#define NUM_XSTREAMS    NUM_THREADS
+#define NUM_THREADS 2
+#define NUM_XSTREAMS NUM_THREADS
 
 typedef struct {
-    ABT_mutex    mutex;
-    ABT_cond     cond;
-    int          count;
+    ABT_mutex mutex;
+    ABT_cond cond;
+    int count;
     volatile int curcount;
     volatile int generation;
 } barrier_t;
@@ -25,7 +25,6 @@ typedef struct {
     int tid;
     barrier_t *barrier;
 } thread_arg_t;
-
 
 barrier_t *barrier_create(int count)
 {
@@ -61,33 +60,33 @@ void barrier_free(barrier_t *barrier)
 void thread_wait(thread_arg_t *my_arg)
 {
     int generation;
-    barrier_t* barrier = my_arg->barrier;
+    barrier_t *barrier = my_arg->barrier;
 
     ABT_mutex_lock(barrier->mutex);
     if ((barrier->curcount + 1) == barrier->count) {
         barrier->generation++;
         barrier->curcount = 0;
 
-        ATS_printf(3, "<S%d:TH%d> T%d broadcast-1\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+        ATS_printf(3, "<S%d:TH%d> T%d broadcast-1\n", my_arg->eid, my_arg->uid,
+                   my_arg->tid);
         ABT_cond_broadcast(barrier->cond);
         ABT_mutex_unlock(barrier->mutex);
-        ATS_printf(3, "<S%d:TH%d> T%d broadcast-2\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+        ATS_printf(3, "<S%d:TH%d> T%d broadcast-2\n", my_arg->eid, my_arg->uid,
+                   my_arg->tid);
         return;
     }
     barrier->curcount++;
     generation = barrier->generation;
     do {
-        ATS_printf(3, "<S%d:TH%d> T%d wait-1\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+        ATS_printf(3, "<S%d:TH%d> T%d wait-1\n", my_arg->eid, my_arg->uid,
+                   my_arg->tid);
         ABT_cond_wait(barrier->cond, barrier->mutex);
-        ATS_printf(3, "<S%d:TH%d> T%d wait-2\n",
-                        my_arg->eid, my_arg->uid, my_arg->tid);
+        ATS_printf(3, "<S%d:TH%d> T%d wait-2\n", my_arg->eid, my_arg->uid,
+                   my_arg->tid);
     } while (generation == barrier->generation);
     ABT_mutex_unlock(barrier->mutex);
-    ATS_printf(3, "<S%d:TH%d> T%d wait-3\n",
-                    my_arg->eid, my_arg->uid, my_arg->tid);
+    ATS_printf(3, "<S%d:TH%d> T%d wait-3\n", my_arg->eid, my_arg->uid,
+               my_arg->tid);
 }
 
 void cond_test(void *arg)
@@ -111,11 +110,11 @@ void cond_test(void *arg)
 
 void thread_work(void *arg)
 {
-    ABT_xstream  xstreams[NUM_XSTREAMS];
-    ABT_pool     pools[NUM_XSTREAMS];
-    ABT_thread   threads[NUM_THREADS];
+    ABT_xstream xstreams[NUM_XSTREAMS];
+    ABT_pool pools[NUM_XSTREAMS];
+    ABT_thread threads[NUM_THREADS];
     thread_arg_t args[NUM_THREADS];
-    barrier_t   *barrier;
+    barrier_t *barrier;
     int i, t, ret;
     int iter = (int)(size_t)arg;
 
@@ -172,12 +171,13 @@ void thread_work(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream xstream;
-    ABT_pool    pool;
-    ABT_thread  thread;
+    ABT_pool pool;
+    ABT_thread thread;
     int ret;
     int iter = 5;
 
-    if (argc > 1) iter = atoi(argv[1]);
+    if (argc > 1)
+        iter = atoi(argv[1]);
 
     /* Initialize */
     ATS_read_args(argc, argv);
@@ -206,4 +206,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/cond_signal_in_main.c
+++ b/test/basic/cond_signal_in_main.c
@@ -50,8 +50,8 @@ int main(int argc, char *argv[])
 
     /* Create the ULT */
     ABT_thread thread;
-    ret = ABT_thread_create(pool, wait_on_condition, NULL,
-                            ABT_THREAD_ATTR_NULL, &thread);
+    ret = ABT_thread_create(pool, wait_on_condition, NULL, ABT_THREAD_ATTR_NULL,
+                            &thread);
     ATS_ERROR(ret, "ABT_thread_create");
 
     /* Switch to the other user level thread */
@@ -78,4 +78,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_test.c
+++ b/test/basic/cond_test.c
@@ -8,16 +8,16 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    2
-#define DEFAULT_NUM_THREADS     3
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_THREADS 3
 
 /* Total number of threads (num_xstreams * num_threads) should be equal to
  * or larger than 3. */
 int num_xstreams = DEFAULT_NUM_XSTREAMS;
 int num_threads = DEFAULT_NUM_THREADS;
 
-#define TCOUNT          10
-#define COUNT_LIMIT     15
+#define TCOUNT 10
+#define COUNT_LIMIT 15
 
 int g_counter = 0;
 int g_num_incthreads = 0;
@@ -28,8 +28,8 @@ ABT_cond cond = ABT_COND_NULL;
 ABT_cond broadcast = ABT_COND_NULL;
 
 typedef struct thread_arg {
-    int sid;    /* stream ID */
-    int tid;    /* thread ID */
+    int sid; /* stream ID */
+    int tid; /* thread ID */
 } thread_arg_t;
 
 void inc_counter(void *arg)
@@ -44,11 +44,13 @@ void inc_counter(void *arg)
         g_counter++;
 
         if (g_counter == COUNT_LIMIT) {
-            ATS_printf(1, "[ES%d:TH%d] inc_counter(): threshold(%d) "
-                    "reached\n", es_id, my_id, g_counter);
+            ATS_printf(1,
+                       "[ES%d:TH%d] inc_counter(): threshold(%d) "
+                       "reached\n",
+                       es_id, my_id, g_counter);
             ABT_cond_signal(cond);
-            ATS_printf(1, "[ES%d:TH%d] inc_counter(): sent signal\n",
-                    es_id, my_id);
+            ATS_printf(1, "[ES%d:TH%d] inc_counter(): sent signal\n", es_id,
+                       my_id);
         }
 
         ABT_mutex_unlock(mutex);
@@ -73,11 +75,10 @@ void watch_counter(void *arg)
 
     ABT_mutex_lock(mutex);
     while (g_counter < COUNT_LIMIT) {
-        ATS_printf(1, "[ES%d:TH%d] watch_count(): waiting\n",
-                es_id, my_id);
+        ATS_printf(1, "[ES%d:TH%d] watch_count(): waiting\n", es_id, my_id);
         ABT_cond_wait(cond, mutex);
-        ATS_printf(1, "[ES%d:TH%d] watch_count(): received signal\n",
-                es_id, my_id);
+        ATS_printf(1, "[ES%d:TH%d] watch_count(): received signal\n", es_id,
+                   my_id);
         g_waiting = 1;
         g_counter += 100;
     }
@@ -96,9 +97,11 @@ int main(int argc, char *argv[])
 {
     int i, j;
     int ret, expected;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     if (num_xstreams * num_threads < 3) {
@@ -135,7 +138,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -153,18 +156,18 @@ int main(int argc, char *argv[])
     args[0][0].sid = 0;
     args[0][0].tid = 1;
     ret = ABT_thread_create(pools[0], watch_counter, (void *)&args[0][0],
-            ABT_THREAD_ATTR_NULL, NULL);
+                            ABT_THREAD_ATTR_NULL, NULL);
     ATS_ERROR(ret, "ABT_thread_create");
 
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            if (!i && !j) continue;
+            if (!i && !j)
+                continue;
             int tid = i * num_threads + j + 1;
             args[i][j].sid = i;
             args[i][j].tid = tid;
-            ret = ABT_thread_create(pools[i],
-                    inc_counter, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], inc_counter, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -172,7 +175,8 @@ int main(int argc, char *argv[])
     /* Join and free ULTs */
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            if (!i && !j) continue;
+            if (!i && !j)
+                continue;
             ret = ABT_thread_free(&threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_free");
         }
@@ -220,4 +224,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/cond_timedwait.c
+++ b/test/basic/cond_timedwait.c
@@ -10,19 +10,18 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 static ABT_mutex mutex = ABT_MUTEX_NULL;
 static ABT_cond cond = ABT_COND_NULL;
 static int g_counter = 0;
 
-
 void cond_test(void *arg)
 {
     int ret;
     struct timespec ts;
-    struct timeval  tv;
+    struct timeval tv;
     int eid;
     ABT_thread_id tid;
 
@@ -34,7 +33,7 @@ void cond_test(void *arg)
     ret = gettimeofday(&tv, NULL);
     assert(!ret);
 
-    ts.tv_sec  = tv.tv_sec;
+    ts.tv_sec = tv.tv_sec;
     ts.tv_nsec = tv.tv_usec * 1000;
     ts.tv_sec += 1;
 
@@ -73,10 +72,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -117,7 +116,7 @@ int main(int argc, char *argv[])
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
         ret = ABT_thread_create(pools[pidx], cond_test, NULL,
-                ABT_THREAD_ATTR_NULL, &threads[i]);
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
         pidx = (pidx + 1) % num_xstreams;
     }
@@ -171,4 +170,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -13,16 +13,18 @@
 ABT_thread th1, th2, th3;
 ABT_eventual myeventual;
 
-#define LOOP_CNT  10
+#define LOOP_CNT 10
 void fn1(void *args)
 {
     ATS_UNUSED(args);
     int i = 0;
-    void *data =  malloc(EVENTUAL_SIZE);
+    void *data = malloc(EVENTUAL_SIZE);
     ATS_printf(1, "Thread 1 iteration %d waiting for eventual\n", i);
-    ABT_eventual_wait(myeventual,&data);
-    ATS_printf(1, "Thread 1 continue iteration %d returning from "
-            "eventual\n", i);
+    ABT_eventual_wait(myeventual, &data);
+    ATS_printf(1,
+               "Thread 1 continue iteration %d returning from "
+               "eventual\n",
+               i);
 }
 
 void fn2(void *args)
@@ -31,14 +33,16 @@ void fn2(void *args)
     int i = 0, is_ready = 0;
     void *data = malloc(EVENTUAL_SIZE);
     ATS_printf(1, "Thread 2 iteration %d waiting from eventual\n", i);
-    ABT_eventual_test(myeventual,&data, &is_ready);
+    ABT_eventual_test(myeventual, &data, &is_ready);
     while (!is_ready) {
-       ABT_thread_yield();
-       ABT_eventual_test(myeventual,&data, &is_ready);
+        ABT_thread_yield();
+        ABT_eventual_test(myeventual, &data, &is_ready);
     }
-    ABT_eventual_wait(myeventual,&data);
-    ATS_printf(1, "Thread 2 continue iteration %d returning from "
-            "eventual\n", i);
+    ABT_eventual_wait(myeventual, &data);
+    ATS_printf(1,
+               "Thread 2 continue iteration %d returning from "
+               "eventual\n",
+               i);
 }
 
 void fn3(void *args)
@@ -46,7 +50,7 @@ void fn3(void *args)
     ATS_UNUSED(args);
     int i = 0;
     ATS_printf(1, "Thread 3 iteration %d signal eventual \n", i);
-    char *data = (char *) malloc(EVENTUAL_SIZE);
+    char *data = (char *)malloc(EVENTUAL_SIZE);
     ABT_eventual_set(myeventual, data, EVENTUAL_SIZE);
     ATS_printf(1, "Thread 3 continue iteration %d \n", i);
 }
@@ -82,9 +86,11 @@ int main(int argc, char *argv[])
 
     void *data;
     ATS_printf(1, "Thread main iteration %d waiting for eventual\n", 0);
-    ABT_eventual_wait(myeventual,&data);
-    ATS_printf(1, "Thread main continue iteration %d returning from "
-            "eventual\n", 0);
+    ABT_eventual_wait(myeventual, &data);
+    ATS_printf(1,
+               "Thread main continue iteration %d returning from "
+               "eventual\n",
+               0);
 
     /* Join and free other threads */
     ret = ABT_thread_free(&th1);

--- a/test/basic/eventual_test.c
+++ b/test/basic/eventual_test.c
@@ -8,10 +8,10 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_TASKS       4
-#define DEFAULT_NUM_THREADS     (DEFAULT_NUM_TASKS * 2)
-#define DEFAULT_NUM_ITER        100
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_TASKS 4
+#define DEFAULT_NUM_THREADS (DEFAULT_NUM_TASKS * 2)
+#define DEFAULT_NUM_ITER 100
 
 static int num_xstreams;
 static int num_threads;
@@ -19,8 +19,8 @@ static int num_tasks;
 static int num_iter;
 static ABT_pool *pools;
 
-#define OP_WAIT     0
-#define OP_SET      1
+#define OP_WAIT 0
+#define OP_SET 1
 
 typedef struct {
     int eid;
@@ -36,7 +36,7 @@ void thread_func(void *arg)
     arg_t *my_arg = (arg_t *)arg;
 
     ATS_printf(3, "[U%d:E%d] %s\n", my_arg->tid, my_arg->eid,
-                       my_arg->op_type == OP_WAIT ? "wait" : "set");
+               my_arg->op_type == OP_WAIT ? "wait" : "set");
 
     if (my_arg->op_type == OP_WAIT) {
         if (my_arg->nbytes == 0) {
@@ -127,21 +127,22 @@ void eventual_test(void *arg)
         for (t = 0; t < num_threads; t += 2) {
             thread_args[t].eid = eid;
             thread_args[t].tid = t;
-            thread_args[t].ev = evs1[t/2];
-            thread_args[t].nbytes = nbytes[t/2];
+            thread_args[t].ev = evs1[t / 2];
+            thread_args[t].nbytes = nbytes[t / 2];
             thread_args[t].op_type = OP_WAIT;
             ret = ABT_thread_create(pools[pid], thread_func, &thread_args[t],
                                     ABT_THREAD_ATTR_NULL, &threads[t]);
             ATS_ERROR(ret, "ABT_thread_create");
             pid = (pid + 1) % num_xstreams;
 
-            thread_args[t+1].eid = eid;
-            thread_args[t+1].tid = t + 1;
-            thread_args[t+1].ev = evs1[t/2];
-            thread_args[t+1].nbytes = nbytes[t/2];
-            thread_args[t+1].op_type = OP_SET;
-            ret = ABT_thread_create(pools[pid], thread_func, &thread_args[t+1],
-                                    ABT_THREAD_ATTR_NULL, &threads[t+1]);
+            thread_args[t + 1].eid = eid;
+            thread_args[t + 1].tid = t + 1;
+            thread_args[t + 1].ev = evs1[t / 2];
+            thread_args[t + 1].nbytes = nbytes[t / 2];
+            thread_args[t + 1].op_type = OP_SET;
+            ret =
+                ABT_thread_create(pools[pid], thread_func, &thread_args[t + 1],
+                                  ABT_THREAD_ATTR_NULL, &threads[t + 1]);
             ATS_ERROR(ret, "ABT_thread_create");
             pid = (pid + 1) % num_xstreams;
         }
@@ -159,7 +160,8 @@ void eventual_test(void *arg)
             task_args[t].ev = evs2[t];
             task_args[t].nbytes = nbytes[t];
             task_args[t].op_type = OP_SET;
-            ret = ABT_task_create(pools[pid], task_func, &task_args[t], &tasks[t]);
+            ret = ABT_task_create(pools[pid], task_func, &task_args[t],
+                                  &tasks[t]);
             ATS_ERROR(ret, "ABT_task_create");
             pid = (pid + 1) % num_xstreams;
         }
@@ -182,7 +184,6 @@ void eventual_test(void *arg)
             ret = ABT_eventual_reset(evs2[t]);
             ATS_ERROR(ret, "ABT_eventual_reset");
         }
-
     }
 
     for (t = 0; t < num_tasks; t++) {
@@ -216,14 +217,14 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_tasks    = DEFAULT_NUM_TASKS;
-        num_iter     = DEFAULT_NUM_ITER;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_tasks = DEFAULT_NUM_TASKS;
+        num_iter = DEFAULT_NUM_ITER;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
-        num_threads  = num_tasks * 2;
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_threads = num_tasks * 2;
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -233,8 +234,8 @@ int main(int argc, char *argv[])
     ATS_printf(1, "# of iter       : %d\n", num_iter);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);
@@ -282,4 +283,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/ext_thread.c
+++ b/test/basic/ext_thread.c
@@ -16,9 +16,9 @@
 #define BUF_SIZE 10
 
 ABT_mutex g_mutex = ABT_MUTEX_NULL;
-ABT_cond  g_cond  = ABT_COND_NULL;
-ABT_eventual g_eventual[2] = {ABT_EVENTUAL_NULL, ABT_EVENTUAL_NULL};
-ABT_future   g_future[2]   = {ABT_FUTURE_NULL, ABT_FUTURE_NULL};
+ABT_cond g_cond = ABT_COND_NULL;
+ABT_eventual g_eventual[2] = { ABT_EVENTUAL_NULL, ABT_EVENTUAL_NULL };
+ABT_future g_future[2] = { ABT_FUTURE_NULL, ABT_FUTURE_NULL };
 int g_counter = 0;
 volatile int g_threads = 0;
 
@@ -61,7 +61,8 @@ void thread_func(void *arg)
 
     /* ULT 1 and pthread are waiting, and ULT 0 broadcasts. */
     if (my_id == 0) {
-        while (g_threads < 2) ABT_thread_yield();
+        while (g_threads < 2)
+            ABT_thread_yield();
         ABT_mutex_lock(g_mutex);
         ABT_cond_broadcast(g_cond);
         ABT_mutex_unlock(g_mutex);
@@ -149,7 +150,8 @@ void *pthread_test(void *arg)
 
     /* Test condition variable */
     /* Wake up other ULTs that are waiting on the condition variable */
-    while (g_threads < 2);
+    while (g_threads < 2)
+        ;
     ABT_mutex_lock(g_mutex);
     g_threads = 0;
     ABT_cond_broadcast(g_cond);
@@ -237,4 +239,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/future_create.c
+++ b/test/basic/future_create.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    2
-#define DEFAULT_NUM_THREADS     3
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_THREADS 3
 #define BUFFER_SIZE 10
 
 ABT_future myfuture;
@@ -19,7 +19,6 @@ ABT_future myfuture2;
 int num_xstreams = DEFAULT_NUM_XSTREAMS;
 int num_threads = DEFAULT_NUM_THREADS;
 int total_num_threads;
-
 
 void future_wait(void *args)
 {
@@ -43,11 +42,11 @@ void future_cb(void **args)
     for (i = 0; i < total_num_threads; i++) {
         total += (int)(intptr_t)args[i];
     }
-    if (total_num_threads*(total_num_threads-1)/2 != total) {
+    if (total_num_threads * (total_num_threads - 1) / 2 != total) {
         ATS_ERROR(ABT_ERR_OTHER, "Wrong value!");
     }
 
-    ABT_future_set(myfuture2,  NULL);
+    ABT_future_set(myfuture2, NULL);
     ATS_printf(1, "Callback signals future\n");
 }
 
@@ -55,11 +54,13 @@ int main(int argc, char *argv[])
 {
     int i, j;
     int ret;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
-    total_num_threads = num_threads*num_xstreams;
+    total_num_threads = num_threads * num_xstreams;
 
     /* init and thread creation */
     ATS_read_args(argc, argv);
@@ -67,7 +68,7 @@ int main(int argc, char *argv[])
 
     /* Create Execution Streams */
     ABT_xstream *xstreams =
-      (ABT_xstream *)malloc(num_xstreams*sizeof(ABT_xstream));
+        (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     ret = ABT_xstream_self(&xstreams[0]);
     ATS_ERROR(ret, "ABT_xstream_self");
     for (i = 1; i < num_xstreams; i++) {
@@ -76,9 +77,9 @@ int main(int argc, char *argv[])
     }
 
     /* Get the pools attached to an execution stream */
-    ABT_pool *pools = (ABT_pool *)malloc(num_xstreams*sizeof(ABT_pool));
+    ABT_pool *pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -89,9 +90,9 @@ int main(int argc, char *argv[])
 
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
-            int idx = i*num_threads+j;
+            int idx = i * num_threads + j;
             ret = ABT_thread_create(pools[i], future_wait,
-                                    (void *)(intptr_t)(idx+total_num_threads),
+                                    (void *)(intptr_t)(idx + total_num_threads),
                                     ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
             ret = ABT_thread_create(pools[i], future_set, (void *)(intptr_t)idx,

--- a/test/basic/info_print.c
+++ b/test/basic/info_print.c
@@ -8,7 +8,7 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    2
+#define DEFAULT_NUM_XSTREAMS 2
 
 void thread_func(void *arg)
 {
@@ -62,10 +62,10 @@ int main(int argc, char *argv[])
     ATS_printf(1, "# of ESs        : %d\n", num_xstreams);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    scheds   = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    threads  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
-    tasks    = (ABT_task *)malloc(num_xstreams * sizeof(ABT_task));
+    scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    tasks = (ABT_task *)malloc(num_xstreams * sizeof(ABT_task));
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);
@@ -144,5 +144,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-
-

--- a/test/basic/info_stackdump.c
+++ b/test/basic/info_stackdump.c
@@ -9,8 +9,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 int g_go = 0;
 
@@ -131,8 +131,8 @@ int main(int argc, char *argv[])
         for (j = 0; j < num_threads; j++) {
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
-            args[i][j].issue_signal = (i == num_xstreams / 2)
-                                      && (j == num_threads / 2);
+            args[i][j].issue_signal =
+                (i == num_xstreams / 2) && (j == num_threads / 2);
             args[i][j].dummy_ptr = NULL;
             args[i][j].stack = NULL;
             if (tid % 3 == 0) {
@@ -147,8 +147,8 @@ int main(int argc, char *argv[])
                 ret = ABT_thread_attr_set_stacksize(attr, 32768);
                 ATS_ERROR(ret, "ABT_thread_attr_set_stacksize");
                 ret = ABT_thread_create(pools[i], thread_func,
-                                        (void *)&args[i][j],
-                                        attr, &threads[i][j]);
+                                        (void *)&args[i][j], attr,
+                                        &threads[i][j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 ret = ABT_thread_attr_free(&attr);
                 ATS_ERROR(ret, "ABT_thread_attr_free");
@@ -162,8 +162,8 @@ int main(int argc, char *argv[])
                                                 stacksize);
                 ATS_ERROR(ret, "ABT_thread_attr_set_stack");
                 ret = ABT_thread_create(pools[i], thread_func,
-                                        (void *)&args[i][j],
-                                        attr, &threads[i][j]);
+                                        (void *)&args[i][j], attr,
+                                        &threads[i][j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 ret = ABT_thread_attr_free(&attr);
                 ATS_ERROR(ret, "ABT_thread_attr_free");

--- a/test/basic/info_stackdump2.c
+++ b/test/basic/info_stackdump2.c
@@ -9,8 +9,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     8
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 8
 
 int g_counter = 0;
 int g_stop = 0;
@@ -144,8 +144,8 @@ int main(int argc, char *argv[])
         for (j = 0; j < num_threads; j++) {
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
-            args[i][j].issue_signal = (i == ((num_xstreams - 1) / 2) + 1)
-                                      && (j == num_threads / 2);
+            args[i][j].issue_signal =
+                (i == ((num_xstreams - 1) / 2) + 1) && (j == num_threads / 2);
             args[i][j].stop = (j == num_threads / 2);
             args[i][j].num_xstreams = num_xstreams;
             args[i][j].dummy_ptr = NULL;
@@ -162,8 +162,8 @@ int main(int argc, char *argv[])
                 ret = ABT_thread_attr_set_stacksize(attr, 32768);
                 ATS_ERROR(ret, "ABT_thread_attr_set_stacksize");
                 ret = ABT_thread_create(pools[i], thread_func,
-                                        (void *)&args[i][j],
-                                        attr, &threads[i][j]);
+                                        (void *)&args[i][j], attr,
+                                        &threads[i][j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 ret = ABT_thread_attr_free(&attr);
                 ATS_ERROR(ret, "ABT_thread_attr_free");
@@ -177,8 +177,8 @@ int main(int argc, char *argv[])
                                                 stacksize);
                 ATS_ERROR(ret, "ABT_thread_attr_set_stack");
                 ret = ABT_thread_create(pools[i], thread_func,
-                                        (void *)&args[i][j],
-                                        attr, &threads[i][j]);
+                                        (void *)&args[i][j], attr,
+                                        &threads[i][j]);
                 ATS_ERROR(ret, "ABT_thread_create");
                 ret = ABT_thread_attr_free(&attr);
                 ATS_ERROR(ret, "ABT_thread_attr_free");

--- a/test/basic/init_finalize.c
+++ b/test/basic/init_finalize.c
@@ -9,8 +9,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_THREADS     10
-#define DEFAULT_NUM_ITER        10
+#define DEFAULT_NUM_THREADS 10
+#define DEFAULT_NUM_ITER 10
 
 static int num_iter = DEFAULT_NUM_ITER;
 
@@ -47,10 +47,9 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 2) {
         num_threads = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_iter    = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_threads);
-
 
     threads = (pthread_t *)malloc(num_threads * sizeof(pthread_t));
     assert(threads);

--- a/test/basic/mutex.c
+++ b/test/basic/mutex.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_ITER        100
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
 
 int g_counter = 0;
 int g_iter = DEFAULT_NUM_ITER;
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -107,9 +107,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -158,4 +157,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_prio.c
+++ b/test/basic/mutex_prio.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_ITER        100
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
 
 int g_counter = 0;
 int g_iter = DEFAULT_NUM_ITER;
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -117,9 +117,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -168,4 +167,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_recursive.c
+++ b/test/basic/mutex_recursive.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define RECURSIVE_DEPTH         5
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define RECURSIVE_DEPTH 5
 
 static ABT_mutex g_mutex = ABT_MUTEX_NULL;
 static int g_counter = 0;
@@ -52,10 +52,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 
     /* Get the main pool associated with each ES */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
             args[i][j].id = tid;
             args[i][j].depth = RECURSIVE_DEPTH;
             ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
-                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -153,4 +153,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_spinlock.c
+++ b/test/basic/mutex_spinlock.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_ITER        100
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
 
 int g_counter = 0;
 int g_iter = DEFAULT_NUM_ITER;
@@ -63,7 +63,6 @@ int main(int argc, char *argv[])
     }
     ATS_init(argc, argv, num_xstreams);
 
-
     ATS_printf(2, "# of ESs : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs: %d\n", num_threads);
     ATS_printf(1, "# of iter: %d\n", g_iter);
@@ -95,7 +94,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -109,9 +108,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -160,4 +158,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/mutex_unlock_se.c
+++ b/test/basic/mutex_unlock_se.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_ITER        100
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
 
 int g_counter = 0;
 int g_iter = DEFAULT_NUM_ITER;
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -107,9 +107,8 @@ int main(int argc, char *argv[])
             int tid = i * num_threads + j + 1;
             args[i][j].id = tid;
             args[i][j].mutex = mutex;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -158,4 +157,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/pool_access.c
+++ b/test/basic/pool_access.c
@@ -8,10 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-
 ABT_pool_access accesses[5] = {
-  ABT_POOL_ACCESS_PRIV, ABT_POOL_ACCESS_SPSC, ABT_POOL_ACCESS_MPSC,
-  ABT_POOL_ACCESS_SPMC, ABT_POOL_ACCESS_MPMC,
+    ABT_POOL_ACCESS_PRIV, ABT_POOL_ACCESS_SPSC, ABT_POOL_ACCESS_MPSC,
+    ABT_POOL_ACCESS_SPMC, ABT_POOL_ACCESS_MPMC,
 };
 
 int add_to_another_ES(int accessIdx, int result)
@@ -47,14 +46,14 @@ int add_to_another_ES(int accessIdx, int result)
     ATS_ERROR(ret, "ABT_xstream_get_main_pools");
 
     /* Use the pool with two schedulers in the same ES */
-    ret =  ABT_pool_add_sched(pool1, scheds[0]);
+    ret = ABT_pool_add_sched(pool1, scheds[0]);
     ATS_ERROR(ret, "ABT_pool_add_sched");
 
-    ret =  ABT_pool_add_sched(pool1, scheds[1]);
+    ret = ABT_pool_add_sched(pool1, scheds[1]);
     ATS_ERROR(ret, "ABT_pool_add_sched");
 
     /* Use the pool with another scheduler in another ES */
-    ret =  ABT_pool_add_sched(pool2, scheds[2]);
+    ret = ABT_pool_add_sched(pool2, scheds[2]);
 
     /* Free scheds[2] if it was not added to pool2 */
     if (ret != ABT_SUCCESS) {
@@ -77,11 +76,11 @@ void task_func1(void *arg)
 {
     int ret;
     void **args = (void **)arg;
-    int result           = *(int *)      args[0];
-    ABT_pool pool_main   = *(ABT_pool *) args[1];
-    ABT_pool pool_dest   = *(ABT_pool *) args[2];
+    int result = *(int *)args[0];
+    ABT_pool pool_main = *(ABT_pool *)args[1];
+    ABT_pool pool_dest = *(ABT_pool *)args[2];
     ABT_sched sched_dest = *(ABT_sched *)args[3];
-    ABT_sched sched      = *(ABT_sched *)args[4];
+    ABT_sched sched = *(ABT_sched *)args[4];
 
     ret = ABT_pool_add_sched(pool_main, sched_dest);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -121,7 +120,8 @@ int add_to_another_access(int accessIdx, int *results)
 
         /* Test */
         ABT_pool pool_dest;
-        ret = ABT_pool_create_basic(ABT_POOL_FIFO, accesses[p], ABT_TRUE, &pool_dest);
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, accesses[p], ABT_TRUE,
+                                    &pool_dest);
         ATS_ERROR(ret, "ABT_pool_create_basic");
         ABT_sched sched_dest;
         ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_dest,
@@ -129,12 +129,12 @@ int add_to_another_access(int accessIdx, int *results)
         ATS_ERROR(ret, "ABT_sched_create_basic");
 
         ABT_sched_config config;
-        ret = ABT_sched_config_create(&config,
-                                      ABT_sched_config_access, access,
+        ret = ABT_sched_config_create(&config, ABT_sched_config_access, access,
                                       ABT_sched_config_var_end);
         ATS_ERROR(ret, "ABT_sched_config_create");
         ABT_sched sched;
-        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config, &sched);
+        ret =
+            ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config, &sched);
         ATS_ERROR(ret, "ABT_sched_create_basic");
         ret = ABT_sched_config_free(&config);
         ATS_ERROR(ret, "ABT_sched_config_free");
@@ -167,7 +167,7 @@ void task_func2(void *arg)
         ret = ABT_task_create(pool, task_func2, NULL, NULL);
         if ((ret != ABT_SUCCESS && result == ABT_SUCCESS) ||
             (ret == ABT_SUCCESS && result != ABT_SUCCESS))
-            ret =  ABT_ERR_INV_POOL_ACCESS;
+            ret = ABT_ERR_INV_POOL_ACCESS;
         else
             ret = ABT_SUCCESS;
         ATS_ERROR(ret, "ABT_task_create");
@@ -183,8 +183,7 @@ int push_from_another_es(int accessIdx, int *results)
 
     /* Creation of the ES */
     ABT_sched_config config;
-    ret = ABT_sched_config_create(&config,
-                                  ABT_sched_config_access, access,
+    ret = ABT_sched_config_create(&config, ABT_sched_config_access, access,
                                   ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
     ABT_sched sched;
@@ -231,37 +230,37 @@ int main(int argc, char *argv[])
 
     /* ABT_POOL_ACCESS_PRIV */
     ret_add_to_another_ES[0] = error;
-    int temp00[5] = {success, success, success, error, error};
+    int temp00[5] = { success, success, success, error, error };
     ret_add_to_another_access[0] = temp00;
-    int temp01[2] = {error, error};
+    int temp01[2] = { error, error };
     ret_push_from_another_pool[0] = temp01;
 
     /* ABT_POOL_ACCESS_SPSC */
     ret_add_to_another_ES[1] = error;
-    int temp10[5] = {success, success, success, error, error};
+    int temp10[5] = { success, success, success, error, error };
     ret_add_to_another_access[1] = temp10;
-    int temp11[2] = {success, error};
+    int temp11[2] = { success, error };
     ret_push_from_another_pool[1] = temp11;
 
     /* ABT_POOL_ACCESS_MPSC */
     ret_add_to_another_ES[2] = error;
-    int temp20[5] = {success, success, success, error, error};
+    int temp20[5] = { success, success, success, error, error };
     ret_add_to_another_access[2] = temp20;
-    int temp21[2] = {success, success};
+    int temp21[2] = { success, success };
     ret_push_from_another_pool[2] = temp21;
 
     /* ABT_POOL_ACCESS_SPMC */
     ret_add_to_another_ES[3] = success;
-    int temp30[5] = {success, success, success, success, success};
+    int temp30[5] = { success, success, success, success, success };
     ret_add_to_another_access[3] = temp30;
-    int temp31[2] = {success, error};
+    int temp31[2] = { success, error };
     ret_push_from_another_pool[3] = temp31;
 
     /* ABT_POOL_ACCESS_MPMC */
     ret_add_to_another_ES[4] = success;
-    int temp40[5] = {success, success, success, success, success};
+    int temp40[5] = { success, success, success, success, success };
     ret_add_to_another_access[4] = temp40;
-    int temp41[2] = {success, success};
+    int temp41[2] = { success, success };
     ret_push_from_another_pool[4] = temp41;
 
     for (i = 0; i < 5; i++) {
@@ -277,5 +276,3 @@ int main(int argc, char *argv[])
     ret = ATS_finalize(0);
     return ret;
 }
-
-

--- a/test/basic/rwlock_reader_incl.c
+++ b/test/basic/rwlock_reader_incl.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS     4
-#define DEFAULT_NUM_THREADS      4
-#define DEFAULT_NUM_TESTS       10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TESTS 10
 #define DEFAULT_NUM_TEST_ITERS 100
 
 typedef struct test_arg test_arg_t;
@@ -63,9 +63,9 @@ void run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -88,13 +88,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -128,7 +132,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -137,8 +141,8 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_rwlock_create");
 
     /* Create a barrier */
-    ret = ABT_barrier_create(targ.num_xstreams * targ.num_threads,
-            &targ.barrier);
+    ret =
+        ABT_barrier_create(targ.num_xstreams * targ.num_threads, &targ.barrier);
     ATS_ERROR(ret, "ABT_barrier_create");
 
     /* Execute tests */
@@ -176,4 +180,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/rwlock_reader_writer_excl.c
+++ b/test/basic/rwlock_reader_writer_excl.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS     4
-#define DEFAULT_NUM_THREADS      4
-#define DEFAULT_NUM_TESTS       10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TESTS 10
 #define DEFAULT_NUM_TEST_ITERS 100
 
 static int g_counter = 0;
@@ -48,12 +48,10 @@ void thread_func(void *arg)
             if (t_arg->id == 1) {
                 g_counter++;
                 ATS_printf(1, "[TH%d] read+increased\n", t_arg->id);
-            }
-            else {
+            } else {
                 ATS_printf(1, "[TH%d] read\n", t_arg->id);
             }
-        }
-        else {
+        } else {
             ret = ABT_rwlock_wrlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_wrlock");
             g_counter++;
@@ -66,8 +64,8 @@ void thread_func(void *arg)
 
 int run_test(test_arg_t *targ)
 {
-    int expected = ((targ->num_xstreams * targ->num_threads) / 2 + 1) *
-        targ->iters;
+    int expected =
+        ((targ->num_xstreams * targ->num_threads) / 2 + 1) * targ->iters;
     int i, j;
     int ret;
 
@@ -79,9 +77,9 @@ int run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -100,8 +98,7 @@ int run_test(test_arg_t *targ)
                 "g_counter = %d, expected = %d (%d xstreams, %d threads)\n",
                 g_counter, expected, targ->num_xstreams, targ->num_threads);
         return 1;
-    }
-    else {
+    } else {
         return 0;
     }
 }
@@ -115,13 +112,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -199,4 +200,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/rwlock_writer_excl.c
+++ b/test/basic/rwlock_writer_excl.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS     4
-#define DEFAULT_NUM_THREADS      4
-#define DEFAULT_NUM_TESTS       10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TESTS 10
 #define DEFAULT_NUM_TEST_ITERS 100
 
 static int g_counter = 0;
@@ -45,8 +45,7 @@ static void thread_func(void *arg)
             ret = ABT_rwlock_rdlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_rdlock");
             ATS_printf(1, "[TH%d] read\n", t_arg->id);
-        }
-        else {
+        } else {
             ret = ABT_rwlock_wrlock(t_arg->targ->rwlock);
             ATS_ERROR(ret, "ABT_rwlock_wrlock");
             g_counter++;
@@ -59,8 +58,7 @@ static void thread_func(void *arg)
 
 int run_test(test_arg_t *targ)
 {
-    int expected = ((targ->num_xstreams * targ->num_threads) / 2) *
-        targ->iters;
+    int expected = ((targ->num_xstreams * targ->num_threads) / 2) * targ->iters;
     int i, j;
     int ret;
 
@@ -72,9 +70,9 @@ int run_test(test_arg_t *targ)
             int tid = i * targ->num_threads + j + 1;
             targ->args[i][j].id = tid;
             targ->args[i][j].targ = targ;
-            ret = ABT_thread_create(targ->pools[i],
-                    thread_func, (void *)&targ->args[i][j],
-                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
+            ret = ABT_thread_create(targ->pools[i], thread_func,
+                                    (void *)&targ->args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &targ->threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -93,8 +91,7 @@ int run_test(test_arg_t *targ)
                 "g_counter = %d, expected = %d (%d xstreams, %d threads)\n",
                 g_counter, expected, targ->num_xstreams, targ->num_threads);
         return 1;
-    }
-    else {
+    } else {
         return 0;
     }
 }
@@ -108,13 +105,17 @@ int main(int argc, char *argv[])
     targ.num_xstreams = DEFAULT_NUM_XSTREAMS;
     targ.num_threads = DEFAULT_NUM_THREADS;
     targ.iters = DEFAULT_NUM_TEST_ITERS;
-    if (argc > 1) targ.num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        targ.num_xstreams = atoi(argv[1]);
     assert(targ.num_xstreams >= 0);
-    if (argc > 2) targ.num_threads = atoi(argv[2]);
+    if (argc > 2)
+        targ.num_threads = atoi(argv[2]);
     assert(targ.num_threads >= 0);
-    if (argc > 3) num_tests = atoi(argv[3]);
+    if (argc > 3)
+        num_tests = atoi(argv[3]);
     assert(num_tests > 0);
-    if (argc > 4) targ.iters = atoi(argv[4]);
+    if (argc > 4)
+        targ.iters = atoi(argv[4]);
     assert(targ.iters > 0);
 
     ABT_xstream *xstreams;
@@ -148,7 +149,7 @@ int main(int argc, char *argv[])
     /* Get the pools attached to an execution stream */
     targ.pools = (ABT_pool *)malloc(sizeof(ABT_pool) * targ.num_xstreams);
     for (i = 0; i < targ.num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, targ.pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -192,4 +193,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_basic.c
+++ b/test/basic/sched_basic.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -47,8 +49,8 @@ int main(int argc, char *argv[])
                                   ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                     config, &scheds[i]);
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, config,
+                                     &scheds[i]);
         ATS_ERROR(ret, "ABT_sched_create_basic");
     }
     ret = ABT_sched_config_free(&config);
@@ -66,7 +68,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -74,9 +76,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -102,4 +103,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_basic_wait.c
+++ b/test/basic/sched_basic_wait.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -60,7 +62,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -68,9 +70,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/sched_config.c
+++ b/test/basic/sched_config.c
@@ -11,15 +11,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-ABT_sched_config_var param_a = {
-  .idx = 0,
-  .type = ABT_SCHED_CONFIG_INT
-};
+ABT_sched_config_var param_a = { .idx = 0, .type = ABT_SCHED_CONFIG_INT };
 
-ABT_sched_config_var param_b = {
-  .idx = 1,
-  .type = ABT_SCHED_CONFIG_DOUBLE
-};
+ABT_sched_config_var param_b = { .idx = 1, .type = ABT_SCHED_CONFIG_DOUBLE };
 
 int main(int argc, char *argv[])
 {
@@ -35,27 +29,31 @@ int main(int argc, char *argv[])
     ATS_init(argc, argv, 1);
 
     ABT_sched_config_create(&config1, param_a, a, ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config1, 2, &a2, &b2);
     ABT_sched_config_free(&config1);
     assert(a2 == a && b2 == 0.0);
 
     ABT_sched_config_create(&config2, param_b, b, ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config2, 2, &a2, &b2);
     ABT_sched_config_free(&config2);
     assert(a2 == 0 && b2 == b);
 
     ABT_sched_config_create(&config3, param_a, a, param_b, b,
-                          ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+                            ABT_sched_config_var_end);
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config3, 2, &a2, &b2);
     ABT_sched_config_free(&config3);
     assert(a2 == a && b2 == b);
 
     ABT_sched_config_create(&config4, param_b, b, param_a, a,
-                          ABT_sched_config_var_end);
-    a2 = 0; b2 = 0.0;
+                            ABT_sched_config_var_end);
+    a2 = 0;
+    b2 = 0.0;
     ABT_sched_config_read(config4, 2, &a2, &b2);
     ABT_sched_config_free(&config4);
     assert(a2 == a && b2 == b);
@@ -63,4 +61,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/sched_prio.c
+++ b/test/basic/sched_prio.c
@@ -11,16 +11,12 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_UNITS       6
+#define DEFAULT_NUM_UNITS 6
 int num_units = DEFAULT_NUM_UNITS;
 
-ABT_pool_access accesses[] = {
-    ABT_POOL_ACCESS_PRIV,
-    ABT_POOL_ACCESS_SPSC,
-    ABT_POOL_ACCESS_MPSC,
-    ABT_POOL_ACCESS_SPMC,
-    ABT_POOL_ACCESS_MPMC
-};
+ABT_pool_access accesses[] = { ABT_POOL_ACCESS_PRIV, ABT_POOL_ACCESS_SPSC,
+                               ABT_POOL_ACCESS_MPSC, ABT_POOL_ACCESS_SPMC,
+                               ABT_POOL_ACCESS_MPMC };
 
 typedef struct {
     int *num_pools;
@@ -33,19 +29,18 @@ const int num_scheds = sizeof(accesses) / sizeof(accesses[0]) + 1;
 
 static g_data_t g_data;
 
-
 static void init_global_data(void);
 static void fini_global_data(void);
 static void create_scheds_and_xstreams(void);
 static void free_scheds_and_xstreams(void);
 static void create_work_units(void);
 
-
 int main(int argc, char *argv[])
 {
     int i, ret;
 
-    if (argc > 1) num_units = atoi(argv[1]);
+    if (argc > 1)
+        num_units = atoi(argv[1]);
     assert(num_units >= 0);
 
     /* Initialize */
@@ -87,7 +82,8 @@ static void fini_global_data(void)
     int i;
 
     for (i = 0; i < num_scheds; i++) {
-        if (g_data.pools[i]) free(g_data.pools[i]);
+        if (g_data.pools[i])
+            free(g_data.pools[i]);
     }
 
     free(g_data.num_pools);
@@ -105,7 +101,7 @@ static void create_scheds_and_xstreams(void)
     ABT_xstream *xstreams = g_data.xstreams;
 
     for (i = 0; i < num_scheds; i++) {
-        if (i == num_scheds-1) {
+        if (i == num_scheds - 1) {
             /* Create pools and then create a scheduler */
             num_pools[i] = 2;
             pools[i] = (ABT_pool *)malloc(num_pools[i] * sizeof(ABT_pool));
@@ -117,15 +113,14 @@ static void create_scheds_and_xstreams(void)
             }
 
             ret = ABT_sched_create_basic(ABT_SCHED_PRIO, num_pools[i], pools[i],
-                                         ABT_SCHED_CONFIG_NULL,
-                                         &scheds[i]);
+                                         ABT_SCHED_CONFIG_NULL, &scheds[i]);
             ATS_ERROR(ret, "ABT_sched_create_basic");
         } else {
             /* Create a scheduler and then get the list of pools */
             ABT_sched_config config;
-            ret = ABT_sched_config_create(&config,
-                                          ABT_sched_config_access, accesses[i],
-                                          ABT_sched_config_var_end);
+            ret =
+                ABT_sched_config_create(&config, ABT_sched_config_access,
+                                        accesses[i], ABT_sched_config_var_end);
             ATS_ERROR(ret, "ABT_sched_config_create");
             ret = ABT_sched_create_basic(ABT_SCHED_PRIO, 0, NULL, config,
                                          &scheds[i]);
@@ -176,7 +171,6 @@ static void free_scheds_and_xstreams(void)
     }
 }
 
-
 typedef struct {
     int es_id;
     int my_id;
@@ -185,7 +179,8 @@ typedef struct {
 
 static ABT_bool verify_exec_order(int es_id, int my_prio)
 {
-    if (my_prio == 0) return ABT_TRUE;
+    if (my_prio == 0)
+        return ABT_TRUE;
 
     ABT_pool *my_pools = g_data.pools[es_id];
     size_t pool_size;
@@ -194,7 +189,8 @@ static ABT_bool verify_exec_order(int es_id, int my_prio)
     for (i = 0; i < my_prio; i++) {
         ret = ABT_pool_get_size(my_pools[i], &pool_size);
         ATS_ERROR(ret, "ABT_pool_get_size");
-        if (pool_size > 0) return ABT_FALSE;
+        if (pool_size > 0)
+            return ABT_FALSE;
     }
     return ABT_TRUE;
 }
@@ -206,15 +202,15 @@ static void thread_func(void *arg)
 
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
-    ATS_printf(1, "[E%d:U%d:P%d] before yield\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+    ATS_printf(1, "[E%d:U%d:P%d] before yield\n", my_arg->es_id, my_arg->my_id,
+               my_arg->prio);
 
     ABT_thread_yield();
 
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
-    ATS_printf(1, "[E%d:U%d:P%d] after yield\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+    ATS_printf(1, "[E%d:U%d:P%d] after yield\n", my_arg->es_id, my_arg->my_id,
+               my_arg->prio);
 
     free(my_arg);
 }
@@ -226,8 +222,8 @@ static void task_func(void *arg)
 
     valid = verify_exec_order(my_arg->es_id, my_arg->prio);
     assert(valid == ABT_TRUE);
-    ATS_printf(1, "[E%d:T%d:P%d] running\n",
-                    my_arg->es_id, my_arg->my_id, my_arg->prio);
+    ATS_printf(1, "[E%d:T%d:P%d] running\n", my_arg->es_id, my_arg->my_id,
+               my_arg->prio);
 
     free(my_arg);
 }
@@ -252,14 +248,12 @@ static void gen_work(void *arg)
         my_arg->prio = rand_r(&seed) % num_pools;
 
         if (i & 1) {
-            ret = ABT_thread_create(my_pools[my_arg->prio],
-                                    thread_func, (void *)my_arg,
-                                    ABT_THREAD_ATTR_NULL, NULL);
+            ret = ABT_thread_create(my_pools[my_arg->prio], thread_func,
+                                    (void *)my_arg, ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         } else {
-            ret = ABT_task_create(my_pools[my_arg->prio],
-                                  task_func, (void *)my_arg,
-                                  NULL);
+            ret = ABT_task_create(my_pools[my_arg->prio], task_func,
+                                  (void *)my_arg, NULL);
             ATS_ERROR(ret, "ABT_task_create");
         }
     }
@@ -271,12 +265,12 @@ static void gen_work(void *arg)
         if (accesses[idx] == ABT_POOL_ACCESS_PRIV ||
             accesses[idx] == ABT_POOL_ACCESS_SPSC ||
             accesses[idx] == ABT_POOL_ACCESS_SPMC) {
-                ABT_pool main_pool;
-                ret = ABT_xstream_get_main_pools(g_data.xstreams[idx],
-                                                 1, &main_pool);
-                ATS_ERROR(ret, "ABT_xstream_get_main_pools");
-                ret = ABT_pool_add_sched(main_pool, g_data.scheds[idx]);
-                ATS_ERROR(ret, "ABT_pool_add_sched");
+            ABT_pool main_pool;
+            ret =
+                ABT_xstream_get_main_pools(g_data.xstreams[idx], 1, &main_pool);
+            ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+            ret = ABT_pool_add_sched(main_pool, g_data.scheds[idx]);
+            ATS_ERROR(ret, "ABT_pool_add_sched");
         }
     }
 }
@@ -297,4 +291,3 @@ static void create_work_units(void)
         ATS_ERROR(ret, "ABT_thread_create");
     }
 }
-

--- a/test/basic/sched_randws.c
+++ b/test/basic/sched_randws.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 static int num_threads = DEFAULT_NUM_THREADS;
 
@@ -79,8 +79,8 @@ static void create_threads(void *arg)
     ATS_printf(1, "[U%lu:E%d] creating ULTs\n", id, rank);
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ret = ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -106,18 +106,19 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
-    ATS_printf(1, "# of ESs    : %d\n"
-                       "# of ULTs/ES: %d\n",
-                       num_xstreams, num_threads);
+    ATS_printf(1,
+               "# of ESs    : %d\n"
+               "# of ULTs/ES: %d\n",
+               num_xstreams, num_threads);
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    scheds   = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create a mutex */
     ret = ABT_mutex_create(&g_mutex);
@@ -195,4 +196,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_set_main.c
+++ b/test/basic/sched_set_main.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 static int num_threads = DEFAULT_NUM_THREADS;
 
@@ -89,12 +89,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
-    ATS_printf(1, "num_xstreams=%d num_threads=%d\n",
-                    num_xstreams, num_threads);
+    ATS_printf(1, "num_xstreams=%d num_threads=%d\n", num_xstreams,
+               num_threads);
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_create");
 
         /* Get the first associated pool */
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -144,4 +144,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/sched_stack.c
+++ b/test/basic/sched_stack.c
@@ -20,8 +20,8 @@ long int value = 0;
 
 void task_func(void *arg)
 {
-    long int v = (long int) arg;
-    assert(v == value+1);
+    long int v = (long int)arg;
+    assert(v == value + 1);
     value++;
 }
 
@@ -31,7 +31,8 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_tasks = DEFAULT_NUM_TASKS;
 
-    if (argc > 1) num_tasks = atoi(argv[1]);
+    if (argc > 1)
+        num_tasks = atoi(argv[1]);
     assert(num_tasks >= 0);
 
     ABT_xstream xstream;
@@ -44,8 +45,8 @@ int main(int argc, char *argv[])
     ATS_init(argc, argv, 1);
 
     /* Creation of the main pool/sched */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_mainsched);
+    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                                &pool_mainsched);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_mainsched,
                                  ABT_SCHED_CONFIG_NULL, &mainsched);
@@ -57,31 +58,29 @@ int main(int argc, char *argv[])
     ret = ABT_xstream_set_main_sched(xstream, mainsched);
     ATS_ERROR(ret, "ABT_xstream_set_main_sched");
 
-
     /* Creation of subsched1 */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_subsched1);
+    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                                &pool_subsched1);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_subsched1,
                                  ABT_SCHED_CONFIG_NULL, &subsched1);
     ATS_ERROR(ret, "ABT_sched_create_basic");
 
     /* Creation of subsched2 */
-    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV,
-                                ABT_TRUE, &pool_subsched2);
+    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE,
+                                &pool_subsched2);
     ATS_ERROR(ret, "ABT_pool_create_basic");
     ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool_subsched2,
                                  ABT_SCHED_CONFIG_NULL, &subsched2);
     ATS_ERROR(ret, "ABT_sched_create_basic");
-
 
     long int num = 0;
     ret = ABT_task_create(pool_mainsched, task_func, (void *)++num, NULL);
     ATS_ERROR(ret, "ABT_task_create");
 
     for (i = 0; i < num_tasks; i++) {
-      ret = ABT_task_create(pool_subsched1, task_func, (void *)++num, NULL);
-      ATS_ERROR(ret, "ABT_task_create");
+        ret = ABT_task_create(pool_subsched1, task_func, (void *)++num, NULL);
+        ATS_ERROR(ret, "ABT_task_create");
     }
     ret = ABT_pool_add_sched(pool_mainsched, subsched1);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -90,8 +89,8 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_task_create");
 
     for (i = 0; i < num_tasks; i++) {
-      ret = ABT_task_create(pool_subsched2, task_func, (void *)++num, NULL);
-      ATS_ERROR(ret, "ABT_task_create");
+        ret = ABT_task_create(pool_subsched2, task_func, (void *)++num, NULL);
+        ATS_ERROR(ret, "ABT_task_create");
     }
     ret = ABT_pool_add_sched(pool_mainsched, subsched2);
     ATS_ERROR(ret, "ABT_pool_add_sched");
@@ -102,8 +101,6 @@ int main(int argc, char *argv[])
     /* Finalize */
     ret = ATS_finalize(0);
 
-    assert(value == 3+2*num_tasks);
+    assert(value == 3 + 2 * num_tasks);
     return ret;
 }
-
-

--- a/test/basic/sched_user_ws.c
+++ b/test/basic/sched_user_ws.c
@@ -12,8 +12,8 @@
 /* This test creates a user-defined scheduler, which is a simple work-stealing
  * scheduler, and uses it for ESs. */
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 static int num_xstreams = DEFAULT_NUM_XSTREAMS;
 static int num_threads = DEFAULT_NUM_THREADS;
@@ -77,7 +77,8 @@ static void sched_run(ABT_sched sched)
             ABT_xstream_run_unit(unit, my_pool);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
-            target = (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools-1) + 1);
+            target =
+                (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             ABT_pool tar_pool = pools[target];
             ABT_pool_get_size(tar_pool, &size);
             if (size > 0) {
@@ -93,7 +94,8 @@ static void sched_run(ABT_sched sched)
             ABT_bool stop;
             ret = ABT_sched_has_to_stop(sched, &stop);
             ATS_ERROR(ret, "ABT_sched_has_to_stop");
-            if (stop == ABT_TRUE) break;
+            if (stop == ABT_TRUE)
+                break;
             work_count = 0;
             ABT_xstream_check_events(sched);
         }
@@ -136,23 +138,18 @@ static ABT_sched *create_scheds(int num, ABT_pool *pools)
     ABT_sched *scheds;
     ABT_sched_config config;
 
-    ABT_sched_config_var cv_event_freq = {
-        .idx = 0,
-        .type = ABT_SCHED_CONFIG_INT
-    };
+    ABT_sched_config_var cv_event_freq = { .idx = 0,
+                                           .type = ABT_SCHED_CONFIG_INT };
 
-    ABT_sched_def sched_def = {
-        .type = ABT_SCHED_TYPE_ULT,
-        .init = sched_init,
-        .run = sched_run,
-        .free = sched_free,
-        .get_migr_pool = NULL
-    };
+    ABT_sched_def sched_def = { .type = ABT_SCHED_TYPE_ULT,
+                                .init = sched_init,
+                                .run = sched_run,
+                                .free = sched_free,
+                                .get_migr_pool = NULL };
 
     /* Create a scheduler config */
     /* NOTE: The same scheduler config can be used for all schedulers. */
-    ret = ABT_sched_config_create(&config,
-                                  cv_event_freq, 10,
+    ret = ABT_sched_config_create(&config, cv_event_freq, 10,
                                   ABT_sched_config_var_end);
     ATS_ERROR(ret, "ABT_sched_config_create");
 
@@ -249,8 +246,8 @@ static void create_threads(void *arg)
     ATS_printf(1, "[U%lu:E%d] creating ULTs\n", id, rank);
     threads = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ret = ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -274,12 +271,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc > 1) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 
     ATS_printf(1, "num_xstreams=%d num_threads=%d\n", num_xstreams,
-                    num_threads);
+               num_threads);
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
 
@@ -324,4 +321,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -36,7 +36,7 @@ void task_hello(void *arg)
     assert(ret == ABT_SUCCESS);
 
     ATS_printf(1, "TASK %d: running on the %s\n", (int)(size_t)arg,
-                    (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
+               (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
 }
 
 void thread_hello(void *arg)
@@ -82,7 +82,7 @@ void thread_hello(void *arg)
     assert(ret == ABT_SUCCESS);
 
     ATS_printf(1, "ULT %lu running on the %s\n", my_id,
-                    (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
+               (flag == ABT_TRUE ? "primary ES" : "secondary ES"));
 }
 
 void *pthread_hello(void *arg)
@@ -214,4 +214,3 @@ int main(int argc, char *argv[])
     /* Finalize */
     return ATS_finalize(0);
 }
-

--- a/test/basic/task_create.c
+++ b/test/basic/task_create.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    2
-#define DEFAULT_NUM_TASKS       4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_TASKS 4
 
 typedef struct {
     size_t num;
@@ -43,9 +43,11 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -71,26 +73,23 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create tasks with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func1, (void *)num,
+        ret = ABT_task_create(pools[i % num_xstreams], task_func1, (void *)num,
                               NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
-
     /* Create tasks with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         args[i].num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func2, (void *)&args[i],
-                              &tasks[i]);
+        ret = ABT_task_create(pools[i % num_xstreams], task_func2,
+                              (void *)&args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -102,8 +101,8 @@ int main(int argc, char *argv[])
             ABT_thread_yield();
         } while (state != ABT_TASK_STATE_TERMINATED);
 
-        ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-               args[i].num, args[i].result);
+        ATS_printf(1, "task_func2: num=%lu result=%llu\n", args[i].num,
+                   args[i].result);
 
         /* Free named tasks */
         ret = ABT_task_free(&tasks[i]);
@@ -132,4 +131,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/task_create_on_xstream.c
+++ b/test/basic/task_create_on_xstream.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    2
-#define DEFAULT_NUM_TASKS       4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_TASKS 4
 
 typedef struct {
     size_t num;
@@ -43,9 +43,11 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -71,19 +73,16 @@ int main(int argc, char *argv[])
     /* Create tasklets with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams],
-                              task_func1, (void *)num,
-                              NULL);
+        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams], task_func1,
+                                         (void *)num, NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
-
 
     /* Create tasklets with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         args[i].num = 100 + i;
-        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams],
-                              task_func2, (void *)&args[i],
-                              &tasks[i]);
+        ret = ABT_task_create_on_xstream(xstreams[i % num_xstreams], task_func2,
+                                         (void *)&args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -95,8 +94,8 @@ int main(int argc, char *argv[])
             ABT_thread_yield();
         } while (state != ABT_TASK_STATE_TERMINATED);
 
-        ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-                        args[i].num, args[i].result);
+        ATS_printf(1, "task_func2: num=%lu result=%llu\n", args[i].num,
+                   args[i].result);
 
         /* Free named tasklets */
         ret = ABT_task_free(&tasks[i]);
@@ -124,4 +123,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_TASKS       4
-#define NUM_TLS                 4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_TASKS 4
+#define NUM_TLS 4
 
 static ABT_key tls[NUM_TLS];
 static int num_tasks;
@@ -115,10 +115,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_tasks  = DEFAULT_NUM_TASKS;
+        num_tasks = DEFAULT_NUM_TASKS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 

--- a/test/basic/task_revive.c
+++ b/test/basic/task_revive.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_TASKS       4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_TASKS 4
 
 int num_tasks = DEFAULT_NUM_TASKS;
 
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -170,4 +170,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_attr.c
+++ b/test/basic/thread_attr.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -40,9 +40,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_thread_attr attr;
@@ -65,7 +67,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -78,10 +80,9 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid,
-                    (tid % 2 ? attr : ABT_THREAD_ATTR_NULL),
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    (tid % 2 ? attr : ABT_THREAD_ATTR_NULL),
+                                    NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_create.c
+++ b/test/basic/thread_create.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -48,7 +50,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -56,9 +58,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_create2.c
+++ b/test/basic/thread_create2.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 int num_threads = DEFAULT_NUM_THREADS;
 
@@ -34,9 +34,8 @@ void thread_create(void *arg)
     /* Create threads */
     for (i = 0; i < num_threads; i++) {
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create(my_pool,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(my_pool, thread_func, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -48,9 +47,11 @@ int main(int argc, char *argv[])
     int i;
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -73,16 +74,15 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create one thread for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create(pools[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(pools[i], thread_create, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -106,4 +106,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_create_on_xstream.c
+++ b/test/basic/thread_create_on_xstream.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 int num_threads = DEFAULT_NUM_THREADS;
 
@@ -31,9 +31,8 @@ void thread_create(void *arg)
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create_on_xstream(my_xstream,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create_on_xstream(my_xstream, thread_func, (void *)tid,
+                                           ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create_on_xstream");
     }
 
@@ -45,9 +44,11 @@ int main(int argc, char *argv[])
     int i;
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -71,9 +72,9 @@ int main(int argc, char *argv[])
     /* Create one ULT for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create_on_xstream(xstreams[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                &threads[i]);
+        ret = ABT_thread_create_on_xstream(xstreams[i], thread_create,
+                                           (void *)tid, ABT_THREAD_ATTR_NULL,
+                                           &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create_on_xstream");
     }
 
@@ -101,4 +102,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define NUM_TLS                 4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define NUM_TLS 4
 
 static ABT_key tls[NUM_TLS];
 static int num_threads;
@@ -122,10 +122,10 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
+        num_threads = DEFAULT_NUM_THREADS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
 

--- a/test/basic/thread_id.c
+++ b/test/basic/thread_id.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -27,9 +27,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -51,7 +53,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -59,9 +61,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_migrate.c
+++ b/test/basic/thread_migrate.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 int value = 0;
 
@@ -38,9 +38,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -67,7 +69,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -75,9 +77,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -102,7 +103,7 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_free");
     }
 
-    if (value != num_xstreams*num_threads)
+    if (value != num_xstreams * num_threads)
         ATS_ERROR(ABT_ERR_OTHER, "wrong value");
 
     /* Finalize */
@@ -117,4 +118,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_revive.c
+++ b/test/basic/thread_revive.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 int num_threads = DEFAULT_NUM_THREADS;
 
@@ -114,10 +114,9 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     }
     ATS_init(argc, argv, num_xstreams);
-
 
     ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
     ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);
@@ -172,4 +171,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_self_suspend_resume.c
+++ b/test/basic/thread_self_suspend_resume.c
@@ -8,9 +8,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_ITER        10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 10
 
 static ABT_pool *pools;
 static int num_xstreams;
@@ -102,12 +102,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_iter     = DEFAULT_NUM_ITER;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_iter = DEFAULT_NUM_ITER;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    for (i = 0; i< num_xstreams; i++) {
+    for (i = 0; i < num_xstreams; i++) {
         free(threads[i]);
         free(values[i]);
     }
@@ -196,4 +196,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task.c
+++ b/test/basic/thread_task.c
@@ -9,9 +9,9 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_TASKS       4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TASKS 4
 
 typedef struct {
     size_t num;
@@ -37,7 +37,8 @@ ABT_thread pick_one(ABT_thread *threads, int num_threads, unsigned *seed,
         next = threads[i];
         ret = ABT_thread_equal(next, caller, &is_same);
         ATS_ERROR(ret, "ABT_thread_equal");
-        if (is_same == ABT_TRUE) continue;
+        if (is_same == ABT_TRUE)
+            continue;
 
         if (next != ABT_THREAD_NULL) {
             ret = ABT_thread_get_state(next, &state);
@@ -147,11 +148,14 @@ int main(int argc, char *argv[])
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
-    if (argc > 3) num_tasks = atoi(argv[3]);
+    if (argc > 3)
+        num_tasks = atoi(argv[3]);
     assert(num_tasks >= 0);
 
     ABT_xstream *xstreams;
@@ -162,14 +166,15 @@ int main(int argc, char *argv[])
 
     xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
     threads = (ABT_thread **)malloc(sizeof(ABT_thread *) * num_xstreams);
-    thread_args = (thread_arg_t **)malloc(sizeof(thread_arg_t*) * num_xstreams);
+    thread_args =
+        (thread_arg_t **)malloc(sizeof(thread_arg_t *) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
         threads[i] = (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
         for (j = 0; j < num_threads; j++) {
             threads[i][j] = ABT_THREAD_NULL;
         }
-        thread_args[i] = (thread_arg_t *)malloc(sizeof(thread_arg_t) *
-                                                num_threads);
+        thread_args[i] =
+            (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_threads);
     }
     tasks = (ABT_task *)malloc(sizeof(ABT_task) * num_tasks);
     task_args = (task_arg_t *)malloc(sizeof(task_arg_t) * num_tasks);
@@ -190,7 +195,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -201,10 +206,9 @@ int main(int argc, char *argv[])
             thread_args[i][j].id = tid;
             thread_args[i][j].num_threads = num_threads;
             thread_args[i][j].threads = &threads[i][0];
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&thread_args[i][j],
-                    ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func,
+                                    (void *)&thread_args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -212,8 +216,7 @@ int main(int argc, char *argv[])
     /* Create tasks with task_func1 */
     for (i = 0; i < num_tasks; i++) {
         size_t num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func1, (void *)num,
+        ret = ABT_task_create(pools[i % num_xstreams], task_func1, (void *)num,
                               NULL);
         ATS_ERROR(ret, "ABT_task_create");
     }
@@ -221,9 +224,8 @@ int main(int argc, char *argv[])
     /* Create tasks with task_func2 */
     for (i = 0; i < num_tasks; i++) {
         task_args[i].num = 100 + i;
-        ret = ABT_task_create(pools[i % num_xstreams],
-                              task_func2, (void *)&task_args[i],
-                              &tasks[i]);
+        ret = ABT_task_create(pools[i % num_xstreams], task_func2,
+                              (void *)&task_args[i], &tasks[i]);
         ATS_ERROR(ret, "ABT_task_create");
     }
 
@@ -235,8 +237,8 @@ int main(int argc, char *argv[])
             ABT_thread_yield();
         } while (state != ABT_TASK_STATE_TERMINATED);
 
-        ATS_printf(1, "task_func2: num=%lu result=%llu\n",
-               task_args[i].num, task_args[i].result);
+        ATS_printf(1, "task_func2: num=%lu result=%llu\n", task_args[i].num,
+                   task_args[i].result);
 
         /* Free named tasks */
         ret = ABT_task_free(&tasks[i]);
@@ -256,7 +258,8 @@ int main(int argc, char *argv[])
             ATS_ERROR(ret, "ABT_thread_free");
         }
 
-        if (i == 0) continue;
+        if (i == 0)
+            continue;
 
         ret = ABT_xstream_free(&xstreams[i]);
         ATS_ERROR(ret, "ABT_xstream_free");
@@ -278,4 +281,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task_arg.c
+++ b/test/basic/thread_task_arg.c
@@ -8,10 +8,10 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_TASKS       4
-#define DEFAULT_NUM_ITER        10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TASKS 4
+#define DEFAULT_NUM_ITER 10
 
 void thread_func(void *arg)
 {
@@ -64,12 +64,12 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc < 2) {
         num_xstreams = DEFAULT_NUM_XSTREAMS;
-        num_threads  = DEFAULT_NUM_THREADS;
-        num_tasks    = DEFAULT_NUM_TASKS;
+        num_threads = DEFAULT_NUM_THREADS;
+        num_tasks = DEFAULT_NUM_TASKS;
     } else {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
-        num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -129,4 +129,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_task_num.c
+++ b/test/basic/thread_task_num.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_THREADS     4
-#define DEFAULT_NUM_TASKS       4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_TASKS 4
 
 void thread_func(void *arg)
 {
@@ -28,12 +28,14 @@ int main(int argc, char *argv[])
     int i, ret;
     int num_threads = DEFAULT_NUM_THREADS;
     int num_tasks = DEFAULT_NUM_TASKS;
-    if (argc > 1) num_threads = atoi(argv[1]);
+    if (argc > 1)
+        num_threads = atoi(argv[1]);
     assert(num_threads >= 0);
-    if (argc > 2) num_tasks = atoi(argv[2]);
+    if (argc > 2)
+        num_tasks = atoi(argv[2]);
     assert(num_tasks >= 0);
 
-    unsigned long num_units = (unsigned long)(num_threads+num_tasks);
+    unsigned long num_units = (unsigned long)(num_threads + num_tasks);
 
     ABT_xstream xstream;
     size_t n_units;
@@ -55,8 +57,8 @@ int main(int argc, char *argv[])
 
     /* Create ULTs */
     for (i = 0; i < num_threads; i++) {
-        ret = ABT_thread_create(pool, thread_func, NULL,
-                ABT_THREAD_ATTR_NULL, NULL);
+        ret = ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                                NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -75,8 +77,8 @@ int main(int argc, char *argv[])
 
     if (n_units != num_units) {
         err++;
-        printf("# of units: expected(%lu) vs. result(%lu)\n",
-               num_units, (unsigned long)n_units);
+        printf("# of units: expected(%lu) vs. result(%lu)\n", num_units,
+               (unsigned long)n_units);
     }
 
     do {
@@ -91,8 +93,8 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_sched_get_total_size");
     if (n_units != 0) {
         err++;
-        printf("# of units: expected(%d) vs. result(%lu)\n",
-               0, (unsigned long)n_units);
+        printf("# of units: expected(%d) vs. result(%lu)\n", 0,
+               (unsigned long)n_units);
     }
 
     /* Finalize */
@@ -100,4 +102,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/thread_yield.c
+++ b/test/basic/thread_yield.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -27,9 +27,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -51,7 +53,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -59,9 +61,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             size_t tid = i * num_threads + j + 1;
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                    NULL);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL, NULL);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }

--- a/test/basic/thread_yield_to.c
+++ b/test/basic/thread_yield_to.c
@@ -9,8 +9,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    1
-#define DEFAULT_NUM_THREADS     2
+#define DEFAULT_NUM_XSTREAMS 1
+#define DEFAULT_NUM_THREADS 2
 
 typedef struct thread_arg {
     int id;
@@ -31,7 +31,8 @@ ABT_thread pick_one(ABT_thread *threads, int num_threads, unsigned *seed,
         next = threads[i];
         ret = ABT_thread_equal(next, caller, &is_same);
         ATS_ERROR(ret, "ABT_thread_equal");
-        if (is_same == ABT_TRUE) continue;
+        if (is_same == ABT_TRUE)
+            continue;
 
         if (next != ABT_THREAD_NULL) {
             ret = ABT_thread_get_state(next, &state);
@@ -80,9 +81,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -115,7 +118,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -126,9 +129,8 @@ int main(int argc, char *argv[])
             args[i][j].id = tid;
             args[i][j].num_threads = num_threads;
             args[i][j].threads = &threads[i][0];
-            ret = ABT_thread_create(pools[i],
-                    thread_func, (void *)&args[i][j], ABT_THREAD_ATTR_NULL,
-                    &threads[i][j]);
+            ret = ABT_thread_create(pools[i], thread_func, (void *)&args[i][j],
+                                    ABT_THREAD_ATTR_NULL, &threads[i][j]);
             ATS_ERROR(ret, "ABT_thread_create");
         }
     }
@@ -146,7 +148,8 @@ int main(int argc, char *argv[])
             ATS_ERROR(ret, "ABT_thread_free");
         }
 
-        if (i == 0) continue;
+        if (i == 0)
+            continue;
 
         ret = ABT_xstream_free(&xstreams[i]);
         ATS_ERROR(ret, "ABT_xstream_free");

--- a/test/basic/timer.c
+++ b/test/basic/timer.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 ABT_timer timer = ABT_TIMER_NULL;
 int num_threads = DEFAULT_NUM_THREADS;
@@ -27,7 +27,7 @@ void thread_create(void *arg)
     ABT_thread my_thread;
     ABT_pool my_pool;
     ABT_timer my_timer;
-    double t_start  = 0.0;
+    double t_start = 0.0;
     double t_create = 0.0;
 
     ret = ABT_timer_dup(timer, &my_timer);
@@ -44,15 +44,14 @@ void thread_create(void *arg)
     for (i = 0; i < num_threads; i++) {
         ABT_timer_start(my_timer);
         size_t tid = 100 * my_id + i;
-        ret = ABT_thread_create(my_pool,
-                thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(my_pool, thread_func, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
         ABT_timer_stop_and_add(my_timer, &t_create);
     }
 
     ATS_printf(1, "[T%d] start: %.9f, %d ULTs creation time: %.9f\n",
-                    (int)my_id, t_start, num_threads, t_create);
+               (int)my_id, t_start, num_threads, t_create);
     ret = ABT_timer_free(&my_timer);
     ATS_ERROR(ret, "ABT_timer_free");
 }
@@ -61,9 +60,11 @@ int main(int argc, char *argv[])
 {
     int i, ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     double t_init = 0.0;
@@ -99,16 +100,15 @@ int main(int argc, char *argv[])
 
     /* Get the first pool attached to each ES */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
     /* Create one ULT for each ES */
     for (i = 0; i < num_xstreams; i++) {
         size_t tid = i + 1;
-        ret = ABT_thread_create(pools[i],
-                thread_create, (void *)tid, ABT_THREAD_ATTR_NULL,
-                NULL);
+        ret = ABT_thread_create(pools[i], thread_create, (void *)tid,
+                                ABT_THREAD_ATTR_NULL, NULL);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
@@ -139,11 +139,10 @@ int main(int argc, char *argv[])
     ATS_printf(1, "# of ULTs/ES  : %d\n", num_threads);
     ATS_printf(1, "Timer overhead: %.9f sec\n", t_overhead);
     ATS_printf(1, "Init. time    : %.9f sec\n", t_init);
-    ATS_printf(1, "Exec. time    : %.9f sec (w/o overhead: %.9f sec)\n",
-                    t_exec, t_exec - t_overhead);
-    ATS_printf(1, "Fini. time    : %.9f sec (w/o overhead: %.9f sec)\n",
-                    t_fini, t_fini - t_overhead);
+    ATS_printf(1, "Exec. time    : %.9f sec (w/o overhead: %.9f sec)\n", t_exec,
+               t_exec - t_overhead);
+    ATS_printf(1, "Fini. time    : %.9f sec (w/o overhead: %.9f sec)\n", t_fini,
+               t_fini - t_overhead);
 
     return ret;
 }
-

--- a/test/basic/xstream_affinity.c
+++ b/test/basic/xstream_affinity.c
@@ -9,7 +9,7 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
+#define DEFAULT_NUM_XSTREAMS 4
 
 static ABT_barrier barrier = ABT_BARRIER_NULL;
 static int num_xstreams = DEFAULT_NUM_XSTREAMS;
@@ -32,8 +32,7 @@ static void print_cpuset(int rank, int cpuset_size, int *cpuset)
         len = strlen(&cpuset_str[pos]);
         pos += len;
     }
-    ATS_printf(1, "[E%d] CPU set (%d): {%s}\n",
-                    rank, cpuset_size, cpuset_str);
+    ATS_printf(1, "[E%d] CPU set (%d): {%s}\n", rank, cpuset_size, cpuset_str);
 
     free(cpuset_str);
 }
@@ -57,8 +56,7 @@ static void test_affinity(void *arg)
     ATS_printf(1, "[E%d] CPU bind: %d\n", rank, cpuid);
 
     new_cpuid = (cpuid + 1) % num_xstreams;
-    ATS_printf(1, "[E%d] change binding: %d -> %d\n",
-                    rank, cpuid, new_cpuid);
+    ATS_printf(1, "[E%d] change binding: %d -> %d\n", rank, cpuid, new_cpuid);
     ret = ABT_xstream_set_cpubind(xstream, new_cpuid);
     ATS_ERROR(ret, "ABT_xstream_set_cpubind");
     ret = ABT_xstream_get_cpubind(xstream, &cpuid);
@@ -179,4 +177,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/xstream_barrier.c
+++ b/test/basic/xstream_barrier.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_ITER        10
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_ITER 10
 
 static int num_iter = DEFAULT_NUM_ITER;
 static ABT_xstream_barrier barrier = ABT_XSTREAM_BARRIER_NULL;
@@ -21,7 +21,8 @@ void test_xstream_barrier(void *arg)
     int i, ret;
 
     for (i = 0; i < num_iter; i++) {
-        if (rank == 0) value = i;
+        if (rank == 0)
+            value = i;
         ret = ABT_xstream_barrier_wait(barrier);
         ATS_ERROR(ret, "ABT_xstream_barrier_wait");
 
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
     ATS_read_args(argc, argv);
     if (argc >= 2) {
         num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-        num_iter     = ATS_get_arg_val(ATS_ARG_N_ITER);
+        num_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
     }
     ATS_init(argc, argv, num_xstreams);
 
@@ -109,4 +110,3 @@ int main(int argc, char *argv[])
 
     return ret;
 }
-

--- a/test/basic/xstream_create.c
+++ b/test/basic/xstream_create.c
@@ -8,7 +8,7 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
+#define DEFAULT_NUM_XSTREAMS 4
 
 int main(int argc, char *argv[])
 {

--- a/test/basic/xstream_rank.c
+++ b/test/basic/xstream_rank.c
@@ -8,7 +8,7 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
+#define DEFAULT_NUM_XSTREAMS 4
 
 int main(int argc, char *argv[])
 {

--- a/test/basic/xstream_revive.c
+++ b/test/basic/xstream_revive.c
@@ -8,8 +8,8 @@
 #include "abt.h"
 #include "abttest.h"
 
-#define DEFAULT_NUM_XSTREAMS    4
-#define DEFAULT_NUM_THREADS     4
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
 
 void thread_func(void *arg)
 {
@@ -23,9 +23,11 @@ int main(int argc, char *argv[])
     int ret;
     int num_xstreams = DEFAULT_NUM_XSTREAMS;
     int num_threads = DEFAULT_NUM_THREADS;
-    if (argc > 1) num_xstreams = atoi(argv[1]);
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
     assert(num_xstreams >= 0);
-    if (argc > 2) num_threads = atoi(argv[2]);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
     assert(num_threads >= 0);
 
     ABT_xstream *xstreams;
@@ -48,7 +50,7 @@ int main(int argc, char *argv[])
 
     /* Get the pools attached to an execution stream */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
@@ -64,9 +66,8 @@ int main(int argc, char *argv[])
         for (i = 0; i < num_xstreams; i++) {
             for (j = 0; j < num_threads; j++) {
                 size_t tid = i * num_threads + j + 1;
-                ret = ABT_thread_create(pools[i],
-                        thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
-                        NULL);
+                ret = ABT_thread_create(pools[i], thread_func, (void *)tid,
+                                        ABT_THREAD_ATTR_NULL, NULL);
                 ATS_ERROR(ret, "ABT_thread_create");
             }
         }
@@ -76,7 +77,6 @@ int main(int argc, char *argv[])
             ATS_ERROR(ret, "ABT_xstream_join");
         }
     }
-
 
     /* Free Execution Streams */
     for (i = 1; i < num_xstreams; i++) {

--- a/test/benchmark/bench_util.h
+++ b/test/benchmark/bench_util.h
@@ -7,48 +7,50 @@
 #define BENCH_UTIL_H_INCLUDED
 
 #ifdef USE_PAPI
-#define ABTX_papi_assert(expr)                   \
-do {                                             \
-    if (expr != PAPI_OK) {                       \
-        fprintf(stderr, "Error at " #expr "\n"); \
-        exit(-1);                                \
-    }                                            \
-} while (0)
+#define ABTX_papi_assert(expr)                                                 \
+    do {                                                                       \
+        if (expr != PAPI_OK) {                                                 \
+            fprintf(stderr, "Error at " #expr "\n");                           \
+            exit(-1);                                                          \
+        }                                                                      \
+    } while (0)
 #endif
 
 #ifndef USE_PAPI
-#define ABTX_start_prof(start_time, evset)       \
-do {                                             \
-    start_time = ATS_get_cycles();               \
-} while (0)
+#define ABTX_start_prof(start_time, evset)                                     \
+    do {                                                                       \
+        start_time = ATS_get_cycles();                                         \
+    } while (0)
 #else
-#define ABTX_start_prof(start_time, evset)       \
-do {                                             \
-    start_time = ATS_get_cycles();               \
-    ABTX_papi_assert(PAPI_start(evset));         \
-} while (0)
+#define ABTX_start_prof(start_time, evset)                                     \
+    do {                                                                       \
+        start_time = ATS_get_cycles();                                         \
+        ABTX_papi_assert(PAPI_start(evset));                                   \
+    } while (0)
 #endif
 
 #ifndef USE_PAPI
-#define ABTX_stop_prof(start_time, num, time_sum, time_sqrsum, evset, vals, \
-                       llcm_sum, llcm_sqrsum, totm_sum, tlbm_sqrsum)        \
-do {                                                                        \
-    float elaps_time = (float)(ATS_get_cycles() - start_time)/num;          \
-    time_sum += elaps_time;                                                 \
-    time_sqrsum += elaps_time*elaps_time;                                   \
-} while (0)
+#define ABTX_stop_prof(start_time, num, time_sum, time_sqrsum, evset, vals,    \
+                       llcm_sum, llcm_sqrsum, totm_sum, tlbm_sqrsum)           \
+    do {                                                                       \
+        float elaps_time = (float)(ATS_get_cycles() - start_time) / num;       \
+        time_sum += elaps_time;                                                \
+        time_sqrsum += elaps_time * elaps_time;                                \
+    } while (0)
 #else
-#define ABTX_stop_prof(start_time, num, time_sum, time_sqrsum, evset, vals, \
-                       llcm_sum, llcm_sqrsum, totm_sum, tlbm_sqrsum)        \
-do {                                                                        \
-    ABTX_papi_assert(PAPI_stop(evset, vals));                               \
-    float llcm = (float)vals[0]/num, tlbm = (float)vals[1]/num;             \
-    llcm_sum += llcm; llcm_sqrsum += llcm*llcm;                             \
-    totm_sum += tlbm; tlbm_sqrsum += tlbm*tlbm;                             \
-    float elaps_time = (float)(ATS_get_cycles() - start_time)/num;          \
-    time_sum += elaps_time;                                                 \
-    time_sqrsum += elaps_time*elaps_time;                                   \
-} while (0)
+#define ABTX_stop_prof(start_time, num, time_sum, time_sqrsum, evset, vals,    \
+                       llcm_sum, llcm_sqrsum, totm_sum, tlbm_sqrsum)           \
+    do {                                                                       \
+        ABTX_papi_assert(PAPI_stop(evset, vals));                              \
+        float llcm = (float)vals[0] / num, tlbm = (float)vals[1] / num;        \
+        llcm_sum += llcm;                                                      \
+        llcm_sqrsum += llcm * llcm;                                            \
+        totm_sum += tlbm;                                                      \
+        tlbm_sqrsum += tlbm * tlbm;                                            \
+        float elaps_time = (float)(ATS_get_cycles() - start_time) / num;       \
+        time_sum += elaps_time;                                                \
+        time_sqrsum += elaps_time * elaps_time;                                \
+    } while (0)
 #endif
 
 #ifdef USE_PAPI
@@ -87,7 +89,8 @@ static inline void print_header(char *wu, int need_join)
     line_size = need_join ? 86 : 65;
     ATS_print_line(stdout, '-', line_size);
     printf("%-3s %8s %8s %22s ", "ES#", wu, "#Iter", "Create: cycles [std]");
-    if (need_join) printf("%20s ", "Join: cycles [std]");
+    if (need_join)
+        printf("%20s ", "Join: cycles [std]");
     printf("%20s\n", "Free: cycles [std]");
 #else
 
@@ -96,27 +99,39 @@ static inline void print_header(char *wu, int need_join)
     printf("%-3s %8s %8s ", "ES#", wu, "#Iter");
 #if (defined __MIC__) || (defined __KNC__)
 #ifdef USE_PAPI_L1M_L2M
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Dm [std]", "L1Im [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Dm [std]",
+           "L1Im [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "L1Dm [std]", "L1Im [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Dm [std]", "L1Im [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "L1Dm [std]",
+               "L1Im [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Dm [std]",
+           "L1Im [std]");
 #else
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L2Dm [std]", "TLBm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L2Dm [std]",
+           "TLBm [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "L2Dm [std]", "TLBm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L2Dm [std]", "TLBm [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "L2Dm [std]",
+               "TLBm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L2Dm [std]",
+           "TLBm [std]");
 #endif /* USE_PAPI_L1M_L2M */
 #else
 #ifdef USE_PAPI_L1M_L2M
-    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Cm [std]", "L2Cm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "L1Cm [std]",
+           "L2Cm [std]");
     if (need_join)
-    printf("%20s %14s %14s", "Join: cycles [std]", "L1Cm [std]", "L2Cm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Cm [std]", "L2Cm [std]");
+        printf("%20s %14s %14s", "Join: cycles [std]", "L1Cm [std]",
+               "L2Cm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "L1Cm [std]",
+           "L2Cm [std]");
 #else
-    printf("%22s %14s %14s ", "Create: cycles [std]", "LLCm [std]", "TLBm [std]");
+    printf("%22s %14s %14s ", "Create: cycles [std]", "LLCm [std]",
+           "TLBm [std]");
     if (need_join)
-    printf("%20s %14s %14s ", "Join: cycles [std]", "LLCm [std]", "TLBm [std]");
-    printf("%20s %14s %14s\n", "Free: cycles [std]", "LLCm [std]", "TLBm [std]");
+        printf("%20s %14s %14s ", "Join: cycles [std]", "LLCm [std]",
+               "TLBm [std]");
+    printf("%20s %14s %14s\n", "Free: cycles [std]", "LLCm [std]",
+           "TLBm [std]");
 #endif /* USE_PAPI_L1M_L2M */
 #endif
 #endif /* USE_PAPI */
@@ -125,7 +140,8 @@ static inline void print_header(char *wu, int need_join)
 }
 
 #ifdef USE_PAPI
-static inline unsigned long ABTX_xstream_get_self(void) {
+static inline unsigned long ABTX_xstream_get_self(void)
+{
     ABT_xstream self;
     ABT_xstream_self(&self);
     return (unsigned long)self;
@@ -149,9 +165,8 @@ typedef struct seq_state_t {
     int max_nonpow_terms;
 } seq_state_t;
 
-static inline void seq_init(seq_state_t* state, const int base,
-                            const int prev_term,
-                            const int last_pow_term,
+static inline void seq_init(seq_state_t *state, const int base,
+                            const int prev_term, const int last_pow_term,
                             const int max_nonpow_terms)
 {
     state->base = base;
@@ -162,12 +177,12 @@ static inline void seq_init(seq_state_t* state, const int base,
 }
 
 /* Core of the sequence generator */
-static inline int seq_get_next_term(seq_state_t* state)
+static inline int seq_get_next_term(seq_state_t *state)
 {
     int cur_term; /* term to return */
     cur_term = state->prev_term + state->cur_stride;
-    if (cur_term == state->last_pow_term*state->base) {
-        while (cur_term/state->cur_stride - 1 > state->max_nonpow_terms)
+    if (cur_term == state->last_pow_term * state->base) {
+        while (cur_term / state->cur_stride - 1 > state->max_nonpow_terms)
             state->cur_stride *= state->base;
         state->last_pow_term = cur_term;
     }
@@ -176,4 +191,3 @@ static inline int seq_get_next_term(seq_state_t* state)
 }
 
 #endif /* BENCH_UTIL_H_INCLUDED */
-

--- a/test/benchmark/init_finalize.c
+++ b/test/benchmark/init_finalize.c
@@ -8,7 +8,6 @@
 #include "abt.h"
 #include "abttest.h"
 
-
 enum {
     T_INIT_FINALIZE_COLD = 0,
     T_INIT,
@@ -18,16 +17,10 @@ enum {
     T_LAST
 };
 
-static char *t_names[] = {
-    "init/finalize (cold)",
-    "init",
-    "finalize",
-    "init/finalize",
-    "init/finalize with work"
-};
+static char *t_names[] = { "init/finalize (cold)", "init", "finalize",
+                           "init/finalize", "init/finalize with work" };
 
 static double t_timers[T_LAST];
-
 
 void thread_func(void *arg)
 {
@@ -49,7 +42,8 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_timers[i] = 0.0;
+    for (i = 0; i < T_LAST; i++)
+        t_timers[i] = 0.0;
 
     /* measure init/finalize time (cold) */
     ABT_timer_start(timer);
@@ -82,8 +76,7 @@ int main(int argc, char *argv[])
 
         ABT_xstream_create(ABT_SCHED_NULL, &xstream);
         ABT_xstream_get_main_pools(xstream, 1, &pool);
-        ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
-                          NULL);
+        ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL, NULL);
         ABT_xstream_join(xstream);
         ABT_xstream_free(&xstream);
 
@@ -108,4 +101,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/sync_ops.c
+++ b/test/benchmark/sync_ops.c
@@ -8,7 +8,6 @@
 #include "abt.h"
 #include "abttest.h"
 
-
 enum {
     T_MUTEX_CREATE_COLD = 0,
     T_MUTEX_FREE_COLD,
@@ -32,7 +31,7 @@ static char *t_names[] = {
 };
 
 typedef struct {
-    int eid;            /* ES id */
+    int eid; /* ES id */
     int test_kind;
 } launch_t;
 
@@ -40,7 +39,6 @@ typedef struct {
     int eid;
     int tid;
 } arg_t;
-
 
 static int iter;
 static int num_xstreams;
@@ -51,7 +49,6 @@ static ABT_mutex g_mutex = ABT_MUTEX_NULL;
 
 static double t_overhead = 0.0;
 static double t_timers[T_LAST];
-
 
 void mutex_lock_unlock(void *arg)
 {
@@ -71,7 +68,8 @@ void mutex_lock_unlock(void *arg)
     ABT_barrier_wait(g_barrier);
 
     /* start timer */
-    if (eid == 0 && tid == 0) ABT_timer_start(timer);
+    if (eid == 0 && tid == 0)
+        ABT_timer_start(timer);
 
     /* measure mutex lock/unlock time */
     for (i = 0; i < iter; i++) {
@@ -97,7 +95,7 @@ void launch_test(void *arg)
     int test_kind = my_arg->test_kind;
 
     ABT_xstream xstream;
-    ABT_pool    pool;
+    ABT_pool pool;
     ABT_thread *threads;
     void (*test_fn)(void *);
     int i;
@@ -123,8 +121,8 @@ void launch_test(void *arg)
     for (i = 0; i < num_threads; i++) {
         args[i].eid = eid;
         args[i].tid = i;
-        ABT_thread_create(pool, test_fn, (void *)&args[i],
-                          ABT_THREAD_ATTR_NULL, &threads[i]);
+        ABT_thread_create(pool, test_fn, (void *)&args[i], ABT_THREAD_ATTR_NULL,
+                          &threads[i]);
     }
     for (i = 0; i < num_threads; i++) {
         ABT_thread_join(threads[i]);
@@ -138,9 +136,9 @@ void launch_test(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream *xstreams;
-    ABT_pool    *pools;
-    ABT_thread  *threads;
-    ABT_mutex   *mutexes;
+    ABT_pool *pools;
+    ABT_thread *threads;
+    ABT_mutex *mutexes;
     ABT_timer timer;
     launch_t *largs;
     double t_time;
@@ -149,7 +147,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -160,12 +158,13 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_timers[i] = 0.0;
+    for (i = 0; i < T_LAST; i++)
+        t_timers[i] = 0.0;
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    threads  = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
-    mutexes  = (ABT_mutex *)malloc(iter * sizeof(ABT_mutex));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    mutexes = (ABT_mutex *)malloc(iter * sizeof(ABT_mutex));
 
     /* mutex create (cold) time */
     ABT_timer_start(timer);
@@ -184,8 +183,8 @@ int main(int argc, char *argv[])
     t_timers[T_MUTEX_FREE_COLD] = (t_time - t_overhead) / iter;
 
     /* mutex create/free (cold) time */
-    t_timers[T_MUTEX_CREATE_FREE_COLD] = t_timers[T_MUTEX_CREATE_COLD]
-                                       + t_timers[T_MUTEX_FREE_COLD];
+    t_timers[T_MUTEX_CREATE_FREE_COLD] =
+        t_timers[T_MUTEX_CREATE_COLD] + t_timers[T_MUTEX_FREE_COLD];
 
     /* mutex create time */
     ABT_timer_start(timer);
@@ -204,8 +203,8 @@ int main(int argc, char *argv[])
     t_timers[T_MUTEX_FREE] = (t_time - t_overhead) / iter;
 
     /* mutex create/free time */
-    t_timers[T_MUTEX_CREATE_FREE] = t_timers[T_MUTEX_CREATE]
-                                  + t_timers[T_MUTEX_FREE];
+    t_timers[T_MUTEX_CREATE_FREE] =
+        t_timers[T_MUTEX_CREATE] + t_timers[T_MUTEX_FREE];
 
     /* mutex lock/unlock time */
     ABT_timer_start(timer);
@@ -265,4 +264,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_fork_join.c
+++ b/test/benchmark/task_fork_join.c
@@ -14,59 +14,51 @@
 #include "bench_util.h"
 
 #ifndef USE_PAPI
-#define ABTX_prof_summary(my_es, ntasks, iter,                      \
-                          crea_time, crea_timestd,                  \
-                          crea_llcm, crea_llcmstd,                  \
-                          crea_tlbm, crea_tlbmstd,                  \
-                          free_time, free_timestd,                  \
-                          free_llcm, free_llcmstd,                  \
-                          free_tlbm, free_tlbmstd)                  \
-do {                                                                \
-    crea_time /= iter;                                              \
-    crea_timestd = sqrt(crea_timestd/iter - crea_time*crea_time);   \
-    free_time /= iter;                                              \
-    free_timestd = sqrt(free_timestd/iter - free_time*free_time);   \
-    printf("%-3d %8d %8d %12.2f [%.2f] %10.2f [%.2f]\n",            \
-           my_es, ntasks, iter, crea_time, crea_timestd,            \
-           free_time, free_timestd);                                \
-    fflush(stdout);                                                 \
-} while (0)
+#define ABTX_prof_summary(my_es, ntasks, iter, crea_time, crea_timestd,        \
+                          crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,    \
+                          free_time, free_timestd, free_llcm, free_llcmstd,    \
+                          free_tlbm, free_tlbmstd)                             \
+    do {                                                                       \
+        crea_time /= iter;                                                     \
+        crea_timestd = sqrt(crea_timestd / iter - crea_time * crea_time);      \
+        free_time /= iter;                                                     \
+        free_timestd = sqrt(free_timestd / iter - free_time * free_time);      \
+        printf("%-3d %8d %8d %12.2f [%.2f] %10.2f [%.2f]\n", my_es, ntasks,    \
+               iter, crea_time, crea_timestd, free_time, free_timestd);        \
+        fflush(stdout);                                                        \
+    } while (0)
 #else
-#define ABTX_prof_summary(my_es, ntasks, iter,                      \
-                          crea_time, crea_timestd,                  \
-                          crea_llcm, crea_llcmstd,                  \
-                          crea_tlbm, crea_tlbmstd,                  \
-                          free_time, free_timestd,                  \
-                          free_llcm, free_llcmstd,                  \
-                          free_tlbm, free_tlbmstd)                  \
-do {                                                                \
-    crea_time /= iter;                                              \
-    crea_timestd = sqrt(crea_timestd/iter - crea_time*crea_time);   \
-    crea_llcm /= iter;                                              \
-    crea_llcmstd = sqrt(crea_llcmstd/iter - crea_llcm*crea_llcm);   \
-    crea_tlbm /= iter;                                              \
-    crea_tlbmstd = sqrt(crea_tlbmstd/iter - crea_tlbm*crea_tlbm);   \
-    free_time /= iter;                                              \
-    free_timestd = sqrt(free_timestd/iter - free_time*free_time);   \
-    free_llcm /= iter;                                              \
-    free_llcmstd = sqrt(free_llcmstd/iter - free_llcm*free_llcm);   \
-    free_tlbm /= iter;                                              \
-    free_tlbmstd = sqrt(free_tlbmstd/iter - free_tlbm*free_tlbm);   \
-    printf("%-3d %8d %8d %12.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "  \
-           "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f]\n",             \
-           my_es, ntasks, iter, crea_time, crea_timestd,            \
-           crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,        \
-           free_time, free_timestd, free_llcm, free_llcmstd,        \
-           free_tlbm, free_tlbmstd);                                \
-    fflush(stdout);                                                 \
-} while (0)
+#define ABTX_prof_summary(my_es, ntasks, iter, crea_time, crea_timestd,        \
+                          crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,    \
+                          free_time, free_timestd, free_llcm, free_llcmstd,    \
+                          free_tlbm, free_tlbmstd)                             \
+    do {                                                                       \
+        crea_time /= iter;                                                     \
+        crea_timestd = sqrt(crea_timestd / iter - crea_time * crea_time);      \
+        crea_llcm /= iter;                                                     \
+        crea_llcmstd = sqrt(crea_llcmstd / iter - crea_llcm * crea_llcm);      \
+        crea_tlbm /= iter;                                                     \
+        crea_tlbmstd = sqrt(crea_tlbmstd / iter - crea_tlbm * crea_tlbm);      \
+        free_time /= iter;                                                     \
+        free_timestd = sqrt(free_timestd / iter - free_time * free_time);      \
+        free_llcm /= iter;                                                     \
+        free_llcmstd = sqrt(free_llcmstd / iter - free_llcm * free_llcm);      \
+        free_tlbm /= iter;                                                     \
+        free_tlbmstd = sqrt(free_tlbmstd / iter - free_tlbm * free_tlbm);      \
+        printf("%-3d %8d %8d %12.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "         \
+               "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f]\n",                    \
+               my_es, ntasks, iter, crea_time, crea_timestd, crea_llcm,        \
+               crea_llcmstd, crea_tlbm, crea_tlbmstd, free_time, free_timestd, \
+               free_llcm, free_llcmstd, free_tlbm, free_tlbmstd);              \
+        fflush(stdout);                                                        \
+    } while (0)
 #endif
 
 /* Initial test config in terms of #Tasks*/
-#define START_NTASKS    64
+#define START_NTASKS 64
 
 static ABT_xstream *xstreams;
-static ABT_pool    *pools;
+static ABT_pool *pools;
 static int niter, max_tasks, ness;
 static ABT_xstream_barrier g_xbarrier = ABT_XSTREAM_BARRIER_NULL;
 
@@ -93,7 +85,7 @@ static void master_thread_func(void *arg)
     ABTX_papi_add_event(event_set);
 #endif /* USE_PAPI */
 
-    ABT_task *my_tasks = (ABT_task *)malloc(max_tasks*sizeof(ABT_task));
+    ABT_task *my_tasks = (ABT_task *)malloc(max_tasks * sizeof(ABT_task));
 
     /* warm-up */
     for (t = 0; t < max_tasks; t++)
@@ -102,7 +94,7 @@ static void master_thread_func(void *arg)
         ABT_task_free(&my_tasks[t]);
 
     seq_state_t state;
-    seq_init(&state, 2, START_NTASKS/2, START_NTASKS/2, 1);
+    seq_init(&state, 2, START_NTASKS / 2, START_NTASKS / 2, 1);
     while ((ntasks = seq_get_next_term(&state)) <= max_tasks) {
         ABT_xstream_barrier_wait(g_xbarrier);
         float crea_time = 0.0, crea_timestd = 0.0;
@@ -115,8 +107,9 @@ static void master_thread_func(void *arg)
 #endif
         int i;
 
-        /* The following line tries to keep the total number of iterations constant */
-        int iter = niter/(ntasks/START_NTASKS);
+        /* The following line tries to keep the total number of iterations
+         * constant */
+        int iter = niter / (ntasks / START_NTASKS);
         for (i = 0; i < iter; i++) {
             unsigned long long start_time;
 
@@ -163,11 +156,11 @@ int main(int argc, char *argv[])
     int i;
     ATS_read_args(argc, argv);
     niter = ATS_get_arg_val(ATS_ARG_N_ITER);
-    ness  = ATS_get_arg_val(ATS_ARG_N_ES);
+    ness = ATS_get_arg_val(ATS_ARG_N_ES);
     max_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
 
-    xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
-    pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
+    xstreams = (ABT_xstream *)malloc(ness * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(ness * sizeof(ABT_pool));
 
     ATS_init(argc, argv, ness);
 
@@ -206,7 +199,8 @@ int main(int argc, char *argv[])
 
     /* Create ESs*/
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1, &pools[0]);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &pools[0]);
     for (i = 1; i < ness; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pools[i],
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
@@ -228,4 +222,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_ops.c
+++ b/test/benchmark/task_ops.c
@@ -8,7 +8,6 @@
 #include "abt.h"
 #include "abttest.h"
 
-
 enum {
     T_CREATE_COLD = 0,
     T_FREE_COLD,
@@ -20,13 +19,8 @@ enum {
     T_LAST
 };
 static char *t_names[] = {
-    "create (cold)",
-    "free (cold)",
-    "create/free (cold)",
-    "create",
-    "free",
-    "create/free",
-    "create (unnamed)",
+    "create (cold)", "free (cold)", "create/free (cold)", "create",
+    "free",          "create/free", "create (unnamed)",
 };
 
 enum {
@@ -54,7 +48,6 @@ static ABT_task **g_tasks;
 static uint64_t (*t_times)[T_LAST];
 static uint64_t t_all[T_ALL_LAST];
 
-
 void task_func(void *arg)
 {
     ATS_UNUSED(arg);
@@ -63,7 +56,7 @@ void task_func(void *arg)
 void task_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_task *my_tasks = g_tasks[eid];
     uint64_t *my_times = t_times[eid];
     uint64_t t_all_start, t_start, t_time;
@@ -74,7 +67,8 @@ void task_test(void *arg)
     /*************************************************************************/
     /* tasklet: create/join (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     for (i = 0; i < num_tasks; i++) {
@@ -95,8 +89,8 @@ void task_test(void *arg)
     }
     my_times[T_CREATE_COLD] /= num_tasks;
     my_times[T_FREE_COLD] /= num_tasks;
-    my_times[T_CREATE_FREE_COLD] = my_times[T_CREATE_COLD]
-                                 + my_times[T_FREE_COLD];
+    my_times[T_CREATE_FREE_COLD] =
+        my_times[T_CREATE_COLD] + my_times[T_FREE_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -122,7 +116,8 @@ void task_test(void *arg)
 
     /* measure tasklet create/free time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_tasks; t++) {
@@ -144,7 +139,8 @@ void task_test(void *arg)
 
     /* measure tasklet create (unnamed) time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_tasks; t++) {
@@ -154,7 +150,8 @@ void task_test(void *arg)
             ABT_thread_yield();
             size_t size;
             ABT_pool_get_size(my_pool, &size);
-            if (size == 0) break;
+            if (size == 0)
+                break;
         }
     }
     my_times[T_CREATE_UNNAMED] = ATS_get_cycles() - t_start;
@@ -178,7 +175,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -193,14 +190,14 @@ int main(int argc, char *argv[])
         t_all[i] = 0;
     }
 
-
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_tasks    = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_tasks = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
     for (i = 0; i < num_xstreams; i++) {
         g_tasks[i] = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t(*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -220,8 +217,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -240,8 +237,10 @@ int main(int argc, char *argv[])
     /* find min, max, avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -263,8 +262,8 @@ int main(int argc, char *argv[])
     printf("%-23s %11s %11s %11s\n", "operation", "avg", "min", "max");
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_LAST; i++) {
-        printf("%-22s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n",
-               t_names[i], t_avg[i], t_min[i], t_max[i]);
+        printf("%-22s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n", t_names[i],
+               t_avg[i], t_min[i], t_max[i]);
     }
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_ALL_LAST; i++) {
@@ -282,4 +281,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/task_ops_all.c
+++ b/test/benchmark/task_ops_all.c
@@ -8,12 +8,7 @@
 #include "abt.h"
 #include "abttest.h"
 
-
-enum {
-    T_CREATE_JOIN = 0,
-    T_CREATE_UNNAMED,
-    T_LAST
-};
+enum { T_CREATE_JOIN = 0, T_CREATE_UNNAMED, T_LAST };
 static char *t_names[] = {
     "create/join",
     "create (unnamed)",
@@ -29,7 +24,6 @@ static ABT_task **g_tasks;
 
 static uint64_t t_times[T_LAST];
 
-
 void task_func(void *arg)
 {
     ATS_UNUSED(arg);
@@ -38,7 +32,7 @@ void task_func(void *arg)
 void test_create_join(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_task *my_tasks = g_tasks[eid];
     int i, t;
 
@@ -56,7 +50,7 @@ void test_create_join(void *arg)
 void test_create_unnamed(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool  my_pool  = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     int i, t;
 
     for (i = 0; i < iter; i++) {
@@ -69,7 +63,7 @@ void test_create_unnamed(void *arg)
 
 int main(int argc, char *argv[])
 {
-    ABT_pool (*all_pools)[2];
+    ABT_pool(*all_pools)[2];
     ABT_sched *scheds;
     ABT_thread *top_threads;
     size_t i, t;
@@ -78,7 +72,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_tasks    = ATS_get_arg_val(ATS_ARG_N_TASK);
+    num_tasks = ATS_get_arg_val(ATS_ARG_N_TASK);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -88,14 +82,13 @@ int main(int argc, char *argv[])
         t_times[i] = 0;
     }
 
-
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_tasks    = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_tasks = (ABT_task **)malloc(num_xstreams * sizeof(ABT_task *));
     for (i = 0; i < num_xstreams; i++) {
         g_tasks[i] = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
     }
-    all_pools = (ABT_pool (*)[2])malloc(num_xstreams * sizeof(ABT_pool) * 2);
+    all_pools = (ABT_pool(*)[2])malloc(num_xstreams * sizeof(ABT_pool) * 2);
     scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
     top_threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
@@ -123,11 +116,14 @@ int main(int argc, char *argv[])
         void (*test_fn)(void *);
 
         switch (t) {
-            case T_CREATE_JOIN:    test_fn = test_create_join;
-                                   break;
-            case T_CREATE_UNNAMED: test_fn = test_create_unnamed;
-                                   break;
-            default: assert(0);
+            case T_CREATE_JOIN:
+                test_fn = test_create_join;
+                break;
+            case T_CREATE_UNNAMED:
+                test_fn = test_create_unnamed;
+                break;
+            default:
+                assert(0);
         }
 
         /* warm-up */
@@ -192,4 +188,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_fork_join.c
+++ b/test/benchmark/thread_fork_join.c
@@ -14,63 +14,65 @@
 #include "bench_util.h"
 
 #ifndef USE_PAPI
-#define ABTX_prof_summary(my_es, nults, iter,                                  \
-    crea_time, crea_timestd, crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd, \
-    join_time, join_timestd, join_llcm, join_llcmstd, join_tlbm, join_tlbmstd, \
-    free_time, free_timestd, free_llcm, free_llcmstd, free_tlbm, free_tlbmstd) \
-do {                                                                           \
-    crea_time /= iter;                                                         \
-    crea_timestd = sqrt(crea_timestd/iter - crea_time*crea_time);              \
-    join_time /= iter;                                                         \
-    join_timestd = sqrt(join_timestd/iter - join_time*join_time);              \
-    free_time /= iter;                                                         \
-    free_timestd = sqrt(free_timestd/iter - free_time*free_time);              \
-    printf("%-3d %8d %8d %12.2f [%.2f] %10.2f [%.2f] %10.2f [%.2f]\n",         \
-           my_es, nults, iter, crea_time, crea_timestd,                        \
-           join_time, join_timestd, free_time, free_timestd);                  \
-    fflush(stdout);                                                            \
-} while (0)
+#define ABTX_prof_summary(my_es, nults, iter, crea_time, crea_timestd,         \
+                          crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,    \
+                          join_time, join_timestd, join_llcm, join_llcmstd,    \
+                          join_tlbm, join_tlbmstd, free_time, free_timestd,    \
+                          free_llcm, free_llcmstd, free_tlbm, free_tlbmstd)    \
+    do {                                                                       \
+        crea_time /= iter;                                                     \
+        crea_timestd = sqrt(crea_timestd / iter - crea_time * crea_time);      \
+        join_time /= iter;                                                     \
+        join_timestd = sqrt(join_timestd / iter - join_time * join_time);      \
+        free_time /= iter;                                                     \
+        free_timestd = sqrt(free_timestd / iter - free_time * free_time);      \
+        printf("%-3d %8d %8d %12.2f [%.2f] %10.2f [%.2f] %10.2f [%.2f]\n",     \
+               my_es, nults, iter, crea_time, crea_timestd, join_time,         \
+               join_timestd, free_time, free_timestd);                         \
+        fflush(stdout);                                                        \
+    } while (0)
 #else
-#define ABTX_prof_summary(my_es, nults, iter,                                  \
-    crea_time, crea_timestd, crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd, \
-    join_time, join_timestd, join_llcm, join_llcmstd, join_tlbm, join_tlbmstd, \
-    free_time, free_timestd, free_llcm, free_llcmstd, free_tlbm, free_tlbmstd) \
-do {                                                                           \
-    crea_time /= iter;                                                         \
-    crea_timestd = sqrt(crea_timestd/iter - crea_time*crea_time);              \
-    crea_llcm /= iter;                                                         \
-    crea_llcmstd = sqrt(crea_llcmstd/iter - crea_llcm*crea_llcm);              \
-    crea_tlbm /= iter;                                                         \
-    crea_tlbmstd = sqrt(crea_tlbmstd/iter - crea_tlbm*crea_tlbm);              \
-    join_time /= iter;                                                         \
-    join_timestd = sqrt(join_timestd/iter - join_time*join_time);              \
-    join_llcm /= iter;                                                         \
-    join_llcmstd = sqrt(join_llcmstd/iter - join_llcm*join_llcm);              \
-    join_tlbm /= iter;                                                         \
-    join_tlbmstd = sqrt(join_tlbmstd/iter - join_tlbm*join_tlbm);              \
-    free_time /= iter;                                                         \
-    free_timestd = sqrt(free_timestd/iter - free_time*free_time);              \
-    free_llcm /= iter;                                                         \
-    free_llcmstd = sqrt(free_llcmstd/iter - free_llcm*free_llcm);              \
-    free_tlbm /= iter;                                                         \
-    free_tlbmstd = sqrt(free_tlbmstd/iter - free_tlbm*free_tlbm);              \
-    printf("%-3d %8d %8d %12.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "             \
-           "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "                          \
-           "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f]\n",                        \
-           my_es, nults, iter, crea_time, crea_timestd,                        \
-           crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,                   \
-           join_time, join_timestd, join_llcm, join_llcmstd,                   \
-           join_tlbm, join_tlbmstd, free_time, free_timestd,                   \
-           free_llcm, free_llcmstd, free_tlbm, free_tlbmstd);                  \
-    fflush(stdout);                                                            \
-} while (0)
+#define ABTX_prof_summary(my_es, nults, iter, crea_time, crea_timestd,         \
+                          crea_llcm, crea_llcmstd, crea_tlbm, crea_tlbmstd,    \
+                          join_time, join_timestd, join_llcm, join_llcmstd,    \
+                          join_tlbm, join_tlbmstd, free_time, free_timestd,    \
+                          free_llcm, free_llcmstd, free_tlbm, free_tlbmstd)    \
+    do {                                                                       \
+        crea_time /= iter;                                                     \
+        crea_timestd = sqrt(crea_timestd / iter - crea_time * crea_time);      \
+        crea_llcm /= iter;                                                     \
+        crea_llcmstd = sqrt(crea_llcmstd / iter - crea_llcm * crea_llcm);      \
+        crea_tlbm /= iter;                                                     \
+        crea_tlbmstd = sqrt(crea_tlbmstd / iter - crea_tlbm * crea_tlbm);      \
+        join_time /= iter;                                                     \
+        join_timestd = sqrt(join_timestd / iter - join_time * join_time);      \
+        join_llcm /= iter;                                                     \
+        join_llcmstd = sqrt(join_llcmstd / iter - join_llcm * join_llcm);      \
+        join_tlbm /= iter;                                                     \
+        join_tlbmstd = sqrt(join_tlbmstd / iter - join_tlbm * join_tlbm);      \
+        free_time /= iter;                                                     \
+        free_timestd = sqrt(free_timestd / iter - free_time * free_time);      \
+        free_llcm /= iter;                                                     \
+        free_llcmstd = sqrt(free_llcmstd / iter - free_llcm * free_llcm);      \
+        free_tlbm /= iter;                                                     \
+        free_tlbmstd = sqrt(free_tlbmstd / iter - free_tlbm * free_tlbm);      \
+        printf("%-3d %8d %8d %12.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "         \
+               "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f] "                      \
+               "%10.2f [%.2f] %6.2f [%.2f] %6.2f [%.2f]\n",                    \
+               my_es, nults, iter, crea_time, crea_timestd, crea_llcm,         \
+               crea_llcmstd, crea_tlbm, crea_tlbmstd, join_time, join_timestd, \
+               join_llcm, join_llcmstd, join_tlbm, join_tlbmstd, free_time,    \
+               free_timestd, free_llcm, free_llcmstd, free_tlbm,               \
+               free_tlbmstd);                                                  \
+        fflush(stdout);                                                        \
+    } while (0)
 #endif
 
 /* Initial test config in terms of #ULTs*/
-#define START_NULTS     64
+#define START_NULTS 64
 
 static ABT_xstream *xstreams;
-static ABT_pool    *pools;
+static ABT_pool *pools;
 static int niter, max_ults, ness;
 static ABT_xstream_barrier g_xbarrier = ABT_XSTREAM_BARRIER_NULL;
 
@@ -97,12 +99,12 @@ static void master_thread_func(void *arg)
     ABTX_papi_add_event(event_set);
 #endif /* USE_PAPI */
 
-    ABT_thread *my_ults = (ABT_thread *)malloc(max_ults*sizeof(ABT_thread));
+    ABT_thread *my_ults = (ABT_thread *)malloc(max_ults * sizeof(ABT_thread));
 
     /* warm-up */
     for (t = 0; t < max_ults; t++)
-        ABT_thread_create(pools[my_es], thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, &my_ults[t]);
+        ABT_thread_create(pools[my_es], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          &my_ults[t]);
 #ifdef USE_JOIN_MANY
     ABT_thread_join_many(max_ults, my_ults);
 #else
@@ -113,7 +115,7 @@ static void master_thread_func(void *arg)
         ABT_thread_free(&my_ults[t]);
 
     seq_state_t state;
-    seq_init(&state, 2, START_NULTS/2, START_NULTS/2, 1);
+    seq_init(&state, 2, START_NULTS / 2, START_NULTS / 2, 1);
     while ((nults = seq_get_next_term(&state)) <= max_ults) {
         ABT_xstream_barrier_wait(g_xbarrier);
         float crea_time = 0.0, crea_timestd = 0.0;
@@ -129,8 +131,9 @@ static void master_thread_func(void *arg)
 #endif
         int i;
 
-        /* The following line tries to keep the total number of iterations constant */
-        int iter = niter/(nults/START_NULTS);
+        /* The following line tries to keep the total number of iterations
+         * constant */
+        int iter = niter / (nults / START_NULTS);
         for (i = 0; i < iter; i++) {
             unsigned long long start_time;
 
@@ -190,11 +193,11 @@ int main(int argc, char *argv[])
     int i;
     ATS_read_args(argc, argv);
     niter = ATS_get_arg_val(ATS_ARG_N_ITER);
-    ness  = ATS_get_arg_val(ATS_ARG_N_ES);
+    ness = ATS_get_arg_val(ATS_ARG_N_ES);
     max_ults = ATS_get_arg_val(ATS_ARG_N_ULT);
 
-    xstreams = (ABT_xstream *)malloc(ness*sizeof(ABT_xstream));
-    pools = (ABT_pool *)malloc(ness*sizeof(ABT_pool));
+    xstreams = (ABT_xstream *)malloc(ness * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(ness * sizeof(ABT_pool));
 
     ATS_init(argc, argv, ness);
 
@@ -233,7 +236,8 @@ int main(int argc, char *argv[])
 
     /* Create ESs*/
     ABT_xstream_self(&xstreams[0]);
-    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1, &pools[0]);
+    ABT_xstream_set_main_sched_basic(xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &pools[0]);
     for (i = 1; i < ness; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pools[i],
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
@@ -255,4 +259,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_many_ops.c
+++ b/test/benchmark/thread_many_ops.c
@@ -18,15 +18,13 @@ enum {
     T_YIELD,
     T_LAST
 };
-static char *t_names[] = {
-    "create_many (cold)",
-    "join_many (cold)",
-    "create_many/join_many (cold)",
-    "create_many",
-    "join_many",
-    "create_many/join_many",
-    "yield"
-};
+static char *t_names[] = { "create_many (cold)",
+                           "join_many (cold)",
+                           "create_many/join_many (cold)",
+                           "create_many",
+                           "join_many",
+                           "create_many/join_many",
+                           "yield" };
 
 enum {
     T_ALL_CREATE_MANY_JOIN_MANY_COLD = 0,
@@ -34,17 +32,13 @@ enum {
     T_ALL_YIELD,
     T_ALL_LAST
 };
-static char *t_all_names[] = {
-    "all create_many/join_many (cold)",
-    "all create_many/join_many",
-    "all yield"
-};
+static char *t_all_names[] = { "all create_many/join_many (cold)",
+                               "all create_many/join_many", "all yield" };
 
 typedef struct {
     int eid;
     int tid;
 } arg_t;
-
 
 static int iter;
 static int num_xstreams;
@@ -58,7 +52,6 @@ static ABT_thread **g_threads;
 
 static uint64_t (*t_times)[T_LAST];
 static uint64_t t_all[T_ALL_LAST];
-
 
 void thread_func(void *arg)
 {
@@ -122,9 +115,9 @@ void thread_func_migrate_to_xstream(void *arg)
 void thread_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
-    uint64_t   *my_times   = t_times[eid];
+    uint64_t *my_times = t_times[eid];
     ABT_pool *pool_list;
     void (**thread_func_list)(void *);
 
@@ -135,8 +128,8 @@ void thread_test(void *arg)
     ATS_printf(1, "[E%d] main ULT: start\n", eid);
 
     pool_list = (ABT_pool *)malloc(num_threads * sizeof(ABT_pool));
-    thread_func_list = (void (**)(void *))
-                       malloc(num_threads * sizeof(void (*)(void *)));
+    thread_func_list =
+        (void (**)(void *))malloc(num_threads * sizeof(void (*)(void *)));
     for (i = 0; i < num_threads; i++) {
         pool_list[i] = my_pool;
         thread_func_list[i] = thread_func;
@@ -145,7 +138,8 @@ void thread_test(void *arg)
     /*************************************************************************/
     /* ULT: create_many/join_many (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
@@ -159,12 +153,13 @@ void thread_test(void *arg)
     ABT_xstream_barrier_wait(g_xbarrier);
     if (eid == 0) {
         /* execution time for all ESs */
-        t_all[T_ALL_CREATE_MANY_JOIN_MANY_COLD] = ATS_get_cycles() - t_all_start;
+        t_all[T_ALL_CREATE_MANY_JOIN_MANY_COLD] =
+            ATS_get_cycles() - t_all_start;
     }
     my_times[T_CREATE_MANY_COLD] /= num_threads;
     my_times[T_JOIN_MANY_COLD] /= num_threads;
-    my_times[T_CREATE_MANY_JOIN_MANY_COLD] = my_times[T_CREATE_MANY_COLD]
-                                           + my_times[T_JOIN_MANY_COLD];
+    my_times[T_CREATE_MANY_JOIN_MANY_COLD] =
+        my_times[T_CREATE_MANY_COLD] + my_times[T_JOIN_MANY_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -186,7 +181,8 @@ void thread_test(void *arg)
 
     /* measure the time for create/join operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
@@ -215,7 +211,8 @@ void thread_test(void *arg)
 
     /* measure the time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     ABT_thread_create_many(num_threads, pool_list, thread_func_list, NULL,
                            ABT_THREAD_ATTR_NULL, my_threads);
@@ -249,7 +246,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -265,12 +262,13 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t(*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -290,8 +288,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -310,8 +308,10 @@ int main(int argc, char *argv[])
     /* find min, max, and avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -335,8 +335,8 @@ int main(int argc, char *argv[])
     printf("%-30s %11s %11s %11s\n", "operation", "avg", "min", "max");
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_LAST; i++) {
-        printf("%-29s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n",
-               t_names[i], t_avg[i], t_min[i], t_max[i]);
+        printf("%-29s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n", t_names[i],
+               t_avg[i], t_min[i], t_max[i]);
     }
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_ALL_LAST; i++) {
@@ -354,4 +354,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_ops.c
+++ b/test/benchmark/thread_ops.c
@@ -11,9 +11,9 @@
 //#define TEST_MIGRATE_TO
 #define USE_JOIN_MANY
 #ifdef USE_JOIN_MANY
-#define ABT_THREAD_JOIN_MANY(n,tl)      ABT_thread_join_many(n,tl)
+#define ABT_THREAD_JOIN_MANY(n, tl) ABT_thread_join_many(n, tl)
 #else
-#define ABT_THREAD_JOIN_MANY(n,tl)
+#define ABT_THREAD_JOIN_MANY(n, tl)
 #endif
 
 enum {
@@ -31,18 +31,17 @@ enum {
 #endif
     T_LAST
 };
-static char *t_names[] = {
-    "create (cold)",
-    "join (cold)",
-    "create/join (cold)",
-    "create",
-    "join",
-    "create/join",
-    "create (unnamed)",
-    "yield",
-    "yield_to",
+static char *t_names[] = { "create (cold)",
+                           "join (cold)",
+                           "create/join (cold)",
+                           "create",
+                           "join",
+                           "create/join",
+                           "create (unnamed)",
+                           "yield",
+                           "yield_to",
 #ifdef TEST_MIGRATE_TO
-    "migrate_to_xstream"
+                           "migrate_to_xstream"
 #endif
 };
 
@@ -57,14 +56,11 @@ enum {
 #endif
     T_ALL_LAST
 };
-static char *t_all_names[] = {
-    "all create/join (cold)",
-    "all create/join",
-    "all create (unnamed)",
-    "all yield",
-    "all yield_to",
+static char *t_all_names[] = { "all create/join (cold)", "all create/join",
+                               "all create (unnamed)",   "all yield",
+                               "all yield_to",
 #ifdef TEST_MIGRATE_TO
-    "all migrate_to_xstream"
+                               "all migrate_to_xstream"
 #endif
 };
 
@@ -72,7 +68,6 @@ typedef struct {
     int eid;
     int tid;
 } arg_t;
-
 
 static int iter;
 static int num_xstreams;
@@ -86,7 +81,6 @@ static ABT_thread **g_threads;
 
 static uint64_t (*t_times)[T_LAST];
 static uint64_t t_all[T_ALL_LAST];
-
 
 void thread_func(void *arg)
 {
@@ -150,9 +144,9 @@ void thread_func_migrate_to_xstream(void *arg)
 void thread_test(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
-    uint64_t   *my_times   = t_times[eid];
+    uint64_t *my_times = t_times[eid];
 
     uint64_t t_all_start, t_start, t_time;
     int i, t;
@@ -163,12 +157,13 @@ void thread_test(void *arg)
     /*************************************************************************/
     /* ULT: create/join (cold) */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
 
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
-        ABT_thread_create(my_pool, thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, &my_threads[i]);
+        ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          &my_threads[i]);
     }
     my_times[T_CREATE_COLD] = ATS_get_cycles() - t_start;
 
@@ -186,8 +181,8 @@ void thread_test(void *arg)
     }
     my_times[T_CREATE_COLD] /= num_threads;
     my_times[T_JOIN_COLD] /= num_threads;
-    my_times[T_CREATE_JOIN_COLD] = my_times[T_CREATE_COLD]
-                                 + my_times[T_JOIN_COLD];
+    my_times[T_CREATE_JOIN_COLD] =
+        my_times[T_CREATE_COLD] + my_times[T_JOIN_COLD];
     /*************************************************************************/
 
     /*************************************************************************/
@@ -214,12 +209,13 @@ void thread_test(void *arg)
 
     /* measure the time for create/join operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, &my_threads[t]);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              &my_threads[t]);
         }
 
         ABT_THREAD_JOIN_MANY(num_threads, my_threads);
@@ -238,18 +234,20 @@ void thread_test(void *arg)
 
     /* measure the time for create (unnamed) operations */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         while (1) {
             ABT_thread_yield();
             size_t size;
             ABT_pool_get_size(my_pool, &size);
-            if (size == 0) break;
+            if (size == 0)
+                break;
         }
     }
     my_times[T_CREATE_UNNAMED] = ATS_get_cycles() - t_start;
@@ -276,7 +274,8 @@ void thread_test(void *arg)
 
     /* measure the time */
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         ABT_thread_create(my_pool, thread_func_yield, NULL,
@@ -320,7 +319,8 @@ void thread_test(void *arg)
     /* measure the time */
     args = (arg_t *)malloc(num_threads * sizeof(arg_t));
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         args[i].eid = eid;
@@ -353,7 +353,8 @@ void thread_test(void *arg)
     /* ULT: migrate_to_xstream */
     args = (arg_t *)malloc(num_threads * sizeof(arg_t));
     ABT_xstream_barrier_wait(g_xbarrier);
-    if (eid == 0) t_all_start = ATS_get_cycles();
+    if (eid == 0)
+        t_all_start = ATS_get_cycles();
     t_start = ATS_get_cycles();
     for (i = 0; i < num_threads; i++) {
         args[i].eid = eid;
@@ -394,7 +395,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -410,12 +411,13 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
-    t_times = (uint64_t (*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t)*T_LAST);
+    t_times =
+        (uint64_t(*)[T_LAST])calloc(num_xstreams, sizeof(uint64_t) * T_LAST);
 
     /* create a global barrier */
     ABT_xstream_barrier_create(num_xstreams, &g_xbarrier);
@@ -435,8 +437,8 @@ int main(int argc, char *argv[])
 
     /* create ESs with a new default scheduler */
     ABT_xstream_self(&g_xstreams[0]);
-    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT,
-                                     1, &g_pools[0]);
+    ABT_xstream_set_main_sched_basic(g_xstreams[0], ABT_SCHED_DEFAULT, 1,
+                                     &g_pools[0]);
     for (i = 1; i < num_xstreams; i++) {
         ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &g_pools[i],
                                  ABT_SCHED_CONFIG_NULL, &g_xstreams[i]);
@@ -455,8 +457,10 @@ int main(int argc, char *argv[])
     /* find min, max, and avg of each case */
     for (i = 0; i < num_xstreams; i++) {
         for (t = 0; t < T_LAST; t++) {
-            if (t_times[i][t] < t_min[t]) t_min[t] = t_times[i][t];
-            if (t_times[i][t] > t_max[t]) t_max[t] = t_times[i][t];
+            if (t_times[i][t] < t_min[t])
+                t_min[t] = t_times[i][t];
+            if (t_times[i][t] > t_max[t])
+                t_max[t] = t_times[i][t];
             t_avg[t] += t_times[i][t];
         }
     }
@@ -480,8 +484,8 @@ int main(int argc, char *argv[])
     printf("%-20s %11s %11s %11s\n", "operation", "avg", "min", "max");
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_LAST; i++) {
-        printf("%-19s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n",
-               t_names[i], t_avg[i], t_min[i], t_max[i]);
+        printf("%-19s  %11" PRIu64 " %11" PRIu64 " %11" PRIu64 "\n", t_names[i],
+               t_avg[i], t_min[i], t_max[i]);
     }
     ATS_print_line(stdout, '-', line_size);
     for (i = 0; i < T_ALL_LAST; i++) {
@@ -499,4 +503,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/thread_ops_all.c
+++ b/test/benchmark/thread_ops_all.c
@@ -11,9 +11,9 @@
 //#define TEST_MIGRATE_TO
 #define USE_JOIN_MANY
 #ifdef USE_JOIN_MANY
-#define ABT_THREAD_JOIN_MANY(n,tl)      ABT_thread_join_many(n,tl)
+#define ABT_THREAD_JOIN_MANY(n, tl) ABT_thread_join_many(n, tl)
 #else
-#define ABT_THREAD_JOIN_MANY(n,tl)
+#define ABT_THREAD_JOIN_MANY(n, tl)
 #endif
 
 enum {
@@ -30,17 +30,16 @@ enum {
 #endif
     T_LAST
 };
-static char *t_names[] = {
-    "create/join",
-    "create (unnamed)",
-    "yield_overhead",
-    "yield_all",
-    "yield",
-    "yield_to_overhead",
-    "yield_to_all",
-    "yield_to",
+static char *t_names[] = { "create/join",
+                           "create (unnamed)",
+                           "yield_overhead",
+                           "yield_all",
+                           "yield",
+                           "yield_to_overhead",
+                           "yield_to_all",
+                           "yield_to",
 #ifdef TEST_MIGRATE_TO
-    "migrate_to_xstream"
+                           "migrate_to_xstream"
 #endif
 };
 
@@ -48,7 +47,6 @@ typedef struct {
     int eid;
     int tid;
 } arg_t;
-
 
 static int iter;
 static int num_xstreams;
@@ -63,7 +61,6 @@ static double t_times[T_LAST];
 #else
 static uint64_t t_times[T_LAST];
 #endif
-
 
 void thread_func(void *arg)
 {
@@ -150,14 +147,14 @@ void thread_func_migrate_to_xstream(void *arg)
 void test_create_join(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i, t;
 
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, &my_threads[t]);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              &my_threads[t]);
         }
 
         ABT_THREAD_JOIN_MANY(num_threads, my_threads);
@@ -175,8 +172,8 @@ void test_create_unnamed(void *arg)
 
     for (i = 0; i < iter; i++) {
         for (t = 0; t < num_threads; t++) {
-            ABT_thread_create(my_pool, thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(my_pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         ABT_thread_yield();
     }
@@ -185,7 +182,7 @@ void test_create_unnamed(void *arg)
 void test_yield_overhead(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -202,7 +199,7 @@ void test_yield_overhead(void *arg)
 void test_yield(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -219,7 +216,7 @@ void test_yield(void *arg)
 void test_yield_to_overhead(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -241,7 +238,7 @@ void test_yield_to_overhead(void *arg)
 void test_yield_to(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -263,7 +260,7 @@ void test_yield_to(void *arg)
 void test_migrate_to_xstream(void *arg)
 {
     int eid = (int)(size_t)arg;
-    ABT_pool    my_pool    = g_pools[eid];
+    ABT_pool my_pool = g_pools[eid];
     ABT_thread *my_threads = g_threads[eid];
     int i;
 
@@ -283,10 +280,9 @@ void test_migrate_to_xstream(void *arg)
 }
 #endif
 
-
 int main(int argc, char *argv[])
 {
-    ABT_pool (*all_pools)[2];
+    ABT_pool(*all_pools)[2];
     ABT_sched *scheds;
     ABT_thread *top_threads;
     size_t i, t;
@@ -295,7 +291,7 @@ int main(int argc, char *argv[])
     /* read command-line arguments */
     ATS_read_args(argc, argv);
     num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
-    num_threads  = ATS_get_arg_val(ATS_ARG_N_ULT);
+    num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
     iter = ATS_get_arg_val(ATS_ARG_N_ITER);
 
     /* initialize */
@@ -306,12 +302,12 @@ int main(int argc, char *argv[])
     }
 
     g_xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
-    g_pools    = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    g_threads  = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
+    g_pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    g_threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     for (i = 0; i < num_xstreams; i++) {
         g_threads[i] = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
     }
-    all_pools = (ABT_pool (*)[2])malloc(num_xstreams * sizeof(ABT_pool) * 2);
+    all_pools = (ABT_pool(*)[2])malloc(num_xstreams * sizeof(ABT_pool) * 2);
     scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
     top_threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
@@ -347,7 +343,8 @@ int main(int argc, char *argv[])
             continue;
         } else if (t == T_YIELD_TO) {
             if (t_times[T_YIELD_TO_ALL] > t_times[T_YIELD_TO_OVERHEAD]) {
-                t_times[t] = t_times[T_YIELD_TO_ALL] - t_times[T_YIELD_TO_OVERHEAD];
+                t_times[t] =
+                    t_times[T_YIELD_TO_ALL] - t_times[T_YIELD_TO_OVERHEAD];
             } else {
                 t_times[t] = 0;
             }
@@ -355,23 +352,31 @@ int main(int argc, char *argv[])
         }
 
         switch (t) {
-            case T_CREATE_JOIN:        test_fn = test_create_join;
-                                       break;
-            case T_CREATE_UNNAMED:     test_fn = test_create_unnamed;
-                                       break;
-            case T_YIELD_OVERHEAD:     test_fn = test_yield_overhead;
-                                       break;
-            case T_YIELD_ALL:          test_fn = test_yield;
-                                       break;
-            case T_YIELD_TO_OVERHEAD:  test_fn = test_yield_to_overhead;
-                                       break;
-            case T_YIELD_TO_ALL:       test_fn = test_yield_to;
-                                       break;
+            case T_CREATE_JOIN:
+                test_fn = test_create_join;
+                break;
+            case T_CREATE_UNNAMED:
+                test_fn = test_create_unnamed;
+                break;
+            case T_YIELD_OVERHEAD:
+                test_fn = test_yield_overhead;
+                break;
+            case T_YIELD_ALL:
+                test_fn = test_yield;
+                break;
+            case T_YIELD_TO_OVERHEAD:
+                test_fn = test_yield_to_overhead;
+                break;
+            case T_YIELD_TO_ALL:
+                test_fn = test_yield_to;
+                break;
 #ifdef TEST_MIGRATE_TO
-            case T_MIGRATE_TO_XSTREAM: test_fn = test_migrate_to_xstream;
-                                       break;
+            case T_MIGRATE_TO_XSTREAM:
+                test_fn = test_migrate_to_xstream;
+                break;
 #endif
-            default: assert(0);
+            default:
+                assert(0);
         }
 
         /* warm-up */
@@ -450,4 +455,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/benchmark/xstream_ops.c
+++ b/test/benchmark/xstream_ops.c
@@ -8,7 +8,6 @@
 #include "abt.h"
 #include "abttest.h"
 
-
 enum {
     T_CREATE_JOIN = 0,
     T_CREATE_JOIN_FREE,
@@ -17,15 +16,12 @@ enum {
     T_LAST
 };
 
-static char *t_names[] = {
-    "ES: create/join without creating a ULT",
-    "ES: create/join/free without creating a ULT",
-    "ES: create/join with creating a ULT",
-    "ES: create/join/free with creating a ULT"
-};
+static char *t_names[] = { "ES: create/join without creating a ULT",
+                           "ES: create/join/free without creating a ULT",
+                           "ES: create/join with creating a ULT",
+                           "ES: create/join/free with creating a ULT" };
 
 static double t_times[T_LAST];
-
 
 void thread_func(void *arg)
 {
@@ -54,8 +50,8 @@ int main(int argc, char *argv[])
     ABT_timer_start(timer);
     ABT_timer_stop(timer);
     ABT_timer_get_overhead(&t_overhead);
-    for (i = 0; i < T_LAST; i++) t_times[i] = 0.0;
-
+    for (i = 0; i < T_LAST; i++)
+        t_times[i] = 0.0;
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
@@ -64,8 +60,8 @@ int main(int argc, char *argv[])
     for (t = 0; t < num_xstreams; t++) {
         ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
         ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-        ABT_thread_create(pools[t], thread_func, NULL,
-                          ABT_THREAD_ATTR_NULL, NULL);
+        ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                          NULL);
     }
     for (t = 0; t < num_xstreams; t++) {
         ABT_xstream_join(xstreams[t]);
@@ -111,8 +107,8 @@ int main(int argc, char *argv[])
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
             ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-            ABT_thread_create(pools[t], thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_join(xstreams[t]);
@@ -132,8 +128,8 @@ int main(int argc, char *argv[])
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_create(ABT_SCHED_NULL, &xstreams[t]);
             ABT_xstream_get_main_pools(xstreams[t], 1, &pools[t]);
-            ABT_thread_create(pools[t], thread_func, NULL,
-                              ABT_THREAD_ATTR_NULL, NULL);
+            ABT_thread_create(pools[t], thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                              NULL);
         }
         for (t = 0; t < num_xstreams; t++) {
             ABT_xstream_join(xstreams[t]);
@@ -170,4 +166,3 @@ int main(int argc, char *argv[])
 
     return EXIT_SUCCESS;
 }
-

--- a/test/util/abttest.c
+++ b/test/util/abttest.c
@@ -15,7 +15,7 @@ static int g_num_errs = 0;
 
 /* NOTE: The below NUM_ARG_KINDS should match the number of values in enum
  * ATS_arg in abttest.h. */
-#define NUM_ARG_KINDS   4
+#define NUM_ARG_KINDS 4
 static int g_arg_val[NUM_ARG_KINDS];
 
 void ATS_init(int argc, char **argv, int num_xstreams)
@@ -46,8 +46,7 @@ void ATS_init(int argc, char **argv, int num_xstreams)
             g_verbose = val;
         } else {
             /* Negative value */
-            fprintf(stderr, "WARNING: %s is invalid for ATS_VERBOSE\n",
-                    envval);
+            fprintf(stderr, "WARNING: %s is invalid for ATS_VERBOSE\n", envval);
             fflush(stderr);
         }
     }
@@ -94,7 +93,8 @@ void ATS_error(int err, const char *msg, const char *file, int line)
     size_t len;
     int ret;
 
-    if (err == ABT_SUCCESS) return;
+    if (err == ABT_SUCCESS)
+        return;
     if (err == ABT_ERR_FEATURE_NA) {
         printf("Skipped\n");
         fflush(stdout);
@@ -107,8 +107,7 @@ void ATS_error(int err, const char *msg, const char *file, int line)
     assert(err_str != NULL);
     ret = ABT_error_get_str(err, err_str, NULL);
 
-    fprintf(stderr, "%s (%d): %s (%s:%d)\n",
-            err_str, err, msg, file, line);
+    fprintf(stderr, "%s (%d): %s (%s:%d)\n", err_str, err, msg, file, line);
 
     free(err_str);
 
@@ -119,8 +118,10 @@ void ATS_error(int err, const char *msg, const char *file, int line)
 
 static void ATS_print_help(char *prog)
 {
-    fprintf(stderr, "Usage: %s [-e num_es] [-u num_ult] [-t num_task] "
-                    "[-i iter] [-v verbose_level]\n", prog);
+    fprintf(stderr,
+            "Usage: %s [-e num_es] [-u num_ult] [-t num_task] "
+            "[-i iter] [-v verbose_level]\n",
+            prog);
     fflush(stderr);
 }
 
@@ -129,8 +130,10 @@ void ATS_read_args(int argc, char **argv)
     static int read = 0;
     int i, opt;
 
-    if (read == 0) read = 1;
-    else return;
+    if (read == 0)
+        read = 1;
+    else
+        return;
 
     for (i = 0; i < NUM_ARG_KINDS; i++) {
         g_arg_val[i] = 1;
@@ -181,4 +184,3 @@ void ATS_print_line(FILE *fp, char c, int len)
     fprintf(fp, "\n");
     fflush(fp);
 }
-

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -17,7 +17,6 @@
 #endif
 #include <assert.h>
 
-
 /** @defgroup TESTUTIL Test utility
  * This group is for test utility routines.
  */
@@ -83,12 +82,11 @@ void ATS_printf(int level, const char *format, ...);
  */
 void ATS_error(int err, const char *msg, const char *file, int line);
 
-
 typedef enum {
-    ATS_ARG_N_ES   = 0,    /* # of ESs */
-    ATS_ARG_N_ULT  = 1,    /* # of ULTs */
-    ATS_ARG_N_TASK = 2,    /* # of tasklets */
-    ATS_ARG_N_ITER = 3     /* # of iterations */
+    ATS_ARG_N_ES = 0,   /* # of ESs */
+    ATS_ARG_N_ULT = 1,  /* # of ULTs */
+    ATS_ARG_N_TASK = 2, /* # of tasklets */
+    ATS_ARG_N_ITER = 3  /* # of iterations */
 } ATS_arg;
 
 /**
@@ -128,14 +126,14 @@ int ATS_get_arg_val(ATS_arg arg);
  */
 void ATS_print_line(FILE *fp, char c, int len);
 
-#define ATS_ERROR(e,m)     ATS_error(e,m,__FILE__,__LINE__)
-#define ATS_UNUSED(a)      (void)(a)
+#define ATS_ERROR(e, m) ATS_error(e, m, __FILE__, __LINE__)
+#define ATS_UNUSED(a) (void)(a)
 
 #if defined(__x86_64__)
 static inline uint64_t ATS_get_cycles()
 {
     unsigned hi, lo;
-    __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
     uint64_t cycle = ((uint64_t)lo) | (((int64_t)hi) << 32);
     return cycle;
 }
@@ -143,7 +141,7 @@ static inline uint64_t ATS_get_cycles()
 static inline uint64_t ATS_get_cycles()
 {
     register uint64_t cycle;
-    __asm__ __volatile__ ("isb; mrs %0, cntvct_el0" : "=r"(cycle));
+    __asm__ __volatile__("isb; mrs %0, cntvct_el0" : "=r"(cycle));
     return cycle;
 }
 #else


### PR DESCRIPTION
This PR updates `maint/code-cleanup.sh` to use Travis CI effectively.

Note that this PR is a Clang-format indent version; the other is a GNU indent version (#109).

Any feedback is welcome!

---
**Changes in common:**

- No single-line `if`/`while`/`for`
```cpp
BEFORE:
    if (stop == ABT_TRUE) break;
AFTER:
    if (stop == ABT_TRUE)
        break;
```

- No aligned assignment/declaration.
```cpp
BEFORE:
    p_def->p_free               = pool_free;
    p_def->p_get_size           = pool_get_size;

    ABT_sched   scheds[NUM_XSTREAMS];
    ABT_pool    shared_pool;
AFTER:
    p_def->p_free = pool_free;
    p_def->p_get_size = pool_get_size;

    ABT_sched scheds[NUM_XSTREAMS];
    ABT_pool shared_pool;
```

---
**Clang-format-specific changes / side effects:**

- Specific version requirement (Clang-format >= 3.9 is necessary for `SortInclude:false` features; otherwise `abti.h` will be broken).

- No aligned macros.
```cpp
BEFORE:
	#define N               10
	#define NUM_XSTREAMS    4
AFTER:
	#define N 10
	#define NUM_XSTREAMS 4
```

- No 2 spaces for `goto` labels.
```cpp
BEFORE:
  fn_exit:
     return result;
}
AFTER:
fn_exit:
     return result;
}
```

- Weird indent of bracket-based initialization (I failed to turn it off).
```cpp
BEFORE:
    ABT_sched_def sched_def = {
        .type = ABT_SCHED_TYPE_ULT,
        .init = sched_init,
        .run = sched_run,
        .free = sched_free,
        .get_migr_pool = NULL
    };
AFTER: 
    ABT_sched_def sched_def = { .type = ABT_SCHED_TYPE_ULT,
                                .init = sched_init,
                                .run = sched_run,
                                .free = sched_free,
                                .get_migr_pool = NULL };
```

- 80-character alignment of backslash.
```cpp
BEFORE:
#define ABTX_start_prof(start_time, evset)       \
do {                                             \
    start_time = ATS_get_cycles();               \
    ABTX_papi_assert(PAPI_start(evset));         \
} while (0)
AFTER:
#define ABTX_start_prof(start_time, evset)                                     \
    do {                                                                       \
        start_time = ATS_get_cycles();                                         \
        ABTX_papi_assert(PAPI_start(evset));                                   \
    } while (0)
```

- Break after assignment operator (I can finely tune penalties, but don't want to modify a lot. Now I'm using the default one.)
```cpp
BEFORE: (it satisfies 80-character rule.)
         abt_errno = ABT_sched_create(ABTI_sched_get_randws_def(),
                                      num_pools, pool_list,
                                      config, newsched);
AFTER: (why does clang-format prefer this?)
         abt_errno =
             ABT_sched_create(ABTI_sched_get_randws_def(), num_pools,
                              pool_list, config, newsched);
```
