### PR TITLE
Fix TLS Caching Issue (#55, #111)

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -44,6 +44,7 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
 void ABTD_thread_func_wrapper(int func_upper, int func_lower,
                               int arg_upper, int arg_lower)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     void (*thread_func)(void *);
     void *p_arg;
     size_t ptr_size, int_size;
@@ -71,7 +72,7 @@ void ABTD_thread_func_wrapper(int func_upper, int func_lower,
     /* Now, the ULT has finished its job. Terminate the ULT.
      * We don't need to use the atomic operation here because the ULT will be
      * terminated regardless of other requests. */
-    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
+    ABTI_thread *p_thread = p_local->p_thread;
     p_thread->request |= ABTI_THREAD_REQ_TERMINATE;
 }
 #endif
@@ -190,9 +191,10 @@ static inline void ABTD_thread_terminate_sched(ABTI_thread *p_thread)
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
 void ABTD_thread_terminate_thread_no_arg()
 {
+    ABTI_local *p_local = lp_ABTI_local;
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
-    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
+    ABTI_thread *p_thread = p_local->p_thread;
     ABTD_thread_terminate_thread(p_thread);
 }
 #endif

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -71,7 +71,7 @@ void ABTD_thread_func_wrapper(int func_upper, int func_lower,
     /* Now, the ULT has finished its job. Terminate the ULT.
      * We don't need to use the atomic operation here because the ULT will be
      * terminated regardless of other requests. */
-    ABTI_thread *p_thread = ABTI_local_get_thread();
+    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
     p_thread->request |= ABTI_THREAD_REQ_TERMINATE;
 }
 #endif
@@ -192,7 +192,7 @@ void ABTD_thread_terminate_thread_no_arg()
 {
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
-    ABTI_thread *p_thread = ABTI_local_get_thread();
+    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
     ABTD_thread_terminate_thread(p_thread);
 }
 #endif

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -24,7 +24,7 @@ void ABTD_thread_func_wrapper_thread(void *p_arg)
     ABTI_ASSERT(p_thread->is_sched == NULL);
 #endif
 
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTD_thread_terminate_thread(p_local, p_thread);
 }
 
@@ -41,14 +41,14 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
     ABTI_ASSERT(p_thread->is_sched != NULL);
 #endif
 
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTD_thread_terminate_sched(p_local, p_thread);
 }
 #else
 void ABTD_thread_func_wrapper(int func_upper, int func_lower,
                               int arg_upper, int arg_lower)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     void (*thread_func)(void *);
     void *p_arg;
     size_t ptr_size, int_size;
@@ -200,7 +200,7 @@ static inline void ABTD_thread_terminate_sched(ABTI_local *p_local,
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
 void ABTD_thread_terminate_thread_no_arg()
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
     ABTI_thread *p_thread = p_local->p_thread;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -162,7 +162,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         int32_t ext_signal = 0;
 
         if (lp_ABTI_local != NULL) {
-            p_thread = ABTI_local_get_thread();
+            p_thread = lp_ABTI_local->p_thread;
             if (p_thread == NULL) {
                 abt_errno = ABT_ERR_BARRIER;
                 goto fn_fail;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -188,7 +188,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
 
         if (type == ABT_UNIT_TYPE_THREAD) {
             /* Suspend the current ULT */
-            ABTI_thread_suspend(p_thread);
+            ABTI_thread_suspend(&p_local, p_thread);
         } else {
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
@@ -200,7 +200,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         for (i = 0; i < p_barrier->num_waiters - 1; i++) {
             ABTI_thread *p_thread = p_barrier->waiters[i];
             if (p_barrier->waiter_type[i] == ABT_UNIT_TYPE_THREAD) {
-                ABTI_thread_set_ready(p_thread);
+                ABTI_thread_set_ready(p_local, p_thread);
             } else {
                 /* When p_cur is an external thread */
                 int32_t *p_ext_signal = (int32_t *)p_thread;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -146,7 +146,7 @@ int ABT_barrier_free(ABT_barrier *barrier)
 int ABT_barrier_wait(ABT_barrier barrier)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
     uint32_t pos;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -146,6 +146,7 @@ int ABT_barrier_free(ABT_barrier *barrier)
 int ABT_barrier_wait(ABT_barrier barrier)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
     uint32_t pos;
@@ -161,8 +162,8 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABT_unit_type type;
         int32_t ext_signal = 0;
 
-        if (lp_ABTI_local != NULL) {
-            p_thread = lp_ABTI_local->p_thread;
+        if (p_local != NULL) {
+            p_thread = p_local->p_thread;
             if (p_thread == NULL) {
                 abt_errno = ABT_ERR_BARRIER;
                 goto fn_fail;

--- a/src/cond.c
+++ b/src/cond.c
@@ -93,7 +93,7 @@ int ABT_cond_free(ABT_cond *cond)
 int ABT_cond_wait(ABT_cond cond, ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
@@ -180,7 +180,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
                        const struct timespec *abstime)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
@@ -274,7 +274,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
 int ABT_cond_signal(ABT_cond cond)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
 
@@ -336,7 +336,7 @@ int ABT_cond_signal(ABT_cond cond)
 int ABT_cond_broadcast(ABT_cond cond)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
 

--- a/src/cond.c
+++ b/src/cond.c
@@ -179,6 +179,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
                        const struct timespec *abstime)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
@@ -239,7 +240,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
             continue;
         }
 #endif
-        ABTI_thread_yield(lp_ABTI_local->p_thread);
+        ABTI_thread_yield(p_local->p_thread);
     }
     ABTU_free(p_unit);
 

--- a/src/cond.c
+++ b/src/cond.c
@@ -239,7 +239,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
             continue;
         }
 #endif
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
     }
     ABTU_free(p_unit);
 

--- a/src/event.c
+++ b/src/event.c
@@ -667,9 +667,8 @@ void ABTI_event_set_num_xstreams(int num_xstreams)
     }
 }
 
-ABT_bool ABTI_event_check_power(void)
+ABT_bool ABTI_event_check_power(ABTI_local *p_local)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     ABT_bool stop_xstream = ABT_FALSE;
     int rank, n, ret;
     char recv_buf[ABTI_MSG_BUF_LEN];
@@ -966,9 +965,8 @@ void ABTI_event_inc_unit_cnt(ABTI_xstream *p_xstream, ABT_unit_type type)
     }
 }
 
-void ABTI_event_publish_info(void)
+void ABTI_event_publish_info(ABTI_local *p_local)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream;
     int rank, i, ret;
     double cur_time, elapsed_time;

--- a/src/event.c
+++ b/src/event.c
@@ -351,7 +351,7 @@ static void ABTI_event_free_xstream(void *arg)
             continue;
         }
 #endif
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
     }
 
     abt_errno = ABTI_xstream_join(p_xstream);
@@ -384,7 +384,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
                 continue;
             }
 #endif
-            ABTI_thread_yield(ABTI_local_get_thread());
+            ABTI_thread_yield(lp_ABTI_local->p_thread);
         }
 
         abt_errno = ABTI_xstream_join(p_xstream);
@@ -674,7 +674,7 @@ ABT_bool ABTI_event_check_power(void)
 
     if (gp_ABTI_global->pm_connected == ABT_FALSE) goto fn_exit;
 
-    p_xstream = ABTI_local_get_xstream();
+    p_xstream = lp_ABTI_local->p_xstream;
     ABTI_ASSERT(p_xstream);
     rank = (int)p_xstream->rank;
 
@@ -751,7 +751,7 @@ ABT_bool ABTI_event_check_power(void)
 
     ABTI_mutex_unlock(&gp_einfo->mutex);
 
-    p_xstream = ABTI_local_get_xstream();
+    p_xstream = lp_ABTI_local->p_xstream;
     if (p_xstream->request & ABTI_XSTREAM_REQ_STOP) {
         stop_xstream = ABT_TRUE;
     }
@@ -976,7 +976,7 @@ void ABTI_event_publish_info(void)
 
     if (gp_ABTI_global->pub_needed == ABT_FALSE) return;
 
-    p_xstream = ABTI_local_get_xstream();
+    p_xstream = lp_ABTI_local->p_xstream;
     rank = (int)p_xstream->rank;
     if (rank > gp_einfo->max_xstream_rank) {
         ABTI_event_realloc_pub_arrays(rank);

--- a/src/event.c
+++ b/src/event.c
@@ -338,7 +338,7 @@ void ABTI_event_send_num_xstream(void)
 
 static void ABTI_event_free_xstream(void *arg)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     char send_buf[ABTI_MSG_BUF_LEN];
     ABT_xstream xstream = (ABT_xstream)arg;
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -370,7 +370,7 @@ static void ABTI_event_free_xstream(void *arg)
 
 static void ABTI_event_free_multiple_xstreams(void *arg)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     char send_buf[ABTI_MSG_BUF_LEN];
     ABTI_xstream **p_xstreams = (ABTI_xstream **)arg;
     int num_xstreams = (int)(intptr_t)p_xstreams[0];

--- a/src/event.c
+++ b/src/event.c
@@ -338,6 +338,7 @@ void ABTI_event_send_num_xstream(void)
 
 static void ABTI_event_free_xstream(void *arg)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     char send_buf[ABTI_MSG_BUF_LEN];
     ABT_xstream xstream = (ABT_xstream)arg;
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -351,7 +352,7 @@ static void ABTI_event_free_xstream(void *arg)
             continue;
         }
 #endif
-        ABTI_thread_yield(lp_ABTI_local->p_thread);
+        ABTI_thread_yield(p_local->p_thread);
     }
 
     abt_errno = ABTI_xstream_join(p_xstream);
@@ -369,6 +370,7 @@ static void ABTI_event_free_xstream(void *arg)
 
 static void ABTI_event_free_multiple_xstreams(void *arg)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     char send_buf[ABTI_MSG_BUF_LEN];
     ABTI_xstream **p_xstreams = (ABTI_xstream **)arg;
     int num_xstreams = (int)(intptr_t)p_xstreams[0];
@@ -384,7 +386,7 @@ static void ABTI_event_free_multiple_xstreams(void *arg)
                 continue;
             }
 #endif
-            ABTI_thread_yield(lp_ABTI_local->p_thread);
+            ABTI_thread_yield(p_local->p_thread);
         }
 
         abt_errno = ABTI_xstream_join(p_xstream);
@@ -667,6 +669,7 @@ void ABTI_event_set_num_xstreams(int num_xstreams)
 
 ABT_bool ABTI_event_check_power(void)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     ABT_bool stop_xstream = ABT_FALSE;
     int rank, n, ret;
     char recv_buf[ABTI_MSG_BUF_LEN];
@@ -674,7 +677,7 @@ ABT_bool ABTI_event_check_power(void)
 
     if (gp_ABTI_global->pm_connected == ABT_FALSE) goto fn_exit;
 
-    p_xstream = lp_ABTI_local->p_xstream;
+    p_xstream = p_local->p_xstream;
     ABTI_ASSERT(p_xstream);
     rank = (int)p_xstream->rank;
 
@@ -751,7 +754,7 @@ ABT_bool ABTI_event_check_power(void)
 
     ABTI_mutex_unlock(&gp_einfo->mutex);
 
-    p_xstream = lp_ABTI_local->p_xstream;
+    p_xstream = p_local->p_xstream;
     if (p_xstream->request & ABTI_XSTREAM_REQ_STOP) {
         stop_xstream = ABT_TRUE;
     }
@@ -965,6 +968,7 @@ void ABTI_event_inc_unit_cnt(ABTI_xstream *p_xstream, ABT_unit_type type)
 
 void ABTI_event_publish_info(void)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream;
     int rank, i, ret;
     double cur_time, elapsed_time;
@@ -976,7 +980,7 @@ void ABTI_event_publish_info(void)
 
     if (gp_ABTI_global->pub_needed == ABT_FALSE) return;
 
