### PR TITLE
Fix test/basic/info_stackdump2.c

### DIFF
--- a/test/basic/info_stackdump2.c
+++ b/test/basic/info_stackdump2.c
@@ -209,11 +209,13 @@ int main(int argc, char *argv[])
     /* Finalize */
     ret = ATS_finalize(0);
 
-    for (i = 0; i < num_xstreams; i++) {
+    for (i = 1; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {
             if (args[i][j].stack)
                 free(args[i][j].stack);
         }
+    }
+    for (i = 0; i < num_xstreams; i++) {
         free(threads[i]);
         free(args[i]);
     }


### PR DESCRIPTION
This patch fixes the loop range in `test/basic/info_stackdump2.c` which sometimes causes an illegal memory free error.

The bug is as follows: `args[i][j].stack` is only initialized with `i != 1` (see line 143)
```c
    /* Create ULTs. */
    /* i starts from 1 because one execution stream must be busy-scheduling. */
    for (i = 1; i < num_xstreams; i++) {
        for (j = 0; j < num_threads; j++) {
            [...]
            args[i][j].stack = NULL;
```
while previously it iterates over all `args[i][j].stack`, some of which are uninitialized (see line 212).
```c
    for (i = 0; i < num_xstreams; i++) { // this "0" is the problem
        for (j = 0; j < num_threads; j++) {
            if (args[i][j].stack)
                free(args[i][j].stack);
        }
        [...]
```