### PR TITLE
Support i386 (aka, 32-bit Intel architecture)

### DIFF
--- a/src/arch/fcontext/jump_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_elf_gas.S
@@ -24,9 +24,6 @@
 .align 2
 .type jump_fcontext,@function
 jump_fcontext:
-    /* fourth arg of jump_fcontext() == flag indicating preserving FPU */
-    movl  0x10(%esp), %ecx
-
     pushl  %ebp  /* save EBP */
     pushl  %ebx  /* save EBX */
     pushl  %esi  /* save ESI */

--- a/src/arch/fcontext/jump_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_elf_gas.S
@@ -72,8 +72,9 @@ jump_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* use value in EAX as return-value after jump */
-    /* use value in EAX as first arg in context function */
+    /* use value in EAX (originally third arg) as
+     * 1. return value after jump or
+     * 2. first arg in context function. */
     movl  %eax, 0x4(%esp)
 
     /* indirect jump to context */

--- a/src/arch/fcontext/jump_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_elf_gas.S
@@ -52,7 +52,7 @@ jump_fcontext:
     movl  0x20(%esp), %edx
 
     /* third arg of jump_fcontext() == value to be returned after jump */
-    /* movl  0x24(%esp), %eax */
+    movl  0x24(%esp), %eax
 
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp

--- a/src/arch/fcontext/jump_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_macho_gas.S
@@ -23,9 +23,6 @@
 .globl _jump_fcontext
 .align 2
 _jump_fcontext:
-    /* fourth arg of jump_fcontext() == flag indicating preserving FPU */
-    movl  0x10(%esp), %ecx
-
     pushl  %ebp  /* save EBP */
     pushl  %ebx  /* save EBX */
     pushl  %esi  /* save ESI */

--- a/src/arch/fcontext/jump_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_macho_gas.S
@@ -51,7 +51,7 @@ _jump_fcontext:
     movl  0x20(%esp), %edx
 
     /* third arg of jump_fcontext() == value to be returned after jump */
-    /* movl  0x24(%esp), %eax */
+    movl  0x24(%esp), %eax
 
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp

--- a/src/arch/fcontext/jump_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/jump_i386_sysv_macho_gas.S
@@ -71,8 +71,9 @@ _jump_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* use value in EAX as return-value after jump */
-    /* use value in EAX as first arg in context function */
+    /* use value in EAX (originally third arg) as
+     * 1. return value after jump or
+     * 2. first arg in context function. */
     movl  %eax, 0x4(%esp)
 
     /* indirect jump to context */

--- a/src/arch/fcontext/take_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_elf_gas.S
@@ -28,10 +28,10 @@ take_fcontext:
     movl  0x10(%esp), %ecx
 
     /* second arg of take_fcontext() == context jumping to */
-    movl  0x20(%esp), %edx
+    movl  0x8(%esp), %edx
 
     /* third arg of take_fcontext() == value to be returned after jump */
-    movl  0x24(%esp), %eax
+    movl  0xc(%esp), %eax
 
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp

--- a/src/arch/fcontext/take_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_elf_gas.S
@@ -24,6 +24,8 @@
 .align 2
 .type take_fcontext,@function
 take_fcontext:
+    /* first arg is ignored. */
+
     /* second arg of take_fcontext() == context jumping to */
     movl  0x8(%esp), %edx
 
@@ -51,8 +53,9 @@ take_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* use value in EAX as return-value after jump */
-    /* use value in EAX as first arg in context function */
+    /* use value in EAX (originally third arg) as
+     * 1. return value after jump or
+     * 2. first arg in context function. */
     movl  %eax, 0x4(%esp)
 
     /* indirect jump to context */

--- a/src/arch/fcontext/take_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_elf_gas.S
@@ -24,9 +24,6 @@
 .align 2
 .type take_fcontext,@function
 take_fcontext:
-    /* fourth arg of take_fcontext() == flag indicating preserving FPU */
-    movl  0x10(%esp), %ecx
-
     /* second arg of take_fcontext() == context jumping to */
     movl  0x8(%esp), %edx
 

--- a/src/arch/fcontext/take_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_macho_gas.S
@@ -23,6 +23,8 @@
 .globl _take_fcontext
 .align 2
 _take_fcontext:
+    /* first arg is ignored. */
+
     /* second arg of take_fcontext() == context jumping to */
     movl  0x8(%esp), %edx
 
@@ -50,8 +52,9 @@ _take_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* use value in EAX as return-value after jump */
-    /* use value in EAX as first arg in context function */
+    /* use value in EAX (originally third arg) as
+     * 1. return value after jump or
+     * 2. first arg in context function. */
     movl  %eax, 0x4(%esp)
 
     /* indirect jump to context */

--- a/src/arch/fcontext/take_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_macho_gas.S
@@ -23,9 +23,6 @@
 .globl _take_fcontext
 .align 2
 _take_fcontext:
-    /* fourth arg of take_fcontext() == flag indicating preserving FPU */
-    movl  0x10(%esp), %ecx
-
     /* second arg of take_fcontext() == context jumping to */
     movl  0x8(%esp), %edx
 

--- a/src/arch/fcontext/take_i386_sysv_macho_gas.S
+++ b/src/arch/fcontext/take_i386_sysv_macho_gas.S
@@ -27,10 +27,10 @@ _take_fcontext:
     movl  0x10(%esp), %ecx
 
     /* second arg of take_fcontext() == context jumping to */
-    movl  0x20(%esp), %edx
+    movl  0x8(%esp), %edx
 
     /* third arg of take_fcontext() == value to be returned after jump */
-    movl  0x24(%esp), %eax
+    movl  0xc(%esp), %eax
 
     /* restore ESP (pointing to context-data) from EDX */
     movl  %edx, %esp

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -23,21 +23,21 @@ struct ABTI_thread_queue {
     uint32_t pad0;
     ABTI_thread *head;
     ABTI_thread *tail;
-    char pad1[64-8*4];
+    char pad1[64 - sizeof(uint32_t) * 4 - sizeof(ABTI_thread *) * 2];
 
     /* low priority queue */
     uint32_t low_mutex; /* can be initialized by just assigning 0*/
     uint32_t low_num_threads;
     ABTI_thread *low_head;
     ABTI_thread *low_tail;
-    char pad2[64-8*3];
+    char pad2[64 - sizeof(uint32_t) * 2 - sizeof(ABTI_thread *) * 2];
 
     /* two doubly-linked lists */
     ABTI_thread_queue *p_h_next;
     ABTI_thread_queue *p_h_prev;
     ABTI_thread_queue *p_l_next;
     ABTI_thread_queue *p_l_prev;
-    char pad3[64-8*4];
+    char pad3[64 - sizeof(ABTI_thread_queue *) * 4];
 };
 
 struct ABTI_thread_htable {

--- a/src/log.c
+++ b/src/log.c
@@ -43,7 +43,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
     ABTI_task *p_task = NULL;
     char *prefix_fmt = NULL, *prefix = NULL;
     char *newfmt;
-    size_t tid, rank;
+    uint64_t tid;
+    int rank;
     int tid_len = 0, rank_len = 0;
     size_t newfmt_len;
 


### PR DESCRIPTION
This PR fixes the implementation of fcontext for i386 so that Argobots can be compiled on x86/32 systems.

On an x86/64 system, 32-bit Argobots can be built as follows (multilib support is necessary):
```sh
# assuming gcc on Intel x86/64
./configure --host=i686-pc-linux-gnu CFLAGS=-m32 CCASFLAGS=-m32
make
```

The mutex patch should address the issue #104, which was originally reported by @mdorier. Thanks, @mdorier!
