### PR TITLE
remove internal use of public ABT_ functions

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -120,23 +120,6 @@ double convert_timespec_to_sec(const struct timespec *p_ts)
 }
 
 static inline
-double get_cur_time(void)
-{
-#if defined(HAVE_CLOCK_GETTIME)
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    return convert_timespec_to_sec(&ts);
-#elif defined(HAVE_GETTIMEOFDAY)
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return ((double)tv.tv_sec) + 1.0e-6 * ((double)tv.tv_usec);
-#else
-#error "No timer function available"
-    return 0.0;
-#endif
-}
-
-static inline
 void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
 {
     if (p_unit->p_next == NULL) return;
@@ -244,7 +227,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     ABTI_mutex_unlock(p_mutex);
 
     while (!ABTD_atomic_load_int32(&ext_signal)) {
-        double cur_time = get_cur_time();
+        double cur_time = ABTI_get_wtime();
         if (cur_time >= tar_time) {
             remove_unit(p_cond, p_unit);
             abt_errno = ABT_ERR_COND_TIMEDOUT;

--- a/src/cond.c
+++ b/src/cond.c
@@ -233,7 +233,13 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
             abt_errno = ABT_ERR_COND_TIMEDOUT;
             break;
         }
-        ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+            ABTD_atomic_pause();
+            continue;
+        }
+#endif
+        ABTI_thread_yield(ABTI_local_get_thread());
     }
     ABTU_free(p_unit);
 

--- a/src/event.c
+++ b/src/event.c
@@ -354,7 +354,7 @@ static void ABTI_event_free_xstream(void *arg)
         ABTI_thread_yield(ABTI_local_get_thread());
     }
 
-    abt_errno = ABT_xstream_join(xstream);
+    abt_errno = ABTI_xstream_join(p_xstream);
     ABTI_ASSERT(abt_errno == ABT_SUCCESS);
     abt_errno = ABTI_xstream_free(p_xstream);
     ABTI_ASSERT(abt_errno == ABT_SUCCESS);
@@ -387,8 +387,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
             ABTI_thread_yield(ABTI_local_get_thread());
         }
 
-        ABT_xstream xstream = ABTI_xstream_get_handle(p_xstream);
-        abt_errno = ABT_xstream_join(xstream);
+        abt_errno = ABTI_xstream_join(p_xstream);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);
         abt_errno = ABTI_xstream_free(p_xstream);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);

--- a/src/event.c
+++ b/src/event.c
@@ -329,7 +329,7 @@ void ABTI_event_send_num_xstream(void)
     int num_xstreams;
     int n;
 
-    ABT_xstream_get_num(&num_xstreams);
+    num_xstreams = gp_ABTI_global->num_xstreams;
 
     sprintf(send_buf, "%d", num_xstreams);
     n = write(gp_einfo->pfd.fd, send_buf, strlen(send_buf));

--- a/src/event.c
+++ b/src/event.c
@@ -221,7 +221,7 @@ void ABTI_event_init(void)
                 gp_einfo->max_xstream_rank, sizeof(uint32_t));
         gp_einfo->old_timestamp = (double *)ABTU_calloc(
                 gp_einfo->max_xstream_rank, sizeof(double));
-        gp_einfo->timestamp = ABT_get_wtime();
+        gp_einfo->timestamp = ABTI_get_wtime();
 
         int ret = RAPLREADER_INIT(&gp_einfo->rr);
         if (ret) {
@@ -970,7 +970,7 @@ void ABTI_event_publish_info(void)
         ABTI_event_realloc_pub_arrays(rank);
     }
 
-    cur_time = ABT_get_wtime();
+    cur_time = ABTI_get_wtime();
     elapsed_time = cur_time - gp_einfo->timestamp;
 
     /* Update the idle time of the current ES */
@@ -1110,7 +1110,7 @@ int ABT_event_prof_start(void)
 #ifdef ABT_CONFIG_PUBLISH_INFO
     if (gp_ABTI_global->pub_needed == ABT_FALSE) return ABT_SUCCESS;
 
-    gp_einfo->prof_start_time = ABT_get_wtime();
+    gp_einfo->prof_start_time = ABTI_get_wtime();
     RAPLREADER_SAMPLE(&gp_einfo->rr);
 #endif
 
@@ -1133,7 +1133,7 @@ int ABT_event_prof_stop(void)
 #ifdef ABT_CONFIG_PUBLISH_INFO
     if (gp_ABTI_global->pub_needed == ABT_FALSE) return ABT_SUCCESS;
 
-    gp_einfo->prof_stop_time = ABT_get_wtime();
+    gp_einfo->prof_stop_time = ABTI_get_wtime();
     RAPLREADER_SAMPLE(&gp_einfo->rr);
 #endif
 
@@ -1177,13 +1177,13 @@ int ABT_event_prof_publish(const char *unit_name, double local_work,
     sprintf(info,
             "{\"node\":\"%s\",\"sample\":\"%s\",\"time\":%lf,\"%s_per_sec_per_node\":%lf,"
             "\"%s_per_watt_per_node\":%lf,\"%s_per_sec\":%lf}\n",
-            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name, local_rate,
+            gp_einfo->hostname, sample_name, ABTI_get_wtime(), unit_name, local_rate,
             unit_name, local_work/power, unit_name, global_rate);
 #else
     sprintf(info,
             "{\"node\":\"%s\",\"sample\":\"%s\",\"time\":%lf,\"%s_per_sec_per_node\":%lf,"
             "\"%s_per_sec\":%lf}\n",
-            gp_einfo->hostname, sample_name, ABT_get_wtime(), unit_name, local_rate,
+            gp_einfo->hostname, sample_name, ABTI_get_wtime(), unit_name, local_rate,
             unit_name, global_rate);
 #endif
 

--- a/src/event.c
+++ b/src/event.c
@@ -356,7 +356,7 @@ static void ABTI_event_free_xstream(void *arg)
 
     abt_errno = ABT_xstream_join(xstream);
     ABTI_ASSERT(abt_errno == ABT_SUCCESS);
-    abt_errno = ABT_xstream_free(&xstream);
+    abt_errno = ABTI_xstream_free(p_xstream);
     ABTI_ASSERT(abt_errno == ABT_SUCCESS);
 
     if (gp_ABTI_global->pm_connected == ABT_TRUE) {
@@ -390,7 +390,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
         ABT_xstream xstream = ABTI_xstream_get_handle(p_xstream);
         abt_errno = ABT_xstream_join(xstream);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);
-        abt_errno = ABT_xstream_free(&xstream);
+        abt_errno = ABTI_xstream_free(p_xstream);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);
     }
     ABTU_free(p_xstreams);

--- a/src/event.c
+++ b/src/event.c
@@ -679,7 +679,9 @@ ABT_bool ABTI_event_check_power(void)
 
     if (gp_ABTI_global->pm_connected == ABT_FALSE) goto fn_exit;
 
-    ABT_xstream_self_rank(&rank);
+    p_xstream = ABTI_local_get_xstream();
+    ABTI_ASSERT(p_xstream);
+    rank = (int)p_xstream->rank;
 
     ret = ABTI_mutex_trylock(&gp_einfo->mutex);
     if (ret == ABT_ERR_MUTEX_LOCKED) goto fn_exit;

--- a/src/event.c
+++ b/src/event.c
@@ -437,8 +437,9 @@ ABT_bool ABTI_event_stop_xstream(ABTI_xstream *p_xstream)
         /* Create a ULT on the primary ES to join the target ES */
         primary = ABTI_xstream_get_handle(gp_ABTI_global->p_xstreams[0]);
         ABT_xstream_get_main_pools(primary, 1, &pool);
-        abt_errno = ABT_thread_create(pool, ABTI_event_free_xstream, xstream,
-                                      ABT_THREAD_ATTR_NULL, NULL);
+        ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+        abt_errno = ABTI_thread_create(p_pool, ABTI_event_free_xstream, xstream,
+                                       ABT_THREAD_ATTR_NULL, NULL);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);
     }
 
@@ -559,9 +560,11 @@ void ABTI_event_shrink_xstreams(int num_xstreams)
     xstream = ABTI_xstream_get_handle(gp_ABTI_global->p_xstreams[0]);
     ABT_xstream_get_main_pools(xstream, 1, &pool);
     p_xstreams[0] = (ABTI_xstream *)(intptr_t)n;
-    int abt_errno = ABT_thread_create(pool, ABTI_event_free_multiple_xstreams,
-                                      (void *)p_xstreams,
-                                      ABT_THREAD_ATTR_NULL, NULL);
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    int abt_errno;
+    abt_errno = ABTI_thread_create(p_pool, ABTI_event_free_multiple_xstreams,
+                                   (void *)p_xstreams, ABT_THREAD_ATTR_NULL,
+                                   NULL);
     ABTI_ASSERT(abt_errno == ABT_SUCCESS);
 }
 

--- a/src/event.c
+++ b/src/event.c
@@ -410,8 +410,7 @@ ABT_bool ABTI_event_stop_xstream(ABTI_xstream *p_xstream)
     ABT_bool can_stop = ABT_TRUE;
     ABT_event_cb_fn cb_fn;
     ABT_xstream xstream = ABTI_xstream_get_handle(p_xstream);
-    ABT_xstream primary;
-    ABT_pool pool;
+    ABTI_xstream *p_primary;
     int i;
 
     /* Ask whether the target ES can be stopped */
@@ -435,9 +434,8 @@ ABT_bool ABTI_event_stop_xstream(ABTI_xstream *p_xstream)
         }
 
         /* Create a ULT on the primary ES to join the target ES */
-        primary = ABTI_xstream_get_handle(gp_ABTI_global->p_xstreams[0]);
-        ABT_xstream_get_main_pools(primary, 1, &pool);
-        ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+        p_primary = gp_ABTI_global->p_xstreams[0];
+        ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_primary);
         abt_errno = ABTI_thread_create(p_pool, ABTI_event_free_xstream, xstream,
                                        ABT_THREAD_ATTR_NULL, NULL);
         ABTI_ASSERT(abt_errno == ABT_SUCCESS);
