### PR TITLE
mutex_attr: remove unnecessary atomic operations

### DIFF
--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -98,9 +98,9 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
 
     /* Set the value */
     if (recursive == ABT_TRUE) {
-        ABTD_atomic_fetch_or_uint32(&p_attr->attrs, ABTI_MUTEX_ATTR_RECURSIVE);
+        p_attr->attrs |= ABTI_MUTEX_ATTR_RECURSIVE;
     } else {
-        ABTD_atomic_fetch_and_uint32(&p_attr->attrs, ~ABTI_MUTEX_ATTR_RECURSIVE);
+        p_attr->attrs &= ~ABTI_MUTEX_ATTR_RECURSIVE;
     }
 
   fn_exit:


### PR DESCRIPTION
`ABT_mutex_attr_set_recursive()` uses atomic operations to update a recursive flag, but racy flag change should be forbidden (e.g., two threads try to change a recursive mode of the same `ABT_mutex_attr` simultaneously). This commit removes these unnecessary atomic operations.