-    p_xstream = lp_ABTI_local->p_xstream;
+    p_xstream = p_local->p_xstream;
     rank = (int)p_xstream->rank;
     if (rank > gp_einfo->max_xstream_rank) {
         ABTI_event_realloc_pub_arrays(rank);

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -105,6 +105,7 @@ int ABT_eventual_free(ABT_eventual *eventual)
 int ABT_eventual_wait(ABT_eventual eventual, void **value)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
 
@@ -115,8 +116,8 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         ABT_unit_type type;
         int32_t ext_signal = 0;
 
-        if (lp_ABTI_local != NULL) {
-            p_current = lp_ABTI_local->p_thread;
+        if (p_local != NULL) {
+            p_current = p_local->p_thread;
             ABTI_CHECK_TRUE(p_current != NULL, ABT_ERR_EVENTUAL);
 
             type = ABT_UNIT_TYPE_THREAD;

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -147,7 +147,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
             ABTI_spinlock_release(&p_eventual->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(p_current);
+            ABTI_thread_suspend(&p_local, p_current);
 
         } else {
             ABTI_spinlock_release(&p_eventual->lock);
@@ -230,6 +230,7 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
 int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
     ABTI_CHECK_TRUE(nbytes <= p_eventual->nbytes, ABT_ERR_INV_EVENTUAL);
@@ -255,7 +256,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 
         if (type == ABT_UNIT_TYPE_THREAD) {
             ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->handle.thread);
-            ABTI_thread_set_ready(p_thread);
+            ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
             int32_t *p_ext_signal = (int32_t *)p_unit->pool;

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -105,7 +105,7 @@ int ABT_eventual_free(ABT_eventual *eventual)
 int ABT_eventual_wait(ABT_eventual eventual, void **value)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
 
@@ -230,7 +230,7 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
 int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
     ABTI_CHECK_TRUE(nbytes <= p_eventual->nbytes, ABT_ERR_INV_EVENTUAL);

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -116,7 +116,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         int32_t ext_signal = 0;
 
         if (lp_ABTI_local != NULL) {
-            p_current = ABTI_local_get_thread();
+            p_current = lp_ABTI_local->p_thread;
             ABTI_CHECK_TRUE(p_current != NULL, ABT_ERR_EVENTUAL);
 
             type = ABT_UNIT_TYPE_THREAD;

--- a/src/futures.c
+++ b/src/futures.c
@@ -130,6 +130,7 @@ int ABT_future_free(ABT_future *future)
 int ABT_future_wait(ABT_future future)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
@@ -140,8 +141,8 @@ int ABT_future_wait(ABT_future future)
         ABT_unit_type type;
         int32_t ext_signal = 0;
 
-        if (lp_ABTI_local != NULL) {
-            p_current = lp_ABTI_local->p_thread;
+        if (p_local != NULL) {
+            p_current = p_local->p_thread;
             ABTI_CHECK_TRUE(p_current != NULL, ABT_ERR_FUTURE);
 
             type = ABT_UNIT_TYPE_THREAD;

--- a/src/futures.c
+++ b/src/futures.c
@@ -130,7 +130,7 @@ int ABT_future_free(ABT_future *future)
 int ABT_future_wait(ABT_future future)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
@@ -242,7 +242,7 @@ int ABT_future_test(ABT_future future, ABT_bool *flag)
 int ABT_future_set(ABT_future future, void *value)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -141,7 +141,7 @@ int ABT_future_wait(ABT_future future)
         int32_t ext_signal = 0;
 
         if (lp_ABTI_local != NULL) {
-            p_current = ABTI_local_get_thread();
+            p_current = lp_ABTI_local->p_thread;
             ABTI_CHECK_TRUE(p_current != NULL, ABT_ERR_FUTURE);
 
             type = ABT_UNIT_TYPE_THREAD;

--- a/src/futures.c
+++ b/src/futures.c
@@ -172,7 +172,7 @@ int ABT_future_wait(ABT_future future)
             ABTI_spinlock_release(&p_future->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(p_current);
+            ABTI_thread_suspend(&p_local, p_current);
 
         } else {
             ABTI_spinlock_release(&p_future->lock);
@@ -242,6 +242,7 @@ int ABT_future_test(ABT_future future, ABT_bool *flag)
 int ABT_future_set(ABT_future future, void *value)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
@@ -274,7 +275,7 @@ int ABT_future_set(ABT_future future, void *value)
             if (type == ABT_UNIT_TYPE_THREAD) {
                 ABTI_thread *p_thread =
                     ABTI_thread_get_ptr(p_unit->handle.thread);
-                ABTI_thread_set_ready(p_thread);
+                ABTI_thread_set_ready(p_local, p_thread);
             } else {
                 /* When the head is an external thread */
                 int32_t *p_ext_signal = (int32_t *)p_unit->pool;

--- a/src/global.c
+++ b/src/global.c
@@ -148,7 +148,7 @@ int ABT_init(int argc, char **argv)
 int ABT_finalize(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* First, take a global lock protecting the initialization/finalization
      * process. Don't go to fn_exit before taking a lock */

--- a/src/global.c
+++ b/src/global.c
@@ -89,19 +89,19 @@ int ABT_init(int argc, char **argv)
     ABTI_spinlock_create(&gp_ABTI_global->xstreams_lock);
 
     /* Init the ES local data */
-    abt_errno = ABTI_local_init();
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = NULL;
+    abt_errno = ABTI_local_init(&p_local);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_local_init");
 
     /* Create the primary ES */
     ABTI_xstream *p_newxstream;
-    abt_errno = ABTI_xstream_create_primary(&p_newxstream);
+    abt_errno = ABTI_xstream_create_primary(&p_local, &p_newxstream);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_create_primary");
     p_local->p_xstream = p_newxstream;
 
     /* Create the primary ULT, i.e., the main thread */
     ABTI_thread *p_main_thread;
-    abt_errno = ABTI_thread_create_main(p_newxstream, &p_main_thread);
+    abt_errno = ABTI_thread_create_main(p_local, p_newxstream, &p_main_thread);
     /* Set as if p_newxstream is currently running the main thread. */
     p_main_thread->state = ABT_THREAD_STATE_RUNNING;
     p_main_thread->p_last_xstream = p_newxstream;
@@ -110,7 +110,8 @@ int ABT_init(int argc, char **argv)
     p_local->p_thread = p_main_thread;
 
     /* Start the primary ES */
-    abt_errno = ABTI_xstream_start_primary(p_newxstream, p_main_thread);
+    abt_errno = ABTI_xstream_start_primary(&p_local, p_newxstream,
+                                           p_main_thread);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_start_primary");
 
     if (gp_ABTI_global->print_config == ABT_TRUE) {
@@ -188,7 +189,7 @@ int ABT_finalize(void)
 
         /* Switch to the top scheduler */
         ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-        ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
+        ABTI_thread_context_switch_thread_to_sched(&p_local, p_thread, p_sched);
 
         /* Back to the original thread */
         LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",
@@ -196,14 +197,14 @@ int ABT_finalize(void)
     }
 
     /* Remove the primary ULT */
-    ABTI_thread_free_main(p_thread);
+    ABTI_thread_free_main(p_local, p_thread);
 
     /* Free the primary ES */
-    abt_errno = ABTI_xstream_free(p_xstream);
+    abt_errno = ABTI_xstream_free(p_local, p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Finalize the ES local data */
-    abt_errno = ABTI_local_finalize();
+    abt_errno = ABTI_local_finalize(&p_local);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Finalize the event environment */

--- a/src/global.c
+++ b/src/global.c
@@ -96,7 +96,7 @@ int ABT_init(int argc, char **argv)
     ABTI_xstream *p_newxstream;
     abt_errno = ABTI_xstream_create_primary(&p_newxstream);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_create_primary");
-    ABTI_local_set_xstream(p_newxstream);
+    lp_ABTI_local->p_xstream = p_newxstream;
 
     /* Create the primary ULT, i.e., the main thread */
     ABTI_thread *p_main_thread;
@@ -106,7 +106,7 @@ int ABT_init(int argc, char **argv)
     p_main_thread->p_last_xstream = p_newxstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
-    ABTI_local_set_thread(p_main_thread);
+    lp_ABTI_local->p_thread = p_main_thread;
 
     /* Start the primary ES */
     abt_errno = ABTI_xstream_start_primary(p_newxstream, p_main_thread);
@@ -163,12 +163,12 @@ int ABT_finalize(void)
     /* If called by an external thread, return an error. */
     ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
     ABTI_CHECK_TRUE_MSG(p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY,
                         ABT_ERR_INV_XSTREAM,
                         "ABT_finalize must be called by the primary ES.");
 
-    ABTI_thread *p_thread = ABTI_local_get_thread();
+    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
     ABTI_CHECK_TRUE_MSG(p_thread->type == ABTI_THREAD_TYPE_MAIN,
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");

--- a/src/global.c
+++ b/src/global.c
@@ -90,13 +90,14 @@ int ABT_init(int argc, char **argv)
 
     /* Init the ES local data */
     abt_errno = ABTI_local_init();
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_local_init");
 
     /* Create the primary ES */
     ABTI_xstream *p_newxstream;
     abt_errno = ABTI_xstream_create_primary(&p_newxstream);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_create_primary");
-    lp_ABTI_local->p_xstream = p_newxstream;
+    p_local->p_xstream = p_newxstream;
 
     /* Create the primary ULT, i.e., the main thread */
     ABTI_thread *p_main_thread;
@@ -106,7 +107,7 @@ int ABT_init(int argc, char **argv)
     p_main_thread->p_last_xstream = p_newxstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
-    lp_ABTI_local->p_thread = p_main_thread;
+    p_local->p_thread = p_main_thread;
 
     /* Start the primary ES */
     abt_errno = ABTI_xstream_start_primary(p_newxstream, p_main_thread);
@@ -146,6 +147,7 @@ int ABT_init(int argc, char **argv)
 int ABT_finalize(void)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     /* First, take a global lock protecting the initialization/finalization
      * process. Don't go to fn_exit before taking a lock */
@@ -161,14 +163,14 @@ int ABT_finalize(void)
         goto fn_exit;
 
     /* If called by an external thread, return an error. */
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_INV_XSTREAM);
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_CHECK_TRUE_MSG(p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY,
                         ABT_ERR_INV_XSTREAM,
                         "ABT_finalize must be called by the primary ES.");
 
-    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
+    ABTI_thread *p_thread = p_local->p_thread;
     ABTI_CHECK_TRUE_MSG(p_thread->type == ABTI_THREAD_TYPE_MAIN,
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -49,8 +49,8 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
 
 /* ULT Context */
 #include "abtd_thread.h"
-void ABTD_thread_exit(ABTI_thread *p_thread);
-void ABTD_thread_cancel(ABTI_thread *p_thread);
+void ABTD_thread_exit(ABTI_local *p_local, ABTI_thread *p_thread);
+void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread);
 
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
 #include <time.h>

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -450,24 +450,29 @@ extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 void ABTI_global_update_max_xstreams(int new_size);
 
 /* ES Local Data */
-int ABTI_local_init(void);
-int ABTI_local_finalize(void);
+int ABTI_local_init(ABTI_local **pp_local);
+int ABTI_local_finalize(ABTI_local **pp_local);
 
 /* Execution Stream (ES) */
-int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream);
-int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
-int ABTI_xstream_start(ABTI_xstream *p_xstream);
-int ABTI_xstream_start_primary(ABTI_xstream *p_xstream, ABTI_thread *p_thread);
-int ABTI_xstream_free(ABTI_xstream *p_xstream);
-int ABTI_xstream_join(ABTI_xstream *p_xstream);
+int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
+                        ABTI_xstream **pp_xstream);
+int ABTI_xstream_create_primary(ABTI_local **pp_local, ABTI_xstream **pp_xstream);
+int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream);
+int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream,
+                               ABTI_thread *p_thread);
+int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream);
+int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream);
 void ABTI_xstream_schedule(void *p_arg);
-int ABTI_xstream_run_unit(ABTI_xstream *p_xstream, ABT_unit unit,
-                          ABTI_pool *p_pool);
-int ABTI_xstream_schedule_thread(ABTI_xstream *p_xstream,
+int ABTI_xstream_run_unit(ABTI_local **pp_local, ABTI_xstream *p_xstream,
+                          ABT_unit unit, ABTI_pool *p_pool);
+int ABTI_xstream_schedule_thread(ABTI_local **pp_local,
+                                 ABTI_xstream *p_xstream,
                                  ABTI_thread *p_thread);
-void ABTI_xstream_schedule_task(ABTI_xstream *p_xstream, ABTI_task *p_task);
-int ABTI_xstream_migrate_thread(ABTI_thread *p_thread);
-int ABTI_xstream_set_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
+void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                                ABTI_task *p_task);
+int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread);
+int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
+                                ABTI_sched *p_sched);
 int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched);
 void *ABTI_xstream_launch_main_sched(void *p_arg);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
@@ -486,13 +491,14 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                             ABT_pool *pools, ABT_sched_config config,
                             ABTI_sched **pp_newsched);
-int ABTI_sched_free(ABTI_sched *p_sched);
+int ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched);
 int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);
 ABTI_sched_kind ABTI_sched_get_kind(ABT_sched_def *def);
-ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream);
+ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched,
+                                ABTI_xstream *p_xstream);
 size_t ABTI_sched_get_size(ABTI_sched *p_sched);
 size_t ABTI_sched_get_total_size(ABTI_sched *p_sched);
-size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched);
+size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched);
 void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
                       ABT_bool print_sub);
 void ABTI_sched_reset_id(void);
@@ -526,19 +532,24 @@ void ABTI_pool_reset_id(void);
 void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 
 /* User-level Thread (ULT)  */
-int   ABTI_thread_migrate_to_pool(ABTI_thread *p_thread, ABTI_pool *p_pool);
-int   ABTI_thread_create(ABTI_pool *p_pool, void (*thread_func)(void *),
-                         void *arg, ABTI_thread_attr *p_attr,
-                         ABTI_thread **pp_newthread);
-int   ABTI_thread_create_main(ABTI_xstream *p_xstream, ABTI_thread **p_thread);
-int   ABTI_thread_create_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
-int   ABTI_thread_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched);
-void  ABTI_thread_free(ABTI_thread *p_thread);
-void  ABTI_thread_free_main(ABTI_thread *p_thread);
-void  ABTI_thread_free_main_sched(ABTI_thread *p_thread);
+int   ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
+                                  ABTI_pool *p_pool);
+int   ABTI_thread_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                         void (*thread_func)(void *), void *arg,
+                         ABTI_thread_attr *p_attr, ABTI_thread **pp_newthread);
+int   ABTI_thread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                              ABTI_thread **p_thread);
+int   ABTI_thread_create_main_sched(ABTI_local *p_local,
+                                    ABTI_xstream *p_xstream,
+                                    ABTI_sched *p_sched);
+int   ABTI_thread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
+                               ABTI_sched *p_sched);
+void  ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
+void  ABTI_thread_free_main(ABTI_local *p_local, ABTI_thread *p_thread);
+void  ABTI_thread_free_main_sched(ABTI_local *p_local, ABTI_thread *p_thread);
 int   ABTI_thread_set_blocked(ABTI_thread *p_thread);
-void  ABTI_thread_suspend(ABTI_thread *p_thread);
-int   ABTI_thread_set_ready(ABTI_thread *p_thread);
+void  ABTI_thread_suspend(ABTI_local **pp_local, ABTI_thread *p_thread);
+int   ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread);
 void  ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 int   ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -553,9 +564,9 @@ void  ABTI_thread_retain(ABTI_thread *p_thread);
 void  ABTI_thread_release(ABTI_thread *p_thread);
 void  ABTI_thread_reset_id(void);
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread);
-ABT_thread_id ABTI_thread_self_id(void);
+ABT_thread_id ABTI_thread_self_id(ABTI_local *p_local);
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread);
-int ABTI_thread_self_xstream_rank(void);
+int ABTI_thread_self_xstream_rank(ABTI_local *p_local);
 
 /* ULT Attributes */
 void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent);
@@ -577,13 +588,15 @@ ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
                                     ABTI_thread_queue *p_queue);
 ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
                                         ABTI_thread_queue *p_queue);
-ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
+ABT_bool ABTI_thread_htable_switch_low(ABTI_local **pp_local,
+                                       ABTI_thread_queue *p_queue,
                                        ABTI_thread *p_thread,
                                        ABTI_thread_htable *p_htable);
 
 /* Tasklet */
-int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched);
-void ABTI_task_free(ABTI_task *p_task);
+int ABTI_task_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
+                           ABTI_sched *p_sched);
+void ABTI_task_free(ABTI_local *p_local, ABTI_task *p_task);
 void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent);
 void ABTI_task_retain(ABTI_task *p_task);
 void ABTI_task_release(ABTI_task *p_task);
@@ -595,10 +608,10 @@ ABTI_ktable *ABTI_ktable_alloc(int size);
 void ABTI_ktable_free(ABTI_ktable *p_ktable);
 
 /* Mutex */
-void ABTI_mutex_wait(ABTI_mutex *p_mutex, int val);
-void ABTI_mutex_wait_low(ABTI_mutex *p_mutex, int val);
+void ABTI_mutex_wait(ABTI_local **pp_local, ABTI_mutex *p_mutex, int val);
+void ABTI_mutex_wait_low(ABTI_local **pp_local, ABTI_mutex *p_mutex, int val);
 void ABTI_mutex_wake_se(ABTI_mutex *p_mutex, int num);
-void ABTI_mutex_wake_de(ABTI_mutex *p_mutex);
+void ABTI_mutex_wake_de(ABTI_local *p_local, ABTI_mutex *p_mutex);
 
 /* Mutex Attributes */
 void ABTI_mutex_attr_print(ABTI_mutex_attr *p_attr, FILE *p_os, int indent);
@@ -610,7 +623,7 @@ void ABTI_event_finalize(void);
 #ifdef ABT_CONFIG_HANDLE_POWER_EVENT
 void ABTI_event_connect_power(char *p_host, int port);
 void ABTI_event_disconnect_power(void);
-ABT_bool ABTI_event_check_power(void);
+ABT_bool ABTI_event_check_power(ABTI_local *p_local);
 #endif
 #ifdef ABT_CONFIG_PUBLISH_INFO
 void ABTI_event_inc_unit_cnt(ABTI_xstream *p_xstream, ABT_unit_type type);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -93,6 +93,7 @@ enum ABTI_stack_type {
 /* Data Types */
 typedef struct ABTI_global          ABTI_global;
 typedef struct ABTI_local           ABTI_local;
+typedef struct ABTI_local_func      ABTI_local_func;
 typedef struct ABTI_xstream         ABTI_xstream;
 typedef enum ABTI_xstream_type      ABTI_xstream_type;
 typedef struct ABTI_sched           ABTI_sched;
@@ -200,6 +201,13 @@ struct ABTI_global {
 #endif
 
     ABT_bool print_config;      /* Whether to print config on ABT_init */
+};
+
+struct ABTI_local_func {
+    char padding1[ABT_CONFIG_STATIC_CACHELINE_SIZE];
+    ABTI_local *(*get_local_f)(void);
+    void (*set_local_f)(ABTI_local *);
+    char padding2[ABT_CONFIG_STATIC_CACHELINE_SIZE];
 };
 
 struct ABTI_local {
@@ -442,6 +450,7 @@ struct ABTI_timer {
 
 /* Global Data */
 extern ABTI_global *gp_ABTI_global;
+extern ABTI_local_func gp_ABTI_local_func;
 
 /* ES Local Data */
 extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -64,11 +64,12 @@ ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 }
 
 static inline
-int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
+int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
+                   ABTI_mutex *p_mutex)
 {
     int abt_errno = ABT_SUCCESS;
 
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = *pp_local;
     ABTI_thread *p_thread;
     ABTI_unit *p_unit;
     ABT_unit_type type;
@@ -126,14 +127,14 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 
         /* Unlock the mutex that the calling ULT is holding */
         /* FIXME: should check if mutex was locked by the calling ULT */
-        ABTI_mutex_unlock(p_mutex);
+        ABTI_mutex_unlock(p_local, p_mutex);
 
         /* Suspend the current ULT */
-        ABTI_thread_suspend(p_thread);
+        ABTI_thread_suspend(pp_local, p_thread);
 
     } else { /* TYPE == ABT_UNIT_TYPE_EXT */
         ABTI_spinlock_release(&p_cond->lock);
-        ABTI_mutex_unlock(p_mutex);
+        ABTI_mutex_unlock(p_local, p_mutex);
 
         /* External thread is waiting here polling ext_signal. */
         /* FIXME: need a better implementation */
@@ -142,7 +143,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
     }
 
     /* Lock the mutex again */
-    ABTI_mutex_lock(p_mutex);
+    ABTI_mutex_lock(pp_local, p_mutex);
 
   fn_exit:
     return abt_errno;
@@ -153,7 +154,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 }
 
 static inline
