### PR TITLE
Clean up the interface of ABTI_spinlock

### DIFF
--- a/src/barrier.c
+++ b/src/barrier.c
@@ -31,7 +31,7 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
 
     p_newbarrier = (ABTI_barrier *)ABTU_malloc(sizeof(ABTI_barrier));
 
-    ABTI_spinlock_create(&p_newbarrier->lock);
+    ABTI_spinlock_clear(&p_newbarrier->lock);
     p_newbarrier->num_waiters = num_waiters;
     p_newbarrier->counter = 0;
     p_newbarrier->waiters =
@@ -116,7 +116,6 @@ int ABT_barrier_free(ABT_barrier *barrier)
      * freed here. */
     ABTI_spinlock_acquire(&p_barrier->lock);
 
-    ABTI_spinlock_free(&p_barrier->lock);
     ABTU_free(p_barrier->waiters);
     ABTU_free(p_barrier->waiter_type);
     ABTU_free(p_barrier);

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -36,7 +36,7 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
     ABTI_eventual *p_eventual;
 
     p_eventual = (ABTI_eventual *)ABTU_malloc(sizeof(ABTI_eventual));
-    ABTI_spinlock_create(&p_eventual->lock);
+    ABTI_spinlock_clear(&p_eventual->lock);
     p_eventual->ready = ABT_FALSE;
     p_eventual->nbytes = nbytes;
     p_eventual->value = (nbytes == 0) ? NULL : ABTU_malloc(nbytes);
@@ -71,7 +71,6 @@ int ABT_eventual_free(ABT_eventual *eventual)
      * freed here. */
     ABTI_spinlock_acquire(&p_eventual->lock);
 
-    ABTI_spinlock_free(&p_eventual->lock);
     if (p_eventual->value) ABTU_free(p_eventual->value);
     ABTU_free(p_eventual);
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -61,7 +61,7 @@ int ABT_future_create(uint32_t compartments, void (*cb_func)(void **arg),
     ABTI_future *p_future;
 
     p_future = (ABTI_future *)ABTU_malloc(sizeof(ABTI_future));
-    ABTI_spinlock_create(&p_future->lock);
+    ABTI_spinlock_clear(&p_future->lock);
     p_future->ready = ABT_FALSE;
     p_future->counter = 0;
     p_future->compartments = compartments;
@@ -98,7 +98,6 @@ int ABT_future_free(ABT_future *future)
      * freed here. */
     ABTI_spinlock_acquire(&p_future->lock);
 
-    ABTI_spinlock_free(&p_future->lock);
     ABTU_free(p_future->array);
     ABTU_free(p_future);
 

--- a/src/global.c
+++ b/src/global.c
@@ -85,8 +85,8 @@ int ABT_init(int argc, char **argv)
             gp_ABTI_global->max_xstreams, sizeof(ABTI_xstream *));
     gp_ABTI_global->num_xstreams = 0;
 
-    /* Create a spinlock */
-    ABTI_spinlock_create(&gp_ABTI_global->xstreams_lock);
+    /* Initialize a spinlock */
+    ABTI_spinlock_clear(&gp_ABTI_global->xstreams_lock);
 
     /* Init the ES local data */
     ABTI_local *p_local = NULL;
@@ -217,9 +217,6 @@ int ABT_finalize(void)
 
     /* Finalize the memory pool */
     ABTI_mem_finalize(gp_ABTI_global);
-
-    /* Free the spinlock */
-    ABTI_spinlock_free(&gp_ABTI_global->xstreams_lock);
 
     /* Restore the affinity */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -13,7 +13,7 @@
 static inline
 void ABTI_cond_init(ABTI_cond *p_cond)
 {
-    ABTI_spinlock_create(&p_cond->lock);
+    ABTI_spinlock_clear(&p_cond->lock);
     p_cond->p_waiter_mutex = NULL;
     p_cond->num_waiters  = 0;
     p_cond->p_head = NULL;
@@ -27,8 +27,6 @@ void ABTI_cond_fini(ABTI_cond *p_cond)
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
     ABTI_spinlock_acquire(&p_cond->lock);
-
-    ABTI_spinlock_free(&p_cond->lock);
 }
 
 static inline

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -10,14 +10,11 @@ struct ABTI_spinlock {
     uint8_t val;
 };
 
