### PR TITLE
global: restore cpuset (affinity) at ABT_finalize()

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -221,6 +221,11 @@ int ABT_finalize(void)
     /* Free the spinlock */
     ABTI_spinlock_free(&gp_ABTI_global->xstreams_lock);
 
+    /* Restore the affinity */
+    if (gp_ABTI_global->set_affinity == ABT_TRUE) {
+        ABTD_affinity_finalize();
+    }
+
     /* Free the ABTI_global structure */
     ABTU_free(gp_ABTI_global);
     gp_ABTI_global = NULL;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -38,6 +38,7 @@ int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */
 void ABTD_affinity_init(void);
+void ABTD_affinity_finalize(void);
 int ABTD_affinity_set(ABTD_xstream_context ctx, int rank);
 int ABTD_affinity_set_cpuset(ABTD_xstream_context ctx, int cpuset_size,
                              int *p_cpuset);


### PR DESCRIPTION
## Problem

The `cpuset` (affinity) of the main pthread is changed if `ABT_ENV_SET_AFFINITY` is on, but it is not restored at finialization, which limits the number of cores in the following execution.

For example,

```c
/* 1st exec */
ABT_init(0, NULL);
...
ABT_finalize();

/* 2nd exec */
ABT_init(0, NULL);
...
ABT_finalize();
```

the above second execution only uses one core even if multiple ESes are created, since the `cpuset` of the main pthread is set to `core 0` at `ABT_init()`.

## Solution

Save `cpuset` at `ABT_init()`, and restore it at `ABT_finalize()`.