### PR TITLE
Solve Most Warnings for CI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -487,11 +487,11 @@ AS_IF([test "x$enable_error_check" = "xno"],
     [ABT_NULL="0"])
 AC_SUBST([ABT_NULL])
 
-AS_IF([test "x$enable_pool_producer_check" = "xno"],
+AS_IF([test "x$enable_error_check" = "xno" -o "x$enable_pool_producer_check" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK, 1,
         [Define to disable pool producer check])])
 
-AS_IF([test "x$enable_pool_consumer_check" = "xno"],
+AS_IF([test "x$enable_error_check" = "xno" -o "x$enable_pool_consumer_check" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK, 1,
         [Define to disable pool consumer check])])
 

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -244,10 +244,9 @@ void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
     char *prefix = ABTU_get_indent_str(indent);
     ABTD_thread_context *p_ctx = &p_thread->ctx;
 #if defined(ABT_CONFIG_USE_FCONTEXT)
-    fprintf(p_os, "%sfctx     : %p\n", prefix, p_ctx->fctx);
-    fprintf(p_os, "%sf_thread : %p\n", prefix, p_ctx->f_thread);
+    fprintf(p_os, "%sfctx     : %p\n", prefix, (void *)p_ctx->fctx);
     fprintf(p_os, "%sp_arg    : %p\n", prefix, p_ctx->p_arg);
-    fprintf(p_os, "%sp_link   : %p\n", prefix, p_ctx->p_link);
+    fprintf(p_os, "%sp_link   : %p\n", prefix, (void *)p_ctx->p_link);
 #else
     /* TODO: print information in more detail. */
     fprintf(p_os, "%suc_link     : %p\n", prefix, p_ctx->uc_link);

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -228,6 +228,7 @@ void ABTD_thread_cancel(ABTI_thread *p_thread)
 #endif
 }
 
+#if !defined(ABT_CONFIG_USE_FCONTEXT)
 static inline
 void print_bytes(size_t size, void *p_val, FILE *p_os) {
     size_t i;
@@ -236,6 +237,7 @@ void print_bytes(size_t size, void *p_val, FILE *p_os) {
         fprintf(p_os, "%02" PRIx8, val);
     }
 }
+#endif
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
 {

--- a/src/cond.c
+++ b/src/cond.c
@@ -299,7 +299,7 @@ int ABT_cond_signal(ABT_cond cond)
     p_unit->p_next = NULL;
 
     if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
-        ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->thread);
+        ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->handle.thread);
         ABTI_thread_set_ready(p_thread);
     } else {
         /* When the head is an external thread */

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -121,7 +121,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
             type = ABT_UNIT_TYPE_THREAD;
             p_unit = &p_current->unit_def;
-            p_unit->thread = ABTI_thread_get_handle(p_current);
+            p_unit->handle.thread = ABTI_thread_get_handle(p_current);
             p_unit->type = type;
         } else {
             /* external thread */
@@ -253,7 +253,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
         p_unit->p_next = NULL;
 
         if (type == ABT_UNIT_TYPE_THREAD) {
-            ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->thread);
+            ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->handle.thread);
             ABTI_thread_set_ready(p_thread);
         } else {
             /* When the head is an external thread */

--- a/src/futures.c
+++ b/src/futures.c
@@ -146,7 +146,7 @@ int ABT_future_wait(ABT_future future)
 
             type = ABT_UNIT_TYPE_THREAD;
             p_unit = &p_current->unit_def;
-            p_unit->thread = ABTI_thread_get_handle(p_current);
+            p_unit->handle.thread = ABTI_thread_get_handle(p_current);
             p_unit->type = type;
         } else {
             /* external thread */
@@ -271,7 +271,8 @@ int ABT_future_set(ABT_future future, void *value)
             p_unit->p_next = NULL;
 
             if (type == ABT_UNIT_TYPE_THREAD) {
-                ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->thread);
+                ABTI_thread *p_thread =
+                    ABTI_thread_get_ptr(p_unit->handle.thread);
                 ABTI_thread_set_ready(p_thread);
             } else {
                 /* When the head is an external thread */

--- a/src/global.c
+++ b/src/global.c
@@ -29,10 +29,6 @@ static inline void ABTI_init_lock_acquire() {
     }
 }
 
