### PR TITLE
Disable expensive valgrind specific tracking if valgrind isn't running

### DIFF
--- a/src/include/abti_valgrind.h
+++ b/src/include/abti_valgrind.h
@@ -13,10 +13,19 @@
 
 void ABTI_valgrind_register_stack(const void *p_stack, size_t size);
 void ABTI_valgrind_unregister_stack(const void *p_stack);
-#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size) \
-            ABTI_valgrind_register_stack  (p_stack, size)
-#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack) \
-            ABTI_valgrind_unregister_stack(p_stack)
+#define ABTI_VALGRIND_REGISTER_STACK(p_stack, size)         \
+        do {                                                \
+            if (!RUNNING_ON_VALGRIND)                       \
+                break;                                      \
+            ABTI_valgrind_register_stack  (p_stack, size);  \
+        } while (0)
+
+#define ABTI_VALGRIND_UNREGISTER_STACK(p_stack)         \
+        do {                                            \
+            if (!RUNNING_ON_VALGRIND)                   \
+                break;                                  \
+            ABTI_valgrind_unregister_stack(p_stack);    \
+        } while (0)
 
 #else
 

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -45,9 +45,6 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
     if (p_stack == 0)
         return;
 
-    if (!RUNNING_ON_VALGRIND)
-	    return;
-
     const void *p_start = (char *)(p_stack);
     const void *p_end   = (char *)(p_stack) + size;
 
@@ -73,9 +70,6 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
 void ABTI_valgrind_unregister_stack(const void *p_stack) {
     if (p_stack == 0)
         return;
-
-    if (!RUNNING_ON_VALGRIND)
-	    return;
 
     ABTI_valgrind_lock_acquire();
     if (gp_valgrind_id_list_head->p_stack == p_stack) {

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -45,6 +45,9 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
     if (p_stack == 0)
         return;
 
+    if (!RUNNING_ON_VALGRIND)
+	    return;
+
     const void *p_start = (char *)(p_stack);
     const void *p_end   = (char *)(p_stack) + size;
 
@@ -70,6 +73,9 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
 void ABTI_valgrind_unregister_stack(const void *p_stack) {
     if (p_stack == 0)
         return;
+
+    if (!RUNNING_ON_VALGRIND)
+	    return;
 
     ABTI_valgrind_lock_acquire();
     if (gp_valgrind_id_list_head->p_stack == p_stack) {


### PR DESCRIPTION
This enables users of argobots to keep one build that
supports valgrind without losing significant performance.

test:jenkins

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>