@@ -556,11 +554,9 @@ void ABTI_event_shrink_xstreams(int num_xstreams)
 
     /* Create a ULT on the primary ES to join the target ESs */
     /* NOTE: p_xstreams will be freed by the ULT. */
-    ABT_pool pool;
-    xstream = ABTI_xstream_get_handle(gp_ABTI_global->p_xstreams[0]);
-    ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ABTI_xstream *p_primary = gp_ABTI_global->p_xstreams[0];
     p_xstreams[0] = (ABTI_xstream *)(intptr_t)n;
-    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_primary);
     int abt_errno;
     abt_errno = ABTI_thread_create(p_pool, ABTI_event_free_multiple_xstreams,
                                    (void *)p_xstreams, ABT_THREAD_ATTR_NULL,

--- a/src/event.c
+++ b/src/event.c
@@ -345,7 +345,13 @@ static void ABTI_event_free_xstream(void *arg)
 
     while (ABTD_atomic_load_uint32((uint32_t *)p_xstream->state)
            != ABT_XSTREAM_STATE_TERMINATED) {
-        ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+            ABTD_atomic_pause();
+            continue;
+        }
+#endif
+        ABTI_thread_yield(ABTI_local_get_thread());
     }
 
     abt_errno = ABT_xstream_join(xstream);
@@ -372,7 +378,13 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
         ABTI_xstream *p_xstream = p_xstreams[n+1];
         while (ABTD_atomic_load_uint32((uint32_t *)p_xstream->state)
                != ABT_XSTREAM_STATE_TERMINATED) {
-            ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+            if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+                ABTD_atomic_pause();
+                continue;
+            }
+#endif
+            ABTI_thread_yield(ABTI_local_get_thread());
         }
 
         ABT_xstream xstream = ABTI_xstream_get_handle(p_xstream);

--- a/src/global.c
+++ b/src/global.c
@@ -117,7 +117,7 @@ int ABT_init(int argc, char **argv)
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_start_primary");
 
     if (gp_ABTI_global->print_config == ABT_TRUE) {
-        ABT_info_print_config(stdout);
+        ABTI_info_print_config(stdout);
     }
     ABTD_atomic_store_uint32(&g_ABTI_initialized, 1);
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -479,6 +479,12 @@ ABT_sched_def *ABTI_sched_get_prio_def(void);
 ABT_sched_def *ABTI_sched_get_randws_def(void);
 void ABTI_sched_finish(ABTI_sched *p_sched);
 void ABTI_sched_exit(ABTI_sched *p_sched);
+int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
+                      ABT_sched_config config, ABT_bool automatic,
+                      ABTI_sched **pp_newsched);
+int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
+                            ABT_pool *pools, ABT_sched_config config,
+                            ABTI_sched **pp_newsched);
 int ABTI_sched_free(ABTI_sched *p_sched);
 int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);
 ABTI_sched_kind ABTI_sched_get_kind(ABT_sched_def *def);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -513,6 +513,9 @@ int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source);
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
 
+/* Work Unit */
+void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
+
 /* User-level Thread (ULT)  */
 int   ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool);
 int   ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -598,6 +598,7 @@ void ABTI_event_publish_info(void);
 #endif
 
 /* Information */
+int ABTI_info_print_config(FILE *fp);
 void ABTI_info_check_print_all_thread_stacks(void);
 
 #include "abti_log.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -496,6 +496,11 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
                                   ABT_pool_access *access, ABT_bool *automatic);
 
 /* Pool */
+int ABTI_pool_create(ABT_pool_def *def, ABT_pool_config config,
+                     ABT_bool automatic, ABTI_pool **pp_newpool);
+int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
+                           ABT_bool automatic, ABTI_pool **pp_newpool);
+void ABTI_pool_free(ABTI_pool *p_pool);
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def);
 int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def);
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -459,6 +459,7 @@ int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
 int ABTI_xstream_start(ABTI_xstream *p_xstream);
 int ABTI_xstream_start_primary(ABTI_xstream *p_xstream, ABTI_thread *p_thread);
 int ABTI_xstream_free(ABTI_xstream *p_xstream);
+int ABTI_xstream_join(ABTI_xstream *p_xstream);
 void ABTI_xstream_schedule(void *p_arg);
 int ABTI_xstream_run_unit(ABTI_xstream *p_xstream, ABT_unit unit,
                           ABTI_pool *p_pool);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -477,6 +477,7 @@ ABT_sched_def *ABTI_sched_get_basic_def(void);
 ABT_sched_def *ABTI_sched_get_basic_wait_def(void);
 ABT_sched_def *ABTI_sched_get_prio_def(void);
 ABT_sched_def *ABTI_sched_get_randws_def(void);
+void ABTI_sched_finish(ABTI_sched *p_sched);
 void ABTI_sched_exit(ABTI_sched *p_sched);
 int ABTI_sched_free(ABTI_sched *p_sched);
 int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -477,6 +477,7 @@ ABT_sched_def *ABTI_sched_get_basic_def(void);
 ABT_sched_def *ABTI_sched_get_basic_wait_def(void);
 ABT_sched_def *ABTI_sched_get_prio_def(void);
 ABT_sched_def *ABTI_sched_get_randws_def(void);
+void ABTI_sched_exit(ABTI_sched *p_sched);
 int ABTI_sched_free(ABTI_sched *p_sched);
 int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);
 ABTI_sched_kind ABTI_sched_get_kind(ABT_sched_def *def);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -526,6 +526,9 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 
 /* User-level Thread (ULT)  */
 int   ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool);
+int   ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
+                         void *arg, ABTI_thread_attr *p_attr,
+                         ABTI_thread **pp_newthread);
 int   ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread);
 int   ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 int   ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched);

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -81,7 +81,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABT_thread_yield();
+            ABTI_thread_yield(ABTI_local_get_thread());
         }
         LOG_EVENT("%p: lock - acquired\n", p_mutex);
     } else {

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -77,8 +77,7 @@ static inline
 void ABTI_mutex_lock(ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
-    ABT_unit_type type;
-    ABT_self_get_type(&type);
+    ABT_unit_type type = ABTI_self_get_type();
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
@@ -90,11 +89,10 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     }
 #else
     int abt_errno;
-    ABT_unit_type type;
+    ABT_unit_type type = ABTI_self_get_type();
 
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
-    ABT_self_get_type(&type);
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
         int c;

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -255,5 +255,15 @@ size_t ABTI_pool_get_size(ABTI_pool *p_pool)
     return p_pool->p_get_size(ABTI_pool_get_handle(p_pool));
 }
 
+static inline
+size_t ABTI_pool_get_total_size(ABTI_pool *p_pool)
+{
+    size_t total_size;
+    total_size = ABTI_pool_get_size(p_pool);
+    total_size += p_pool->num_blocked;
+    total_size += p_pool->num_migrations;
+    return total_size;
+}
+
 #endif /* POOL_H_INCLUDED */
 

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -250,12 +250,6 @@ int32_t ABTI_pool_release(ABTI_pool *p_pool)
 }
 
 static inline
-void *ABTI_pool_get_data(ABTI_pool *p_pool)
-{
-    return p_pool->data;
-}
-
-static inline
 size_t ABTI_pool_get_size(ABTI_pool *p_pool)
 {
     return p_pool->p_get_size(ABTI_pool_get_handle(p_pool));

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -38,5 +38,27 @@ ABTI_unit *ABTI_self_get_unit(void)
     return p_unit;
 }
 
+static inline
+ABT_unit_type ABTI_self_get_type(void)
+{
+    ABTI_ASSERT(gp_ABTI_global);
+
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+    /* This is when an external thread called this routine. */
+    if (lp_ABTI_local == NULL) {
+        return ABT_UNIT_TYPE_EXT;
+    }
+#endif
+
+    if (ABTI_local_get_task() != NULL) {
+        return ABT_UNIT_TYPE_TASK;
+    } else {
+        /* Since ABTI_local_get_thread() can return NULL during executing
+         * ABTI_init(), it should always be safe to say that the type of caller
+         * is ULT if the control reaches here. */
+        return ABT_UNIT_TYPE_THREAD;
+    }
+}
+
 #endif /* SELF_H_INCLUDED */
 

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -123,6 +123,14 @@ void ABTI_xstream_push_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     p_xstream->scheds[p_xstream->num_scheds++] = p_sched;
 }
 