-static inline int ABTI_init_lock_is_locked() {
-    return ABTD_atomic_load_uint8(&g_ABTI_init_lock) != 0;
-}
-
 static inline void ABTI_init_lock_release() {
     ABTD_atomic_clear_uint8(&g_ABTI_init_lock);
 }

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -300,7 +300,7 @@ struct ABTI_unit {
     union {
         ABT_thread thread;
         ABT_task   task;
-    };
+    } handle;
     ABT_unit_type type;
 };
 

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -79,7 +79,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 
         type = ABT_UNIT_TYPE_THREAD;
         p_unit = &p_thread->unit_def;
-        p_unit->thread = ABTI_thread_get_handle(p_thread);
+        p_unit->handle.thread = ABTI_thread_get_handle(p_thread);
         p_unit->type = type;
     } else {
         /* external thread */
@@ -171,7 +171,7 @@ void ABTI_cond_broadcast(ABTI_cond *p_cond)
         p_unit->p_next = NULL;
 
         if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
-            ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->thread);
+            ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->handle.thread);
             ABTI_thread_set_ready(p_thread);
         } else {
             /* When the head is an external thread */

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -31,7 +31,7 @@
 #define ABTI_CHECK_ERROR(abt_errno)             \
     if (abt_errno != ABT_SUCCESS) goto fn_fail
 #else
-#define ABTI_CHECK_ERROR(abt_errno)
+#define ABTI_CHECK_ERROR(abt_errno) do { (void)(abt_errno); } while (0)
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK

--- a/src/info.c
+++ b/src/info.c
@@ -533,6 +533,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
         }
         if (print_cb_func)
             print_cb_func(force_print, print_arg);
+        ABTI_info_finalize_pool_set(&pool_set);
         /* Update print_stack_flag to 3. */
         ABTD_atomic_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_FINALIZE);
     } else {

--- a/src/info.c
+++ b/src/info.c
@@ -297,7 +297,7 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
         fprintf(fp, "id        : %" PRIu64 "\n"
                     "ctx       : %p\n",
                     (uint64_t)thread_id,
-                    &p_thread->ctx);
+                    (void *)&p_thread->ctx);
         ABTD_thread_print_context(p_thread, fp, 2);
         fprintf(fp, "stack     : %p\n"
                     "stacksize : %" PRIu64 "\n",
@@ -354,7 +354,7 @@ int ABTI_info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool)
         abt_errno = ABT_ERR_POOL;
         goto fn_fail;
     }
-    fprintf(fp, "== pool (%p) ==\n", p_pool);
+    fprintf(fp, "== pool (%p) ==\n", (void *)p_pool);
     struct ABTI_info_print_unit_arg_t arg;
     arg.fp = fp;
     arg.pool = ABTI_pool_get_handle(pool);
@@ -513,14 +513,14 @@ void ABTI_info_check_print_all_thread_stacks(void)
         for (i = 0; i < gp_ABTI_global->num_xstreams; i++) {
             ABTI_xstream *p_xstream = gp_ABTI_global->p_xstreams[i];
             ABTI_sched *p_main_sched = p_xstream->p_main_sched;
-            fprintf(fp, "= xstream[%d] (%p) =\n", i, p_xstream);
-            fprintf(fp, "main_sched : %p\n", p_main_sched);
+            fprintf(fp, "= xstream[%d] (%p) =\n", i, (void *)p_xstream);
+            fprintf(fp, "main_sched : %p\n", (void *)p_main_sched);
             if (!p_main_sched)
                 continue;
             for (j = 0; j < p_main_sched->num_pools; j++) {
                 ABT_pool pool = p_main_sched->pools[j];
                 ABTI_ASSERT(pool != ABT_POOL_NULL);
-                fprintf(fp, "  pools[%d] : %p\n", j, pool);
+                fprintf(fp, "  pools[%d] : %p\n", j, (void *)ABTI_pool_get_ptr(pool));
                 ABTI_info_add_pool_set(pool, &pool_set);
             }
         }

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -377,9 +377,11 @@ static char *ABTI_mem_alloc_large_page(int pgsize, ABT_bool *p_is_mmapped)
 
         case ABTI_MEM_LP_THP:
             *p_is_mmapped = ABT_FALSE;
-            size_t alignment = gp_ABTI_global->huge_page_size;
-            p_page = (char *)ABTU_memalign(alignment, pgsize);
-            LOG_DEBUG("memalign a THP (%d): %p\n", pgsize, p_page);
+            {
+                size_t alignment = gp_ABTI_global->huge_page_size;
+                p_page = (char *)ABTU_memalign(alignment, pgsize);
+                LOG_DEBUG("memalign a THP (%d): %p\n", pgsize, p_page);
+            }
             break;
 
         default:

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -142,7 +142,7 @@ void ABTI_mutex_attr_get_str(ABTI_mutex_attr *p_attr, char *p_buf)
         "]",
         p_attr->attrs,
         p_attr->nesting_cnt,