-static inline void ABTI_spinlock_create(ABTI_spinlock *p_lock)
+#define ABTI_SPINLOCK_STATIC_INITIALIZER() {0}
+
+static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 {
     p_lock->val = 0;
-}
-
-static inline void ABTI_spinlock_free(ABTI_spinlock *p_lock)
-{
-    ABTI_UNUSED(p_lock);
 }
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -53,7 +53,7 @@ static uint64_t g_sp_id = 0;
 void ABTI_mem_init(ABTI_global *p_global)
 {
     p_global->p_mem_stack = NULL;
-    ABTI_spinlock_create(&p_global->mem_task_lock);
+    ABTI_spinlock_clear(&p_global->mem_task_lock);
     p_global->p_mem_task = NULL;
     p_global->p_mem_sph = NULL;
 
@@ -78,7 +78,6 @@ void ABTI_mem_finalize(ABTI_global *p_global)
     p_global->p_mem_stack = NULL;
 
     /* Free all task blocks */
-    ABTI_spinlock_free(&p_global->mem_task_lock);
     ABTI_mem_free_page_list(p_global->p_mem_task);
     p_global->p_mem_task = NULL;
 

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -23,21 +23,9 @@ typedef struct ABTI_valgrind_id_list_t {
 } ABTI_valgrind_id_list;
 
 /* The list is protected by a global lock. */
-uint8_t g_valgrind_id_list_lock = 0;
+ABTI_spinlock g_valgrind_id_list_lock = ABTI_SPINLOCK_STATIC_INITIALIZER();
 ABTI_valgrind_id_list *gp_valgrind_id_list_head = NULL;
 ABTI_valgrind_id_list *gp_valgrind_id_list_tail = NULL;
-
-static inline
-void ABTI_valgrind_lock_acquire() {
-    while (ABTD_atomic_test_and_set_uint8(&g_valgrind_id_list_lock)) {
-        while (ABTD_atomic_load_uint8(&g_valgrind_id_list_lock) != 0);
-    }
-}
-
-static inline
-void ABTI_valgrind_lock_release() {
-    ABTD_atomic_clear_uint8(&g_valgrind_id_list_lock);
-}
 
 #include <valgrind/valgrind.h>
 
@@ -48,7 +36,7 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
     const void *p_start = (char *)(p_stack);
     const void *p_end   = (char *)(p_stack) + size;
 
-    ABTI_valgrind_lock_acquire();
+    ABTI_spinlock_acquire(&g_valgrind_id_list_lock);
     ABTI_valgrind_id valgrind_id = VALGRIND_STACK_REGISTER(p_start, p_end);
     ABTI_valgrind_id_list *p_valgrind_id_list =
                  (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
@@ -64,14 +52,14 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size) {
     }
     LOG_DEBUG("valgrind : register stack %p (id = %d)\n",
               p_stack, (int) valgrind_id);
-    ABTI_valgrind_lock_release();
+    ABTI_spinlock_release(&g_valgrind_id_list_lock);
 }
 
 void ABTI_valgrind_unregister_stack(const void *p_stack) {
     if (p_stack == 0)
         return;
 
-    ABTI_valgrind_lock_acquire();
+    ABTI_spinlock_acquire(&g_valgrind_id_list_lock);
     if (gp_valgrind_id_list_head->p_stack == p_stack) {
         VALGRIND_STACK_DEREGISTER(gp_valgrind_id_list_head->valgrind_id);
         ABTI_valgrind_id_list *p_next = gp_valgrind_id_list_head->p_next;
@@ -101,7 +89,7 @@ void ABTI_valgrind_unregister_stack(const void *p_stack) {
         }
         ABTI_ASSERT(deregister_flag);
     }
-    ABTI_valgrind_lock_release();
+    ABTI_spinlock_release(&g_valgrind_id_list_lock);
 }
 
 #endif

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -127,7 +127,7 @@ int pool_init(ABT_pool pool, ABT_pool_config config)
 
     if (access != ABT_POOL_ACCESS_PRIV) {
         /* Initialize the mutex */
-        ABTI_spinlock_create(&p_data->mutex);
+        ABTI_spinlock_clear(&p_data->mutex);
     }
 
     p_data->num_units = 0;