-void ABTI_cond_broadcast(ABTI_cond *p_cond)
+void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
 {
     ABTI_spinlock_acquire(&p_cond->lock);
 
@@ -173,7 +174,7 @@ void ABTI_cond_broadcast(ABTI_cond *p_cond)
 
         if (p_unit->type == ABT_UNIT_TYPE_THREAD) {
             ABTI_thread *p_thread = ABTI_thread_get_ptr(p_unit->handle.thread);
-            ABTI_thread_set_ready(p_thread);
+            ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
             int32_t *p_ext_signal = (int32_t *)p_unit->pool;

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -74,7 +74,7 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
     int32_t ext_signal = 0;
 
     if (lp_ABTI_local != NULL) {
-        p_thread = ABTI_local_get_thread();
+        p_thread = lp_ABTI_local->p_thread;
         ABTI_CHECK_TRUE(p_thread != NULL, ABT_ERR_COND);
 
         type = ABT_UNIT_TYPE_THREAD;

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -68,13 +68,14 @@ int ABTI_cond_wait(ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 {
     int abt_errno = ABT_SUCCESS;
 
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_unit *p_unit;
     ABT_unit_type type;
     int32_t ext_signal = 0;
 
-    if (lp_ABTI_local != NULL) {
-        p_thread = lp_ABTI_local->p_thread;
+    if (p_local != NULL) {
+        p_thread = p_local->p_thread;
         ABTI_CHECK_TRUE(p_thread != NULL, ABT_ERR_COND);
 
         type = ABT_UNIT_TYPE_THREAD;

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -6,7 +6,61 @@
 #ifndef LOCAL_H_INCLUDED
 #define LOCAL_H_INCLUDED
 
-/* Inlined functions for ES Local Data */
+/*
+ * An inlined getter function for ES Local Data.  This function is more
+ * efficient than ABTI_local_get_local_uninlined, but it can be used once only
+ * at the beginning of the function to avoid TLS caching across context switch.
+ *
+ * Consider the following case:
+ *
+ * int ABT_any_func()
+ * {
+ *     ABTI_xstream *p_xstream = ABTI_local_get_local()->p_xstream;
+ *     [context switch (e.g., ABTI_thread_yield())];
+ *     ABTI_xstream *p_xstream2 = ABTI_local_get_local()->p_xstream;
+ * }
+ *
+ * p_xstream and p_xstream2 can be always the same although context switch
+ * changes the running execution stream because a compiler assumes that the
+ * running Pthreads is the same across the function call
+ * (i.e., ABTI_thread_yield()) and caches a thread local value as a compiler
+ * optimization.  To avoid this, we need to assure that the second
+ * ABTI_local_get_local() really reads the thread local value again.
+ *
+ * See https://github.com/pmodels/argobots/issues/55 for details.
+ *
+ * ABTI_local_get_local_uninlined() guarantees that it truly reads the thread
+ * local value of the current Pthreads, but it is slow.
+ * ABTI_local_get_local_uninlined() should be used only after context switch
+ * happens, and in other cases, ABTI_local_get_local() should be called for
+ * performance.
+ *
+ * If you don't understand this problem well and it is not in the critical path,
+ * use the uninlined version for correctness.
+ */
+static inline ABTI_local *ABTI_local_get_local(void)
+{
+    return lp_ABTI_local;
+}
+
+/*
+ * A safe getter function for ES Local Data, which guarantees that it reads
+ * the thread local value without referring to the cached TLS.  This is slower
+ * than ABTI_local_get_local(), so use ABTI_local_get_local() if possible.
+ */
+static inline ABTI_local *ABTI_local_get_local_uninlined(void)
+{
+    return gp_ABTI_local_func.get_local_f();
+}
+
+/*
+ * A setter function for ES Local Data.  This function is rarely called, so it
+ * uses a slow version for correctness.
+ */
+static inline void ABTI_local_set_local(ABTI_local *p_local)
+{
+    gp_ABTI_local_func.set_local_f(p_local);
+}
 
 
 #endif /* LOCAL_H_INCLUDED */

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -8,35 +8,6 @@
 
 /* Inlined functions for ES Local Data */
 
-static inline
-ABTI_xstream *ABTI_local_get_xstream(void) {
-    return lp_ABTI_local->p_xstream;
-}
-
-static inline
-void ABTI_local_set_xstream(ABTI_xstream *p_xstream) {
-    lp_ABTI_local->p_xstream = p_xstream;
-}
-
-static inline
-ABTI_thread *ABTI_local_get_thread(void) {
-    return lp_ABTI_local->p_thread;
-}
-
-static inline
-void ABTI_local_set_thread(ABTI_thread *p_thread) {
-    lp_ABTI_local->p_thread = p_thread;
-}
-
-static inline
-ABTI_task *ABTI_local_get_task(void) {
-    return lp_ABTI_local->p_task;
-}
-
-static inline
-void ABTI_local_set_task(ABTI_task *p_task) {
-    lp_ABTI_local->p_task = p_task;
-}
 
 #endif /* LOCAL_H_INCLUDED */
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -138,14 +138,14 @@ ABTI_thread *ABTI_mem_alloc_thread_with_stacksize(size_t stacksize,
 }
 
 static inline
-ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
+ABTI_thread *ABTI_mem_alloc_thread(ABTI_local *p_local,
+                                   ABTI_thread_attr *p_attr)
 {
     /* Basic idea: allocate a memory for stack and use the first some memory as
      * ABTI_stack_header and ABTI_thread. So, the effective stack area is
      * reduced as much as the size of ABTI_stack_header and ABTI_thread. */
 
     size_t stacksize, def_stacksize, actual_stacksize;
-    ABTI_local *p_local = lp_ABTI_local;
     char *p_blk = NULL;
     ABTI_thread *p_thread;
     ABTI_stack_header *p_sh;
@@ -236,9 +236,8 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
 }
 
 static inline
-void ABTI_mem_free_thread(ABTI_thread *p_thread)
+void ABTI_mem_free_thread(ABTI_local *p_local, ABTI_thread *p_thread)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     ABTI_stack_header *p_sh;
     ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
 
@@ -267,10 +266,9 @@ void ABTI_mem_free_thread(ABTI_thread *p_thread)
 }
 
 static inline
-ABTI_task *ABTI_mem_alloc_task(void)
+ABTI_task *ABTI_mem_alloc_task(ABTI_local *p_local)
 {
     ABTI_task *p_task = NULL;
-    ABTI_local *p_local = lp_ABTI_local;
     const size_t blk_size = sizeof(ABTI_blk_header) + sizeof(ABTI_task);
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
@@ -324,9 +322,8 @@ ABTI_task *ABTI_mem_alloc_task(void)
 }
 
 static inline
-void ABTI_mem_free_task(ABTI_task *p_task)
+void ABTI_mem_free_task(ABTI_local *p_local, ABTI_task *p_task)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     ABTI_blk_header *p_head;
     ABTI_page_header *p_ph;
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -238,7 +238,7 @@ ABTI_thread *ABTI_mem_alloc_thread(ABTI_thread_attr *p_attr)
 static inline
 void ABTI_mem_free_thread(ABTI_thread *p_thread)
 {
-    ABTI_local *p_local;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_stack_header *p_sh;
     ABTI_VALGRIND_UNREGISTER_STACK(p_thread->attr.p_stack);
 
@@ -246,7 +246,6 @@ void ABTI_mem_free_thread(ABTI_thread *p_thread)
         ABTU_free((void *)p_thread);
         return;
     }
-    p_local = lp_ABTI_local;
     p_sh = (ABTI_stack_header *)((char *)p_thread + sizeof(ABTI_thread));
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
@@ -327,7 +326,7 @@ ABTI_task *ABTI_mem_alloc_task(void)
 static inline
 void ABTI_mem_free_task(ABTI_task *p_task)
 {
-    ABTI_local *p_local;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_blk_header *p_head;
     ABTI_page_header *p_ph;
 
@@ -339,7 +338,7 @@ void ABTI_mem_free_task(ABTI_task *p_task)
         /* This was allocated by an external thread. */
         ABTU_free(p_head);
         return;
-    } else if (!lp_ABTI_local) {
+    } else if (!p_local) {
         /* This task has been allocated internally,
          * but now is being freed by an external thread. */
         ABTI_mem_free_remote(p_ph, p_head);
@@ -347,7 +346,6 @@ void ABTI_mem_free_task(ABTI_task *p_task)
     }
 #endif
 
-    p_local = lp_ABTI_local;
     if (p_ph->p_owner == p_local->p_xstream) {
         p_head->p_next = p_ph->p_head;
         p_ph->p_head = p_head;

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -76,12 +76,13 @@ void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
 static inline
 void ABTI_mutex_lock(ABTI_mutex *p_mutex)
 {
+    ABTI_local *p_local = lp_ABTI_local;
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABT_unit_type type = ABTI_self_get_type();
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABTI_thread_yield(lp_ABTI_local->p_thread);
+            ABTI_thread_yield(p_local->p_thread);
         }
         LOG_EVENT("%p: lock - acquired\n", p_mutex);
     } else {
@@ -107,7 +108,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
                  * other ULT on the same ES, we don't need to change the mutex
                  * state. */
                 if (p_mutex->p_handover) {
-                    ABTI_thread *p_self = lp_ABTI_local->p_thread;
+                    ABTI_thread *p_self = p_local->p_thread;
                     if (p_self == p_mutex->p_handover) {
                         p_mutex->p_handover = NULL;
                         p_mutex->val = 2;

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -81,7 +81,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABTI_thread_yield(ABTI_local_get_thread());
+            ABTI_thread_yield(lp_ABTI_local->p_thread);
         }
         LOG_EVENT("%p: lock - acquired\n", p_mutex);
     } else {
@@ -107,7 +107,7 @@ void ABTI_mutex_lock(ABTI_mutex *p_mutex)
                  * other ULT on the same ES, we don't need to change the mutex
                  * state. */
                 if (p_mutex->p_handover) {
-                    ABTI_thread *p_self = ABTI_local_get_thread();
+                    ABTI_thread *p_self = lp_ABTI_local->p_thread;
                     if (p_self == p_mutex->p_handover) {
                         p_mutex->p_handover = NULL;
                         p_mutex->val = 2;

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -8,7 +8,7 @@
 
 /* Inlined functions for Pool */
 
-static inline ABTI_xstream *ABTI_xstream_self(void);
+static inline ABTI_xstream *ABTI_xstream_self(ABTI_local *p_local);
 
 static inline
 ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)

--- a/src/include/abti_rwlock.h
+++ b/src/include/abti_rwlock.h
@@ -60,47 +60,47 @@ void ABTI_rwlock_fini(ABTI_rwlock *p_rwlock)
 }
 
 static inline
-int ABTI_rwlock_rdlock(ABTI_rwlock *p_rwlock)
+int ABTI_rwlock_rdlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
 
-    ABTI_mutex_lock(&p_rwlock->mutex);
+    ABTI_mutex_lock(pp_local, &p_rwlock->mutex);
 
     while (p_rwlock->write_flag && abt_errno == ABT_SUCCESS) {
-        abt_errno = ABTI_cond_wait(&p_rwlock->cond, &p_rwlock->mutex);
+        abt_errno = ABTI_cond_wait(pp_local, &p_rwlock->cond, &p_rwlock->mutex);
     }
 
     if (abt_errno == ABT_SUCCESS) {
         p_rwlock->reader_count++;
     }
 
-    ABTI_mutex_unlock(&p_rwlock->mutex);
+    ABTI_mutex_unlock(*pp_local, &p_rwlock->mutex);
     return abt_errno;
 }
 
 static inline
-int ABTI_rwlock_wrlock(ABTI_rwlock *p_rwlock)
+int ABTI_rwlock_wrlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_mutex_lock(&p_rwlock->mutex);
+    ABTI_mutex_lock(pp_local, &p_rwlock->mutex);
 
     while ((p_rwlock->write_flag || p_rwlock->reader_count)
             && abt_errno == ABT_SUCCESS) {
-        abt_errno = ABTI_cond_wait(&p_rwlock->cond, &p_rwlock->mutex);
+        abt_errno = ABTI_cond_wait(pp_local, &p_rwlock->cond, &p_rwlock->mutex);
     }
 
     if (abt_errno == ABT_SUCCESS) {
         p_rwlock->write_flag = 1;
     }
 
-    ABTI_mutex_unlock(&p_rwlock->mutex);
+    ABTI_mutex_unlock(*pp_local, &p_rwlock->mutex);
     return abt_errno;
 }
 
 static inline
-void ABTI_rwlock_unlock(ABTI_rwlock *p_rwlock)
+void ABTI_rwlock_unlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
 {
-    ABTI_mutex_lock(&p_rwlock->mutex);
+    ABTI_mutex_lock(pp_local, &p_rwlock->mutex);
 
     if (p_rwlock->write_flag) {
         p_rwlock->write_flag = 0;
@@ -110,9 +110,10 @@ void ABTI_rwlock_unlock(ABTI_rwlock *p_rwlock)
     }
 
     /* TODO: elision */
-    ABTI_cond_broadcast(&p_rwlock->cond);
+    ABTI_local *p_local = *pp_local;
+    ABTI_cond_broadcast(p_local, &p_rwlock->cond);
 
-    ABTI_mutex_unlock(&p_rwlock->mutex);
+    ABTI_mutex_unlock(p_local, &p_rwlock->mutex);
 }
 
 #endif /* RWLOCK_H_INCLUDED */

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -43,12 +43,12 @@ ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 /* Set `used` of p_sched to NOT_USED and free p_sched if its `automatic` is
  * ABT_TRUE, which means it is safe to free p_sched inside the runtime. */
 static inline
-int ABTI_sched_discard_and_free(ABTI_sched *p_sched)
+int ABTI_sched_discard_and_free(ABTI_local *p_local, ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     p_sched->used = ABTI_SCHED_NOT_USED;
     if (p_sched->automatic == ABT_TRUE) {
-        abt_errno = ABTI_sched_free(p_sched);
+        abt_errno = ABTI_sched_free(p_local, p_sched);
     }
     return abt_errno;
 }

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -25,9 +25,9 @@ ABTI_unit *ABTI_self_get_unit(void)
     }
 #endif
 
-    if ((p_thread = ABTI_local_get_thread())) {
+    if ((p_thread = lp_ABTI_local->p_thread)) {
         p_unit = &p_thread->unit_def;
-    } else if ((p_task = ABTI_local_get_task())) {
+    } else if ((p_task = lp_ABTI_local->p_task)) {
         p_unit = &p_task->unit_def;
     } else {
         /* should not reach here */
@@ -50,10 +50,10 @@ ABT_unit_type ABTI_self_get_type(void)
     }
 #endif
 
-    if (ABTI_local_get_task() != NULL) {
+    if (lp_ABTI_local->p_task != NULL) {
         return ABT_UNIT_TYPE_TASK;
     } else {
-        /* Since ABTI_local_get_thread() can return NULL during executing
+        /* Since lp_ABTI_local->p_thread can return NULL during executing
          * ABTI_init(), it should always be safe to say that the type of caller
          * is ULT if the control reaches here. */
         return ABT_UNIT_TYPE_THREAD;

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -11,13 +11,14 @@ ABTI_unit *ABTI_self_get_unit(void)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_unit *p_unit;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         ABTD_xstream_context ctx;
         ABTD_xstream_context_self(&ctx);
         p_unit = (ABTI_unit *)ctx;
@@ -25,9 +26,9 @@ ABTI_unit *ABTI_self_get_unit(void)
     }
 #endif
 
-    if ((p_thread = lp_ABTI_local->p_thread)) {
+    if ((p_thread = p_local->p_thread)) {
         p_unit = &p_thread->unit_def;
-    } else if ((p_task = lp_ABTI_local->p_task)) {
+    } else if ((p_task = p_local->p_task)) {
         p_unit = &p_task->unit_def;
     } else {
         /* should not reach here */
@@ -43,17 +44,18 @@ ABT_unit_type ABTI_self_get_type(void)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
+    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         return ABT_UNIT_TYPE_EXT;
     }
 #endif
 
-    if (lp_ABTI_local->p_task != NULL) {
+    if (p_local->p_task != NULL) {
         return ABT_UNIT_TYPE_TASK;
     } else {
-        /* Since lp_ABTI_local->p_thread can return NULL during executing
+        /* Since p_local->p_thread can return NULL during executing
          * ABTI_init(), it should always be safe to say that the type of caller
          * is ULT if the control reaches here. */
         return ABT_UNIT_TYPE_THREAD;

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -7,11 +7,10 @@
 #define SELF_H_INCLUDED
 
 static inline
-ABTI_unit *ABTI_self_get_unit(void)
+ABTI_unit *ABTI_self_get_unit(ABTI_local *p_local)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
-    ABTI_local *p_local = lp_ABTI_local;
     ABTI_unit *p_unit;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
@@ -40,11 +39,10 @@ ABTI_unit *ABTI_self_get_unit(void)
 }
 
 static inline
-ABT_unit_type ABTI_self_get_type(void)
+ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
-    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (p_local == NULL) {

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -57,7 +57,7 @@ ABTI_xstream *ABTI_xstream_self(void)
 {
     ABTI_xstream *p_xstream;
     if (lp_ABTI_local != NULL) {
-        p_xstream = ABTI_local_get_xstream();
+        p_xstream = lp_ABTI_local->p_xstream;
     } else {
         /* We allow external threads to call Argobots APIs. However, since it
          * is not trivial to identify them, we use ABTD_xstream_context to

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -53,9 +53,8 @@ void ABTI_xstream_unset_request(ABTI_xstream *p_xstream, uint32_t req)
 }
 
 static inline
-ABTI_xstream *ABTI_xstream_self(void)
+ABTI_xstream *ABTI_xstream_self(ABTI_local *p_local)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream;
     if (p_local != NULL) {
         p_xstream = p_local->p_xstream;
@@ -133,7 +132,7 @@ ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 }
 
 static inline
-void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
+void ABTI_xstream_terminate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
 {
     LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
@@ -141,13 +140,13 @@ void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
     if (p_thread->refcount == 0) {
         ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
-        ABTI_thread_free(p_thread);
+        ABTI_thread_free(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
         ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_thread->is_sched);
+        ABTI_sched_discard_and_free(p_local, p_thread->is_sched);
 #endif
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
@@ -160,7 +159,7 @@ void ABTI_xstream_terminate_thread(ABTI_thread *p_thread)
 }
 
 static inline
-void ABTI_xstream_terminate_task(ABTI_task *p_task)
+void ABTI_xstream_terminate_task(ABTI_local *p_local, ABTI_task *p_task)
 {
     LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n",
               ABTI_task_get_id(p_task), p_task->p_xstream->rank);
@@ -168,13 +167,13 @@ void ABTI_xstream_terminate_task(ABTI_task *p_task)
     if (p_task->refcount == 0) {
         ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
-        ABTI_task_free(p_task);
+        ABTI_task_free(p_local, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
         ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_task->is_sched);
+        ABTI_sched_discard_and_free(p_local, p_task->is_sched);
 #endif
     } else {
         /* NOTE: We set the task's state as TERMINATED after checking refcount

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -55,9 +55,10 @@ void ABTI_xstream_unset_request(ABTI_xstream *p_xstream, uint32_t req)
 static inline
 ABTI_xstream *ABTI_xstream_self(void)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream;
-    if (lp_ABTI_local != NULL) {
-        p_xstream = lp_ABTI_local->p_xstream;
+    if (p_local != NULL) {
+        p_xstream = p_local->p_xstream;
     } else {
         /* We allow external threads to call Argobots APIs. However, since it
          * is not trivial to identify them, we use ABTD_xstream_context to

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -294,7 +294,7 @@ void ABTI_thread_context_switch_thread_to_thread(ABTI_local **pp_local,
     ABTI_thread_context_switch_thread_to_thread_internal(*pp_local,
                                                          p_old, p_new,
                                                          ABT_FALSE);
-    *pp_local = lp_ABTI_local;
+    *pp_local = ABTI_local_get_local_uninlined();
 }
 
 static inline
@@ -304,7 +304,7 @@ void ABTI_thread_context_switch_thread_to_sched(ABTI_local **pp_local,
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new,
                                                         ABT_FALSE);
-    *pp_local = lp_ABTI_local;
+    *pp_local = ABTI_local_get_local_uninlined();
 }
 
 static inline
@@ -314,7 +314,7 @@ void ABTI_thread_context_switch_sched_to_thread(ABTI_local **pp_local,
 {
     ABTI_thread_context_switch_sched_to_thread_internal(*pp_local, p_old, p_new,
                                                         ABT_FALSE);
-    *pp_local = lp_ABTI_local;
+    *pp_local = ABTI_local_get_local_uninlined();
 }
 
 static inline
@@ -323,7 +323,7 @@ void ABTI_thread_context_switch_sched_to_sched(ABTI_local **pp_local,
                                                ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_FALSE);
-    *pp_local = lp_ABTI_local;
+    *pp_local = ABTI_local_get_local_uninlined();
 }
 
 static inline

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -143,10 +143,11 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
                                                           ABTI_thread *p_new,
                                                           ABT_bool is_finish)
 {
+    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
 #endif
-    lp_ABTI_local->p_thread = p_new;
+    p_local->p_thread = p_new;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old is discarded. */
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old)) {
@@ -194,12 +195,13 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                                                          ABTI_thread *p_new,
                                                          ABT_bool is_finish)
 {
+    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->is_sched);
 #endif
     ABTI_LOG_SET_SCHED(NULL);
-    lp_ABTI_local->p_thread = p_new;
-    lp_ABTI_local->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
+    p_local->p_thread = p_new;
+    p_local->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be eagerly initialized. */
     ABTI_ASSERT(!p_old->p_thread
@@ -215,7 +217,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
          * run dynamic promotion, ABTI_thread_context_make_and_call took the
          * fast path. In this case, the request handling has not been done,
          * so it must be done here. */
-        ABTI_thread *p_prev = lp_ABTI_local->p_thread;
+        ABTI_thread *p_prev = p_local->p_thread;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
 #if defined(ABT_CONFIG_USE_FCONTEXT)

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -146,7 +146,7 @@ void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
 #endif
-    ABTI_local_set_thread(p_new);
+    lp_ABTI_local->p_thread = p_new;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old is discarded. */
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old)) {
@@ -198,8 +198,8 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
     ABTI_ASSERT(!p_new->is_sched);
 #endif
     ABTI_LOG_SET_SCHED(NULL);
-    ABTI_local_set_thread(p_new);
-    ABTI_local_set_task(NULL); /* A tasklet scheduler can invoke ULT. */
+    lp_ABTI_local->p_thread = p_new;
+    lp_ABTI_local->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be eagerly initialized. */
     ABTI_ASSERT(!p_old->p_thread
@@ -215,7 +215,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
          * run dynamic promotion, ABTI_thread_context_make_and_call took the
          * fast path. In this case, the request handling has not been done,
          * so it must be done here. */
-        ABTI_thread *p_prev = ABTI_local_get_thread();
+        ABTI_thread *p_prev = lp_ABTI_local->p_thread;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
 #if defined(ABT_CONFIG_USE_FCONTEXT)

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -139,11 +139,11 @@ void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 #endif
 
 static inline
-void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_thread *p_old,
+void ABTI_thread_context_switch_thread_to_thread_internal(ABTI_local *p_local,
+                                                          ABTI_thread *p_old,
                                                           ABTI_thread *p_new,
                                                           ABT_bool is_finish)
 {
-    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
 #endif
@@ -191,11 +191,11 @@ void ABTI_thread_context_switch_thread_to_sched_internal(ABTI_thread *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
+void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_local *p_local,
+                                                         ABTI_sched *p_old,
                                                          ABTI_thread *p_new,
                                                          ABT_bool is_finish)
 {
-    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->is_sched);
 #endif
@@ -232,7 +232,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                 ABTI_thread *p_joiner = (ABTI_thread *)p_link;
                 /* The scheduler may not use a bypass mechanism, so just makes
                  * p_joiner ready. */
-                ABTI_thread_set_ready(p_joiner);
+                ABTI_thread_set_ready(p_local, p_joiner);
 
                 /* We don't need to use the atomic OR operation here because
                  * the ULT will be terminated regardless of other requests. */
@@ -249,7 +249,7 @@ void ABTI_thread_context_switch_sched_to_thread_internal(ABTI_sched *p_old,
                         p_link = (ABTD_thread_context *)
                             ABTD_atomic_load_ptr((void **)&p_fctx->p_link);
                     } while (!p_link);
-                    ABTI_thread_set_ready((ABTI_thread *)p_link);
+                    ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }
             }
 #else
@@ -287,41 +287,51 @@ void ABTI_thread_context_switch_sched_to_sched_internal(ABTI_sched *p_old,
 }
 
 static inline
-void ABTI_thread_context_switch_thread_to_thread(ABTI_thread *p_old,
+void ABTI_thread_context_switch_thread_to_thread(ABTI_local **pp_local,
+                                                 ABTI_thread *p_old,
                                                  ABTI_thread *p_new)
 {
-    ABTI_thread_context_switch_thread_to_thread_internal(p_old, p_new,
+    ABTI_thread_context_switch_thread_to_thread_internal(*pp_local,
+                                                         p_old, p_new,
                                                          ABT_FALSE);
+    *pp_local = lp_ABTI_local;
 }
 
 static inline
-void ABTI_thread_context_switch_thread_to_sched(ABTI_thread *p_old,
+void ABTI_thread_context_switch_thread_to_sched(ABTI_local **pp_local,
+                                                ABTI_thread *p_old,
                                                 ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_thread_to_sched_internal(p_old, p_new,
                                                         ABT_FALSE);
+    *pp_local = lp_ABTI_local;
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_thread(ABTI_sched *p_old,
+void ABTI_thread_context_switch_sched_to_thread(ABTI_local **pp_local,
+                                                ABTI_sched *p_old,
                                                 ABTI_thread *p_new)
 {
-    ABTI_thread_context_switch_sched_to_thread_internal(p_old, p_new,
+    ABTI_thread_context_switch_sched_to_thread_internal(*pp_local, p_old, p_new,
                                                         ABT_FALSE);
+    *pp_local = lp_ABTI_local;
 }
 
 static inline
-void ABTI_thread_context_switch_sched_to_sched(ABTI_sched *p_old,
+void ABTI_thread_context_switch_sched_to_sched(ABTI_local **pp_local,
+                                               ABTI_sched *p_old,
                                                ABTI_sched *p_new)
 {
     ABTI_thread_context_switch_sched_to_sched_internal(p_old, p_new, ABT_FALSE);
+    *pp_local = lp_ABTI_local;
 }
 
 static inline
-void ABTI_thread_finish_context_thread_to_thread(ABTI_thread *p_old,
+void ABTI_thread_finish_context_thread_to_thread(ABTI_local *p_local,
+                                                 ABTI_thread *p_old,
                                                  ABTI_thread *p_new)
 {
-    ABTI_thread_context_switch_thread_to_thread_internal(p_old, p_new,
+    ABTI_thread_context_switch_thread_to_thread_internal(p_local, p_old, p_new,
                                                          ABT_TRUE);
 }
 
@@ -333,10 +343,12 @@ void ABTI_thread_finish_context_thread_to_sched(ABTI_thread *p_old,
 }
 
 static inline
-void ABTI_thread_finish_context_sched_to_thread(ABTI_sched *p_old,
+void ABTI_thread_finish_context_sched_to_thread(ABTI_local *p_local,
+                                                ABTI_sched *p_old,
                                                 ABTI_thread *p_new)
 {
-    ABTI_thread_context_switch_sched_to_thread_internal(p_old, p_new, ABT_TRUE);
+    ABTI_thread_context_switch_sched_to_thread_internal(p_local, p_old, p_new,
+                                                        ABT_TRUE);
 }
 
 static inline
@@ -378,7 +390,7 @@ ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
 #endif /* ABT_CONFIG_DISABLE_MIGRATION */
 
 static inline
-void ABTI_thread_yield(ABTI_thread *p_thread)
+void ABTI_thread_yield(ABTI_local **pp_local, ABTI_thread *p_thread)
 {
     ABTI_sched *p_sched;
 
@@ -390,7 +402,7 @@ void ABTI_thread_yield(ABTI_thread *p_thread)
 
     /* Switch to the top scheduler */
     p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-    ABTI_thread_context_switch_thread_to_sched(p_thread, p_sched);
+    ABTI_thread_context_switch_thread_to_sched(pp_local, p_thread, p_sched);
 
     /* Back to the original thread */
     LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/key.c
+++ b/src/key.c
@@ -126,7 +126,7 @@ int ABT_key_set(ABT_key key, void *value)
     ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer. */
-    p_thread = ABTI_local_get_thread();
+    p_thread = lp_ABTI_local->p_thread;
     if (p_thread) {
         if (p_thread->p_keytable == NULL) {
             int key_table_size = gp_ABTI_global->key_table_size;
@@ -134,7 +134,7 @@ int ABT_key_set(ABT_key key, void *value)
         }
         p_ktable = p_thread->p_keytable;
     } else {
-        p_task = ABTI_local_get_task();
+        p_task = lp_ABTI_local->p_task;
         ABTI_CHECK_TRUE(p_task != NULL, ABT_ERR_INV_TASK);
         if (p_task->p_keytable == NULL) {
             int key_table_size = gp_ABTI_global->key_table_size;
@@ -185,7 +185,7 @@ int ABT_key_get(ABT_key key, void **value)
     ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer */
-    p_thread = ABTI_local_get_thread();
+    p_thread = lp_ABTI_local->p_thread;
     if (p_thread) {
         p_ktable = p_thread->p_keytable;
         if (p_ktable) {
@@ -193,7 +193,7 @@ int ABT_key_get(ABT_key key, void **value)
             keyval = ABTI_ktable_get(p_ktable, p_key);
         }
     } else {
-        p_task = ABTI_local_get_task();
+        p_task = lp_ABTI_local->p_task;
         ABTI_CHECK_TRUE(p_task != NULL, ABT_ERR_INV_TASK);
         p_ktable = p_task->p_keytable;
         if (p_ktable) {

--- a/src/key.c
+++ b/src/key.c
@@ -114,7 +114,7 @@ int ABT_key_free(ABT_key *key)
 int ABT_key_set(ABT_key key, void *value)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
     ABTI_task *p_task;
     ABTI_ktable *p_ktable;
@@ -173,7 +173,7 @@ int ABT_key_set(ABT_key key, void *value)
 int ABT_key_get(ABT_key key, void **value)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
     ABTI_task *p_task;
     ABTI_ktable *p_ktable = NULL;

--- a/src/key.c
+++ b/src/key.c
@@ -114,6 +114,7 @@ int ABT_key_free(ABT_key *key)
 int ABT_key_set(ABT_key key, void *value)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
     ABTI_ktable *p_ktable;
@@ -123,10 +124,10 @@ int ABT_key_set(ABT_key key, void *value)
 
     /* We don't allow an external thread to call this routine. */
     ABTI_CHECK_INITIALIZED();
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer. */
-    p_thread = lp_ABTI_local->p_thread;
+    p_thread = p_local->p_thread;
     if (p_thread) {
         if (p_thread->p_keytable == NULL) {
             int key_table_size = gp_ABTI_global->key_table_size;
@@ -134,7 +135,7 @@ int ABT_key_set(ABT_key key, void *value)
         }
         p_ktable = p_thread->p_keytable;
     } else {
-        p_task = lp_ABTI_local->p_task;
+        p_task = p_local->p_task;
         ABTI_CHECK_TRUE(p_task != NULL, ABT_ERR_INV_TASK);
         if (p_task->p_keytable == NULL) {
             int key_table_size = gp_ABTI_global->key_table_size;
@@ -172,6 +173,7 @@ int ABT_key_set(ABT_key key, void *value)
 int ABT_key_get(ABT_key key, void **value)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
     ABTI_ktable *p_ktable = NULL;
@@ -182,10 +184,10 @@ int ABT_key_get(ABT_key key, void **value)
 
     /* We don't allow an external thread to call this routine. */
     ABTI_CHECK_INITIALIZED();
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer */
-    p_thread = lp_ABTI_local->p_thread;
+    p_thread = p_local->p_thread;
     if (p_thread) {
         p_ktable = p_thread->p_keytable;
         if (p_ktable) {
@@ -193,7 +195,7 @@ int ABT_key_get(ABT_key key, void **value)
             keyval = ABTI_ktable_get(p_ktable, p_key);
         }
     } else {
-        p_task = lp_ABTI_local->p_task;
+        p_task = p_local->p_task;
         ABTI_CHECK_TRUE(p_task != NULL, ABT_ERR_INV_TASK);
         p_ktable = p_task->p_keytable;
         if (p_ktable) {

--- a/src/local.c
+++ b/src/local.c
@@ -13,20 +13,21 @@
 /* ES Local Data */
 ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local = NULL;
 
-int ABTI_local_init(void)
+int ABTI_local_init(ABTI_local **pp_local)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
-    ABTI_CHECK_TRUE(p_local == NULL, ABT_ERR_OTHER);
+    ABTI_CHECK_TRUE(lp_ABTI_local == NULL, ABT_ERR_OTHER);
 
-    p_local = (ABTI_local *)ABTU_malloc(sizeof(ABTI_local));
+    ABTI_local *p_local = (ABTI_local *)ABTU_malloc(sizeof(ABTI_local));
     p_local->p_xstream = NULL;
     p_local->p_thread = NULL;
     p_local->p_task = NULL;
+    lp_ABTI_local = p_local;
 
     ABTI_mem_init_local(p_local);
 
     ABTI_LOG_INIT();
+    *pp_local = p_local;
 
   fn_exit:
     return abt_errno;
@@ -36,14 +37,15 @@ int ABTI_local_init(void)
     goto fn_exit;
 }
 
-int ABTI_local_finalize(void)
+int ABTI_local_finalize(ABTI_local **pp_local)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = *pp_local;
     ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_OTHER);
     ABTI_mem_finalize_local(p_local);
     ABTU_free(p_local);
-    p_local = NULL;
+    lp_ABTI_local = NULL;
+    *pp_local = NULL;
 
     ABTI_LOG_FINALIZE();
 

--- a/src/local.c
+++ b/src/local.c
@@ -38,7 +38,7 @@ int ABTI_local_init(ABTI_local **pp_local)
     p_local->p_xstream = NULL;
     p_local->p_thread = NULL;
     p_local->p_task = NULL;
-    lp_ABTI_local = p_local;
+    ABTI_local_set_local(p_local);
 
     ABTI_mem_init_local(p_local);
 
@@ -62,6 +62,7 @@ int ABTI_local_finalize(ABTI_local **pp_local)
     ABTU_free(p_local);
     lp_ABTI_local = NULL;
     *pp_local = NULL;
+    ABTI_local_set_local(NULL);
 
     ABTI_LOG_FINALIZE();
 

--- a/src/local.c
+++ b/src/local.c
@@ -10,6 +10,22 @@
 /* Private APIs                                                              */
 /*****************************************************************************/
 
+static ABTI_local *ABTI_local_get_local_internal(void)
+{
+    return lp_ABTI_local;
+}
+
+static void ABTI_local_set_local_internal(ABTI_local *p_local)
+{
+    lp_ABTI_local = p_local;
+}
+
+ABTI_local_func gp_ABTI_local_func = {
+    {0},
+    ABTI_local_get_local_internal,
+    ABTI_local_set_local_internal,
+    {0}
+};
 /* ES Local Data */
 ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local = NULL;
 

--- a/src/local.c
+++ b/src/local.c
@@ -16,14 +16,15 @@ ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local = NULL;
 int ABTI_local_init(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_CHECK_TRUE(lp_ABTI_local == NULL, ABT_ERR_OTHER);
+    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_CHECK_TRUE(p_local == NULL, ABT_ERR_OTHER);
 
-    lp_ABTI_local = (ABTI_local *)ABTU_malloc(sizeof(ABTI_local));
-    lp_ABTI_local->p_xstream = NULL;
-    lp_ABTI_local->p_thread = NULL;
-    lp_ABTI_local->p_task = NULL;
+    p_local = (ABTI_local *)ABTU_malloc(sizeof(ABTI_local));
+    p_local->p_xstream = NULL;
+    p_local->p_thread = NULL;
+    p_local->p_task = NULL;
 
-    ABTI_mem_init_local(lp_ABTI_local);
+    ABTI_mem_init_local(p_local);
 
     ABTI_LOG_INIT();
 
@@ -38,10 +39,11 @@ int ABTI_local_init(void)
 int ABTI_local_finalize(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_OTHER);
-    ABTI_mem_finalize_local(lp_ABTI_local);
-    ABTU_free(lp_ABTI_local);
-    lp_ABTI_local = NULL;
+    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_OTHER);
+    ABTI_mem_finalize_local(p_local);
+    ABTU_free(p_local);
+    p_local = NULL;
 
     ABTI_LOG_FINALIZE();
 

--- a/src/log.c
+++ b/src/log.c
@@ -36,7 +36,7 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
 void ABTI_log_event(FILE *fh, const char *format, ...)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local_uninlined();
 
     ABT_unit_type type = ABTI_self_get_type(p_local);
     ABTI_xstream *p_xstream = NULL;

--- a/src/log.c
+++ b/src/log.c
@@ -50,8 +50,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
 
     switch (type) {
         case ABT_UNIT_TYPE_THREAD:
-            p_xstream = ABTI_local_get_xstream();
-            p_thread = ABTI_local_get_thread();
+            p_xstream = lp_ABTI_local->p_xstream;
+            p_thread = lp_ABTI_local->p_thread;
             if (p_thread == NULL) {
                 if (p_xstream && p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY) {
                     prefix_fmt = "<U%" PRIu64 ":E%d> %s";
@@ -74,9 +74,9 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
             break;
 
         case ABT_UNIT_TYPE_TASK:
-            p_xstream = ABTI_local_get_xstream();
+            p_xstream = lp_ABTI_local->p_xstream;
             rank = p_xstream->rank;
-            p_task = ABTI_local_get_task();
+            p_task = lp_ABTI_local->p_task;
             if (lp_ABTI_log->p_sched) {
                 prefix_fmt = "<S%" PRIu64 ":E%d> %s";
                 tid = lp_ABTI_log->p_sched->id;

--- a/src/log.c
+++ b/src/log.c
@@ -35,6 +35,7 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
 
 void ABTI_log_event(FILE *fh, const char *format, ...)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
 
     ABT_unit_type type = ABTI_self_get_type();
@@ -50,8 +51,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
 
     switch (type) {
         case ABT_UNIT_TYPE_THREAD:
-            p_xstream = lp_ABTI_local->p_xstream;
-            p_thread = lp_ABTI_local->p_thread;
+            p_xstream = p_local->p_xstream;
+            p_thread = p_local->p_thread;
             if (p_thread == NULL) {
                 if (p_xstream && p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY) {
                     prefix_fmt = "<U%" PRIu64 ":E%d> %s";
@@ -74,9 +75,9 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
             break;
 
         case ABT_UNIT_TYPE_TASK:
-            p_xstream = lp_ABTI_local->p_xstream;
+            p_xstream = p_local->p_xstream;
             rank = p_xstream->rank;
-            p_task = lp_ABTI_local->p_task;
+            p_task = p_local->p_task;
             if (lp_ABTI_log->p_sched) {
                 prefix_fmt = "<S%" PRIu64 ":E%d> %s";
                 tid = lp_ABTI_log->p_sched->id;

--- a/src/log.c
+++ b/src/log.c
@@ -35,10 +35,10 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
 
 void ABTI_log_event(FILE *fh, const char *format, ...)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
+    ABTI_local *p_local = lp_ABTI_local;
 
-    ABT_unit_type type = ABTI_self_get_type();
+    ABT_unit_type type = ABTI_self_get_type(p_local);
     ABTI_xstream *p_xstream = NULL;
     ABTI_thread *p_thread = NULL;
     ABTI_task *p_task = NULL;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -142,7 +142,7 @@ int ABT_mutex_free(ABT_mutex *mutex)
 int ABT_mutex_lock(ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
@@ -276,7 +276,7 @@ void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
 int ABT_mutex_lock_low(ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
@@ -342,7 +342,7 @@ int ABT_mutex_trylock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_local *p_local = lp_ABTI_local;
+        ABTI_local *p_local = ABTI_local_get_local();
         ABTI_unit *p_self = ABTI_self_get_unit(p_local);
         if (p_self != p_mutex->attr.p_owner) {
             abt_errno = ABTI_mutex_trylock(p_mutex);
@@ -394,7 +394,7 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_local *p_local = lp_ABTI_local;
+        ABTI_local *p_local = ABTI_local_get_local();
         ABTI_unit *p_self = ABTI_self_get_unit(p_local);
         if (p_self != p_mutex->attr.p_owner) {
             ABTI_mutex_spinlock(p_mutex);
@@ -432,7 +432,7 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
 int ABT_mutex_unlock(ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
@@ -591,7 +591,7 @@ int ABTI_mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex)
 int ABT_mutex_unlock_se(ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
@@ -626,7 +626,7 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
 int ABT_mutex_unlock_de(ABT_mutex mutex)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -181,7 +181,7 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
     if (type == ABT_UNIT_TYPE_THREAD) {
         LOG_EVENT("%p: lock_low - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABTI_thread_yield(ABTI_local_get_thread());
+            ABTI_thread_yield(lp_ABTI_local->p_thread);
         }
         LOG_EVENT("%p: lock_low - acquired\n", p_mutex);
     } else {
@@ -201,7 +201,7 @@ void ABTI_mutex_lock_low(ABTI_mutex *p_mutex)
          * low-mutex queue, we give the header ULT a chance to try to get
          * the mutex by context switching to it. */
         ABTI_thread_htable *p_htable = p_mutex->p_htable;
-        ABTI_thread *p_self = ABTI_local_get_thread();
+        ABTI_thread *p_self = lp_ABTI_local->p_thread;
         ABTI_xstream *p_xstream = p_self->p_last_xstream;
         int rank = (int)p_xstream->rank;
         ABTI_thread_queue *p_queue = &p_htable->queue[rank];
@@ -466,9 +466,9 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
     LOG_EVENT("%p: unlock_se\n", p_mutex);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     if (ABTI_self_get_type() == ABT_UNIT_TYPE_THREAD)
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
 #else
-    ABTI_thread_yield(ABTI_local_get_thread());
+    ABTI_thread_yield(lp_ABTI_local->p_thread);
 #endif
 #else
     int i;
@@ -484,9 +484,9 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
         LOG_EVENT("%p: unlock_se\n", p_mutex);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type() == ABT_UNIT_TYPE_THREAD)
-            ABTI_thread_yield(ABTI_local_get_thread());
+            ABTI_thread_yield(lp_ABTI_local->p_thread);
 #else
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
 #endif
         return abt_errno;
     }
@@ -494,9 +494,9 @@ int ABTI_mutex_unlock_se(ABTI_mutex *p_mutex)
     /* There are ULTs waiting in the mutex queue */
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
 
-    p_thread = ABTI_local_get_thread();
+    p_thread = lp_ABTI_local->p_thread;
     p_xstream = p_thread->p_last_xstream;
-    ABTI_ASSERT(p_xstream == ABTI_local_get_xstream());
+    ABTI_ASSERT(p_xstream == lp_ABTI_local->p_xstream);
     i = (int)p_xstream->rank;
     p_queue = &p_htable->queue[i];
 
@@ -655,7 +655,7 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
 void ABTI_mutex_wait(ABTI_mutex *p_mutex, int val)
 {
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
-    ABTI_thread *p_self = ABTI_local_get_thread();
+    ABTI_thread *p_self = lp_ABTI_local->p_thread;
     ABTI_xstream *p_xstream = p_self->p_last_xstream;
 
     int rank = (int)p_xstream->rank;
@@ -708,7 +708,7 @@ void ABTI_mutex_wait(ABTI_mutex *p_mutex, int val)
 void ABTI_mutex_wait_low(ABTI_mutex *p_mutex, int val)
 {
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
-    ABTI_thread *p_self = ABTI_local_get_thread();
+    ABTI_thread *p_self = lp_ABTI_local->p_thread;
     ABTI_xstream *p_xstream = p_self->p_last_xstream;
 
     int rank = (int)p_xstream->rank;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -301,7 +301,7 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = ABTI_POOL_REMOVE(p_pool, unit, ABTI_local_get_xstream());
+    abt_errno = ABTI_POOL_REMOVE(p_pool, unit, lp_ABTI_local->p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -207,7 +207,7 @@ int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
     ABT_unit unit;
 
     /* If called by an external thread, return an error. */
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(ABTI_local_get_local() != NULL, ABT_ERR_INV_XSTREAM);
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -230,7 +230,7 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
     ABT_unit unit;
 
     /* If called by an external thread, return an error. */
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(ABTI_local_get_local() != NULL, ABT_ERR_INV_XSTREAM);
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -269,7 +269,8 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
     ABTI_pool_push(p_pool, unit);
 #else
     /* Save the producer ES information in the pool */
-    abt_errno = ABTI_pool_push(p_pool, unit, ABTI_xstream_self(lp_ABTI_local));
+    abt_errno = ABTI_pool_push(p_pool, unit,
+                               ABTI_xstream_self(ABTI_local_get_local()));
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
@@ -295,12 +296,13 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
     int abt_errno = ABT_SUCCESS;
 
     /* If called by an external thread, return an error. */
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE(ABTI_local_get_local() != NULL, ABT_ERR_INV_XSTREAM);
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = ABTI_POOL_REMOVE(p_pool, unit, lp_ABTI_local->p_xstream);
+    abt_errno = ABTI_POOL_REMOVE(p_pool, unit,
+                                 ABTI_local_get_local()->p_xstream);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
@@ -432,7 +434,7 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     return ABT_ERR_FEATURE_NA;
 #else
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -269,8 +269,7 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
     ABTI_pool_push(p_pool, unit);
 #else
     /* Save the producer ES information in the pool */
-    ABTI_xstream *p_xstream = ABTI_xstream_self();
-    abt_errno = ABTI_pool_push(p_pool, unit, p_xstream);
+    abt_errno = ABTI_pool_push(p_pool, unit, ABTI_xstream_self(lp_ABTI_local));
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
@@ -433,6 +432,7 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     return ABT_ERR_FEATURE_NA;
 #else
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -484,10 +484,10 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     p_sched->used = ABTI_SCHED_IN_POOL;
 
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
-        abt_errno = ABTI_thread_create_sched(p_pool, p_sched);
+        abt_errno = ABTI_thread_create_sched(p_local, p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else if (p_sched->type == ABT_SCHED_TYPE_TASK){
-        abt_errno = ABTI_task_create_sched(p_pool, p_sched);
+        abt_errno = ABTI_task_create_sched(p_local, p_pool, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
         ABTI_CHECK_TRUE(0, ABT_ERR_SCHED);

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -99,10 +99,11 @@ int ABT_rwlock_free(ABT_rwlock *rwlock)
 int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 
-    ABTI_rwlock_rdlock(p_rwlock);
+    ABTI_rwlock_rdlock(&p_local, p_rwlock);
 
   fn_exit:
     return abt_errno;
@@ -132,10 +133,11 @@ int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 
-    ABTI_rwlock_wrlock(p_rwlock);
+    ABTI_rwlock_wrlock(&p_local, p_rwlock);
 
   fn_exit:
     return abt_errno;
@@ -161,10 +163,11 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 int ABT_rwlock_unlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 
-    ABTI_rwlock_unlock(p_rwlock);
+    ABTI_rwlock_unlock(&p_local, p_rwlock);
 
   fn_exit:
     return abt_errno;

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -99,7 +99,7 @@ int ABT_rwlock_free(ABT_rwlock *rwlock)
 int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 
@@ -133,7 +133,7 @@ int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 
@@ -163,7 +163,7 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 int ABT_rwlock_unlock(ABT_rwlock rwlock)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
 

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -118,7 +118,7 @@ static void sched_run(ABT_sched sched)
             /* Pop one work unit */
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
                 break;
             }
@@ -126,7 +126,8 @@ static void sched_run(ABT_sched sched)
 
         if (++work_count >= event_freq) {
             ABTI_xstream_check_events(p_xstream, sched);
-            ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
+                                                   p_xstream);
             if (stop == ABT_TRUE)
                 break;
             work_count = 0;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -90,7 +90,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -90,6 +90,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
@@ -98,7 +99,7 @@ static void sched_run(ABT_sched sched)
     int i;
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -98,7 +98,7 @@ static void sched_run(ABT_sched sched)
     int i;
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -91,7 +91,7 @@ static void sched_run(ABT_sched sched)
     int i;
     int run_cnt_nowait;
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -111,7 +111,7 @@ static void sched_run(ABT_sched sched)
             /* Pop one work unit */
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
                 run_cnt_nowait++;
                 break;
             }
@@ -126,7 +126,7 @@ static void sched_run(ABT_sched sched)
             ABT_unit unit = ABTI_pool_pop_timedwait(
                 ABTI_pool_get_ptr(pools[0]), abstime);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit,
+                ABTI_xstream_run_unit(&p_local, p_xstream, unit,
                     ABTI_pool_get_ptr(pools[0]));
                 break;
             }
@@ -140,7 +140,8 @@ static void sched_run(ABT_sched sched)
          */
         if (!run_cnt_nowait || (++work_count >= event_freq)) {
             ABTI_xstream_check_events(p_xstream, sched);
-            ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
+                                                   p_xstream);
             if (stop == ABT_TRUE)
                 break;
             work_count = 0;

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -83,6 +83,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
@@ -91,7 +92,7 @@ static void sched_run(ABT_sched sched)
     int i;
     int run_cnt_nowait;
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -83,7 +83,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -69,7 +69,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -100,14 +100,15 @@ static void sched_run(ABT_sched sched)
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
                 break;
             }
         }
 
         if (++work_count >= event_freq) {
-            ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
+                                                   p_xstream);
             if (stop == ABT_TRUE) break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -77,7 +77,7 @@ static void sched_run(ABT_sched sched)
     int i;
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -69,6 +69,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     uint32_t work_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
@@ -77,7 +78,7 @@ static void sched_run(ABT_sched sched)
     int i;
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -71,7 +71,7 @@ static void sched_run(ABT_sched sched)
     unsigned seed = time(NULL);
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -89,7 +89,7 @@ static void sched_run(ABT_sched sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
         unit = ABTI_pool_pop(p_pool);
         if (unit != ABT_UNIT_NULL) {
-            ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+            ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
@@ -100,13 +100,14 @@ static void sched_run(ABT_sched sched)
             LOG_EVENT_POOL_POP(p_pool, unit);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_unit_set_associated_pool(unit, p_pool);
-                ABTI_xstream_run_unit(p_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
             }
         }
 
         if (++work_count >= p_data->event_freq) {
-            ABT_bool stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
+                                                   p_xstream);
             if (stop == ABT_TRUE) break;
             work_count = 0;
             ABTI_xstream_check_events(p_xstream, sched);

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -62,7 +62,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     uint32_t work_count = 0;
     sched_data *p_data;
     int num_pools;

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -62,6 +62,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     uint32_t work_count = 0;
     sched_data *p_data;
     int num_pools;
@@ -71,7 +72,7 @@ static void sched_run(ABT_sched sched)
     unsigned seed = time(NULL);
     CNT_DECL(run_cnt);
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_ASSERT(p_sched);
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -125,7 +125,7 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
 int ABT_sched_free(ABT_sched *sched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(*sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -282,7 +282,7 @@ int ABT_sched_exit(ABT_sched sched)
 int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     *stop = ABT_FALSE;
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -281,16 +281,17 @@ int ABT_sched_exit(ABT_sched sched)
 int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     *stop = ABT_FALSE;
 
     /* When this routine is called by an external thread, e.g., pthread */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -502,11 +503,12 @@ size_t ABTI_sched_get_total_size(ABTI_sched *p_sched)
  * between different schedulers associated with different ESs. */
 size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
 {
+    ABTI_local *p_local = lp_ABTI_local;
     size_t pool_size = 0;
     int p;
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
 #endif
 
     for (p = 0; p < p_sched->num_pools; p++) {

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -125,11 +125,12 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
 int ABT_sched_free(ABT_sched *sched)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(*sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     /* Free the scheduler */
-    abt_errno = ABTI_sched_free(p_sched);
+    abt_errno = ABTI_sched_free(p_local, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -296,7 +297,7 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    *stop = ABTI_sched_has_to_stop(p_sched, p_xstream);
+    *stop = ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream);
 
   fn_exit:
     return abt_errno;
@@ -306,7 +307,8 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
     goto fn_exit;
 }
 
-ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream)
+ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched,
+                                ABTI_xstream *p_xstream)
 {
     ABT_bool stop = ABT_FALSE;
     size_t size;
@@ -319,14 +321,14 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream)
         goto fn_exit;
     }
 
-    size = ABTI_sched_get_effective_size(p_sched);
+    size = ABTI_sched_get_effective_size(*pp_local, p_sched);
     if (size == 0) {
         if (p_sched->request & ABTI_SCHED_REQ_FINISH) {
             /* Check join request */
             /* We need to lock in case someone wants to migrate to this
              * scheduler */
             ABTI_spinlock_acquire(&p_xstream->sched_lock);
-            size = ABTI_sched_get_effective_size(p_sched);
+            size = ABTI_sched_get_effective_size(*pp_local, p_sched);
             if (size == 0) {
                 p_sched->state = ABT_SCHED_STATE_TERMINATED;
                 stop = ABT_TRUE;
@@ -345,7 +347,8 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_sched *p_sched, ABTI_xstream *p_xstream)
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
                 ABTI_sched *p_par_sched;
                 p_par_sched = ABTI_xstream_get_parent_sched(p_xstream);
-                ABTI_thread_context_switch_sched_to_sched(p_sched, p_par_sched);
+                ABTI_thread_context_switch_sched_to_sched(pp_local, p_sched,
+                                                          p_par_sched);
             }
         }
     }
@@ -501,9 +504,8 @@ size_t ABTI_sched_get_total_size(ABTI_sched *p_sched)
  * the caller ES is not the latest consumer. This is necessary when the ES
  * associated with the target scheduler has to be joined and the pool is shared
  * between different schedulers associated with different ESs. */
-size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
+size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
 {
-    ABTI_local *p_local = lp_ABTI_local;
     size_t pool_size = 0;
     int p;
 
@@ -769,7 +771,7 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     goto fn_exit;
 }
 
-int ABTI_sched_free(ABTI_sched *p_sched)
+int ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     int p;
@@ -796,14 +798,14 @@ int ABTI_sched_free(ABTI_sched *p_sched)
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         if (p_sched->p_thread) {
             if (p_sched->p_thread->type == ABTI_THREAD_TYPE_MAIN_SCHED) {
-                ABTI_thread_free_main_sched(p_sched->p_thread);
+                ABTI_thread_free_main_sched(p_local, p_sched->p_thread);
             } else {
-                ABTI_thread_free(p_sched->p_thread);
+                ABTI_thread_free(p_local, p_sched->p_thread);
             }
         }
     } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
         if (p_sched->p_task) {
-            ABTI_task_free(p_sched->p_task);
+            ABTI_task_free(p_local, p_sched->p_task);
         }
     }
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -290,7 +290,7 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -506,7 +506,7 @@ size_t ABTI_sched_get_effective_size(ABTI_sched *p_sched)
     int p;
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    ABTI_xstream *p_xstream = ABTI_local_get_xstream();
+    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
 #endif
 
     for (p = 0; p < p_sched->num_pools; p++) {

--- a/src/self.c
+++ b/src/self.c
@@ -74,6 +74,7 @@ int ABT_self_get_type(ABT_unit_type *type)
 int ABT_self_is_primary(ABT_bool *flag)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
 
     /* If Argobots has not been initialized, set flag to ABT_FALSE. */
@@ -85,14 +86,14 @@ int ABT_self_is_primary(ABT_bool *flag)
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *flag = ABT_FALSE;
         goto fn_exit;
     }
 #endif
 
-    p_thread = lp_ABTI_local->p_thread;
+    p_thread = p_local->p_thread;
     if (p_thread) {
         *flag = (p_thread->type == ABTI_THREAD_TYPE_MAIN)
               ? ABT_TRUE : ABT_FALSE;
@@ -123,6 +124,7 @@ int ABT_self_is_primary(ABT_bool *flag)
 int ABT_self_on_primary_xstream(ABT_bool *flag)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream;
 
     /* If Argobots has not been initialized, set flag to ABT_FALSE. */
@@ -134,14 +136,14 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *flag = ABT_FALSE;
         goto fn_exit;
     }
 #endif
 
-    p_xstream = lp_ABTI_local->p_xstream;
+    p_xstream = p_local->p_xstream;
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
@@ -177,6 +179,7 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
 int ABT_self_get_last_pool_id(int *pool_id)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
@@ -189,17 +192,17 @@ int ABT_self_get_last_pool_id(int *pool_id)
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *pool_id = -1;
         goto fn_exit;
     }
 #endif
 
-    if ((p_thread = lp_ABTI_local->p_thread)) {
+    if ((p_thread = p_local->p_thread)) {
         ABTI_ASSERT(p_thread->p_pool);
         *pool_id = (int)(p_thread->p_pool->id);
-    } else if ((p_task = lp_ABTI_local->p_task)) {
+    } else if ((p_task = p_local->p_task)) {
         ABTI_ASSERT(p_task->p_pool);
         *pool_id = (int)(p_task->p_pool->id);
     } else {
@@ -230,14 +233,15 @@ int ABT_self_get_last_pool_id(int *pool_id)
 int ABT_self_suspend(void)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 #ifdef ABT_CONFIG_DISABLE_EXT_THREAD
-    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
+    ABTI_thread *p_thread = p_local->p_thread;
 #else
     ABTI_thread *p_thread = NULL;
 
     /* If this routine is called by non-ULT, just return. */
-    if (lp_ABTI_local != NULL) {
-        p_thread = lp_ABTI_local->p_thread;
+    if (p_local != NULL) {
+        p_thread = p_local->p_thread;
     }
 #endif
     if (p_thread == NULL) {
@@ -272,6 +276,7 @@ int ABT_self_suspend(void)
 int ABT_self_set_arg(void *arg)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
@@ -282,14 +287,14 @@ int ABT_self_set_arg(void *arg)
     }
 
     /* When an external thread called this routine */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         goto fn_exit;
     }
 
-    if ((p_thread = lp_ABTI_local->p_thread)) {
+    if ((p_thread = p_local->p_thread)) {
         ABTD_thread_context_set_arg(&p_thread->ctx, arg);
-    } else if ((p_task = lp_ABTI_local->p_task)) {
+    } else if ((p_task = p_local->p_task)) {
         p_task->p_arg = arg;
     } else {
         abt_errno = ABT_ERR_OTHER;
@@ -321,6 +326,7 @@ int ABT_self_set_arg(void *arg)
 int ABT_self_get_arg(void **arg)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
@@ -333,16 +339,16 @@ int ABT_self_get_arg(void **arg)
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* When an external thread called this routine */
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *arg = NULL;
         goto fn_exit;
     }
 #endif
 
-    if ((p_thread = lp_ABTI_local->p_thread)) {
+    if ((p_thread = p_local->p_thread)) {
         *arg = ABTD_thread_context_get_arg(&p_thread->ctx);
-    } else if ((p_task = lp_ABTI_local->p_task)) {
+    } else if ((p_task = p_local->p_task)) {
         *arg = p_task->p_arg;
     } else {
         *arg = NULL;

--- a/src/self.c
+++ b/src/self.c
@@ -92,7 +92,7 @@ int ABT_self_is_primary(ABT_bool *flag)
     }
 #endif
 
-    p_thread = ABTI_local_get_thread();
+    p_thread = lp_ABTI_local->p_thread;
     if (p_thread) {
         *flag = (p_thread->type == ABTI_THREAD_TYPE_MAIN)
               ? ABT_TRUE : ABT_FALSE;
@@ -141,7 +141,7 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
     }
 #endif
 
-    p_xstream = ABTI_local_get_xstream();
+    p_xstream = lp_ABTI_local->p_xstream;
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
@@ -196,10 +196,10 @@ int ABT_self_get_last_pool_id(int *pool_id)
     }
 #endif
 
-    if ((p_thread = ABTI_local_get_thread())) {
+    if ((p_thread = lp_ABTI_local->p_thread)) {
         ABTI_ASSERT(p_thread->p_pool);
         *pool_id = (int)(p_thread->p_pool->id);
-    } else if ((p_task = ABTI_local_get_task())) {
+    } else if ((p_task = lp_ABTI_local->p_task)) {
         ABTI_ASSERT(p_task->p_pool);
         *pool_id = (int)(p_task->p_pool->id);
     } else {
@@ -231,13 +231,13 @@ int ABT_self_suspend(void)
 {
     int abt_errno = ABT_SUCCESS;
 #ifdef ABT_CONFIG_DISABLE_EXT_THREAD
-    ABTI_thread *p_thread = ABTI_local_get_thread();
+    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
 #else
     ABTI_thread *p_thread = NULL;
 
     /* If this routine is called by non-ULT, just return. */
     if (lp_ABTI_local != NULL) {
-        p_thread = ABTI_local_get_thread();
+        p_thread = lp_ABTI_local->p_thread;
     }
 #endif
     if (p_thread == NULL) {
@@ -287,9 +287,9 @@ int ABT_self_set_arg(void *arg)
         goto fn_exit;
     }
 
-    if ((p_thread = ABTI_local_get_thread())) {
+    if ((p_thread = lp_ABTI_local->p_thread)) {
         ABTD_thread_context_set_arg(&p_thread->ctx, arg);
-    } else if ((p_task = ABTI_local_get_task())) {
+    } else if ((p_task = lp_ABTI_local->p_task)) {
         p_task->p_arg = arg;
     } else {
         abt_errno = ABT_ERR_OTHER;
@@ -340,9 +340,9 @@ int ABT_self_get_arg(void **arg)
     }
 #endif
 
-    if ((p_thread = ABTI_local_get_thread())) {
+    if ((p_thread = lp_ABTI_local->p_thread)) {
         *arg = ABTD_thread_context_get_arg(&p_thread->ctx);
-    } else if ((p_task = ABTI_local_get_task())) {
+    } else if ((p_task = lp_ABTI_local->p_task)) {
         *arg = p_task->p_arg;
     } else {
         *arg = NULL;

--- a/src/self.c
+++ b/src/self.c
@@ -33,7 +33,6 @@
 int ABT_self_get_type(ABT_unit_type *type)
 {
     int abt_errno = ABT_SUCCESS;
-
     /* If Argobots has not been initialized, set type to ABT_UNIT_TYPE_EXIT. */
     if (gp_ABTI_global == NULL) {
         abt_errno = ABT_ERR_UNINITIALIZED;
@@ -41,7 +40,8 @@ int ABT_self_get_type(ABT_unit_type *type)
         goto fn_exit;
     }
 
-    *type = ABTI_self_get_type();
+    ABTI_local *p_local = lp_ABTI_local;
+    *type = ABTI_self_get_type(p_local);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (*type == ABT_UNIT_TYPE_EXT) {
@@ -252,7 +252,7 @@ int ABT_self_suspend(void)
     abt_errno = ABTI_thread_set_blocked(p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
-    ABTI_thread_suspend(p_thread);
+    ABTI_thread_suspend(&p_local, p_thread);
 
   fn_exit:
     return abt_errno;

--- a/src/self.c
+++ b/src/self.c
@@ -40,7 +40,7 @@ int ABT_self_get_type(ABT_unit_type *type)
         goto fn_exit;
     }
 
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     *type = ABTI_self_get_type(p_local);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
@@ -74,7 +74,7 @@ int ABT_self_get_type(ABT_unit_type *type)
 int ABT_self_is_primary(ABT_bool *flag)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
 
     /* If Argobots has not been initialized, set flag to ABT_FALSE. */
@@ -124,7 +124,7 @@ int ABT_self_is_primary(ABT_bool *flag)
 int ABT_self_on_primary_xstream(ABT_bool *flag)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream;
 
     /* If Argobots has not been initialized, set flag to ABT_FALSE. */
@@ -179,7 +179,7 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
 int ABT_self_get_last_pool_id(int *pool_id)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
@@ -233,7 +233,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
 int ABT_self_suspend(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 #ifdef ABT_CONFIG_DISABLE_EXT_THREAD
     ABTI_thread *p_thread = p_local->p_thread;
 #else
@@ -276,7 +276,7 @@ int ABT_self_suspend(void)
 int ABT_self_set_arg(void *arg)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 
@@ -326,7 +326,7 @@ int ABT_self_set_arg(void *arg)
 int ABT_self_get_arg(void **arg)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
     ABTI_task *p_task;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -382,15 +382,16 @@ int ABTI_xstream_start_primary(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
 int ABT_xstream_free(ABT_xstream *xstream)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABT_xstream h_xstream = *xstream;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(h_xstream);
     if (p_xstream == NULL) goto fn_exit;
 
-    /* We first need to check whether lp_ABTI_local is NULL because this
+    /* We first need to check whether p_local is NULL because this
      * routine might be called by external threads. */
-    ABTI_CHECK_TRUE_MSG(lp_ABTI_local == NULL ||
-                          p_xstream != lp_ABTI_local->p_xstream,
+    ABTI_CHECK_TRUE_MSG(p_local == NULL ||
+                          p_xstream != p_local->p_xstream,
                         ABT_ERR_INV_XSTREAM,
                         "The current xstream cannot be freed.");
 
@@ -464,6 +465,7 @@ int ABT_xstream_join(ABT_xstream xstream)
 int ABT_xstream_exit(void)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -472,12 +474,12 @@ int ABT_xstream_exit(void)
         abt_errno = ABT_ERR_UNINITIALIZED;
         goto fn_exit;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Set the exit request */
@@ -491,7 +493,7 @@ int ABT_xstream_exit(void)
             continue;
         }
 #endif
-        ABTI_thread_yield(lp_ABTI_local->p_thread);
+        ABTI_thread_yield(p_local->p_thread);
     } while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state)
              != ABT_XSTREAM_STATE_TERMINATED);
 
@@ -547,6 +549,7 @@ int ABT_xstream_cancel(ABT_xstream xstream)
 int ABT_xstream_self(ABT_xstream *xstream)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -556,13 +559,13 @@ int ABT_xstream_self(ABT_xstream *xstream)
         *xstream = ABT_XSTREAM_NULL;
         goto fn_exit;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *xstream = ABT_XSTREAM_NULL;
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
@@ -589,6 +592,7 @@ int ABT_xstream_self(ABT_xstream *xstream)
 int ABT_xstream_self_rank(int *rank)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -597,12 +601,12 @@ int ABT_xstream_self_rank(int *rank)
         abt_errno = ABT_ERR_UNINITIALIZED;
         goto fn_exit;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
@@ -702,14 +706,15 @@ int ABT_xstream_get_rank(ABT_xstream xstream, int *rank)
 int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_sched *p_sched;
 
-    ABTI_CHECK_TRUE(lp_ABTI_local != NULL, ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_INV_THREAD);
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABTI_thread *p_thread = lp_ABTI_local->p_thread;
+    ABTI_thread *p_thread = p_local->p_thread;
     ABTI_CHECK_TRUE(p_thread != NULL, ABT_ERR_INV_THREAD);
 
     /* For now, if the target ES is running, we allow to change the main
@@ -983,7 +988,8 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *flag)
 int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
 {
     int abt_errno;
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
 
     abt_errno = ABTI_xstream_run_unit(p_xstream, unit, p_pool);
@@ -1044,6 +1050,7 @@ int ABTI_xstream_run_unit(ABTI_xstream *p_xstream, ABT_unit unit,
 int ABT_xstream_check_events(ABT_sched sched)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -1052,12 +1059,12 @@ int ABT_xstream_check_events(ABT_sched sched)
         abt_errno = ABT_ERR_UNINITIALIZED;
         goto fn_exit;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         goto fn_exit;
     }
 
-    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
+    ABTI_xstream *p_xstream = p_local->p_xstream;
 
     abt_errno = ABTI_xstream_check_events(p_xstream, sched);
     ABTI_CHECK_ERROR(abt_errno);
@@ -1246,6 +1253,7 @@ int ABT_xstream_get_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset,
 int ABTI_xstream_join(ABTI_xstream *p_xstream)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread;
     ABT_bool is_blockable = ABT_FALSE;
 
@@ -1268,7 +1276,7 @@ int ABTI_xstream_join(ABTI_xstream *p_xstream)
      * mode, the ULT can be blocked. Otherwise, the access mode, if it is a
      * single-writer access mode, may be violated because another ES has to set
      * the blocked ULT ready. */
-    p_thread = lp_ABTI_local ? lp_ABTI_local->p_thread : NULL;
+    p_thread = p_local ? p_local->p_thread : NULL;
     if (p_thread) {
         ABT_pool_access access = p_thread->p_pool->access;
         if (access == ABT_POOL_ACCESS_MPSC || access == ABT_POOL_ACCESS_MPMC) {
@@ -1278,7 +1286,7 @@ int ABTI_xstream_join(ABTI_xstream *p_xstream)
         /* The target ES must not be the same as the caller ULT's ES if the
          * access mode of the associated pool is not MPMC. */
         if (access != ABT_POOL_ACCESS_MPMC) {
-            ABTI_CHECK_TRUE_MSG(p_xstream != lp_ABTI_local->p_xstream,
+            ABTI_CHECK_TRUE_MSG(p_xstream != p_local->p_xstream,
                                 ABT_ERR_INV_XSTREAM,
                                 "The target ES should be different.");
         }
@@ -1291,7 +1299,7 @@ int ABTI_xstream_join(ABTI_xstream *p_xstream)
 
     /* Wait until the target ES terminates */
     if (is_blockable == ABT_TRUE) {
-        ABTI_POOL_SET_CONSUMER(p_thread->p_pool, lp_ABTI_local->p_xstream);
+        ABTI_POOL_SET_CONSUMER(p_thread->p_pool, p_local->p_xstream);
 
         /* Save the caller ULT to set it ready when the ES is terminated */
         p_xstream->p_req_arg = (void *)p_thread;
@@ -1314,7 +1322,7 @@ int ABTI_xstream_join(ABTI_xstream *p_xstream)
                 continue;
             }
 #endif
-            ABTI_thread_yield(lp_ABTI_local->p_thread);
+            ABTI_thread_yield(p_local->p_thread);
         }
     }
 
@@ -1430,6 +1438,7 @@ void ABTI_xstream_schedule(void *p_arg)
 int ABTI_xstream_schedule_thread(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
     if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
@@ -1480,7 +1489,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
         /* The scheduler continues from here. */
         /* The previous ULT may not be the same as one to which the
          * context has been switched. */
-        p_thread = lp_ABTI_local->p_thread;
+        p_thread = p_local->p_thread;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
@@ -1562,6 +1571,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream *p_xstream, ABTI_thread *p_thread)
 
 void ABTI_xstream_schedule_task(ABTI_xstream *p_xstream, ABTI_task *p_task)
 {
+    ABTI_local *p_local = lp_ABTI_local;
 #ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
     if (p_task->request & ABTI_TASK_REQ_CANCEL) {
         ABTI_xstream_terminate_task(p_task);
@@ -1570,8 +1580,8 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_xstream, ABTI_task *p_task)
 #endif
 
     /* Set the current running tasklet */
-    lp_ABTI_local->p_task = p_task;
-    lp_ABTI_local->p_thread = NULL;
+    p_local->p_task = p_task;
+    p_local->p_thread = NULL;
 
     /* Change the task state */
     p_task->state = ABT_TASK_STATE_RUNNING;
@@ -1632,6 +1642,7 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
     return ABT_ERR_MIGRATION_NA;
 #else
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_pool *p_pool;
     ABTI_xstream *newstream = NULL;
 
@@ -1659,7 +1670,7 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
         p_thread->p_pool = p_pool;
 
         /* Add the unit to the scheduler's pool */
-        ABTI_POOL_PUSH(p_pool, p_thread->unit, lp_ABTI_local->p_xstream);
+        ABTI_POOL_PUSH(p_pool, p_thread->unit, p_local->p_xstream);
     }
     ABTI_spinlock_release(&p_thread->lock);
 
@@ -1686,6 +1697,7 @@ int ABTI_xstream_migrate_thread(ABTI_thread *p_thread)
 int ABTI_xstream_set_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_thread *p_thread = NULL;
     ABTI_sched *p_main_sched;
     ABTI_pool *p_tar_pool = NULL;
@@ -1716,7 +1728,7 @@ int ABTI_xstream_set_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     }
 
     /* If the ES has a main scheduler, we have to free it */
-    p_thread = lp_ABTI_local->p_thread;
+    p_thread = p_local->p_thread;
     ABTI_ASSERT(p_thread != NULL);
 
     p_tar_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
@@ -1871,12 +1883,13 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
 void *ABTI_xstream_launch_main_sched(void *p_arg)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_xstream *p_xstream = (ABTI_xstream *)p_arg;
 
     /* Initialization of the local variables */
     abt_errno = ABTI_local_init();
     ABTI_CHECK_ERROR(abt_errno);
-    lp_ABTI_local->p_xstream = p_xstream;
+    p_local->p_xstream = p_xstream;
 
     /* Create the main sched ULT */
     ABTI_sched *p_sched = p_xstream->p_main_sched;
@@ -1885,7 +1898,7 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     p_sched->p_thread->p_last_xstream = p_xstream;
 
     /* Set the sched ULT as the current ULT */
-    lp_ABTI_local->p_thread = p_sched->p_thread;
+    p_local->p_thread = p_sched->p_thread;
 
     /* Execute the main scheduler of this ES */
     LOG_EVENT("[E%d] start\n", p_xstream->rank);

--- a/src/stream.c
+++ b/src/stream.c
@@ -28,7 +28,7 @@ static void ABTI_xstream_return_rank(ABTI_xstream *);
 int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched;
     ABTI_xstream *p_newxstream;
 
@@ -148,7 +148,7 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
                              ABT_xstream *newxstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_newxstream;
 
     ABTI_sched *p_sched;
@@ -186,7 +186,7 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
                                  ABT_xstream *newxstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_newxstream;
     ABTI_sched *p_sched;
 
@@ -261,7 +261,7 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
 int ABT_xstream_start(ABT_xstream xstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -388,7 +388,7 @@ int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream, A
 int ABT_xstream_free(ABT_xstream *xstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABT_xstream h_xstream = *xstream;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(h_xstream);
@@ -442,7 +442,7 @@ int ABT_xstream_free(ABT_xstream *xstream)
 int ABT_xstream_join(ABT_xstream xstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -472,7 +472,7 @@ int ABT_xstream_join(ABT_xstream xstream)
 int ABT_xstream_exit(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -556,7 +556,7 @@ int ABT_xstream_cancel(ABT_xstream xstream)
 int ABT_xstream_self(ABT_xstream *xstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -599,7 +599,7 @@ int ABT_xstream_self(ABT_xstream *xstream)
 int ABT_xstream_self_rank(int *rank)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -713,7 +713,7 @@ int ABT_xstream_get_rank(ABT_xstream xstream, int *rank)
 int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched;
 
     ABTI_CHECK_TRUE(p_local != NULL, ABT_ERR_INV_THREAD);
@@ -784,7 +784,7 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
         ABT_sched_predef predef, int num_pools, ABT_pool *pools)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     int abt_errno = ABT_SUCCESS;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -997,7 +997,7 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *flag)
 int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
 {
     int abt_errno;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
 
@@ -1059,7 +1059,7 @@ int ABTI_xstream_run_unit(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 int ABT_xstream_check_events(ABT_sched sched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -1285,7 +1285,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
      * mode, the ULT can be blocked. Otherwise, the access mode, if it is a
      * single-writer access mode, may be violated because another ES has to set
      * the blocked ULT ready. */
-    p_local = lp_ABTI_local;
+    p_local = ABTI_local_get_local();
     p_thread = p_local ? p_local->p_thread : NULL;
     if (p_thread) {
         ABT_pool_access access = p_thread->p_pool->access;
@@ -1390,7 +1390,7 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream)
 /* The main scheduler of each ES executes this routine. */
 void ABTI_xstream_schedule(void *p_arg)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = (ABTI_xstream *)p_arg;
 
     while (1) {
@@ -1906,7 +1906,7 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     /* Initialization of the local variables */
     ABTI_local *p_local = NULL;
     abt_errno = ABTI_local_init(&p_local);
-    lp_ABTI_local = p_local;
+    ABTI_local_set_local(p_local);
     ABTI_CHECK_ERROR(abt_errno);
     p_local->p_xstream = p_xstream;
 

--- a/src/task.c
+++ b/src/task.c
@@ -212,6 +212,7 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
 int ABT_task_free(ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABT_task h_task = *task;
     ABTI_task *p_task = ABTI_task_get_ptr(h_task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -225,7 +226,7 @@ int ABT_task_free(ABT_task *task)
             continue;
         }
 #endif
-        ABTI_thread_yield(lp_ABTI_local->p_thread);
+        ABTI_thread_yield(p_local->p_thread);
     }
 
     /* Free the ABTI_task structure */
@@ -257,6 +258,7 @@ int ABT_task_free(ABT_task *task)
 int ABT_task_join(ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     ABTI_task *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -270,7 +272,7 @@ int ABT_task_join(ABT_task task)
             continue;
         }
 #endif
-        ABTI_thread_yield(lp_ABTI_local->p_thread);
+        ABTI_thread_yield(p_local->p_thread);
     }
 
   fn_exit:
@@ -327,6 +329,7 @@ int ABT_task_cancel(ABT_task task)
 int ABT_task_self(ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called
@@ -337,14 +340,14 @@ int ABT_task_self(ABT_task *task)
         *task = ABT_TASK_NULL;
         return abt_errno;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         *task = ABT_TASK_NULL;
         return abt_errno;
     }
 #endif
 
-    ABTI_task *p_task = lp_ABTI_local->p_task;
+    ABTI_task *p_task = p_local->p_task;
     if (p_task != NULL) {
         *task = ABTI_task_get_handle(p_task);
     } else {
@@ -371,6 +374,7 @@ int ABT_task_self(ABT_task *task)
 int ABT_task_self_id(uint64_t *id)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called
@@ -380,13 +384,13 @@ int ABT_task_self_id(uint64_t *id)
         abt_errno = ABT_ERR_UNINITIALIZED;
         return abt_errno;
     }
-    if (lp_ABTI_local == NULL) {
+    if (p_local == NULL) {
         abt_errno = ABT_ERR_INV_XSTREAM;
         return abt_errno;
     }
 #endif
 
-    ABTI_task *p_task = lp_ABTI_local->p_task;
+    ABTI_task *p_task = p_local->p_task;
     if (p_task != NULL) {
         *id = ABTI_task_get_id(p_task);
     } else {

--- a/src/task.c
+++ b/src/task.c
@@ -47,7 +47,7 @@ int ABT_task_create(ABT_pool pool,
                     ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_task *p_newtask;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -135,7 +135,7 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
                                void *arg, ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_task *p_newtask;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -183,7 +183,7 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
                     ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_task *p_task = ABTI_task_get_ptr(*task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -218,7 +218,7 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
 int ABT_task_free(ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABT_task h_task = *task;
     ABTI_task *p_task = ABTI_task_get_ptr(h_task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -264,7 +264,7 @@ int ABT_task_free(ABT_task *task)
 int ABT_task_join(ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_task *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -335,7 +335,7 @@ int ABT_task_cancel(ABT_task task)
 int ABT_task_self(ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called
@@ -380,7 +380,7 @@ int ABT_task_self(ABT_task *task)
 int ABT_task_self_id(uint64_t *id)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called

--- a/src/task.c
+++ b/src/task.c
@@ -225,7 +225,7 @@ int ABT_task_free(ABT_task *task)
             continue;
         }
 #endif
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
     }
 
     /* Free the ABTI_task structure */
@@ -270,7 +270,7 @@ int ABT_task_join(ABT_task task)
             continue;
         }
 #endif
-        ABTI_thread_yield(ABTI_local_get_thread());
+        ABTI_thread_yield(lp_ABTI_local->p_thread);
     }
 
   fn_exit:
@@ -344,7 +344,7 @@ int ABT_task_self(ABT_task *task)
     }
 #endif
 
-    ABTI_task *p_task = ABTI_local_get_task();
+    ABTI_task *p_task = lp_ABTI_local->p_task;
     if (p_task != NULL) {
         *task = ABTI_task_get_handle(p_task);
     } else {
@@ -386,7 +386,7 @@ int ABT_task_self_id(uint64_t *id)
     }
 #endif
 
-    ABTI_task *p_task = ABTI_local_get_task();
+    ABTI_task *p_task = lp_ABTI_local->p_task;
     if (p_task != NULL) {
         *id = ABTI_task_get_id(p_task);
     } else {

--- a/src/task.c
+++ b/src/task.c
@@ -5,11 +5,13 @@
 
 #include "abti.h"
 
-static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
-                            void *arg, ABTI_sched *p_sched, int refcount,
+static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                            void (*task_func)(void *), void *arg,
+                            ABTI_sched *p_sched, int refcount,
                             ABTI_task **pp_newtask);
-static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
-                            void *arg, ABTI_task *p_task);
+static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
+                            void (*task_func)(void *), void *arg,
+                            ABTI_task *p_task);
 static inline uint64_t ABTI_task_get_new_id(void);
 
 
@@ -45,13 +47,14 @@ int ABT_task_create(ABT_pool pool,
                     ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_task *p_newtask;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     int refcount = (newtask != NULL) ? 1 : 0;
-    abt_errno = ABTI_task_create(p_pool, task_func, arg, NULL, refcount,
-                                 &p_newtask);
+    abt_errno = ABTI_task_create(p_local, p_pool, task_func, arg, NULL,
+                                 refcount, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -69,7 +72,8 @@ int ABT_task_create(ABT_pool pool,
 }
 
 /* This routine is to create a tasklet for the scheduler. */
-int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
+int ABTI_task_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
+                           ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_task *p_newtask;
@@ -77,14 +81,14 @@ int ABTI_task_create_sched(ABTI_pool *p_pool, ABTI_sched *p_sched)
     void *arg = (void *)ABTI_sched_get_handle(p_sched);
     /* If p_sched is reused, ABTI_task_revive() can be used. */
     if (p_sched->p_task) {
-        abt_errno = ABTI_task_revive(p_pool, p_sched->run, arg,
+        abt_errno = ABTI_task_revive(p_local, p_pool, p_sched->run, arg,
                                      p_sched->p_task);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
     }
 
     /* Allocate a task object */
-    abt_errno = ABTI_task_create(p_pool, p_sched->run, arg, p_sched, 1,
+    abt_errno = ABTI_task_create(p_local, p_pool, p_sched->run, arg, p_sched, 1,
                                  &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -131,6 +135,7 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
                                void *arg, ABT_task *newtask)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
     ABTI_task *p_newtask;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -139,8 +144,8 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     /* TODO: need to consider the access type of target pool */
     ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newtask != NULL) ? 1 : 0;
-    abt_errno = ABTI_task_create(p_pool, task_func, arg, NULL, refcount,
-                                 &p_newtask);
+    abt_errno = ABTI_task_create(p_local, p_pool, task_func, arg, NULL,
+                                 refcount, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -178,6 +183,7 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
                     ABT_task *task)
 {
     int abt_errno = ABT_SUCCESS;
+    ABTI_local *p_local = lp_ABTI_local;
 
     ABTI_task *p_task = ABTI_task_get_ptr(*task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
@@ -185,7 +191,7 @@ int ABT_task_revive(ABT_pool pool, void (*task_func)(void *), void *arg,
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = ABTI_task_revive(p_pool, task_func, arg, p_task);
+    abt_errno = ABTI_task_revive(p_local, p_pool, task_func, arg, p_task);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
@@ -221,16 +227,16 @@ int ABT_task_free(ABT_task *task)
     while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
            != ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+        if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
             ABTD_atomic_pause();
             continue;
         }
 #endif
-        ABTI_thread_yield(p_local->p_thread);
+        ABTI_thread_yield(&p_local, p_local->p_thread);
     }
 
     /* Free the ABTI_task structure */
-    ABTI_task_free(p_task);
+    ABTI_task_free(p_local, p_task);
 
     /* Return value */
     *task = ABT_TASK_NULL;
@@ -267,12 +273,12 @@ int ABT_task_join(ABT_task task)
     while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state)
            != ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-        if (ABTI_self_get_type() != ABT_UNIT_TYPE_THREAD) {
+        if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
             ABTD_atomic_pause();
             continue;
         }
 #endif
-        ABTI_thread_yield(p_local->p_thread);
+        ABTI_thread_yield(&p_local, p_local->p_thread);
     }
 
   fn_exit:
@@ -730,8 +736,9 @@ int ABT_task_get_arg(ABT_task task, void **arg)
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
-                            void *arg, ABTI_sched *p_sched, int refcount,
+static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                            void (*task_func)(void *), void *arg,
+                            ABTI_sched *p_sched, int refcount,
                             ABTI_task **pp_newtask)
 {
     int abt_errno = ABT_SUCCESS;
@@ -740,7 +747,7 @@ static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     /* Allocate a task object */
-    p_newtask = ABTI_mem_alloc_task();
+    p_newtask = ABTI_mem_alloc_task(p_local);
 
     p_newtask->p_xstream  = NULL;
     p_newtask->state      = ABT_TASK_STATE_READY;
@@ -768,9 +775,10 @@ static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
     ABTI_pool_push(p_pool, p_newtask->unit);
 #else
-    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit, ABTI_xstream_self());
+    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit,
+                               ABTI_xstream_self(p_local));
     if (abt_errno != ABT_SUCCESS) {
-        ABTI_task_free(p_newtask);
+        ABTI_task_free(p_local, p_newtask);
         goto fn_fail;
     }
 #endif
@@ -786,8 +794,9 @@ static int ABTI_task_create(ABTI_pool *p_pool, void (*task_func)(void *),
     goto fn_exit;
 }
 
-static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
-                            void *arg, ABTI_task *p_task)
+static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
+                            void (*task_func)(void *), void *arg,
+                            ABTI_task *p_task)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -820,7 +829,8 @@ static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
     ABTI_pool_push(p_pool, p_task->unit);
 #else
-    abt_errno = ABTI_pool_push(p_pool, p_task->unit, ABTI_xstream_self());
+    abt_errno = ABTI_pool_push(p_pool, p_task->unit,
+                               ABTI_xstream_self(p_local));
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 
@@ -832,7 +842,7 @@ static int ABTI_task_revive(ABTI_pool *p_pool, void (*task_func)(void *),
     goto fn_exit;
 }
 
-void ABTI_task_free(ABTI_task *p_task)
+void ABTI_task_free(ABTI_local *p_local, ABTI_task *p_task)
 {
     LOG_EVENT("[T%" PRIu64 "] freed\n", ABTI_task_get_id(p_task));
 
@@ -844,7 +854,7 @@ void ABTI_task_free(ABTI_task *p_task)
         ABTI_ktable_free(p_task->p_keytable);
     }
 
-    ABTI_mem_free_task(p_task);
+    ABTI_mem_free_task(p_local, p_task);
 }
 
 void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)

--- a/src/thread.c
+++ b/src/thread.c
@@ -56,7 +56,7 @@ int ABT_thread_create(ABT_pool pool, void(*thread_func)(void *),
                       ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newthread;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -126,7 +126,7 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
                       ABT_thread_attr attr, ABT_thread *newthread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newthread;
 
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -182,7 +182,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
                            ABT_thread_attr attr, ABT_thread *newthread_list)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     int i;
 
     if (attr != ABT_THREAD_ATTR_NULL) {
@@ -254,7 +254,7 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
                       ABT_thread *thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_thread *p_thread = ABTI_thread_get_ptr(*thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
@@ -289,7 +289,7 @@ int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
 int ABT_thread_free(ABT_thread *thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABT_thread h_thread = *thread;
 
     ABTI_thread *p_thread = ABTI_thread_get_ptr(h_thread);
@@ -341,7 +341,7 @@ int ABT_thread_free(ABT_thread *thread)
  */
 int ABT_thread_free_many(int num, ABT_thread *thread_list)
 {
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     int i;
 
     for (i = 0; i < num; i++) {
@@ -364,7 +364,7 @@ int ABT_thread_free_many(int num, ABT_thread *thread_list)
 int ABT_thread_join(ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     abt_errno = ABTI_thread_join(&p_local, p_thread);
@@ -393,7 +393,7 @@ int ABT_thread_join(ABT_thread thread)
 int ABT_thread_join_many(int num_threads, ABT_thread *thread_list)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     int i;
     for (i = 0; i < num_threads; i++) {
         abt_errno = ABTI_thread_join(&p_local,
@@ -423,7 +423,7 @@ int ABT_thread_join_many(int num_threads, ABT_thread *thread_list)
 int ABT_thread_exit(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
     /* In case that Argobots has not been initialized or this routine is called
      * by an external thread, e.g., pthread, return an error code instead of
@@ -507,7 +507,7 @@ int ABT_thread_cancel(ABT_thread thread)
 int ABT_thread_self(ABT_thread *thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called
@@ -552,7 +552,7 @@ int ABT_thread_self(ABT_thread *thread)
 int ABT_thread_self_id(ABT_thread_id *id)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* In case that Argobots has not been initialized or this routine is called
@@ -718,7 +718,7 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
 int ABT_thread_yield_to(ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_cur_thread = NULL;
 
 #ifdef ABT_CONFIG_DISABLE_EXT_THREAD
@@ -813,7 +813,7 @@ int ABT_thread_yield_to(ABT_thread thread)
 int ABT_thread_yield(void)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = NULL;
 
 #ifdef ABT_CONFIG_DISABLE_EXT_THREAD
@@ -858,7 +858,7 @@ int ABT_thread_yield(void)
 int ABT_thread_resume(ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread;
 
     p_thread = ABTI_thread_get_ptr(thread);
@@ -897,7 +897,7 @@ int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -939,7 +939,7 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -994,7 +994,7 @@ int ABT_thread_migrate_to_pool(ABT_thread thread, ABT_pool pool)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -1037,7 +1037,7 @@ int ABT_thread_migrate(ABT_thread thread)
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* TODO: fix the bug(s) */
     int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = lp_ABTI_local;
+    ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream;
 
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -218,7 +218,8 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
     return p_thread;
 }
 
-ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
+ABT_bool ABTI_thread_htable_switch_low(ABTI_local **pp_local,
+                                       ABTI_thread_queue *p_queue,
                                        ABTI_thread *p_thread,
                                        ABTI_thread_htable *p_htable)
 {
@@ -247,7 +248,8 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_thread_queue *p_queue,
 
         /* Context-switch to p_target */
         p_target->state = ABT_THREAD_STATE_RUNNING;
-        ABTI_thread_context_switch_thread_to_thread(p_thread, p_target);
+        ABTI_thread_context_switch_thread_to_thread(pp_local, p_thread,
+                                                    p_target);
         return ABT_TRUE;
     } else {
         return ABT_FALSE;


### PR DESCRIPTION
This commit fixes the TLS caching issue mentioned in #55 and #111 

## Problem & Cause

Consider the following code:
```c
__thread ABTI_local *lp_ABTI_local;
int ABT_any_func()
{
    ABTI_xstream *p_xstream = lp_ABTI_local->p_xstream;
    ABTI_thread_yield(...);
    ABTI_xstream *p_xstream2 = lp_ABTI_local->p_xstream;
}
```
However, even if xstream is changed before and after `ABTI_thread_yield()`, `p_xstream` can be always equal to `p_xstream2`. This is because major compilers do not assume the running Pthreads can be changed across function calls and thus cache a TLS value (for example, an `fs` register value). In this specific example, the second `lp_ABTI_local` is that of the original `lp_ABTI_local` even if `ABTI_thread_yield()` changes the running Pthreads by user-level context switches.

It can potentially happen with major compilers (GCC, ICC, and Clang) on any architectures (including x86/64, ARM64, ...) as explained in #55. It has been ignored, it became a real problem (#111).

## Solution

This PR creates new functions: `ABT_local_get_local()` and  `ABT_local_get_local_uninlined()`. The first function is fast but might use a cached TLS while the `_uninlined` is slow but does not use a cached TLS.

However, since `_uninlined` is very slow, we need to use `ABT_local_get_local()` as much as possible. To mitigate the performance degradation, this PR adds new rules:
- Use `ABT_local_get_local()` (if needed) at the beginning of the `ABT_` functions and functions that are used as function pointers (e.g., `sched_run`) and thus cannot be inlined.
- Use a `p_local` argument in other functions (most `ABTI_` and `ABTD_` functions) that just read `lp_ABTI_local`.
- Use a `pp_local` argument in functions may change `lp_ABTI_local` internally by context switching (e.g., ABTI_yield).
- Use `ABT_local_get_local_uninlined()` in functions that really change the running Pthreads or are not in the critical path (e.g., `ABTI_log` functions). 

As a result, most `ABT_` functions load TLS with fast `ABT_local_get_local()` and pass `p_local` or `&p_local` to `ABTI_` functions. `ABTI_` and `ABTD_` functions that use `lp_ABTI_local` become taking either `p_local` or `pp_local`. Very few functions use `ABT_local_get_local_uninlined()`.

## Implementation
`ABT_local_get_local()` is an inline function that just reads a TLS directly from the pointer. `ABT_local_get_local_uninlined()` executes a TLS read function (`ABT_local_get_local_internal()`: the same as `ABT_local_get_local()`) via a function pointer stored in a global structure. Since this function pointer can be changed anywhere, the compiler cannot optimize out this function call. `ABT_local_get_local_internal()` cannot use TLS since it cannot be inlined (because it is a function call), so it freshly reads the current TLS.

## Performance Impact
This change is necessary for correctness, but it negatively affects the performance since it potentially adds a TLS read overhead on `ABT_local_get_local_internal()`. This patch also forces functions to pass TLS, which can increase the register pressure. The optimization can be done in the future.