-        p_attr->p_owner
+        (void *)p_attr->p_owner
     );
 }
 

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -427,7 +427,7 @@ static ABT_thread unit_get_thread(ABT_unit unit)
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
     if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
-        h_thread = p_unit->thread;
+        h_thread = p_unit->handle.thread;
     } else {
         h_thread = ABT_THREAD_NULL;
     }
@@ -439,7 +439,7 @@ static ABT_task unit_get_task(ABT_unit unit)
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
     if (p_unit->type == ABT_UNIT_TYPE_TASK) {
-        h_task = p_unit->task;
+        h_task = p_unit->handle.task;
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -459,7 +459,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     p_unit->pool   = ABT_POOL_NULL;
-    p_unit->thread = thread;
+    p_unit->handle.thread = thread;
     p_unit->type   = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
@@ -472,7 +472,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
+    p_unit->handle.task = task;
     p_unit->type   = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -278,7 +278,7 @@ static ABT_thread unit_get_thread(ABT_unit unit)
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
     if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
-        h_thread = p_unit->thread;
+        h_thread = p_unit->handle.thread;
     } else {
         h_thread = ABT_THREAD_NULL;
     }
@@ -290,7 +290,7 @@ static ABT_task unit_get_task(ABT_unit unit)
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
     if (p_unit->type == ABT_UNIT_TYPE_TASK) {
-        h_task = p_unit->task;
+        h_task = p_unit->handle.task;
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -310,7 +310,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     p_unit->pool   = ABT_POOL_NULL;
-    p_unit->thread = thread;
+    p_unit->handle.thread = thread;
     p_unit->type   = ABT_UNIT_TYPE_THREAD;
 
     return (ABT_unit)p_unit;
@@ -323,7 +323,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     p_unit->pool   = ABT_POOL_NULL;
-    p_unit->task   = task;
+    p_unit->handle.task = task;
     p_unit->type   = ABT_UNIT_TYPE_TASK;
 
     return (ABT_unit)p_unit;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -705,17 +705,18 @@ int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_xstream *p_xstream)
     switch (p_pool->access) {
         case ABT_POOL_ACCESS_PRIV:
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-            if (p_pool->producer && p_xstream != p_pool->producer) {
-                abt_errno = ABT_ERR_INV_POOL_ACCESS;
-                ABTI_CHECK_ERROR(abt_errno);
-            }
+            ABTI_CHECK_TRUE(!p_pool->producer || p_xstream == p_pool->producer,
+                            ABT_ERR_INV_POOL_ACCESS);
 #endif
+            ABTI_CHECK_TRUE(!p_pool->consumer || p_pool->consumer == p_xstream,
+                            ABT_ERR_INV_POOL_ACCESS);
+            p_pool->consumer = p_xstream;
+            break;
+
         case ABT_POOL_ACCESS_SPSC:
         case ABT_POOL_ACCESS_MPSC:
-            if (p_pool->consumer && p_pool->consumer != p_xstream) {
-                abt_errno = ABT_ERR_INV_POOL_ACCESS;
-                ABTI_CHECK_ERROR(abt_errno);
-            }
+            ABTI_CHECK_TRUE(!p_pool->consumer || p_pool->consumer == p_xstream,
+                            ABT_ERR_INV_POOL_ACCESS);
             /* NB: as we do not want to use a mutex, the function can be wrong
              * here */
             p_pool->consumer = p_xstream;
@@ -760,6 +761,11 @@ int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_xstream *p_xstream)
             ABTI_CHECK_TRUE(!p_pool->consumer || p_xstream == p_pool->consumer,
                             ABT_ERR_INV_POOL_ACCESS);
 #endif
