### PR TITLE
xstream: remove unnecessary ABT_XSTREAM_STATE

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -118,8 +118,8 @@ extern "C" {
 
 /* Constants */
 enum ABT_xstream_state {
-    ABT_XSTREAM_STATE_CREATED,
-    ABT_XSTREAM_STATE_READY,
+    ABT_XSTREAM_STATE_CREATED,  /* Deprecated */
+    ABT_XSTREAM_STATE_READY,    /* Deprecated */
     ABT_XSTREAM_STATE_RUNNING,
     ABT_XSTREAM_STATE_TERMINATED
 };

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -404,7 +404,7 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
                              ABT_xstream *newxstream) ABT_API_PUBLIC;
 int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
                                  ABT_xstream *newxstream) ABT_API_PUBLIC;
-int ABT_xstream_start(ABT_xstream xstream) ABT_API_PUBLIC;
+int ABT_xstream_start(ABT_xstream xstream) ABT_API_PUBLIC ABT_DEPRECATED;
 int ABT_xstream_free(ABT_xstream *xstream) ABT_API_PUBLIC;
 int ABT_xstream_join(ABT_xstream xstream) ABT_API_PUBLIC;
 int ABT_xstream_exit(void) ABT_API_PUBLIC;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1634,7 +1634,6 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
 #else
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool;
-    ABTI_xstream *newstream = NULL;
 
     /* callback function */
     if (p_thread->attr.f_cb) {
@@ -1649,12 +1648,9 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
                 ABTI_THREAD_REQ_MIGRATE);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
-#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-        newstream = p_pool->consumer;
-#endif
         LOG_EVENT("[U%" PRIu64 "] migration: E%d -> E%d\n",
                 ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
-                newstream ? newstream->rank : -1);
+                p_pool->consumer ? p_pool->consumer->rank : -1);
 
         /* Change the associated pool */
         p_thread->p_pool = p_pool;


### PR DESCRIPTION
Unlike `ABT_thread_create()` which delays an execution of thread, `ABT_xstream_create_xxx()` immediately starts an execution stream after creation, so `ABT_XSTREAM_STATE_CREATED` and `ABT_XSTREAM_STATE_READY` are useless.

This PR simplifies the state transition by removing the use of `ABT_XSTREAM_STATE_CREATED` and `ABT_XSTREAM_STATE_READY`; `ABT_xstream_state` can be only either `ABT_XSTREAM_STATE_RUNNING` or `ABT_XSTREAM_STATE_TERMINATED`.

In addition to `ABT_XSTREAM_STATE_CREATED` and `ABT_XSTREAM_STATE_READY`, this change marks `ABT_xstream_start()` as deprecated because a user cannot obtain a handle of an execution stream that has not been started yet. It will be removed in the future release.
