### PR TITLE
Clean up ABTI_error.h

### DIFF
--- a/src/futures.c
+++ b/src/futures.c
@@ -319,7 +319,7 @@ int ABT_future_reset(ABT_future future)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_future *p_future = ABTI_future_get_ptr(future);
-    ABTI_CHECK_NULL_EVENTUAL_PTR(p_future);
+    ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
     ABTI_spinlock_acquire(&p_future->lock);
     p_future->ready = ABT_FALSE;

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -190,6 +190,15 @@
         }                                                               \
     } while (0)
 
+#define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)      \
+    do {                                            \
+        if (ABTI_IS_ERROR_CHECK_ENABLED             \
+            && p == (ABTI_xstream_barrier *)NULL) { \
+            abt_errno = ABT_ERR_INV_BARRIER;        \
+            goto fn_fail;                           \
+        }                                           \
+    } while (0)
+
 #define ABTI_CHECK_NULL_TIMER_PTR(p)                                  \
     do {                                                              \
         if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_timer *)NULL) { \

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -9,267 +9,194 @@
 #include <assert.h>
 #include <abt_config.h>
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_ASSERT(cond) assert(cond)
-#else
-#define ABTI_ASSERT(cond)
-#endif
 
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_INITIALIZED()                \
-    do {                                        \
-        if (gp_ABTI_global == NULL) {           \
-            abt_errno = ABT_ERR_UNINITIALIZED;  \
-            goto fn_fail;                       \
-        }                                       \
-    } while(0)
+#define ABTI_IS_ERROR_CHECK_ENABLED 1
 #else
-#define ABTI_CHECK_INITIALIZED()
+#define ABTI_IS_ERROR_CHECK_ENABLED 0
 #endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_ERROR(abt_errno)             \
-    if (abt_errno != ABT_SUCCESS) goto fn_fail
-#else
-#define ABTI_CHECK_ERROR(abt_errno) do { (void)(abt_errno); } while (0)
-#endif
+#define ABTI_ASSERT(cond)                  \
+    do {                                   \
+        if (ABTI_IS_ERROR_CHECK_ENABLED) { \
+            assert(cond);                  \
+        }                                  \
+    } while(0)
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_ERROR_MSG(abt_errno,msg)     \
-    do {                                        \
-        if (abt_errno != ABT_SUCCESS) {         \
-            HANDLE_ERROR(msg);                  \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_INITIALIZED()                                     \
+    do {                                                             \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && gp_ABTI_global == NULL) { \
+            abt_errno = ABT_ERR_UNINITIALIZED;                       \
+            goto fn_fail;                                            \
+        }                                                            \
     } while(0)
-#else
-#define ABTI_CHECK_ERROR_MSG(abt_errno,msg)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_TRUE(cond,val)               \
-    do {                                        \
-        if (!(cond)) {                          \
-            abt_errno = (val);                  \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_ERROR(abt_errno)                                    \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) { \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
-#define ABTI_CHECK_TRUE_RET(cond,val)           \
-    do {                                        \
-        if (!(cond)) {                          \
-            return (val);                       \
-        }                                       \
-    } while(0)
-#else
-#define ABTI_CHECK_TRUE(cond,val)
-#define ABTI_CHECK_TRUE_RET(cond,val)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_TRUE_MSG(cond,val,msg)       \
-    do {                                        \
-        if (!(cond)) {                          \
-            abt_errno = (val);                  \
-            HANDLE_ERROR(msg);                  \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_ERROR_MSG(abt_errno, msg)                           \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) { \
+            HANDLE_ERROR(msg);                                         \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
-#define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)   \
-    do {                                        \
-        if (!(cond)) {                          \
-            HANDLE_ERROR(msg);                  \
-            return (val);                       \
-        }                                       \
-    } while(0)
-#else
-#define ABTI_CHECK_TRUE_MSG(cond,val,msg)
-#define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_XSTREAM_PTR(p)          \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_XSTREAM;    \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_TRUE(cond, val)                                     \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                  \
+            abt_errno = (val);                                         \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_XSTREAM_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_POOL_PTR(p)             \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_POOL;       \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_TRUE_RET(cond, val)                                 \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                  \
+            return (val);                                              \
+        }                                                              \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_POOL_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_SCHED_PTR(p)            \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_SCHED;      \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_TRUE_MSG(cond, val, msg)           \
+    do {                                              \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) { \
+            abt_errno = (val);                        \
+            HANDLE_ERROR(msg);                        \
+            goto fn_fail;                             \
+        }                                             \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_SCHED_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_THREAD_PTR(p)           \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_THREAD;     \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_TRUE_MSG_RET(cond,val,msg)         \
+    do {                                              \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) { \
+            HANDLE_ERROR(msg);                        \
+            return (val);                             \
+        }                                             \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_THREAD_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)          \
-    do {                                            \
-        if (p == NULL) {                            \
-            abt_errno = ABT_ERR_INV_THREAD_ATTR;    \
-            goto fn_fail;                           \
-        }                                           \
+#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                  \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_XSTREAM;            \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_TASK_PTR(p)             \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_TASK;       \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_POOL_PTR(p)                     \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_POOL;               \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_TASK_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_KEY_PTR(p)              \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_KEY;        \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_SCHED_PTR(p)                    \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_SCHED;              \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_KEY_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_MUTEX_PTR(p)            \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_MUTEX;      \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_THREAD_PTR(p)                   \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_THREAD;             \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_MUTEX_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)       \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_MUTEX_ATTR; \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)              \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_THREAD_ATTR;        \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_COND_PTR(p)             \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_COND;       \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_TASK_PTR(p)                     \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_TASK;               \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_COND_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_RWLOCK_PTR(p)             \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_RWLOCK;       \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_KEY_PTR(p)                      \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_KEY;                \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_RWLOCK_PTR(p) \
-    do {                              \
-        if (0) {                      \
-            goto fn_fail;             \
-        }                             \
-    } while(0)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_FUTURE_PTR(p)           \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_FUTURE;     \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_MUTEX_PTR(p)                    \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_MUTEX;              \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_FUTURE_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)         \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_EVENTUAL;   \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)               \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_MUTEX_ATTR;         \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_BARRIER_PTR(p)          \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_BARRIER;    \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_COND_PTR(p)                     \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_COND;               \
+            goto fn_fail;                               \
+        }                                               \
+    } while(0)
+
+#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                   \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_RWLOCK;             \
+            goto fn_fail;                               \
+        }                                               \
+    } while(0)
+
+#define ABTI_CHECK_NULL_FUTURE_PTR(p)                   \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_FUTURE;             \
+            goto fn_fail;                               \
+        }                                               \
+    } while(0)
+
+#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                 \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_EVENTUAL;           \
+            goto fn_fail;                               \
+        }                                               \
+    } while(0)
+
+#define ABTI_CHECK_NULL_BARRIER_PTR(p)                  \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_BARRIER;            \
+            goto fn_fail;                               \
+        }                                               \
     } while (0)
