### PR TITLE
*.h: use full header names for include guards

### DIFF
--- a/src/include/abti_barrier.h
+++ b/src/include/abti_barrier.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef BARRIER_H_INCLUDED
-#define BARRIER_H_INCLUDED
+#ifndef ABTI_BARRIER_H_INCLUDED
+#define ABTI_BARRIER_H_INCLUDED
 
 /* Inlined functions for Barrier */
 
@@ -41,5 +41,5 @@ ABT_barrier ABTI_barrier_get_handle(ABTI_barrier *p_barrier)
 #endif
 }
 
-#endif /* BARRIER_H_INCLUDED */
+#endif /* ABTI_BARRIER_H_INCLUDED */
 

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef COND_H_INCLUDED
-#define COND_H_INCLUDED
+#ifndef ABTI_COND_H_INCLUDED
+#define ABTI_COND_H_INCLUDED
 
 #include "abti_mutex.h"
 
@@ -197,5 +197,5 @@ void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
     ABTI_spinlock_release(&p_cond->lock);
 }
 
-#endif /* COND_H_INCLUDED */
+#endif /* ABTI_COND_H_INCLUDED */
 

--- a/src/include/abti_config.h
+++ b/src/include/abti_config.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef CONFIG_H_INCLUDED
-#define CONFIG_H_INCLUDED
+#ifndef ABTI_CONFIG_H_INCLUDED
+#define ABTI_CONFIG_H_INCLUDED
 
 /* Inlined functions for Config */
 
@@ -40,5 +40,5 @@ ABT_sched_config ABTI_sched_config_get_handle(ABTI_sched_config *p_config)
 #endif
 }
 
-#endif /* CONFIG_H_INCLUDED */
+#endif /* ABTI_CONFIG_H_INCLUDED */
 

--- a/src/include/abti_eventual.h
+++ b/src/include/abti_eventual.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef EVENTUAL_H_INCLUDED
-#define EVENTUAL_H_INCLUDED
+#ifndef ABTI_EVENTUAL_H_INCLUDED
+#define ABTI_EVENTUAL_H_INCLUDED
 
 /* Inlined functions for Eventual */
 
@@ -40,5 +40,5 @@ ABT_eventual ABTI_eventual_get_handle(ABTI_eventual *p_eventual)
 #endif
 }
 
-#endif /* EVENTUAL_H_INCLUDED */
+#endif /* ABTI_EVENTUAL_H_INCLUDED */
 

--- a/src/include/abti_future.h
+++ b/src/include/abti_future.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef FUTURE_H_INCLUDED
-#define FUTURE_H_INCLUDED
+#ifndef ABTI_FUTURE_H_INCLUDED
+#define ABTI_FUTURE_H_INCLUDED
 
 /* Inlined functions for Future */
 
@@ -40,5 +40,5 @@ ABT_future ABTI_future_get_handle(ABTI_future *p_future)
 #endif
 }
 
-#endif /* FUTURE_H_INCLUDED */
+#endif /* ABTI_FUTURE_H_INCLUDED */
 

--- a/src/include/abti_global.h
+++ b/src/include/abti_global.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef GLOBAL_H_INCLUDED
-#define GLOBAL_H_INCLUDED
+#ifndef ABTI_GLOBAL_H_INCLUDED
+#define ABTI_GLOBAL_H_INCLUDED
 
 /* Inlined functions for Global Data */
 
@@ -50,5 +50,5 @@ uint32_t ABTI_global_get_mutex_max_wakeups(void)
     return gp_ABTI_global->mutex_max_wakeups;
 }
 
-#endif /* GLOBAL_H_INCLUDED */
+#endif /* ABTI_GLOBAL_H_INCLUDED */
 

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef KEY_H_INCLUDED
-#define KEY_H_INCLUDED
+#ifndef ABTI_KEY_H_INCLUDED
+#define ABTI_KEY_H_INCLUDED
 
 /* Inlined functions for Work unit-specific data key */
 
@@ -40,5 +40,5 @@ ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 #endif
 }
 
-#endif /* KEY_H_INCLUDED */
+#endif /* ABTI_KEY_H_INCLUDED */
 

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef LOCAL_H_INCLUDED
-#define LOCAL_H_INCLUDED
+#ifndef ABTI_LOCAL_H_INCLUDED
+#define ABTI_LOCAL_H_INCLUDED
 
 /*
  * An inlined getter function for ES Local Data.  This function is more
@@ -63,5 +63,5 @@ static inline void ABTI_local_set_local(ABTI_local *p_local)
 }
 
 
-#endif /* LOCAL_H_INCLUDED */
+#endif /* ABTI_LOCAL_H_INCLUDED */
 

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef MUTEX_H_INCLUDED
-#define MUTEX_H_INCLUDED
+#ifndef ABTI_MUTEX_H_INCLUDED
+#define ABTI_MUTEX_H_INCLUDED
 
 static inline
 ABTI_mutex *ABTI_mutex_get_ptr(ABT_mutex mutex)