+/* Get the first pool of the main scheduler. */
+static inline
+ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
+{
+    ABT_pool pool = p_xstream->p_main_sched->pools[0];
+    return ABTI_pool_get_ptr(pool);
+}
+
 static inline
 void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
 {

--- a/src/include/abti_timer.h
+++ b/src/include/abti_timer.h
@@ -9,6 +9,14 @@
 /* Inlined functions for Timer */
 
 static inline
+double ABTI_get_wtime(void)
+{
+    ABTD_time t;
+    ABTD_time_get(&t);
+    return ABTD_time_read_sec(&t);
+}
+
+static inline
 ABTI_timer *ABTI_timer_get_ptr(ABT_timer timer)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK

--- a/src/info.c
+++ b/src/info.c
@@ -24,94 +24,7 @@
  */
 int ABT_info_print_config(FILE *fp)
 {
-    int abt_errno = ABT_SUCCESS;
-    ABTI_CHECK_INITIALIZED();
-
-    ABTI_global *p_global = gp_ABTI_global;
-
-    fprintf(fp, "Argobots Configuration:\n");
-    fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
-    fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
-    fprintf(fp, " - OS page size: %u\n", p_global->os_page_size);
-    fprintf(fp, " - huge page size: %u\n", p_global->huge_page_size);
-    fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
-    fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
-    fprintf(fp, " - ES affinity: %s\n",
-                (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
-    fprintf(fp, " - logging: %s\n",
-                (p_global->use_logging == ABT_TRUE) ? "on" : "off");
-    fprintf(fp, " - debug output: %s\n",
-                (p_global->use_debug == ABT_TRUE) ? "on" : "off");
-    fprintf(fp, " - key table entries: %d\n", p_global->key_table_size);
-    fprintf(fp, " - ULT stack size: %u KB\n",
-                (unsigned)(p_global->thread_stacksize / 1024));
-    fprintf(fp, " - scheduler stack size: %u KB\n",
-                (unsigned)(p_global->sched_stacksize / 1024));
-    fprintf(fp, " - scheduler event check frequency: %u\n",
-                p_global->sched_event_freq);
-
-    fprintf(fp, " - timer function: "
-#if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
-                "clock_gettime"
-#elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
-                "mach_absolute_time"
-#elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
-                "gettimeofday"
-#endif
-                "\n");
-
-#ifdef ABT_CONFIG_USE_MEM_POOL
-    fprintf(fp, "Memory Pool:\n");
-    fprintf(fp, " - page size for allocation: %u KB\n",
-                p_global->mem_page_size / 1024);
-    fprintf(fp, " - stack page size: %u KB\n", p_global->mem_sp_size / 1024);
-    fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
-    switch (p_global->mem_lp_alloc) {
-        case ABTI_MEM_LP_MALLOC:
-            fprintf(fp, " - large page allocation: malloc\n");
-            break;
-        case ABTI_MEM_LP_MMAP_RP:
-            fprintf(fp, " - large page allocation: mmap regular pages\n");
-            break;
-        case ABTI_MEM_LP_MMAP_HP_RP:
-            fprintf(fp, " - large page allocation: mmap huge pages + "
-                        "regular pages\n");
-            break;
-        case ABTI_MEM_LP_MMAP_HP_THP:
-            fprintf(fp, " - large page allocation: mmap huge pages + THPs\n");
-            break;
-        case ABTI_MEM_LP_THP:
-            fprintf(fp, " - large page allocation: THPs\n");
-            break;
-    }
-#endif /* ABT_CONFIG_USE_MEM_POOL */
-
-#if defined(ABT_CONFIG_HANDLE_POWER_EVENT) || defined(ABT_CONFIG_PUBLISH_INFO)
-    fprintf(fp, "Event:\n");
-
-#ifdef ABT_CONFIG_HANDLE_POWER_EVENT
-    fprintf(fp, " - pm daemon connected: %s\n",
-                (p_global->pm_connected == ABT_TRUE) ? "yes" : "no");
-    fprintf(fp, " - pm hostname: %s\n", p_global->pm_host);
-    fprintf(fp, " - pm port: %d\n", p_global->pm_port);
-#endif /* ABT_CONFIG_HANDLE_POWER_EVENT */
-
-#ifdef ABT_CONFIG_PUBLISH_INFO
-    fprintf(fp, " - publishing needed: %s\n",
-                (p_global->pub_needed == ABT_TRUE) ? "yes" : "no");
-    fprintf(fp, " - publishing filename: %s\n", p_global->pub_filename);
-    fprintf(fp, " - publishing interval: %lf sec.\n", p_global->pub_interval);
-#endif /* ABT_CONFIG_PUBLISH_INFO */
-#endif
-
-    fflush(fp);
-
-  fn_exit:
-    return abt_errno;
-
-  fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABTI_info_print_config(fp);
 }
 
 
@@ -618,4 +531,96 @@ void ABTI_info_check_print_all_thread_stacks(void)
         /* The last execution stream resets the flag. */
         ABTD_atomic_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_UNSET);
     }
+}
+
+int ABTI_info_print_config(FILE *fp)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_CHECK_INITIALIZED();
+
+    ABTI_global *p_global = gp_ABTI_global;
+
+    fprintf(fp, "Argobots Configuration:\n");
+    fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
+    fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
+    fprintf(fp, " - OS page size: %u\n", p_global->os_page_size);
+    fprintf(fp, " - huge page size: %u\n", p_global->huge_page_size);
+    fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
+    fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
+    fprintf(fp, " - ES affinity: %s\n",
+                (p_global->set_affinity == ABT_TRUE) ? "on" : "off");
+    fprintf(fp, " - logging: %s\n",
+                (p_global->use_logging == ABT_TRUE) ? "on" : "off");
+    fprintf(fp, " - debug output: %s\n",
+                (p_global->use_debug == ABT_TRUE) ? "on" : "off");
+    fprintf(fp, " - key table entries: %d\n", p_global->key_table_size);
+    fprintf(fp, " - ULT stack size: %u KB\n",
+                (unsigned)(p_global->thread_stacksize / 1024));
+    fprintf(fp, " - scheduler stack size: %u KB\n",
+                (unsigned)(p_global->sched_stacksize / 1024));
+    fprintf(fp, " - scheduler event check frequency: %u\n",
+                p_global->sched_event_freq);
+
+    fprintf(fp, " - timer function: "
+#if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
+                "clock_gettime"
+#elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
+                "mach_absolute_time"
+#elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
+                "gettimeofday"
+#endif
+                "\n");
+
+#ifdef ABT_CONFIG_USE_MEM_POOL
+    fprintf(fp, "Memory Pool:\n");
+    fprintf(fp, " - page size for allocation: %u KB\n",
+                p_global->mem_page_size / 1024);
+    fprintf(fp, " - stack page size: %u KB\n", p_global->mem_sp_size / 1024);
+    fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
+    switch (p_global->mem_lp_alloc) {
+        case ABTI_MEM_LP_MALLOC:
+            fprintf(fp, " - large page allocation: malloc\n");
+            break;
+        case ABTI_MEM_LP_MMAP_RP:
+            fprintf(fp, " - large page allocation: mmap regular pages\n");
+            break;
+        case ABTI_MEM_LP_MMAP_HP_RP:
+            fprintf(fp, " - large page allocation: mmap huge pages + "
+                        "regular pages\n");
+            break;
+        case ABTI_MEM_LP_MMAP_HP_THP:
+            fprintf(fp, " - large page allocation: mmap huge pages + THPs\n");
+            break;
+        case ABTI_MEM_LP_THP:
+            fprintf(fp, " - large page allocation: THPs\n");
+            break;
+    }
+#endif /* ABT_CONFIG_USE_MEM_POOL */
+
+#if defined(ABT_CONFIG_HANDLE_POWER_EVENT) || defined(ABT_CONFIG_PUBLISH_INFO)
+    fprintf(fp, "Event:\n");
+
+#ifdef ABT_CONFIG_HANDLE_POWER_EVENT
+    fprintf(fp, " - pm daemon connected: %s\n",
+                (p_global->pm_connected == ABT_TRUE) ? "yes" : "no");
+    fprintf(fp, " - pm hostname: %s\n", p_global->pm_host);
+    fprintf(fp, " - pm port: %d\n", p_global->pm_port);
+#endif /* ABT_CONFIG_HANDLE_POWER_EVENT */
+
+#ifdef ABT_CONFIG_PUBLISH_INFO
+    fprintf(fp, " - publishing needed: %s\n",
+                (p_global->pub_needed == ABT_TRUE) ? "yes" : "no");
+    fprintf(fp, " - publishing filename: %s\n", p_global->pub_filename);
+    fprintf(fp, " - publishing interval: %lf sec.\n", p_global->pub_interval);
+#endif /* ABT_CONFIG_PUBLISH_INFO */
+#endif
+
+    fflush(fp);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }

--- a/src/info.c
+++ b/src/info.c
@@ -556,13 +556,13 @@ void ABTI_info_check_print_all_thread_stacks(void)
     uint32_t self_value = ABTD_atomic_fetch_add_uint32(&print_stack_barrier, 1);
     if (self_value == 0) {
         /* This ES becomes a master. */
-        double start_time = ABT_get_wtime();
+        double start_time = ABTI_get_wtime();
         ABT_bool force_print = ABT_FALSE;
         while (ABTD_atomic_load_uint32(&print_stack_barrier)
                < ABTD_atomic_load_int32(&gp_ABTI_global->num_xstreams)) {
             ABTD_atomic_pause();
             if (print_stack_timeout >= 0.0
-                && (ABT_get_wtime() - start_time) >= print_stack_timeout) {
+                && (ABTI_get_wtime() - start_time) >= print_stack_timeout) {
                 force_print = ABT_TRUE;
                 break;
             }

--- a/src/info.c
+++ b/src/info.c
@@ -303,7 +303,7 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
                     "stacksize : %" PRIu64 "\n",
                     p_thread->attr.p_stack,
                     (uint64_t)p_thread->attr.stacksize);
-        int abt_errno = ABT_info_print_thread_stack(fp, thread);
+        int abt_errno = ABTI_thread_print_stack(p_thread, fp);
         if (abt_errno != ABT_SUCCESS)
             fprintf(fp, "Failed to print stack.\n");
     } else if (type == ABT_UNIT_TYPE_TASK) {

--- a/src/log.c
+++ b/src/log.c
@@ -37,7 +37,7 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
 
-    ABT_unit_type type;
+    ABT_unit_type type = ABTI_self_get_type();
     ABTI_xstream *p_xstream = NULL;
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;
@@ -48,7 +48,6 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
     int tid_len = 0, rank_len = 0;
     size_t newfmt_len;
 
-    ABT_self_get_type(&type);
     switch (type) {
         case ABT_UNIT_TYPE_THREAD:
             p_xstream = ABTI_local_get_xstream();

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -181,7 +181,7 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock_low - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABT_thread_yield();
+            ABTI_thread_yield(ABTI_local_get_thread());
         }
         LOG_EVENT("%p: lock_low - acquired\n", p_mutex);
     } else {
@@ -464,7 +464,12 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTD_atomic_store_uint32(&p_mutex->val, 0);
     LOG_EVENT("%p: unlock_se\n", p_mutex);
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+    if (ABTI_self_get_type() == ABT_UNIT_TYPE_THREAD)
+        ABTI_thread_yield(ABTI_local_get_thread());
+#else
     ABTI_thread_yield(ABTI_local_get_thread());
+#endif
 #else
     int i;
     ABTI_xstream *p_xstream;
@@ -477,7 +482,12 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
      * waiter in the mutex queue.  We can just return. */
     if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1) == 1) {
         LOG_EVENT("%p: unlock_se\n", p_mutex);
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() == ABT_UNIT_TYPE_THREAD)
+            ABTI_thread_yield(ABTI_local_get_thread());
+#else
         ABTI_thread_yield(ABTI_local_get_thread());
