### PR TITLE
made possible to remove error messages from std output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ AC_ARG_ENABLE([debug],
         all   - all of the above choices
         most  - same as "all" but not print logs by default
                 (set ABT_ENV_USE_LOG to 1 for logging)
+        err   - print abt_errno information on standard error
         none  - no debugging, i.e., --disable-debug
 ],,[enable_debug=none])
 
@@ -301,18 +302,25 @@ for option in $enable_debug ; do
         log)
             debug_log=yes
             debug_log_print=yes
+            debug_err=yes
         ;;
         all)
             debug_flags=yes
             debug_log=yes
             debug_log_print=yes
+            debug_err=yes
         ;;
         most)
             debug_flags=yes
             debug_log=yes
             debug_log_print=no
+            debug_err=yes
+        ;;
+        err)
+            debug_err=yes
         ;;
         no|none)
+            debug_err=no
             debug_flags=no
             debug_log=no
         ;;
@@ -338,6 +346,9 @@ AS_IF([test "x$debug_log" = "xyes"],
 AS_IF([test "x$debug_log_print" = "xyes"],
     [AC_DEFINE(ABT_CONFIG_USE_DEBUG_LOG_PRINT, 1,
         [Define to enable printing debug log messages])])
+AS_IF([test "x$debug_err" = "xyes"],
+    [AC_DEFINE(ABT_CONFIG_PRINT_ABT_ERRNO, 1,
+        [Define to enable printing abt_errno upon abt call error])])
 
 
 # --enable-fast: compiler optimization flags

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -7,6 +7,7 @@
 #define ABTI_ERROR_H_INCLUDED
 
 #include <assert.h>
+#include <abt_config.h>
 
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
 #define ABTI_ASSERT(cond) assert(cond)
@@ -270,6 +271,8 @@
 #define ABTI_CHECK_NULL_TIMER_PTR(p)
 #endif
 
+#ifdef ABT_CONFIG_PRINT_ABT_ERRNO
+
 #define HANDLE_ERROR(msg) \
     fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg)
     //fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); exit(-1)
@@ -281,5 +284,13 @@
 #define HANDLE_ERROR_FUNC_WITH_CODE(n) \
     fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n)
     //fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n); exit(-1)
+
+#else
+
+#define HANDLE_ERROR(msg)              do { } while (0)
+#define HANDLE_ERROR_WITH_CODE(msg,n)  do { } while (0)
+#define HANDLE_ERROR_FUNC_WITH_CODE(n) do { } while (0)
+
+#endif
 
 #endif /* ABTI_ERROR_H_INCLUDED */


### PR DESCRIPTION
This PR adds an option to `--enable-debug`, `err`, which indicates whether failing function calls should print a message on standard error. By default this will now not be the case.