### PR TITLE
Add a static assert macro

### DIFF
--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -23,6 +23,11 @@
         }                                  \
     } while(0)
 
+#define ABTI_STATIC_ASSERT(cond)                \
+    do {                                        \
+        ((void)sizeof(char[2 * !!(cond) - 1])); \
+    } while(0)
+
 #define ABTI_CHECK_INITIALIZED()                                     \
     do {                                                             \
         if (ABTI_IS_ERROR_CHECK_ENABLED && gp_ABTI_global == NULL) { \

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -8,7 +8,7 @@
 
 ABTI_thread_htable *ABTI_thread_htable_create(uint32_t num_rows)
 {
-    ABTI_ASSERT(sizeof(ABTI_thread_queue) == 192);
+    ABTI_STATIC_ASSERT(sizeof(ABTI_thread_queue) == 192);
 
     ABTI_thread_htable *p_htable;
     size_t q_size = num_rows * sizeof(ABTI_thread_queue);


### PR DESCRIPTION
This PR adds a static assert macro, `ABTI_STATIC_ASSERT()`. Currently Argobots only supports `ABTI_ASSERT()`, which checks a given condition at execution time. However, some conditions are compile-time constant and thus should be checked at compile time. This macro uses a trick to implement a static assert macro similar to `BUILD_BUG_ON()` in the Linux kernel (http://lxr.linux.no/linux+v2.6.26.5/include/linux/kernel.h#L494). 