+#endif
         return abt_errno;
     }
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -177,8 +177,7 @@ static inline
 void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
-    ABT_unit_type type;
-    ABT_self_get_type(&type);
+    ABT_unit_type type = ABTI_self_get_type();
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock_low - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
@@ -190,11 +189,10 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
     }
 #else
     int abt_errno;
-    ABT_unit_type type;
+    ABT_unit_type type = ABTI_self_get_type();
 
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
-    ABT_self_get_type(&type);
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock_low - try\n", p_mutex);
         int c;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -95,11 +95,7 @@ int ABT_pool_free(ABT_pool *pool)
     ABTI_pool *p_pool = ABTI_pool_get_ptr(h_pool);
 
     ABTI_CHECK_TRUE(p_pool != NULL && h_pool != ABT_POOL_NULL, ABT_ERR_INV_POOL);
-
-    LOG_EVENT("[P%" PRIu64 "] freed\n", p_pool->id);
-
-    p_pool->p_free(h_pool);
-    ABTU_free(p_pool);
+    ABTI_pool_free(p_pool);
 
     *pool = ABT_POOL_NULL;
 
@@ -624,6 +620,14 @@ int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
   fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
+}
+
+void ABTI_pool_free(ABTI_pool *p_pool)
+{
+    LOG_EVENT("[P%" PRIu64 "] freed\n", p_pool->id);
+    ABT_pool h_pool = ABTI_pool_get_handle(p_pool);
+    p_pool->p_free(h_pool);
+    ABTU_free(p_pool);
 }
 
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -462,7 +462,7 @@ int ABT_pool_get_data(ABT_pool pool, void **data)
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    *data = ABTI_pool_get_data(p_pool);
+    *data = p_pool->data;
 
   fn_exit:
     return abt_errno;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -207,15 +207,11 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 {
     int abt_errno = ABT_SUCCESS;
-    size_t total_size;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    total_size = ABTI_pool_get_size(p_pool);
-    total_size += p_pool->num_blocked;
-    total_size += p_pool->num_migrations;
-    *size = total_size;
+    *size = ABTI_pool_get_total_size(p_pool);
 
   fn_exit:
     return abt_errno;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -63,7 +63,8 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 #endif
 
     /* Set the variables from the config */
-    ABT_sched_config_read(config, 1, &p_data->event_freq);
+    void *p_event_freq = &p_data->event_freq;
+    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -150,7 +150,7 @@ static int pool_get_access_num(ABT_pool *p_pool)
     ABT_pool_access access;
     int num = 0;
 
-    ABT_pool_get_access(*p_pool, &access);
+    access = ABTI_pool_get_ptr(*p_pool)->access;
     switch (access) {
         case ABT_POOL_ACCESS_PRIV: num = 0; break;
         case ABT_POOL_ACCESS_SPSC:

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -51,6 +51,9 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     int abt_errno = ABT_SUCCESS;
     int num_pools;
 
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+
     /* Default settings */
     sched_data *p_data = (sched_data *)ABTU_malloc(sizeof(sched_data));
     p_data->event_freq = ABTI_global_get_sched_event_freq();
@@ -63,11 +66,10 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABT_sched_config_read(config, 1, &p_data->event_freq);
 
     /* Save the list of pools */
-    ABT_sched_get_num_pools(sched, &num_pools);
+    num_pools = p_sched->num_pools;
     p_data->num_pools = num_pools;
     p_data->pools = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
-    abt_errno = ABT_sched_get_pools(sched, num_pools, 0, p_data->pools);
-    ABTI_CHECK_ERROR(abt_errno);
+    memcpy(p_data->pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
     /* Sort pools according to their access mode so the scheduler can execute
        work units from the private pools. */
@@ -75,7 +77,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
         sched_sort_pools(num_pools, p_data->pools);
     }
 
-    abt_errno = ABT_sched_set_data(sched, (void *)p_data);
+    p_sched->data = p_data;
 
   fn_exit:
     return abt_errno;
@@ -88,7 +90,6 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 static void sched_run(ABT_sched sched)
 {
     uint32_t work_count = 0;
-    void *data;
     sched_data *p_data;
     uint32_t event_freq;
     int num_pools;
@@ -98,9 +99,9 @@ static void sched_run(ABT_sched sched)
 
     ABTI_xstream *p_xstream = ABTI_local_get_xstream();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_ASSERT(p_sched);
 
-    ABT_sched_get_data(sched, &data);
-    p_data = sched_data_get_ptr(data);
+    p_data = sched_data_get_ptr(p_sched->data);
     event_freq = p_data->event_freq;
     num_pools  = p_data->num_pools;
     pools      = p_data->pools;
@@ -134,15 +135,13 @@ static void sched_run(ABT_sched sched)
 
 static int sched_free(ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_ASSERT(p_sched);
 
-    void *data;
-
-    ABT_sched_get_data(sched, &data);
-    sched_data *p_data = sched_data_get_ptr(data);
+    sched_data *p_data = sched_data_get_ptr(p_sched->data);
     ABTU_free(p_data->pools);
     ABTU_free(p_data);
-    return abt_errno;
+    return ABT_SUCCESS;
 }
 
 static int pool_get_access_num(ABT_pool *p_pool)

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -56,7 +56,8 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     p_data->event_freq = ABTI_global_get_sched_event_freq();
 
     /* Set the variables from the config */
-    ABT_sched_config_read(config, 1, &p_data->event_freq);
+    void *p_event_freq = &p_data->event_freq;
+    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -118,7 +118,7 @@ static void sched_run(ABT_sched sched)
          * main loop above.
          */
         if(!run_cnt_nowait) {
-            double abstime = ABT_get_wtime();
+            double abstime = ABTI_get_wtime();
             abstime += 0.1;
             ABT_unit unit = ABTI_pool_pop_timedwait(
                 ABTI_pool_get_ptr(pools[0]), abstime);

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -163,7 +163,7 @@ static int pool_get_access_num(ABT_pool *p_pool)
     ABT_pool_access access;
     int num = 0;
 
-    ABT_pool_get_access(*p_pool, &access);
+    access = ABTI_pool_get_ptr(*p_pool)->access;
     switch (access) {
         case ABT_POOL_ACCESS_PRIV: num = 0; break;
         case ABT_POOL_ACCESS_SPSC:

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -54,7 +54,8 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 #endif
 
     /* Set the variables from the config */
-    ABT_sched_config_read(config, 1, &p_data->event_freq);
+    void *p_event_freq = &p_data->event_freq;
+    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
 
     p_sched->data = p_data;
 

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -42,6 +42,9 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
     int abt_errno = ABT_SUCCESS;
 
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+
     /* Default settings */
     sched_data *p_data = (sched_data *)ABTU_malloc(sizeof(sched_data));
     p_data->event_freq = ABTI_global_get_sched_event_freq();
@@ -53,8 +56,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     /* Set the variables from the config */
     ABT_sched_config_read(config, 1, &p_data->event_freq);
 
-    abt_errno = ABT_sched_set_data(sched, (void *)p_data);
-    ABTI_CHECK_ERROR(abt_errno);
+    p_sched->data = p_data;
 
   fn_exit:
     return abt_errno;
@@ -67,7 +69,6 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 static void sched_run(ABT_sched sched)
 {
     uint32_t work_count = 0;
-    void *data;
     sched_data *p_data;
     uint32_t event_freq;
     int num_pools;
@@ -77,15 +78,15 @@ static void sched_run(ABT_sched sched)
 
     ABTI_xstream *p_xstream = ABTI_local_get_xstream();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_ASSERT(p_sched);
 
-    ABT_sched_get_data(sched, &data);
-    p_data = sched_data_get_ptr(data);
+    p_data = sched_data_get_ptr(p_sched->data);
     event_freq = p_data->event_freq;
 
     /* Get the list of pools */
-    ABT_sched_get_num_pools(sched, &num_pools);
+    num_pools = p_sched->num_pools;
     p_pools = (ABT_pool *)ABTU_malloc(num_pools * sizeof(ABT_pool));
-    ABT_sched_get_pools(sched, num_pools, 0, p_pools);
+    memcpy(p_pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
     while (1) {
         CNT_INIT(run_cnt, 0);
@@ -117,14 +118,12 @@ static void sched_run(ABT_sched sched)
 
 static int sched_free(ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
-    void *data;
-    sched_data *p_data;
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_ASSERT(p_sched);
 
-    ABT_sched_get_data(sched, &data);
-    p_data = sched_data_get_ptr(data);
+    sched_data *p_data = sched_data_get_ptr(p_sched->data);
     ABTU_free(p_data);
 
-    return abt_errno;
+    return ABT_SUCCESS;
 }
 

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -94,7 +94,7 @@ static void sched_run(ABT_sched sched)
             unit = ABTI_pool_pop(p_pool);
             LOG_EVENT_POOL_POP(p_pool, unit);
             if (unit != ABT_UNIT_NULL) {
-                ABT_unit_set_associated_pool(unit, pool);
+                ABTI_unit_set_associated_pool(unit, p_pool);
                 ABTI_xstream_run_unit(p_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
             }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -47,7 +47,8 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 #endif
 
     /* Set the variables from the config */
-    ABT_sched_config_read(config, 1, &p_data->event_freq);
+    void *p_event_freq = &p_data->event_freq;
+    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
 
     p_sched->data = p_data;
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -50,10 +50,12 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
     for (p = 0; p < num_pools; p++) {
         if (pools[p] == ABT_POOL_NULL) {
-            abt_errno = ABT_pool_create_basic(ABT_POOL_FIFO,
-                                              ABT_POOL_ACCESS_MPSC,
-                                              ABT_TRUE, &pool_list[p]);
+            ABTI_pool *p_newpool;
+            abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
+                                               ABT_POOL_ACCESS_MPSC,
+                                               ABT_TRUE, &p_newpool);
             ABTI_CHECK_ERROR(abt_errno);
+            pool_list[p] = ABTI_pool_get_handle(p_newpool);
         } else {
             pool_list[p] = pools[p];
         }
@@ -156,9 +158,12 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
         pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
         for (p = 0; p < num_pools; p++) {
             if (pools[p] == ABT_POOL_NULL) {
-                abt_errno = ABT_pool_create_basic(ABT_POOL_FIFO, access,
-                                                  ABT_TRUE, &pool_list[p]);
+                ABTI_pool *p_newpool;
+                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
+                                                   ABT_POOL_ACCESS_MPSC,
+                                                   ABT_TRUE, &p_newpool);
                 ABTI_CHECK_ERROR(abt_errno);
+                pool_list[p] = ABTI_pool_get_handle(p_newpool);
             } else {
                 pool_list[p] = pools[p];
             }
@@ -229,9 +234,11 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
         ABT_pool pool_list[ABTI_SCHED_NUM_PRIO];
         int p;
         for (p = 0; p < num_pools; p++) {
-            abt_errno = ABT_pool_create_basic(kind, access, ABT_TRUE,
-                                              pool_list+p);
+            ABTI_pool *p_newpool;
+            abt_errno = ABTI_pool_create_basic(kind, access, ABT_TRUE,
+                                               &p_newpool);
             ABTI_CHECK_ERROR(abt_errno);
+            pool_list[p] = ABTI_pool_get_handle(p_newpool);
         }
 
         /* Creation of the scheduler */

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -614,10 +614,8 @@ size_t ABTI_sched_get_size(ABTI_sched *p_sched)
     int p;
 
     for (p = 0; p < p_sched->num_pools; p++) {
-        size_t s;
-        ABT_pool pool = p_sched->pools[p];
-        ABT_pool_get_size(pool, &s);
-        pool_size += s;
+        ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
+        pool_size += ABTI_pool_get_size(p_pool);
     }
 
     return pool_size;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -400,7 +400,7 @@ int ABT_sched_finish(ABT_sched sched)
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_FINISH);
+    ABTI_sched_finish(p_sched);
 
   fn_exit:
     return abt_errno;
@@ -719,6 +719,11 @@ size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/
+
+void ABTI_sched_finish(ABTI_sched *p_sched)
+{
+    ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_FINISH);
+}
 
 void ABTI_sched_exit(ABTI_sched *p_sched)
 {

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -427,7 +427,7 @@ int ABT_sched_exit(ABT_sched sched)
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_EXIT);
+    ABTI_sched_exit(p_sched);
 
   fn_exit:
     return abt_errno;
@@ -719,6 +719,11 @@ size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/
+
+void ABTI_sched_exit(ABTI_sched *p_sched)
+{
+    ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_EXIT);
+}
 
 int ABTI_sched_free(ABTI_sched *p_sched)
 {

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -657,10 +657,8 @@ size_t ABTI_sched_get_total_size(ABTI_sched *p_sched)
     int p;
 
     for (p = 0; p < p_sched->num_pools; p++) {
-        size_t s;
-        ABT_pool pool = p_sched->pools[p];
-        ABT_pool_get_total_size(pool, &s);
-        pool_size += s;
+        ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
+        pool_size += ABTI_pool_get_total_size(p_pool);
     }
 
     return pool_size;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -737,8 +737,9 @@ int ABTI_sched_free(ABTI_sched *p_sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         int32_t num_scheds = ABTI_pool_release(p_pool);
         if (p_pool->automatic == ABT_TRUE && num_scheds == 0) {
-            abt_errno = ABT_pool_free(p_sched->pools+p);
-            ABTI_CHECK_ERROR(abt_errno);
+            ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
+            ABTI_CHECK_NULL_POOL_PTR(p_pool);
+            ABTI_pool_free(p_pool);
         }
     }
     ABTU_free(p_sched->pools);

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -39,60 +39,14 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_sched;
-    int p;
 
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
-
-    p_sched = (ABTI_sched *)ABTU_malloc(sizeof(ABTI_sched));
-
-    /* Copy of the contents of pools */
-    ABT_pool *pool_list;
-    pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
-    for (p = 0; p < num_pools; p++) {
-        if (pools[p] == ABT_POOL_NULL) {
-            ABTI_pool *p_newpool;
-            abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
-                                               ABT_POOL_ACCESS_MPSC,
-                                               ABT_TRUE, &p_newpool);
-            ABTI_CHECK_ERROR(abt_errno);
-            pool_list[p] = ABTI_pool_get_handle(p_newpool);
-        } else {
-            pool_list[p] = pools[p];
-        }
-    }
-
-    /* Check if the pools are available */
-    for (p = 0; p < num_pools; p++) {
-        ABTI_pool_retain(ABTI_pool_get_ptr(pool_list[p]));
-    }
-
-    p_sched->used          = ABTI_SCHED_NOT_USED;
-    p_sched->automatic     = ABT_FALSE;
-    p_sched->kind          = ABTI_sched_get_kind(def);
-    p_sched->state         = ABT_SCHED_STATE_READY;
-    p_sched->request       = 0;
-    p_sched->pools         = pool_list;
-    p_sched->num_pools     = num_pools;
-    p_sched->type          = def->type;
-    p_sched->p_thread      = NULL;
-    p_sched->p_task        = NULL;
-    p_sched->p_ctx         = NULL;
-
-    p_sched->init          = def->init;
-    p_sched->run           = def->run;
-    p_sched->free          = def->free;
-    p_sched->get_migr_pool = def->get_migr_pool;
-
-#ifdef ABT_CONFIG_USE_DEBUG_LOG
-    p_sched->id            = ABTI_sched_get_new_id();
-#endif
-    LOG_EVENT("[S%" PRIu64 "] created\n", p_sched->id);
+    abt_errno = ABTI_sched_create(def, num_pools, pools, config, ABT_FALSE,
+                                  &p_sched);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
     *newsched = ABTI_sched_get_handle(p_sched);
-
-    /* Specific initialization */
-    p_sched->init(*newsched, config);
 
   fn_exit:
     return abt_errno;
@@ -139,141 +93,11 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                            ABT_sched *newsched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_pool_access access;
-    ABT_pool_kind kind = ABT_POOL_FIFO;
-    ABT_bool automatic;
-    int p;
-
-    /* We set the access to the default one */
-    access = ABT_POOL_ACCESS_MPSC;
-    automatic = ABT_TRUE;;
-    /* We read the config and set the configured parameters */
-    abt_errno = ABTI_sched_config_read_global(config, &access, &automatic);
+    ABTI_sched *p_newsched;
+    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools, config,
+                                        &p_newsched);
     ABTI_CHECK_ERROR(abt_errno);
-
-    /* A pool array is provided, predef has to be compatible */
-    if (pools != NULL) {
-        /* Copy of the contents of pools */
-        ABT_pool *pool_list;
-        pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
-        for (p = 0; p < num_pools; p++) {
-            if (pools[p] == ABT_POOL_NULL) {
-                ABTI_pool *p_newpool;
-                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
-                                                   ABT_POOL_ACCESS_MPSC,
-                                                   ABT_TRUE, &p_newpool);
-                ABTI_CHECK_ERROR(abt_errno);
-                pool_list[p] = ABTI_pool_get_handle(p_newpool);
-            } else {
-                pool_list[p] = pools[p];
-            }
-        }
-
-        /* Creation of the scheduler */
-        switch (predef) {
-            case ABT_SCHED_DEFAULT:
-            case ABT_SCHED_BASIC:
-                abt_errno = ABT_sched_create(ABTI_sched_get_basic_def(),
-                                             num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
-                break;
-            case ABT_SCHED_BASIC_WAIT:
-                abt_errno = ABT_sched_create(ABTI_sched_get_basic_wait_def(),
-                                             num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
-                break;
-            case ABT_SCHED_PRIO:
-                abt_errno = ABT_sched_create(ABTI_sched_get_prio_def(),
-                                             num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
-                break;
-            case ABT_SCHED_RANDWS:
-                abt_errno = ABT_sched_create(ABTI_sched_get_randws_def(),
-                                             num_pools, pool_list,
-                                             ABT_SCHED_CONFIG_NULL,
-                                             newsched);
-                break;
-            default:
-                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
-                break;
-        }
-        ABTI_CHECK_ERROR(abt_errno);
-        ABTU_free(pool_list);
-    }
-
-    /* No pool array is provided, predef has to be compatible */
-    else {
-        /* Set the number of pools */
-        switch (predef) {
-            case ABT_SCHED_DEFAULT:
-            case ABT_SCHED_BASIC:
-                num_pools = 1;
-                break;
-            case ABT_SCHED_BASIC_WAIT:
-                /* FIFO_WAIT is default pool for use with BASIC_WAIT sched */
-                kind = ABT_POOL_FIFO_WAIT;
-                num_pools = 1;
-                break;
-            case ABT_SCHED_PRIO:
-                num_pools = ABTI_SCHED_NUM_PRIO;
-                break;
-            case ABT_SCHED_RANDWS:
-                num_pools = 1;
-                break;
-            default:
-                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
-                ABTI_CHECK_ERROR(abt_errno);
-                break;
-        }
-
-        /* Creation of the pools */
-        /* To avoid the malloc overhead, we use a stack array. */
-        ABT_pool pool_list[ABTI_SCHED_NUM_PRIO];
-        int p;
-        for (p = 0; p < num_pools; p++) {
-            ABTI_pool *p_newpool;
-            abt_errno = ABTI_pool_create_basic(kind, access, ABT_TRUE,
-                                               &p_newpool);
-            ABTI_CHECK_ERROR(abt_errno);
-            pool_list[p] = ABTI_pool_get_handle(p_newpool);
-        }
-
-        /* Creation of the scheduler */
-        switch (predef) {
-            case ABT_SCHED_DEFAULT:
-            case ABT_SCHED_BASIC:
-                abt_errno = ABT_sched_create(ABTI_sched_get_basic_def(),
-                                             num_pools, pool_list,
-                                             config, newsched);
-                break;
-            case ABT_SCHED_BASIC_WAIT:
-                abt_errno = ABT_sched_create(ABTI_sched_get_basic_wait_def(),
-                                             num_pools, pool_list,
-                                             config, newsched);
-                break;
-            case ABT_SCHED_PRIO:
-                abt_errno = ABT_sched_create(ABTI_sched_get_prio_def(),
-                                             num_pools, pool_list,
-                                             config, newsched);
-                break;
-            case ABT_SCHED_RANDWS:
-                abt_errno = ABT_sched_create(ABTI_sched_get_randws_def(),
-                                             num_pools, pool_list,
-                                             config, newsched);
-                break;
-            default:
-                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
-                ABTI_CHECK_ERROR(abt_errno);
-                break;
-        }
-    }
-    ABTI_CHECK_ERROR(abt_errno);
-
-    ABTI_sched *p_sched = ABTI_sched_get_ptr(*newsched);
-    p_sched->automatic = automatic;
+    *newsched = ABTI_sched_get_handle(p_newsched);
 
   fn_exit:
     return abt_errno;
@@ -728,6 +552,219 @@ void ABTI_sched_finish(ABTI_sched *p_sched)
 void ABTI_sched_exit(ABTI_sched *p_sched)
 {
     ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_EXIT);
+}
+
+int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
+                      ABT_sched_config config, ABT_bool automatic,
+                      ABTI_sched **pp_newsched)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_sched *p_sched;
+    int p;
+
+    p_sched = (ABTI_sched *)ABTU_malloc(sizeof(ABTI_sched));
+
+    /* Copy of the contents of pools */
+    ABT_pool *pool_list;
+    pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+    for (p = 0; p < num_pools; p++) {
+        if (pools[p] == ABT_POOL_NULL) {
+            ABTI_pool *p_newpool;
+            abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO,
+                                              ABT_POOL_ACCESS_MPSC,
+                                              ABT_TRUE, &p_newpool);
+            ABTI_CHECK_ERROR(abt_errno);
+            pool_list[p] = ABTI_pool_get_handle(p_newpool);
+        } else {
+            pool_list[p] = pools[p];
+        }
+    }
+
+    /* Check if the pools are available */
+    for (p = 0; p < num_pools; p++) {
+        ABTI_pool_retain(ABTI_pool_get_ptr(pool_list[p]));
+    }
+
+    p_sched->used          = ABTI_SCHED_NOT_USED;
+    p_sched->automatic     = automatic;
+    p_sched->kind          = ABTI_sched_get_kind(def);
+    p_sched->state         = ABT_SCHED_STATE_READY;
+    p_sched->request       = 0;
+    p_sched->pools         = pool_list;
+    p_sched->num_pools     = num_pools;
+    p_sched->type          = def->type;
+    p_sched->p_thread      = NULL;
+    p_sched->p_task        = NULL;
+    p_sched->p_ctx         = NULL;
+
+    p_sched->init          = def->init;
+    p_sched->run           = def->run;
+    p_sched->free          = def->free;
+    p_sched->get_migr_pool = def->get_migr_pool;
+
+#ifdef ABT_CONFIG_USE_DEBUG_LOG
+    p_sched->id            = ABTI_sched_get_new_id();
+#endif
+    LOG_EVENT("[S%" PRIu64 "] created\n", p_sched->id);
+
+    /* Return value */
+    ABT_sched newsched = ABTI_sched_get_handle(p_sched);
+
+    /* Specific initialization */
+    p_sched->init(newsched, config);
+    *pp_newsched = p_sched;
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
+                            ABT_pool *pools, ABT_sched_config config,
+                            ABTI_sched **pp_newsched)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABT_pool_access access;
+    ABT_pool_kind kind = ABT_POOL_FIFO;
+    ABT_bool automatic;
+    int p;
+
+    /* We set the access to the default one */
+    access = ABT_POOL_ACCESS_MPSC;
+    automatic = ABT_TRUE;;
+    /* We read the config and set the configured parameters */
+    abt_errno = ABTI_sched_config_read_global(config, &access, &automatic);
+    ABTI_CHECK_ERROR(abt_errno);
+
+    /* A pool array is provided, predef has to be compatible */
+    if (pools != NULL) {
+        /* Copy of the contents of pools */
+        ABT_pool *pool_list;
+        pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+        for (p = 0; p < num_pools; p++) {
+            if (pools[p] == ABT_POOL_NULL) {
+                ABTI_pool *p_newpool;
+                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO, access,
+                                                   ABT_TRUE, &p_newpool);
+                ABTI_CHECK_ERROR(abt_errno);
+                pool_list[p] = ABTI_pool_get_handle(p_newpool);
+            } else {
+                pool_list[p] = pools[p];
+            }
+        }
+
+        /* Creation of the scheduler */
+        switch (predef) {
+            case ABT_SCHED_DEFAULT:
+            case ABT_SCHED_BASIC:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_basic_def(),
+                                              num_pools, pool_list,
+                                              ABT_SCHED_CONFIG_NULL,
+                                              automatic, pp_newsched);
+                break;
+            case ABT_SCHED_BASIC_WAIT:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_basic_wait_def(),
+                                              num_pools, pool_list,
+                                              ABT_SCHED_CONFIG_NULL,
+                                              automatic, pp_newsched);
+                break;
+            case ABT_SCHED_PRIO:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_prio_def(),
+                                              num_pools, pool_list,
+                                              ABT_SCHED_CONFIG_NULL,
+                                              automatic, pp_newsched);
+                break;
+            case ABT_SCHED_RANDWS:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_randws_def(),
+                                              num_pools, pool_list,
+                                              ABT_SCHED_CONFIG_NULL,
+                                              automatic, pp_newsched);
+                break;
+            default:
+                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
+                break;
+        }
+        ABTI_CHECK_ERROR(abt_errno);
+        ABTU_free(pool_list);
+    }
+
+    /* No pool array is provided, predef has to be compatible */
+    else {
+        /* Set the number of pools */
+        switch (predef) {
+            case ABT_SCHED_DEFAULT:
+            case ABT_SCHED_BASIC:
+                num_pools = 1;
+                break;
+            case ABT_SCHED_BASIC_WAIT:
+                /* FIFO_WAIT is default pool for use with BASIC_WAIT sched */
+                kind = ABT_POOL_FIFO_WAIT;
+                num_pools = 1;
+                break;
+            case ABT_SCHED_PRIO:
+                num_pools = ABTI_SCHED_NUM_PRIO;
+                break;
+            case ABT_SCHED_RANDWS:
+                num_pools = 1;
+                break;
+            default:
+                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
+                ABTI_CHECK_ERROR(abt_errno);
+                break;
+        }
+
+        /* Creation of the pools */
+        /* To avoid the malloc overhead, we use a stack array. */
+        ABT_pool pool_list[ABTI_SCHED_NUM_PRIO];
+        int p;
+        for (p = 0; p < num_pools; p++) {
+            ABTI_pool *p_newpool;
+            abt_errno = ABTI_pool_create_basic(kind, access, ABT_TRUE,
+                                               &p_newpool);
+            ABTI_CHECK_ERROR(abt_errno);
+            pool_list[p] = ABTI_pool_get_handle(p_newpool);
+        }
+
+        /* Creation of the scheduler */
+        switch (predef) {
+            case ABT_SCHED_DEFAULT:
+            case ABT_SCHED_BASIC:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_basic_def(),
+                                              num_pools, pool_list,
+                                              config, automatic, pp_newsched);
+                break;
+            case ABT_SCHED_BASIC_WAIT:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_basic_wait_def(),
+                                              num_pools, pool_list,
+                                              config, automatic, pp_newsched);
+                break;
+            case ABT_SCHED_PRIO:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_prio_def(),
+                                              num_pools, pool_list,
+                                              config, automatic, pp_newsched);
+                break;
+            case ABT_SCHED_RANDWS:
+                abt_errno = ABTI_sched_create(ABTI_sched_get_randws_def(),
+                                              num_pools, pool_list,
+                                              config, automatic, pp_newsched);
+                break;
+            default:
+                abt_errno = ABT_ERR_INV_SCHED_PREDEF;
+                ABTI_CHECK_ERROR(abt_errno);
+                break;
+        }
+    }
+    ABTI_CHECK_ERROR(abt_errno);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 int ABTI_sched_free(ABTI_sched *p_sched)