-#else
-#define ABTI_CHECK_NULL_BARRIER_PTR(p)
-#endif
 
-#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-#define ABTI_CHECK_NULL_TIMER_PTR(p)            \
-    do {                                        \
-        if (p == NULL) {                        \
-            abt_errno = ABT_ERR_INV_TIMER;      \
-            goto fn_fail;                       \
-        }                                       \
+#define ABTI_CHECK_NULL_TIMER_PTR(p)                    \
+    do {                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
+            abt_errno = ABT_ERR_INV_TIMER;              \
+            goto fn_fail;                               \
+        }                                               \
     } while(0)
-#else
-#define ABTI_CHECK_NULL_TIMER_PTR(p)
-#endif
 
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
 #define HANDLE_WARNING(msg) \

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -78,124 +78,124 @@
         }                                             \
     } while(0)
 
-#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                  \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_XSTREAM;            \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                  \
+    do {                                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_xstream *)NULL) { \
+            abt_errno = ABT_ERR_INV_XSTREAM;                            \
+            goto fn_fail;                                               \
+        }                                                               \
     } while(0)
 
-#define ABTI_CHECK_NULL_POOL_PTR(p)                     \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_POOL;               \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_POOL_PTR(p)                                  \
+    do {                                                             \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_pool *)NULL) { \
+            abt_errno = ABT_ERR_INV_POOL;                            \
+            goto fn_fail;                                            \
+        }                                                            \
     } while(0)
 
-#define ABTI_CHECK_NULL_SCHED_PTR(p)                    \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_SCHED;              \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_SCHED_PTR(p)                                  \
+    do {                                                              \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_sched *)NULL) { \
+            abt_errno = ABT_ERR_INV_SCHED;                            \
+            goto fn_fail;                                             \
+        }                                                             \
     } while(0)
 
-#define ABTI_CHECK_NULL_THREAD_PTR(p)                   \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_THREAD;             \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_THREAD_PTR(p)                                  \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) { \
+            abt_errno = ABT_ERR_INV_THREAD;                            \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
 
-#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)              \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_THREAD_ATTR;        \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                  \
+    do {                                                                    \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread_attr *)NULL) { \
+            abt_errno = ABT_ERR_INV_THREAD_ATTR;                            \
+            goto fn_fail;                                                   \
+        }                                                                   \
     } while(0)
 
-#define ABTI_CHECK_NULL_TASK_PTR(p)                     \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_TASK;               \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_TASK_PTR(p)                                  \
+    do {                                                             \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_task *)NULL) { \
+            abt_errno = ABT_ERR_INV_TASK;                            \
+            goto fn_fail;                                            \
+        }                                                            \
     } while(0)
 