+            ABTI_CHECK_TRUE(!p_pool->producer || p_pool->producer == p_xstream,
+                            ABT_ERR_INV_POOL_ACCESS);
+            p_pool->producer = p_xstream;
+            break;
+
         case ABT_POOL_ACCESS_SPSC:
         case ABT_POOL_ACCESS_SPMC:
             ABTI_CHECK_TRUE(!p_pool->producer || p_pool->producer == p_xstream,

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -466,10 +466,10 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
             /* we need to ensure that the pool set of the scheduler does
              * not contain an ES private pool  */
             for (p = 0; p < p_sched->num_pools; p++) {
-                ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
-                ABTI_CHECK_TRUE(p_pool->access != ABT_POOL_ACCESS_PRIV &&
-                                  p_pool->access != ABT_POOL_ACCESS_SPSC &&
-                                  p_pool->access != ABT_POOL_ACCESS_MPSC,
+                ABTI_pool *p_local_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
+                ABTI_CHECK_TRUE(p_local_pool->access != ABT_POOL_ACCESS_PRIV &&
+                                p_local_pool->access != ABT_POOL_ACCESS_SPSC &&
+                                p_local_pool->access != ABT_POOL_ACCESS_MPSC,
                                 ABT_ERR_POOL);
             }
             break;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -666,16 +666,16 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
         "%snum_blocked   : %u\n"
         "%snum_migrations: %d\n"
         "%sdata          : %p\n",
-        prefix, p_pool,
+        prefix, (void *)p_pool,
         prefix, p_pool->id,
         prefix, access,
         prefix, (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE",
         prefix, p_pool->num_scheds,
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        prefix, p_pool->consumer, p_pool->consumer ? p_pool->consumer->rank : 0,
+        prefix, (void *)p_pool->consumer, p_pool->consumer ? p_pool->consumer->rank : 0,
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-        prefix, p_pool->producer, p_pool->producer ? p_pool->producer->rank : 0,
+        prefix, (void *)p_pool->producer, p_pool->producer ? p_pool->producer->rank : 0,
 #endif
         prefix, ABTI_pool_get_size(p_pool),
         prefix, p_pool->num_blocked,

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -325,7 +325,7 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream)
             /* We need to lock in case someone wants to migrate to this
              * scheduler */
             ABTI_spinlock_acquire(&p_xstream->sched_lock);
-            size_t size = ABTI_sched_get_effective_size(p_sched);
+            size = ABTI_sched_get_effective_size(p_sched);
             if (size == 0) {
                 p_sched->state = ABT_SCHED_STATE_TERMINATED;
                 stop = ABT_TRUE;
@@ -630,7 +630,6 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     ABT_pool_access access;
     ABT_pool_kind kind = ABT_POOL_FIFO;
     ABT_bool automatic;
-    int p;
 
     /* We set the access to the default one */
     access = ABT_POOL_ACCESS_MPSC;
@@ -644,6 +643,7 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         /* Copy of the contents of pools */
         ABT_pool *pool_list;
         pool_list = (ABT_pool *)ABTU_malloc(num_pools*sizeof(ABT_pool));
+        int p;
         for (p = 0; p < num_pools; p++) {
             if (pools[p] == ABT_POOL_NULL) {
                 ABTI_pool *p_newpool;
@@ -784,7 +784,6 @@ int ABTI_sched_free(ABTI_sched *p_sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         int32_t num_scheds = ABTI_pool_release(p_pool);
         if (p_pool->automatic == ABT_TRUE && num_scheds == 0) {
-            ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
             ABTI_CHECK_NULL_POOL_PTR(p_pool);
             ABTI_pool_free(p_pool);
         }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -917,7 +917,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
     pos = 2;
     for (i = 0; i < p_sched->num_pools; i++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[i]);
-        sprintf(&pools_str[pos], "%p ", p_pool);
+        sprintf(&pools_str[pos], "%p ", (void *)p_pool);
         pos = strlen(pools_str);
     }
     pools_str[pos] = ']';
@@ -938,7 +938,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
         "%ssize     : %zu\n"
         "%stot_size : %zu\n"
         "%sdata     : %p\n",
-        prefix, p_sched,
+        prefix, (void *)p_sched,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
         prefix, p_sched->id,
 #endif

--- a/src/stream.c
+++ b/src/stream.c
@@ -1831,7 +1831,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     scheds_str[1] = ' ';
     pos = 2;
     for (i = 0; i < p_xstream->num_scheds; i++) {
-        sprintf(&scheds_str[pos], "%p ", p_xstream->scheds[i]);
+        sprintf(&scheds_str[pos], "%p ", (void *)p_xstream->scheds[i]);
         pos = strlen(scheds_str);
     }
     scheds_str[pos] = ']';
@@ -1846,7 +1846,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
         "%snum_scheds: %d\n"
         "%sscheds    : %s\n"
         "%smain_sched: %p\n",
-        prefix, p_xstream,
+        prefix, (void *)p_xstream,
         prefix, p_xstream->rank,
         prefix, type,
         prefix, state,
@@ -1854,7 +1854,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
         prefix, p_xstream->max_scheds,
         prefix, p_xstream->num_scheds,
         prefix, scheds_str,
-        prefix, p_xstream->p_main_sched
+        prefix, (void *)p_xstream->p_main_sched
     );
     ABTU_free(scheds_str);
 

--- a/src/task.c
+++ b/src/task.c
@@ -876,25 +876,23 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
 #endif
         "%srefcount  : %u\n"
         "%srequest   : 0x%x\n"
-        "%sf_task    : %p\n"
         "%sp_arg     : %p\n"
         "%skeytable  : %p\n",
-        prefix, p_task,
+        prefix, (void *)p_task,
         prefix, ABTI_task_get_id(p_task),
         prefix, state,
-        prefix, p_task->p_xstream, xstream_rank,
+        prefix, (void *)p_task->p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, p_task->is_sched,
+        prefix, (void *)p_task->is_sched,
 #endif
-        prefix, p_task->p_pool,
+        prefix, (void *)p_task->p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
         prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
 #endif
         prefix, p_task->refcount,
         prefix, p_task->request,
-        prefix, p_task->f_task,
         prefix, p_task->p_arg,
-        prefix, p_task->p_keytable
+        prefix, (void *)p_task->p_keytable
     );
 
   fn_exit:

--- a/src/thread.c
+++ b/src/thread.c
@@ -2317,7 +2317,9 @@ static inline int ABTI_thread_join(ABTI_thread *p_thread)
     }
     goto fn_exit;
 
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
   busywait_based:
+#endif
     while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state)
            != ABT_THREAD_STATE_TERMINATED) {
         ABTD_atomic_pause();

--- a/src/thread.c
+++ b/src/thread.c
@@ -1917,19 +1917,19 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
         "%sreq_arg : %p\n"
         "%skeytable: %p\n"
         "%sattr    : %s\n",
-        prefix, p_thread,
+        prefix, (void *)p_thread,
         prefix, ABTI_thread_get_id(p_thread),
         prefix, type,
         prefix, state,
-        prefix, p_xstream, xstream_rank,
+        prefix, (void *)p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        prefix, p_thread->is_sched,
+        prefix, (void *)p_thread->is_sched,
 #endif
-        prefix, p_thread->p_pool,
+        prefix, (void *)p_thread->p_pool,
         prefix, p_thread->refcount,
         prefix, p_thread->request,
-        prefix, p_thread->p_req_arg,
-        prefix, p_thread->p_keytable,
+        prefix, (void *)p_thread->p_req_arg,
+        prefix, (void *)p_thread->p_keytable,
         prefix, attr
     );
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -13,8 +13,10 @@ static inline int ABTI_thread_create_internal(ABTI_pool *p_pool,
 static int ABTI_thread_revive(ABTI_pool *p_pool, void(*thread_func)(void *),
                               void *arg, ABTI_thread *p_thread);
 static inline int ABTI_thread_join(ABTI_thread *p_thread);
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
 static int ABTI_thread_migrate_to_xstream(ABTI_thread *p_thread,
                                           ABTI_xstream *p_xstream);
+#endif
 static inline ABT_bool ABTI_thread_is_ready(ABTI_thread *p_thread);
 static inline void ABTI_thread_free_internal(ABTI_thread *p_thread);
 static inline ABT_thread_id ABTI_thread_get_new_id(void);
@@ -2329,10 +2331,10 @@ static inline int ABTI_thread_join(ABTI_thread *p_thread)
     goto fn_exit;
 }
 
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
 static int ABTI_thread_migrate_to_xstream(ABTI_thread *p_thread,
                                           ABTI_xstream *p_xstream)
 {
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
 
     /* checking for cases when migration is not allowed */
@@ -2395,10 +2397,8 @@ static int ABTI_thread_migrate_to_xstream(ABTI_thread *p_thread,
   fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
-#else
-    return ABT_ERR_MIGRATION_NA;
-#endif
 }
+#endif
 
 static inline ABT_thread_id ABTI_thread_get_new_id(void)
 {

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -342,14 +342,12 @@ void ABTI_thread_attr_get_str(ABTI_thread_attr *p_attr, char *p_buf)
         "stacksize:%zu "
         "stacktype:%s "
         "migratable:%s "
-        "cb_func:%p "
         "cb_arg:%p"
         "]",
         p_attr->p_stack,
         p_attr->stacksize,
         stacktype,
         (p_attr->migratable == ABT_TRUE ? "TRUE" : "FALSE"),
-        p_attr->f_cb,
         p_attr->p_cb_arg
     );
 #else

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -183,7 +183,7 @@ ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
             p_queue->head = NULL;
             p_queue->tail = NULL;
         } else {
-            ABT_thread next = p_thread->unit_def.p_next->thread;
+            ABT_thread next = p_thread->unit_def.p_next->handle.thread;
             p_queue->head = ABTI_thread_get_ptr(next);
         }
 