@@ -173,5 +173,5 @@ ABT_bool ABTI_mutex_equal(ABTI_mutex *p_mutex1, ABTI_mutex *p_mutex2)
     return (p_mutex1 == p_mutex2) ? ABT_TRUE : ABT_FALSE;
 }
 
-#endif /* MUTEX_H_INCLUDED */
+#endif /* ABTI_MUTEX_H_INCLUDED */
 

--- a/src/include/abti_mutex_attr.h
+++ b/src/include/abti_mutex_attr.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef MUTEX_ATTR_H_INCLUDED
-#define MUTEX_ATTR_H_INCLUDED
+#ifndef ABTI_MUTEX_ATTR_H_INCLUDED
+#define ABTI_MUTEX_ATTR_H_INCLUDED
 
 /* Inlined functions for mutex attributes */
 
@@ -43,5 +43,5 @@ ABT_mutex_attr ABTI_mutex_attr_get_handle(ABTI_mutex_attr *p_attr)
 #define ABTI_mutex_attr_copy(p_dest,p_src)              \
     memcpy(p_dest, p_src, sizeof(ABTI_mutex_attr))
 
-#endif /* MUTEX_ATTR_H_INCLUDED */
+#endif /* ABTI_MUTEX_ATTR_H_INCLUDED */
 

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef POOL_H_INCLUDED
-#define POOL_H_INCLUDED
+#ifndef ABTI_POOL_H_INCLUDED
+#define ABTI_POOL_H_INCLUDED
 
 /* Inlined functions for Pool */
 
@@ -265,5 +265,5 @@ size_t ABTI_pool_get_total_size(ABTI_pool *p_pool)
     return total_size;
 }
 
-#endif /* POOL_H_INCLUDED */
+#endif /* ABTI_POOL_H_INCLUDED */
 

--- a/src/include/abti_rwlock.h
+++ b/src/include/abti_rwlock.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef RWLOCK_H_INCLUDED
-#define RWLOCK_H_INCLUDED
+#ifndef ABTI_RWLOCK_H_INCLUDED
+#define ABTI_RWLOCK_H_INCLUDED
 
 #include "abti_mutex.h"
 #include "abti_cond.h"
@@ -116,5 +116,5 @@ void ABTI_rwlock_unlock(ABTI_local **pp_local, ABTI_rwlock *p_rwlock)
     ABTI_mutex_unlock(p_local, &p_rwlock->mutex);
 }
 
-#endif /* RWLOCK_H_INCLUDED */
+#endif /* ABTI_RWLOCK_H_INCLUDED */
 

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef SCHED_H_INCLUDED
-#define SCHED_H_INCLUDED
+#ifndef ABTI_SCHED_H_INCLUDED
+#define ABTI_SCHED_H_INCLUDED
 
 /* Inlined functions for Scheduler */
 
@@ -93,5 +93,5 @@ ABT_bool ABTI_sched_has_unit(ABTI_sched *p_sched)
 #define SCHED_SLEEP(c,t)
 #endif
 
-#endif /* SCHED_H_INCLUDED */
+#endif /* ABTI_SCHED_H_INCLUDED */
 

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef SELF_H_INCLUDED
-#define SELF_H_INCLUDED
+#ifndef ABTI_SELF_H_INCLUDED
+#define ABTI_SELF_H_INCLUDED
 
 static inline
 ABTI_unit *ABTI_self_get_unit(ABTI_local *p_local)
@@ -60,5 +60,5 @@ ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
     }
 }
 
-#endif /* SELF_H_INCLUDED */
+#endif /* ABTI_SELF_H_INCLUDED */
 

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef SPINLOCK_H_INCLUDED
-#define SPINLOCK_H_INCLUDED
+#ifndef ABTI_SPINLOCK_H_INCLUDED
+#define ABTI_SPINLOCK_H_INCLUDED
 
 struct ABTI_spinlock {
     uint8_t val;
@@ -29,4 +29,4 @@ static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
     ABTD_atomic_clear_uint8((uint8_t *)&p_lock->val);
 }
 