--- a/src/self.c
+++ b/src/self.c
@@ -41,23 +41,14 @@ int ABT_self_get_type(ABT_unit_type *type)
         goto fn_exit;
     }
 
+    *type = ABTI_self_get_type();
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (*type == ABT_UNIT_TYPE_EXT) {
         abt_errno = ABT_ERR_INV_XSTREAM;
-        *type = ABT_UNIT_TYPE_EXT;
         goto fn_exit;
     }
 #endif
-
-    if (ABTI_local_get_task() != NULL) {
-        *type = ABT_UNIT_TYPE_TASK;
-    } else {
-        /* Since ABTI_local_get_thread() can return NULL during executing
-         * ABTI_init(), it should always be safe to say that the type of caller
-         * is ULT if the control reaches here. */
-        *type = ABT_UNIT_TYPE_THREAD;
-    }
 
   fn_exit:
     return abt_errno;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1135,6 +1135,8 @@ int ABT_xstream_check_events(ABT_sched sched)
 int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     ABTI_info_check_print_all_thread_stacks();
 
@@ -1145,15 +1147,13 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
 
     if ((p_xstream->request & ABTI_XSTREAM_REQ_EXIT) ||
         (p_xstream->request & ABTI_XSTREAM_REQ_CANCEL)) {
-        abt_errno = ABT_sched_exit(sched);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_sched_exit(p_sched);
     }
 
     // TODO: check event queue
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
     if (ABTI_event_check_power() == ABT_TRUE) {
-        abt_errno = ABT_sched_exit(sched);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_sched_exit(p_sched);
     }
 #endif
     ABTI_EVENT_PUBLISH_INFO();