@@ -207,7 +207,7 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
             p_queue->low_head = NULL;
             p_queue->low_tail = NULL;
         } else {
-            ABT_thread next = p_thread->unit_def.p_next->thread;
+            ABT_thread next = p_thread->unit_def.p_next->handle.thread;
             p_queue->low_head = ABTI_thread_get_ptr(next);
         }
 
@@ -234,7 +234,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
             p_queue->low_head = p_thread;
             p_queue->low_tail = p_thread;
         } else {
-            ABT_thread next = p_target->unit_def.p_next->thread;
+            ABT_thread next = p_target->unit_def.p_next->handle.thread;
             p_queue->low_head = ABTI_thread_get_ptr(next);
             p_queue->low_tail->unit_def.p_next = &p_thread->unit_def;
             p_queue->low_tail = p_thread;

--- a/test/basic/sched_prio.c
+++ b/test/basic/sched_prio.c
@@ -23,7 +23,6 @@ ABT_pool_access accesses[] = {
 };
 
 typedef struct {
-    int num_scheds;
     int *num_pools;
     ABT_pool **pools;
     ABT_sched *scheds;
@@ -61,7 +60,7 @@ int main(int argc, char *argv[])
     create_work_units();
 
     /* Join ESs */
-    for (i = 1; i < g_data.num_scheds; i++) {
+    for (i = 1; i < num_scheds; i++) {
         ret = ABT_xstream_join(g_data.xstreams[i]);
         ATS_ERROR(ret, "ABT_xstream_join");
     }
@@ -77,7 +76,6 @@ int main(int argc, char *argv[])
 
 static void init_global_data(void)
 {
-    g_data.num_scheds = num_scheds;
     g_data.num_pools = (int *)calloc(num_scheds, sizeof(int));
     g_data.pools = (ABT_pool **)calloc(num_scheds, sizeof(ABT_pool *));
     g_data.scheds = (ABT_sched *)calloc(num_scheds, sizeof(ABT_sched));
@@ -88,7 +86,7 @@ static void fini_global_data(void)
 {
     int i;
 
-    for (i = 0; i < g_data.num_scheds; i++) {
+    for (i = 0; i < num_scheds; i++) {
         if (g_data.pools[i]) free(g_data.pools[i]);
     }
 
@@ -101,7 +99,6 @@ static void fini_global_data(void)
 static void create_scheds_and_xstreams(void)
 {
     int i, k, ret;
-    int num_scheds = g_data.num_scheds;
     ABT_sched *scheds = g_data.scheds;
     int *num_pools = g_data.num_pools;
     ABT_pool **pools = g_data.pools;
@@ -169,7 +166,6 @@ static void create_scheds_and_xstreams(void)
 static void free_scheds_and_xstreams(void)
 {
     int i, ret;
-    int num_scheds = g_data.num_scheds;
     ABT_xstream *xstreams = g_data.xstreams;
 
     /* Free all ESs except the primary ES */
@@ -290,7 +286,7 @@ static void create_work_units(void)
     int i;
     int ret;
 
-    for (i = 0; i < g_data.num_scheds; i++) {
+    for (i = 0; i < num_scheds; i++) {
         /* Create a ULT in the first main pool */
         ABT_pool main_pool;
         ret = ABT_xstream_get_main_pools(g_data.xstreams[i], 1, &main_pool);


### PR DESCRIPTION
This PR solves most warnings with `-Wall`, `-Wextra` to make Argobots warning free. Compiler warnings are useful to detect potential bugs. In the future the Jenkins will check warnings, making the review process easier.

The exceptions are `-Wunused-parameter` and `-Wsign-compare`. It is hard to justify a big code change just to fix them, so they are suppressed by `-Wno-unused-parameter` and `-Wno-sign-compare`.

EDIT: add `-Wno-maybe-uninitialized` since GCC 8.3's false positive warning regarding `memcpy` is annoying (it warns `memcpy` of automatically padded struct that has an uninitialized memory region: see http://www.open-std.org/jtc1/sc22/wg14/www/docs/dr_451.htm).