@@ -142,14 +142,8 @@ int pool_init(ABT_pool pool, ABT_pool_config config)
 static int pool_free(ABT_pool pool)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_pool_access access;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
-
-    access = p_pool->access;
-    if (access != ABT_POOL_ACCESS_PRIV) {
-        ABTI_spinlock_free(&p_data->mutex);
-    }
 
     ABTU_free(p_data);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -80,8 +80,8 @@ int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
     p_newxstream->p_req_arg    = NULL;
     p_newxstream->p_main_sched = NULL;
 
-    /* Create the spinlock */
-    ABTI_spinlock_create(&p_newxstream->sched_lock);
+    /* Initialize the spinlock */
+    ABTI_spinlock_clear(&p_newxstream->sched_lock);
 
     /* Set the main scheduler */
     abt_errno = ABTI_xstream_set_main_sched(pp_local, p_newxstream, p_sched);
@@ -224,8 +224,8 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     p_newxstream->p_req_arg    = NULL;
     p_newxstream->p_main_sched = NULL;
 
-    /* Create the spinlock */
-    ABTI_spinlock_create(&p_newxstream->sched_lock);
+    /* Initialize the spinlock */
+    ABTI_spinlock_clear(&p_newxstream->sched_lock);
 
     /* Set the main scheduler */
     abt_errno = ABTI_xstream_set_main_sched(&p_local, p_newxstream, p_sched);
@@ -1377,9 +1377,6 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream)
     /* Free the context */
     abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
     ABTI_CHECK_ERROR(abt_errno);
-
-    /* Free the spinlock */
-    ABTI_spinlock_free(&p_xstream->sched_lock);
 
     ABTU_free(p_xstream);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1515,8 +1515,8 @@ int ABTI_thread_create_internal(ABTI_local *p_local, ABTI_pool *p_pool,
     p_newthread->id             = ABTI_THREAD_INIT_ID;
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    /* Create a spinlock */
-    ABTI_spinlock_create(&p_newthread->lock);
+    /* Initialize a spinlock */
+    ABTI_spinlock_clear(&p_newthread->lock);
 #endif
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
@@ -1762,11 +1762,6 @@ void ABTI_thread_free_internal(ABTI_thread *p_thread)
     if (p_thread->p_keytable) {
         ABTI_ktable_free(p_thread->p_keytable);
     }
-
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    /* Free the spinlock */
-    ABTI_spinlock_free(&p_thread->lock);
-#endif
 }
 
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread)

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -22,7 +22,7 @@ ABTI_thread_htable *ABTI_thread_htable_create(uint32_t num_rows)
     int ret = pthread_mutex_init(&p_htable->mutex, NULL);
     assert(!ret);
 #else
-    ABTI_spinlock_create(&p_htable->mutex);
+    ABTI_spinlock_clear(&p_htable->mutex);
 #endif
     p_htable->num_elems = 0;
     p_htable->num_rows = num_rows;
@@ -46,7 +46,7 @@ void ABTI_thread_htable_free(ABTI_thread_htable *p_htable)
     int ret = pthread_mutex_destroy(&p_htable->mutex);
     assert(!ret);
 #else
-    ABTI_spinlock_free(&p_htable->mutex);
+    /* ABTI_spinlock needs no finalization. */
 #endif
     ABTU_free(p_htable->queue);
     ABTU_free(p_htable);


### PR DESCRIPTION
This PR cleans up the interface of `ABTI_spinlock`. Specifically, `ABTI_spinlock` can be initialize statically and do not require explicit finalization, but the previous interface requires users to create it dynamically and free it before a program finishes.
This PR changes the interface of `ABTI_spinlock` as follows:

Added function and macro:
- `ABTI_spinlock_clear()`: a function that initializes lock. The term "clear" is established for this usage (for example, `std::atomic_flag::clear` and `__atomic_clear`).
- `ABTI_SPINLOCK_STATIC_INITIALIZER()`: a static initializer.

Removed functions:
- `ABTI_spinlock_create()`: it is renamed to `ABTI_spinlock_clear()` since there is no "release" operation for "clear".
- `ABTI_spinlock_free()`: it is removed since it does nothing.

This change can remove wasteful `ABTI_spinlock_free()` calls from many places and simplify `global.c` and `include/abti_valgrind.h` both of which require static spinlock initializers.