-#endif /* SPINLOCK_H_INCLUDED */
+#endif /* ABTI_SPINLOCK_H_INCLUDED */

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef XSTREAM_H_INCLUDED
-#define XSTREAM_H_INCLUDED
+#ifndef ABTI_XSTREAM_H_INCLUDED
+#define ABTI_XSTREAM_H_INCLUDED
 
 /* Inlined functions for Execution Stream (ES) */
 
@@ -185,4 +185,4 @@ void ABTI_xstream_terminate_task(ABTI_local *p_local, ABTI_task *p_task)
     }
 }
 
-#endif /* XSTREAM_H_INCLUDED */
+#endif /* ABTI_XSTREAM_H_INCLUDED */

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef TASK_H_INCLUDED
-#define TASK_H_INCLUDED
+#ifndef ABTI_TASK_H_INCLUDED
+#define ABTI_TASK_H_INCLUDED
 
 /* Inlined functions for Tasklet  */
 
@@ -52,5 +52,5 @@ void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
     ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }
 
-#endif /* TASK_H_INCLUDED */
+#endif /* ABTI_TASK_H_INCLUDED */
 

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef THREAD_H_INCLUDED
-#define THREAD_H_INCLUDED
+#ifndef ABTI_THREAD_H_INCLUDED
+#define ABTI_THREAD_H_INCLUDED
 
 /* Inlined functions for User-level Thread (ULT) */
 
@@ -386,5 +386,5 @@ void ABTI_thread_yield(ABTI_local **pp_local, ABTI_thread *p_thread)
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 }
 
-#endif /* THREAD_H_INCLUDED */
+#endif /* ABTI_THREAD_H_INCLUDED */
 

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef THREAD_ATTR_H_INCLUDED
-#define THREAD_ATTR_H_INCLUDED
+#ifndef ABTI_THREAD_ATTR_H_INCLUDED
+#define ABTI_THREAD_ATTR_H_INCLUDED
 
 /* Inlined functions for ULT Attributes */
 
@@ -92,5 +92,5 @@ void ABTI_thread_attr_copy(ABTI_thread_attr *p_dest, ABTI_thread_attr *p_src)
     memcpy(p_dest, p_src, sizeof(ABTI_thread_attr));
 }
 
-#endif /* THREAD_ATTR_H_INCLUDED */
+#endif /* ABTI_THREAD_ATTR_H_INCLUDED */
 

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef THREAD_HTABLE_H_INCLUDED
-#define THREAD_HTABLE_H_INCLUDED
+#ifndef ABTI_THREAD_HTABLE_H_INCLUDED
+#define ABTI_THREAD_HTABLE_H_INCLUDED
 
 #include "abt_config.h"
 
@@ -172,4 +172,4 @@ void ABTI_thread_htable_del_l_head(ABTI_thread_htable *p_htable)
     }
 }
 
-#endif /* THREAD_HTABLE_H_INCLUDED */
+#endif /* ABTI_THREAD_HTABLE_H_INCLUDED */

--- a/src/include/abti_timer.h
+++ b/src/include/abti_timer.h
@@ -3,8 +3,8 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef TIMER_H_INCLUDED
-#define TIMER_H_INCLUDED
+#ifndef ABTI_TIMER_H_INCLUDED
+#define ABTI_TIMER_H_INCLUDED
 
 /* Inlined functions for Timer */
 
@@ -48,5 +48,5 @@ ABT_timer ABTI_timer_get_handle(ABTI_timer *p_timer)
 #endif
 }
 
-#endif /* TIMER_H_INCLUDED */
+#endif /* ABTI_TIMER_H_INCLUDED */
 


### PR DESCRIPTION
The current naming convention is inconsistent; some use full file names while others use partial ones.
```c
// full file names
abtd_thread.h:
  #ifndef ABTD_THREAD_H_INCLUDED
abti_error.h:
  #ifndef ABTI_ERROR_H_INCLUDED
// paritial file names
abti_thread.h:
  #ifndef THREAD_H_INCLUDED
abti_xstream.h:
  #ifndef XSTREAM_H_INCLUDED
```
This PR fixes by using full file names for include guard macros in all headers.
```c
abtd_thread.h:
  #ifndef ABTD_THREAD_H_INCLUDED
abti_error.h:
  #ifndef ABTI_ERROR_H_INCLUDED
abti_thread.h:
  #ifndef ABTI_THREAD_H_INCLUDED
abti_xstream.h:
  #ifndef ABTI_XSTREAM_H_INCLUDED
```

