### PR TITLE
sched: clean up the algorithm of the basic scheduler

### DIFF
--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -91,13 +91,13 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 static void sched_run(ABT_sched sched)
 {
     ABTI_local *p_local = ABTI_local_get_local();
-    uint32_t work_count = 0;
+    ABT_unit unit = ABT_UNIT_NULL;
+    uint32_t pop_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
     int num_pools;
     ABT_pool *pools;
     int i;
-    CNT_DECL(run_cnt);
 
     ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -109,29 +109,22 @@ static void sched_run(ABT_sched sched)
     pools      = p_data->pools;
 
     while (1) {
-        CNT_INIT(run_cnt, 0);
-
-        /* Execute one work unit from the scheduler's pool */
         for (i = 0; i < num_pools; i++) {
-            ABT_pool pool = pools[i];
-            ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            /* Pop one work unit */
-            ABT_unit unit = ABTI_pool_pop(p_pool);
-            if (unit != ABT_UNIT_NULL) {
+            ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[i]);
+            ++pop_count;
+            if ((unit = ABTI_pool_pop(p_pool)) != ABT_UNIT_NULL) {
                 ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
-                CNT_INC(run_cnt);
                 break;
             }
         }
-
-        if (++work_count >= event_freq) {
+        /* if we attempted event_freq pops, check for events */
+        if (pop_count >= event_freq) {
             ABTI_xstream_check_events(p_xstream, sched);
-            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
-                                                   p_xstream);
-            if (stop == ABT_TRUE)
+            if (ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream)
+                == ABT_TRUE)
                 break;
-            work_count = 0;
-            SCHED_SLEEP(run_cnt, p_data->sleep_time);
+            SCHED_SLEEP(unit != ABT_UNIT_NULL, p_data->sleep_time);
+            pop_count = 0;
         }
     }
 }


### PR DESCRIPTION
This change to the basic scheduler algorithm checks for events after X ULTs rather than X passes
through all the pools. The core idea is that pop_count is a better metric to check for an event periodically compared with previous work_count (pop_count * num_pools) since this metric does not depend on the number of pools. Also, this change removed run_cnt variable and used unit variable as input for SCHED_SLEEP, which makes the code a bit cleaner since another variable is not required.