-#define ABTI_CHECK_NULL_KEY_PTR(p)                      \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_KEY;                \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_KEY_PTR(p)                                  \
+    do {                                                            \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_key *)NULL) { \
+            abt_errno = ABT_ERR_INV_KEY;                            \
+            goto fn_fail;                                           \
+        }                                                           \
     } while(0)
 
-#define ABTI_CHECK_NULL_MUTEX_PTR(p)                    \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_MUTEX;              \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_MUTEX_PTR(p)                                  \
+    do {                                                              \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex *)NULL) { \
+            abt_errno = ABT_ERR_INV_MUTEX;                            \
+            goto fn_fail;                                             \
+        }                                                             \
     } while(0)
 
-#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)               \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_MUTEX_ATTR;         \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                  \
+    do {                                                                   \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex_attr *)NULL) { \
+            abt_errno = ABT_ERR_INV_MUTEX_ATTR;                            \
+            goto fn_fail;                                                  \
+        }                                                                  \
     } while(0)
 
-#define ABTI_CHECK_NULL_COND_PTR(p)                     \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_COND;               \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_COND_PTR(p)                                  \
+    do {                                                             \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_cond *)NULL) { \
+            abt_errno = ABT_ERR_INV_COND;                            \
+            goto fn_fail;                                            \
+        }                                                            \
     } while(0)
 
-#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                   \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_RWLOCK;             \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                  \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_rwlock *)NULL) { \
+            abt_errno = ABT_ERR_INV_RWLOCK;                            \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
 
-#define ABTI_CHECK_NULL_FUTURE_PTR(p)                   \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_FUTURE;             \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_FUTURE_PTR(p)                                  \
+    do {                                                               \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_future *)NULL) { \
+            abt_errno = ABT_ERR_INV_FUTURE;                            \
+            goto fn_fail;                                              \
+        }                                                              \
     } while(0)
 
-#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                 \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_EVENTUAL;           \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                  \
+    do {                                                                 \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_eventual *)NULL) { \
+            abt_errno = ABT_ERR_INV_EVENTUAL;                            \
+            goto fn_fail;                                                \
+        }                                                                \
     } while(0)
 
-#define ABTI_CHECK_NULL_BARRIER_PTR(p)                  \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_BARRIER;            \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_BARRIER_PTR(p)                                  \
+    do {                                                                \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_barrier *)NULL) { \
+            abt_errno = ABT_ERR_INV_BARRIER;                            \
+            goto fn_fail;                                               \
+        }                                                               \
     } while (0)
 
-#define ABTI_CHECK_NULL_TIMER_PTR(p)                    \
-    do {                                                \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == NULL) { \
-            abt_errno = ABT_ERR_INV_TIMER;              \
-            goto fn_fail;                               \
-        }                                               \
+#define ABTI_CHECK_NULL_TIMER_PTR(p)                                  \
+    do {                                                              \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_timer *)NULL) { \
+            abt_errno = ABT_ERR_INV_TIMER;                            \
+            goto fn_fail;                                             \
+        }                                                             \
     } while(0)
 
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -199,28 +199,38 @@
     } while(0)
 
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
-#define HANDLE_WARNING(msg) \
-    fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg)
-
-#define HANDLE_ERROR(msg) \
-    fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg)
-    //fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); exit(-1)
-
-#define HANDLE_ERROR_WITH_CODE(msg,n) \
-    fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n)
-    //fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n); exit(-1)
-
-#define HANDLE_ERROR_FUNC_WITH_CODE(n) \
-    fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n)
-    //fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__, n); exit(-1)
-
+#define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 1
 #else
-
-#define HANDLE_WARNING(msg)            do { } while (0)
-#define HANDLE_ERROR(msg)              do { } while (0)
-#define HANDLE_ERROR_WITH_CODE(msg,n)  do { } while (0)
-#define HANDLE_ERROR_FUNC_WITH_CODE(n) do { } while (0)
-
+#define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 0
 #endif
+
+#define HANDLE_WARNING(msg)                                           \
+    do {                                                              \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                        \
+            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); \
+        }                                                             \
+    } while(0)
+
+#define HANDLE_ERROR(msg)                                             \
+    do {                                                              \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                        \
+            fprintf(stderr, "[%s:%d] %s\n", __FILE__, __LINE__, msg); \
+        }                                                             \
+    } while(0)
+
+#define HANDLE_ERROR_WITH_CODE(msg, n)                                       \
+    do {                                                                     \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                               \
+            fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, msg, n); \
+        }                                                                    \
+    } while(0)
+
+#define HANDLE_ERROR_FUNC_WITH_CODE(n)                                         \
+    do {                                                                       \
+        if (ABTI_IS_PRINT_ABT_ERRNO_ENABLED) {                                 \
+            fprintf(stderr, "[%s:%d] %s: %d\n", __FILE__, __LINE__, __func__,  \
+                    n);                                                        \
+        }                                                                      \
+    } while(0)
 
 #endif /* ABTI_ERROR_H_INCLUDED */

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -109,7 +109,7 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
     int abt_errno = ABT_SUCCESS;
     ABT_xstream_barrier h_barrier = *barrier;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(h_barrier);