--- a/src/stream.c
+++ b/src/stream.c
@@ -893,9 +893,8 @@ int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched)
  * @ingroup ES
  * @brief   Get the pools of the main scheduler of the target ES.
  *
- * This function is a convenient function that calls
- * \c ABT_xstream_get_main_sched() to get the main scheduler, and then
- * \c ABT_sched_get_pools() to get retrieve the associated pools.
+ * This function is a convenient function that retrieves the associated pools of
+ * the main scheduler.
  *
  * @param[in]  xstream   handle to the target ES
  * @param[in]  max_pools maximum number of pools
@@ -907,12 +906,10 @@ int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
                                ABT_pool *pools)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_sched sched;
 
-    abt_errno = ABT_xstream_get_main_sched(xstream, &sched);
-    ABTI_CHECK_ERROR(abt_errno);
-
-    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
+    ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
+    ABTI_sched *p_sched = p_xstream->p_main_sched;
     max_pools = p_sched->num_pools > max_pools ? max_pools : p_sched->num_pools;
     memcpy(pools, p_sched->pools, sizeof(ABT_pool) * max_pools);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -145,15 +145,17 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
                              ABT_xstream *newxstream)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_xstream *p_newxstream;
 
     ABTI_sched *p_sched;
     abt_errno = ABTI_sched_create_basic(predef, num_pools, pools,
                                         config, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    ABT_sched sched = ABTI_sched_get_handle(p_sched);
-    abt_errno = ABT_xstream_create(sched, newxstream);
+    abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
     ABTI_CHECK_ERROR(abt_errno);
+
+    *newxstream = ABTI_xstream_get_handle(p_newxstream);
 
   fn_exit:
     return abt_errno;

--- a/src/stream.c
+++ b/src/stream.c
@@ -903,8 +903,9 @@ int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
     abt_errno = ABT_xstream_get_main_sched(xstream, &sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABT_sched_get_pools(sched, max_pools, 0, pools);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    max_pools = p_sched->num_pools > max_pools ? max_pools : p_sched->num_pools;
+    memcpy(pools, p_sched->pools, sizeof(ABT_pool) * max_pools);
 
   fn_exit:
     return abt_errno;

--- a/src/stream.c
+++ b/src/stream.c
@@ -32,10 +32,9 @@ int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
     ABTI_xstream *p_newxstream;
 
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                           ABT_SCHED_CONFIG_NULL, &sched);
+        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
+                                            ABT_SCHED_CONFIG_NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched = ABTI_sched_get_ptr(sched);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
@@ -103,14 +102,14 @@ int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_newxstream;
-    ABT_sched sched;
+    ABTI_sched *p_sched;
 
     /* For the primary ES, a default scheduler is created. */
-    abt_errno = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                       ABT_SCHED_CONFIG_NULL, &sched);
+    abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
+                                        ABT_SCHED_CONFIG_NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABTI_xstream_create(ABTI_sched_get_ptr(sched), &p_newxstream);
+    abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
     ABTI_CHECK_ERROR(abt_errno);
 
     p_newxstream->type = ABTI_XSTREAM_TYPE_PRIMARY;