-    ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
+    ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
     abt_errno = ABTD_xstream_barrier_destroy(&p_barrier->bar);
     ABTI_CHECK_ERROR(abt_errno);
@@ -146,7 +146,7 @@ int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
 #ifdef HAVE_PTHREAD_BARRIER_INIT
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(barrier);
-    ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
+    ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
     if (p_barrier->num_waiters > 1) {
         ABTD_xstream_barrier_wait(&p_barrier->bar);

--- a/src/task.c
+++ b/src/task.c
@@ -514,7 +514,7 @@ int ABT_task_get_last_pool_id(ABT_task task, int *id)
     int abt_errno = ABT_SUCCESS;
 
     ABTI_task *p_task = ABTI_task_get_ptr(task);
-    ABTI_CHECK_NULL_THREAD_PTR(p_task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     ABTI_ASSERT(p_task->p_pool);
     *id = (int)(p_task->p_pool->id);
@@ -692,7 +692,7 @@ int ABT_task_get_id(ABT_task task, uint64_t *task_id)
     int abt_errno = ABT_SUCCESS;
 
     ABTI_task *p_task = ABTI_task_get_ptr(task);
-    ABTI_CHECK_NULL_THREAD_PTR(p_task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     *task_id = ABTI_task_get_id(p_task);
 
@@ -721,7 +721,7 @@ int ABT_task_get_arg(ABT_task task, void **arg)
     int abt_errno = ABT_SUCCESS;
 
     ABTI_task *p_task = ABTI_task_get_ptr(task);
-    ABTI_CHECK_NULL_THREAD_PTR(p_task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     *arg = p_task->p_arg;
 


### PR DESCRIPTION
This PR cleans up `ABTI_error.h`.

### 1. Clean up the implementation of `ABTI_CHECK_xxx` and `HANDLE_xxx` macros.

Previously, two implementations of `ABTI_CHECK_` and `HANDLE_xxx` macros exist based on `ABT_CONFIG_DISABLE_ERROR_CHECK` and `ABT_CONFIG_PRINT_ABT_ERRNO`. This PR creates constant values associated with `ABT_CONFIG_DISABLE_ERROR_CHECK` and `ABT_CONFIG_PRINT_ABT_ERRNO` and add a branch in the macros (without creating a macro).

Briefly speaking,
```c
#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
#define ABTI_CHECK_TRUE_RET(cond,val) \
    do {                              \
        if (!(cond)) {                \
            return (val);             \
        }                             \
    } while(0)
#else
#define ABTI_CHECK_TRUE_RET(cond,val)
#endif
```
becomes the following.
```c
// ABT_CONFIG_IS_ERROR_CHECK_ENABLED is defined in another place.
#define ABTI_CHECK_TRUE_RET(cond,val)                       \
    do {                                                    \
        if (ABT_CONFIG_IS_ERROR_CHECK_ENABLED && !(cond)) { \
            return (val);                                   \
        }                                                   \
    } while(0)
```
Note that such a compile-time constant is propagated at compile time and thus this value
is not evaluated at runtime, so there is no performance penalty.

There are two additional merits:
- Fewer `#ifndef` - `#endif`. Code is cleaner.
- Refer to all arguments and labels even if the error check feature is disabled. This does not affect the runtime behavior but can suppress some compiler's "unused" warnings.

### 2. Type check in `ABTI_CHECK-xxx` functions.

The comparison with `NULL` does not check the type of the pointer, so the given argument type might be different from what is intended. This PR casts a `NULL` pointer to a specific type so that it causes a warning or an error if a given pointer has a different type.

For example,
```c
    ABTI_future *p_future = ABTI_future_get_ptr(future);
    ABTI_CHECK_NULL_EVENTUAL_PTR(p_future); // should be FUTURE_PTR,
```
The above code was compiled without any warning since p_future is compared with `NULL` in `ABTI_CHECK_NULL_EVENTUAL_PTR` (and if `NULL` it returns `ABT_ERR_INV_EVENTUAL`, which is wrong).
The new macro casts `NULL` to `(ABTI_eventual *)NULL`, so using a wrong `ABTI_CHECK_xxx` becomes a warning.
```
warning: comparison of distinct pointer types lacks a cast
```