@@ -147,11 +146,12 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
 {
     int abt_errno = ABT_SUCCESS;
 
-    ABT_sched sched;
-    abt_errno = ABT_sched_create_basic(predef, num_pools, pools,
-                                       config, &sched);
+    ABTI_sched *p_sched;
+    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools,
+                                        config, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
+    ABT_sched sched = ABTI_sched_get_handle(p_sched);
     abt_errno = ABT_xstream_create(sched, newxstream);
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -195,10 +195,9 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     }
 
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                           ABT_SCHED_CONFIG_NULL, &sched);
+        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
+                                            ABT_SCHED_CONFIG_NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched = ABTI_sched_get_ptr(sched);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
@@ -792,10 +791,9 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
     }
 
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                           ABT_SCHED_CONFIG_NULL, &sched);
+        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
+                                            ABT_SCHED_CONFIG_NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched = ABTI_sched_get_ptr(sched);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
@@ -834,11 +832,10 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABT_sched sched;
-    abt_errno = ABT_sched_create_basic(predef, num_pools, pools,
-                                       ABT_SCHED_CONFIG_NULL, &sched);
+    ABTI_sched *p_sched;
+    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools,
+                                        ABT_SCHED_CONFIG_NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
-    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
 
     abt_errno = ABTI_xstream_set_main_sched(p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1141,8 +1141,7 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
     ABTI_info_check_print_all_thread_stacks();
 
     if (p_xstream->request & ABTI_XSTREAM_REQ_JOIN) {
-        abt_errno = ABT_sched_finish(sched);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_sched_finish(p_sched);
     }
 
     if ((p_xstream->request & ABTI_XSTREAM_REQ_EXIT) ||

--- a/src/stream.c
+++ b/src/stream.c
@@ -1607,7 +1607,6 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
 #else
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool;
-    ABT_pool pool;
     ABTI_xstream *newstream = NULL;
 
     /* callback function */
@@ -1621,7 +1620,6 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
         /* extracting argument in migration request */
         p_pool = (ABTI_pool *)ABTI_thread_extract_req_arg(p_thread,
                 ABTI_THREAD_REQ_MIGRATE);
-        pool = ABTI_pool_get_handle(p_pool);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
@@ -1635,7 +1633,7 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
         p_thread->p_pool = p_pool;
 
         /* Add the unit to the scheduler's pool */
-        abt_errno = ABT_pool_push(pool, p_thread->unit);
+        ABTI_POOL_PUSH(p_pool, p_thread->unit, ABTI_local_get_xstream());
     }
     ABTI_spinlock_release(&p_thread->lock);
 

--- a/src/task.c
+++ b/src/task.c
@@ -304,7 +304,13 @@ int ABT_task_free(ABT_task *task)
     /* Wait until the task terminates */
     while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
            != ABT_TASK_STATE_TERMINATED) {
-        ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+            ABTD_atomic_pause();
+            continue;
+        }
+#endif
+        ABTI_thread_yield(ABTI_local_get_thread());
     }
 
     /* Free the ABTI_task structure */
@@ -343,7 +349,13 @@ int ABT_task_join(ABT_task task)
     /* TODO: better implementation */
     while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
            != ABT_TASK_STATE_TERMINATED) {
-        ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+            ABTD_atomic_pause();
+            continue;
+        }
+#endif
+        ABTI_thread_yield(ABTI_local_get_thread());
     }
 
   fn_exit:

--- a/src/task.c
+++ b/src/task.c
@@ -131,14 +131,13 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
                                void *arg, ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_pool pool;
     ABTI_task *p_newtask;
 
-    /* TODO: need to consider the access type of target pool */
-    abt_errno = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
+    ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    /* TODO: need to consider the access type of target pool */
+    ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newtask != NULL) ? 1 : 0;
     abt_errno = ABTI_task_create(p_pool, task_func, arg, NULL, refcount,
                                  &p_newtask);

--- a/src/task.c
+++ b/src/task.c
@@ -5,6 +5,9 @@
 
 #include "abti.h"
 
+static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
+                            void *arg, ABTI_sched *p_sched, int refcount,
+                            ABTI_task **pp_newtask);
 static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
                             void *arg, ABTI_task *p_task);
 static inline uint64_t ABTI_task_get_new_id(void);
@@ -43,48 +46,18 @@ int ABT_task_create(ABT_pool pool,
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_task *p_newtask;
-    ABT_task h_newtask;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    /* Allocate a task object */
-    p_newtask = ABTI_mem_alloc_task();
-
-    p_newtask->p_xstream  = NULL;
-    p_newtask->state      = ABT_TASK_STATE_READY;
-    p_newtask->request    = 0;
-    p_newtask->f_task     = task_func;
-    p_newtask->p_arg      = arg;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched   = NULL;
-#endif
-    p_newtask->p_pool     = p_pool;
-    p_newtask->refcount   = (newtask != NULL) ? 1 : 0;
-    p_newtask->p_keytable = NULL;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_newtask->migratable = ABT_TRUE;
-#endif
-    p_newtask->id         = ABTI_TASK_INIT_ID;
-
-    /* Create a wrapper work unit */
-    h_newtask = ABTI_task_get_handle(p_newtask);
-    p_newtask->unit = p_pool->u_create_from_task(h_newtask);
-
-    LOG_EVENT("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
-
-    /* Add this task to the scheduler's pool */
-#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    ABTI_pool_push(p_pool, p_newtask->unit);
-#else
-    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit, ABTI_xstream_self());
-    if (abt_errno != ABT_SUCCESS) {
-        ABTI_task_free(p_newtask);
-        goto fn_fail;
-    }
-#endif
+    int refcount = (newtask != NULL) ? 1 : 0;
+    abt_errno = ABTI_task_create(p_pool, task_func, arg, NULL, refcount,
+                                 &p_newtask);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
-    if (newtask) *newtask = h_newtask;
+    if (newtask) {
+        *newtask = ABTI_task_get_handle(p_newtask);
+    }
 
   fn_exit:
     return abt_errno;
@@ -100,7 +73,6 @@ int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_task *p_newtask;
-    ABT_task h_newtask;
 
     void *arg = (void *)ABTI_sched_get_handle(p_sched);
     /* If p_sched is reused, ABTI_task_revive() can be used. */
@@ -112,45 +84,9 @@ int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
     }
 
     /* Allocate a task object */
-    p_newtask = ABTI_mem_alloc_task();
-
-    p_newtask->p_xstream  = NULL;
-    p_newtask->state      = ABT_TASK_STATE_READY;
-    p_newtask->request    = 0;
-    p_newtask->f_task     = p_sched->run;
-    p_newtask->p_arg      = (void *)ABTI_sched_get_handle(p_sched);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched   = p_sched;
-#endif
-    p_newtask->p_pool     = p_pool;
-    p_newtask->refcount   = 1;
-    p_newtask->p_keytable = NULL;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_newtask->migratable = ABT_TRUE;
-#endif
-    p_newtask->id         = ABTI_TASK_INIT_ID;
-
-    /* Create a wrapper unit */
-    h_newtask = ABTI_task_get_handle(p_newtask);
-    p_newtask->unit = p_pool->u_create_from_task(h_newtask);
-
-    LOG_EVENT("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
-
-    /* Save the tasklet pointer in p_sched */
-    p_sched->p_task = p_newtask;
-
-#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    /* Add this tasklet to the pool */
-    ABTI_pool_push(p_pool, p_newtask->unit);
-#else
-    /* Add this tasklet to the pool */
-    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit, ABTI_xstream_self());
-    if (abt_errno != ABT_SUCCESS) {
-        p_sched->p_task = NULL;
-        ABTI_task_free(p_newtask);
-        goto fn_fail;
-    }
-#endif
+    abt_errno = ABTI_task_create(p_pool, p_sched->run, arg, p_sched, 1,
+                                 &p_newtask);
+    ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
     return abt_errno;
@@ -196,13 +132,21 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
 {
     int abt_errno = ABT_SUCCESS;
     ABT_pool pool;
+    ABTI_task *p_newtask;
 
     /* TODO: need to consider the access type of target pool */
     abt_errno = ABT_xstream_get_main_pools(xstream, 1, &pool);
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABT_task_create(pool, task_func, arg, newtask);
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    int refcount = (newtask != NULL) ? 1 : 0;
+    abt_errno = ABTI_task_create(p_pool, task_func, arg, NULL, refcount,
+                                 &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
+
+    /* Return value */
+    if (newtask)
+        *newtask = ABTI_task_get_handle(p_newtask);
 
   fn_exit:
     return abt_errno;
@@ -782,6 +726,62 @@ int ABT_task_get_arg(ABT_task task, void **arg)
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/
+
+static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
+                            void *arg, ABTI_sched *p_sched, int refcount,
+                            ABTI_task **pp_newtask)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_task *p_newtask;
+    ABT_task h_newtask;
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+
+    /* Allocate a task object */
+    p_newtask = ABTI_mem_alloc_task();
+
+    p_newtask->p_xstream  = NULL;
+    p_newtask->state      = ABT_TASK_STATE_READY;
+    p_newtask->request    = 0;
+    p_newtask->f_task     = task_func;
+    p_newtask->p_arg      = arg;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+    p_newtask->is_sched   = p_sched;
+#endif
+    p_newtask->p_pool     = p_pool;
+    p_newtask->refcount   = refcount;
+    p_newtask->p_keytable = NULL;
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+    p_newtask->migratable = ABT_TRUE;
+#endif
+    p_newtask->id         = ABTI_TASK_INIT_ID;
+
+    /* Create a wrapper work unit */
+    h_newtask = ABTI_task_get_handle(p_newtask);
+    p_newtask->unit = p_pool->u_create_from_task(h_newtask);
+
+    LOG_EVENT("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
+
+    /* Add this task to the scheduler's pool */
+#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
+    ABTI_pool_push(p_pool, p_newtask->unit);
+#else
+    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit, ABTI_xstream_self());
+    if (abt_errno != ABT_SUCCESS) {
+        ABTI_task_free(p_newtask);
+        goto fn_fail;
+    }
+#endif
+
+    /* Return value */
+    *pp_newtask = p_newtask;
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
 
 static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
                             void *arg, ABTI_task *p_task)

--- a/src/thread.c
+++ b/src/thread.c
@@ -392,8 +392,7 @@ int ABT_thread_join(ABT_thread thread)
                         "The main ULT cannot be joined.");
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-    ABT_unit_type type;
-    ABT_self_get_type(&type);
+    ABT_unit_type type = ABTI_self_get_type();
     if (type != ABT_UNIT_TYPE_THREAD) goto yield_based;
 #endif
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1546,6 +1546,19 @@ int ABTI_thread_create_internal(ABTI_pool *p_pool, void (*thread_func)(void *),
     goto fn_exit;
 }
 
+int ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
+                       void *arg, ABTI_thread_attr *p_attr,
+                       ABTI_thread **pp_newthread)
+{
+    int abt_errno = ABT_SUCCESS;
+    int refcount = (pp_newthread != NULL) ? 1 : 0;
+    abt_errno = ABTI_thread_create_internal(p_pool, thread_func, arg, p_attr,
+                                            ABTI_THREAD_TYPE_USER, NULL,
+                                            refcount, NULL, ABT_TRUE,
+                                            pp_newthread);
+    return abt_errno;
+}
+
 int ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION

--- a/src/thread.c
+++ b/src/thread.c
@@ -488,7 +488,13 @@ int ABT_thread_join(ABT_thread thread)
   yield_based:
     while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state)
            != ABT_THREAD_STATE_TERMINATED) {
-        ABT_thread_yield();
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+            ABTD_atomic_pause();
+            continue;
+        }
+#endif
+        ABTI_thread_yield(ABTI_local_get_thread());
     }
 
   fn_exit:

--- a/src/thread.c
+++ b/src/thread.c
@@ -332,20 +332,13 @@ int ABT_thread_free(ABT_thread *thread)
  */
 int ABT_thread_free_many(int num, ABT_thread *thread_list)
 {
-    int abt_errno = ABT_SUCCESS;
     int i;
 
     for (i = 0; i < num; i++) {
-        abt_errno = ABT_thread_free(&thread_list[i]);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_thread *p_thread = ABTI_thread_get_ptr(&thread_list[i]);
+        ABTI_thread_free(p_thread);
     }
-
-  fn_exit:
-    return abt_errno;
-
-  fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**

--- a/src/thread.c
+++ b/src/thread.c
@@ -120,14 +120,13 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
                       ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_pool pool;
     ABTI_thread *p_newthread;
 
-    /* TODO: need to consider the access type of target pool */
-    abt_errno = ABT_xstream_get_main_pools(xstream, 1, &pool);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
+    ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    /* TODO: need to consider the access type of target pool */
+    ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newthread != NULL) ? 1 : 0;
     abt_errno = ABTI_thread_create_internal(p_pool, thread_func, arg,
                                             ABTI_thread_attr_get_ptr(attr),

--- a/src/timer.c
+++ b/src/timer.c
@@ -5,6 +5,7 @@
 
 #include "abti.h"
 
+int ABTI_timer_create(ABTI_timer **pp_newtimer);
 
 /** @defgroup TIMER  Timer
  * This group is for Timer.
@@ -42,13 +43,10 @@ double ABT_get_wtime(void)
 int ABT_timer_create(ABT_timer *newtimer)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_timer *p_newtimer;
 
-    /* We use libc malloc/free for ABT_timer because ABTU_malloc/free might
-     * need the initialization of Argobots if they are not the same as libc
-     * malloc/free.  This is to allow ABT_timer to be used irrespective of
-     * Argobots initialization. */
-    ABTI_timer *p_newtimer = (ABTI_timer *)malloc(sizeof(ABTI_timer));
-    ABTI_CHECK_TRUE(p_newtimer != NULL, ABT_ERR_MEM);
+    abt_errno = ABTI_timer_create(&p_newtimer);
+    ABTI_CHECK_ERROR(abt_errno);
 
     *newtimer = ABTI_timer_get_handle(p_newtimer);
 
@@ -82,16 +80,14 @@ int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
-    ABT_timer h_newtimer;
     ABTI_timer *p_newtimer;
 
-    abt_errno = ABT_timer_create(&h_newtimer);
+    abt_errno = ABTI_timer_create(&p_newtimer);
     ABTI_CHECK_ERROR(abt_errno);
-    p_newtimer = ABTI_timer_get_ptr(h_newtimer);
 
     memcpy(p_newtimer, p_timer, sizeof(ABTI_timer));
 
-    *newtimer = h_newtimer;
+    *newtimer = ABTI_timer_get_handle(p_newtimer);
 
   fn_exit:
     return abt_errno;
@@ -345,3 +341,27 @@ int ABT_timer_get_overhead(double *overhead)
     goto fn_exit;
 }
 
+/*****************************************************************************/
+/* Internal functions                                                        */
+/*****************************************************************************/
+
+int ABTI_timer_create(ABTI_timer **pp_newtimer)
+{
+    int abt_errno = ABT_SUCCESS;
+
+    /* We use libc malloc/free for ABT_timer because ABTU_malloc/free might
+     * need the initialization of Argobots if they are not the same as libc
+     * malloc/free.  This is to allow ABT_timer to be used irrespective of
+     * Argobots initialization. */
+    ABTI_timer *p_newtimer = (ABTI_timer *)malloc(sizeof(ABTI_timer));
+    ABTI_CHECK_TRUE(p_newtimer != NULL, ABT_ERR_MEM);
+
+    *pp_newtimer = p_newtimer;
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}

--- a/src/timer.c
+++ b/src/timer.c
@@ -23,9 +23,7 @@
  */
 double ABT_get_wtime(void)
 {
-    ABTD_time t;
-    ABTD_time_get(&t);
-    return ABTD_time_read_sec(&t);
+    return ABTI_get_wtime();
 }
 
 /**

--- a/src/unit.c
+++ b/src/unit.c
@@ -32,6 +32,22 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
+    ABTI_unit_set_associated_pool(unit, p_pool);
+
+  fn_exit:
+    return abt_errno;
+
+  fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/*****************************************************************************/
+/* Private APIs                                                              */
+/*****************************************************************************/
+
+void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
+{
     ABT_unit_type type = p_pool->u_get_type(unit);
 
     if (type == ABT_UNIT_TYPE_THREAD) {
@@ -45,11 +61,4 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
         ABTI_task *p_task = ABTI_task_get_ptr(task);
         p_task->p_pool = p_pool;
     }
-
-  fn_exit:
-    return abt_errno;
-
-  fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 }


### PR DESCRIPTION
This commit removes all the internal use of public `ABT_` functions in Argobots and have the Argobots functions use private/internal `ABTI_` functions instead. This PR itself directly addresses #52 by making all the internal functions inlinable in theory (e.g., link-time optimization).

In addition, this PR is necessary for the following:
- Better error handling (e.g., #116): all errors must be handled in `ABT_` functions, not in `ABTI_`. To force so, `ABT_` functions should not call `ABT_` functions recursively.
- Fixing the TLS issue (#55, #111): one possible solution for this is passing a TLS variable across `ABTI_` functions. Doing so requires this PR.

An exception of this rule is `ABT_timer_get_overhead()`; it needs to get an overhead including the function call overhead, so `ABT_timer_get_overhead()` uses `ABT_timer_xxx()` functions.
