### PR TITLE
Use proper ID to distinguish ESs, ULTs, tasklets, and external threads.

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -129,6 +129,10 @@ typedef struct ABTI_stack_header    ABTI_stack_header;
 typedef struct ABTI_page_header     ABTI_page_header;
 typedef struct ABTI_sp_header       ABTI_sp_header;
 #endif
+/* ID associated with native thread (e.g, Pthreads), which can distinguish
+ * execution streams and external threads */
+struct ABTI_native_thread_id_opaque;
+typedef struct ABTI_native_thread_id_opaque *ABTI_native_thread_id;
 /* ID associated with work unit (i.e., ULTs, tasklets, and external threads) */
 struct ABTI_unit_id_opaque;
 typedef struct ABTI_unit_id_opaque *ABTI_unit_id;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -270,10 +270,10 @@ struct ABTI_pool {
     int32_t num_scheds;      /* Number of associated schedulers */
                              /* NOTE: int32_t to check if still positive */
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    ABTI_xstream *consumer;  /* Associated consumer ES */
+    ABTI_native_thread_id consumer_id; /* Associated consumer ID */
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    ABTI_xstream *producer;  /* Associated producer ES */
+    ABTI_native_thread_id producer_id; /* Associated producer ID */
 #endif
     uint32_t num_blocked;    /* Number of blocked ULTs */
     int32_t num_migrations;  /* Number of migrating ULTs */
@@ -531,10 +531,12 @@ void ABTI_pool_free(ABTI_pool *p_pool);
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def);
 int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def);
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_xstream *p_xstream);
+int ABTI_pool_set_consumer(ABTI_pool *p_pool,
+                           ABTI_native_thread_id consumer_id);
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_xstream *p_xstream);
+int ABTI_pool_set_producer(ABTI_pool *p_pool,
+                           ABTI_native_thread_id producer_id);
 #endif
 int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source);
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -129,6 +129,9 @@ typedef struct ABTI_stack_header    ABTI_stack_header;
 typedef struct ABTI_page_header     ABTI_page_header;
 typedef struct ABTI_sp_header       ABTI_sp_header;
 #endif
+/* ID associated with work unit (i.e., ULTs, tasklets, and external threads) */
+struct ABTI_unit_id_opaque;
+typedef struct ABTI_unit_id_opaque *ABTI_unit_id;
 
 
 /* Architecture-Dependent Definitions */
@@ -144,7 +147,7 @@ typedef struct ABTI_spinlock        ABTI_spinlock;
 struct ABTI_mutex_attr {
     uint32_t attrs;             /* bit-or'ed attributes */
     uint32_t nesting_cnt;       /* nesting count */
-    ABTI_unit *p_owner;         /* owner work unit */
+    ABTI_unit_id owner_id;      /* owner's ID */
     uint32_t max_handovers;     /* max. # of handovers */
     uint32_t max_wakeups;       /* max. # of wakeups */
 };
@@ -198,6 +201,7 @@ struct ABTI_local_func {
     char padding1[ABT_CONFIG_STATIC_CACHELINE_SIZE];
     ABTI_local *(*get_local_f)(void);
     void (*set_local_f)(ABTI_local *);
+    void *(*get_local_ptr_f)(void);
     char padding2[ABT_CONFIG_STATIC_CACHELINE_SIZE];
 };
 

--- a/src/include/abti_local.h
+++ b/src/include/abti_local.h
@@ -62,6 +62,14 @@ static inline void ABTI_local_set_local(ABTI_local *p_local)
     gp_ABTI_local_func.set_local_f(p_local);
 }
 
+/*
+ * A safe getter function for a pointer to an ES Local Data, which is useful to
+ * identify a native thread (i.e., execution streams and external threads).
+ */
+static inline void *ABTI_local_get_local_ptr(void)
+{
+	return gp_ABTI_local_func.get_local_ptr_f();
+}
 
 #endif /* ABTI_LOCAL_H_INCLUDED */
 

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -21,9 +21,9 @@ void ABTI_log_print(FILE *fh, const char *format, ...);
 void ABTI_log_event(FILE *fh, const char *format, ...);
 void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...);
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
-                        ABTI_xstream *p_producer);
+                        ABTI_native_thread_id producer_id);
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                          ABTI_xstream *p_consumer);
+                          ABTI_native_thread_id consumer_id);
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
 static inline void ABTI_log_set_sched(ABTI_sched *p_sched)
@@ -44,10 +44,10 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
 #define LOG_DEBUG(fmt,...)          \
     ABTI_log_debug(stderr,__FILE__,__LINE__,fmt,__VA_ARGS__)
 
-#define LOG_EVENT_POOL_PUSH(p_pool, unit, p_produer)    \
-    ABTI_log_pool_push(p_pool, unit, p_produer)
-#define LOG_EVENT_POOL_REMOVE(p_pool, unit, p_consumer) \
-    ABTI_log_pool_remove(p_pool, unit, p_consumer)
+#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)    \
+    ABTI_log_pool_push(p_pool, unit, produer_id)
+#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id) \
+    ABTI_log_pool_remove(p_pool, unit, consumer_id)
 #define LOG_EVENT_POOL_POP(p_pool, unit) \
     ABTI_log_pool_pop(p_pool, unit)
 
@@ -61,8 +61,8 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
 #define LOG_EVENT(fmt,...)
 #define LOG_DEBUG(fmt,...)
 
-#define LOG_EVENT_POOL_PUSH(p_pool, unit, p_produer)
-#define LOG_EVENT_POOL_REMOVE(p_pool, unit, p_consumer)
+#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)
+#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id)
 #define LOG_EVENT_POOL_POP(p_pool, unit)
 
 #endif /* ABT_CONFIG_USE_DEBUG_LOG */

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -48,7 +48,7 @@ struct ABTI_page_header {
     uint32_t num_remote_free;   /* Number of remote free blocks */
     ABTI_blk_header *p_head;    /* First empty block */
     ABTI_blk_header *p_free;    /* For remote free */
-    ABTI_xstream *p_owner;      /* Owner ES */
+    ABTI_native_thread_id owner_id; /* Owner's ID */
     ABTI_page_header *p_prev;   /* Prev page header */
     ABTI_page_header *p_next;   /* Next page header */
     ABT_bool is_mmapped;        /* ABT_TRUE if it is mmapped */
@@ -337,7 +337,7 @@ void ABTI_mem_free_task(ABTI_local *p_local, ABTI_task *p_task)
     }
 #endif
 
-    if (p_ph->p_owner == p_local->p_xstream) {
+    if (p_ph->owner_id == ABTI_self_get_native_thread_id(p_local)) {
         p_head->p_next = p_ph->p_head;
         p_ph->p_head = p_head;
         p_ph->num_empty_blks++;

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -118,7 +118,7 @@ void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                         ABTI_thread *p_giver = p_mutex->p_giver;
                         p_giver->state = ABT_THREAD_STATE_READY;
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
-                                       p_self->p_last_xstream);
+                            ABTI_self_get_native_thread_id(*pp_local));
                         break;
                     }
                 }

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -8,8 +8,6 @@
 
 /* Inlined functions for Pool */
 
-static inline ABTI_xstream *ABTI_xstream_self(ABTI_local *p_local);
-
 static inline
 ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
 {

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -7,38 +7,6 @@
 #define ABTI_SELF_H_INCLUDED
 
 static inline
-ABTI_unit *ABTI_self_get_unit(ABTI_local *p_local)
-{
-    ABTI_ASSERT(gp_ABTI_global);
-
-    ABTI_unit *p_unit;
-    ABTI_thread *p_thread;
-    ABTI_task *p_task;
-
-#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-    /* This is when an external thread called this routine. */
-    if (p_local == NULL) {
-        ABTD_xstream_context ctx;
-        ABTD_xstream_context_self(&ctx);
-        p_unit = (ABTI_unit *)ctx;
-        return p_unit;
-    }
-#endif
-
-    if ((p_thread = p_local->p_thread)) {
-        p_unit = &p_thread->unit_def;
-    } else if ((p_task = p_local->p_task)) {
-        p_unit = &p_task->unit_def;
-    } else {
-        /* should not reach here */
-        p_unit = NULL;
-        ABTI_ASSERT(0);
-    }
-
-    return p_unit;
-}
-
-static inline
 ABTI_native_thread_id ABTI_self_get_native_thread_id(ABTI_local *p_local)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -39,6 +39,30 @@ ABTI_unit *ABTI_self_get_unit(ABTI_local *p_local)
 }
 
 static inline
+ABTI_unit_id ABTI_self_get_unit_id(ABTI_local *p_local)
+{
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+    /* This is when an external thread called this routine. */
+    if (p_local == NULL) {
+        /* A pointer to a thread local variable is unique to an external thread
+         * and its value is different from pointers to ULTs and tasks. */
+        return (ABTI_unit_id)ABTI_local_get_local_ptr();
+    }
+#endif
+    ABTI_unit_id id;
+    if (p_local->p_thread) {
+        id = (ABTI_unit_id)p_local->p_thread;
+    } else if (p_local->p_task) {
+        id = (ABTI_unit_id)p_local->p_task;
+    } else {
+        /* should not reach here */
+        id = 0;
+        ABTI_ASSERT(0);
+    }
+    return id;
+}
+
+static inline
 ABT_unit_type ABTI_self_get_type(ABTI_local *p_local)
 {
     ABTI_ASSERT(gp_ABTI_global);

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -39,6 +39,20 @@ ABTI_unit *ABTI_self_get_unit(ABTI_local *p_local)
 }
 
 static inline
+ABTI_native_thread_id ABTI_self_get_native_thread_id(ABTI_local *p_local)
+{
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+    /* This is when an external thread called this routine. */
+    if (p_local == NULL) {
+        /* A pointer to a thread local variable can distinguish all external
+         * threads and execution streams. */
+        return (ABTI_native_thread_id)ABTI_local_get_local_ptr();
+    }
+#endif
+    return (ABTI_native_thread_id)p_local->p_xstream;
+}
+
+static inline
 ABTI_unit_id ABTI_self_get_unit_id(ABTI_local *p_local)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -52,23 +52,6 @@ void ABTI_xstream_unset_request(ABTI_xstream *p_xstream, uint32_t req)
     ABTD_atomic_fetch_and_uint32(&p_xstream->request, ~req);
 }
 
-static inline
-ABTI_xstream *ABTI_xstream_self(ABTI_local *p_local)
-{
-    ABTI_xstream *p_xstream;
-    if (p_local != NULL) {
-        p_xstream = p_local->p_xstream;
-    } else {
-        /* We allow external threads to call Argobots APIs. However, since it
-         * is not trivial to identify them, we use ABTD_xstream_context to
-         * distinguish them for now. */
-        ABTD_xstream_context tmp_ctx;
-        ABTD_xstream_context_self(&tmp_ctx);
-        p_xstream = (ABTI_xstream *)tmp_ctx;
-    }
-    return p_xstream;
-}
-
 /* Get the top scheduler from the sched stack (field scheds) */
 static inline
 ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -185,4 +185,11 @@ void ABTI_xstream_terminate_task(ABTI_local *p_local, ABTI_task *p_task)
     }
 }
 
+/* Get the native thread id associated with the target xstream. */
+static inline
+ABTI_native_thread_id ABTI_xstream_get_native_thread_id(ABTI_xstream *p_xstream)
+{
+    return (ABTI_native_thread_id)p_xstream;
+}
+
 #endif /* ABTI_XSTREAM_H_INCLUDED */

--- a/src/local.c
+++ b/src/local.c
@@ -20,10 +20,16 @@ static void ABTI_local_set_local_internal(ABTI_local *p_local)
     lp_ABTI_local = p_local;
 }
 
+static void *ABTI_local_get_local_ptr_internal(void)
+{
+    return (void *)&lp_ABTI_local;
+}
+
 ABTI_local_func gp_ABTI_local_func = {
     {0},
     ABTI_local_get_local_internal,
     ABTI_local_set_local_internal,
+    ABTI_local_get_local_ptr_internal,
     {0}
 };
 /* ES Local Data */

--- a/src/log.c
+++ b/src/log.c
@@ -142,7 +142,7 @@ void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
 }
 
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
-                        ABTI_xstream *p_producer)
+                        ABTI_native_thread_id producer_id)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
 
@@ -153,17 +153,17 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
             if (p_thread->p_last_xstream) {
                 LOG_EVENT("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
-                          "(producer: E%d)\n",
+                          "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank,
                           p_pool->id,
-                          p_producer->rank);
+                          (void *)producer_id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] pushed to P%" PRIu64 " "
-                          "(producer: E%d)\n",
+                          "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_pool->id,
-                          p_producer->rank);
+                          (void *)producer_id);
             }
             break;
 
@@ -171,17 +171,17 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
             if (p_task->p_xstream) {
                 LOG_EVENT("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
-                          "(producer: E%d)\n",
+                          "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task),
                           p_task->p_xstream->rank,
                           p_pool->id,
-                          p_producer->rank);
+                          (void *)producer_id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] pushed to P%" PRIu64 " "
-                          "(producer: E%d)\n",
+                          "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task),
                           p_pool->id,
-                          p_producer->rank);
+                          (void *)producer_id);
             }
             break;
 
@@ -192,7 +192,7 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 }
 
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                          ABTI_xstream *p_consumer)
+                          ABTI_native_thread_id consumer_id)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE) return;
 
@@ -203,17 +203,17 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
             if (p_thread->p_last_xstream) {
                 LOG_EVENT("[U%" PRIu64 ":E%d] removed from "
-                          "P%" PRIu64 " (consumer: E%d)\n",
+                          "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank,
                           p_pool->id,
-                          p_consumer->rank);
+                          (void *)consumer_id);
             } else {
                 LOG_EVENT("[U%" PRIu64 "] removed from P%" PRIu64 " "
-                          "(consumer: E%d)\n",
+                          "(consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_pool->id,
-                          p_consumer->rank);
+                          (void *)consumer_id);
             }
             break;
 
@@ -221,17 +221,17 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
             if (p_task->p_xstream) {
                 LOG_EVENT("[T%" PRIu64 ":E%d] removed from "
-                          "P%" PRIu64 " (consumer: E%d)\n",
+                          "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_task_get_id(p_task),
                           p_task->p_xstream->rank,
                           p_pool->id,
-                          p_consumer->rank);
+                          (void *)consumer_id);
             } else {
                 LOG_EVENT("[T%" PRIu64 "] removed from P%" PRIu64 " "
-                          "(consumer: E%d)\n",
+                          "(consumer: NT %p)\n",
                           ABTI_task_get_id(p_task),
                           p_pool->id,
-                          p_consumer->rank);
+                          (void *)consumer_id);
             }
             break;
 

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -113,7 +113,7 @@ void ABTI_mem_finalize_local(ABTI_local *p_local)
                 ABTI_mem_take_free(p_tmp);
             }
 
-            p_tmp->p_owner = NULL;
+            p_tmp->owner_id = 0;
             p_tmp->p_prev = NULL;
             p_tmp->p_next = p_rem_head;
             p_rem_head = p_tmp;
@@ -231,7 +231,7 @@ static inline void ABTI_mem_free_page_list(ABTI_page_header *p_ph)
 static inline void ABTI_mem_add_page(ABTI_local *p_local,
                                      ABTI_page_header *p_ph)
 {
-    p_ph->p_owner = p_local->p_xstream;
+    p_ph->owner_id = ABTI_self_get_native_thread_id(p_local);
 
     /* Add the page to the head */
     if (p_local->p_mem_task_head != NULL) {

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -152,10 +152,10 @@ int ABT_mutex_lock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_unit *p_self = ABTI_self_get_unit(p_local);
-        if (p_self != p_mutex->attr.p_owner) {
+        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local);
+        if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_lock(&p_local, p_mutex);
-            p_mutex->attr.p_owner = p_self;
+            p_mutex->attr.owner_id = self_id;
             ABTI_ASSERT(p_mutex->attr.nesting_cnt == 0);
         } else {
             p_mutex->attr.nesting_cnt++;
@@ -286,10 +286,10 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_unit *p_self = ABTI_self_get_unit(p_local);
-        if (p_self != p_mutex->attr.p_owner) {
+        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local);
+        if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_lock_low(&p_local, p_mutex);
-            p_mutex->attr.p_owner = p_self;
+            p_mutex->attr.owner_id = self_id;
             ABTI_ASSERT(p_mutex->attr.nesting_cnt == 0);
         } else {
             p_mutex->attr.nesting_cnt++;
@@ -343,11 +343,11 @@ int ABT_mutex_trylock(ABT_mutex mutex)
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
         ABTI_local *p_local = ABTI_local_get_local();
-        ABTI_unit *p_self = ABTI_self_get_unit(p_local);
-        if (p_self != p_mutex->attr.p_owner) {
+        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local);
+        if (self_id != p_mutex->attr.owner_id) {
             abt_errno = ABTI_mutex_trylock(p_mutex);
             if (abt_errno == ABT_SUCCESS) {
-                p_mutex->attr.p_owner = p_self;
+                p_mutex->attr.owner_id = self_id;
                 ABTI_ASSERT(p_mutex->attr.nesting_cnt == 0);
             }
         } else {
@@ -395,10 +395,10 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
         ABTI_local *p_local = ABTI_local_get_local();
-        ABTI_unit *p_self = ABTI_self_get_unit(p_local);
-        if (p_self != p_mutex->attr.p_owner) {
+        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local);
+        if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_spinlock(p_mutex);
-            p_mutex->attr.p_owner = p_self;
+            p_mutex->attr.owner_id = self_id;
             ABTI_ASSERT(p_mutex->attr.nesting_cnt == 0);
         } else {
             p_mutex->attr.nesting_cnt++;
@@ -442,10 +442,10 @@ int ABT_mutex_unlock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_CHECK_TRUE(ABTI_self_get_unit(p_local) == p_mutex->attr.p_owner,
-                        ABT_ERR_INV_THREAD);
+        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local)
+                        == p_mutex->attr.owner_id, ABT_ERR_INV_THREAD);
         if (p_mutex->attr.nesting_cnt == 0) {
-            p_mutex->attr.p_owner = NULL;
+            p_mutex->attr.owner_id = 0;
             ABTI_mutex_unlock(p_local, p_mutex);
         } else {
             p_mutex->attr.nesting_cnt--;
@@ -601,10 +601,10 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_CHECK_TRUE(ABTI_self_get_unit(p_local) == p_mutex->attr.p_owner,
-                        ABT_ERR_INV_THREAD);
+        ABTI_CHECK_TRUE(ABTI_self_get_unit_id(p_local)
+                        == p_mutex->attr.owner_id, ABT_ERR_INV_THREAD);
         if (p_mutex->attr.nesting_cnt == 0) {
-            p_mutex->attr.p_owner = NULL;
+            p_mutex->attr.owner_id = 0;
             ABTI_mutex_unlock_se(&p_local, p_mutex);
         } else {
             p_mutex->attr.nesting_cnt--;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -238,7 +238,7 @@ void ABTI_mutex_lock_low(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                         ABTI_thread *p_giver = p_mutex->p_giver;
                         p_giver->state = ABT_THREAD_STATE_READY;
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
-                                       p_self->p_last_xstream);
+                            ABTI_self_get_native_thread_id(*pp_local));
                         break;
                     }
                 }

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -34,7 +34,7 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
     /* Default values */
     p_newattr->attrs = ABTI_MUTEX_ATTR_NONE;
     p_newattr->nesting_cnt = 0;
-    p_newattr->p_owner = NULL;
+    p_newattr->owner_id = 0;
     p_newattr->max_handovers = ABTI_global_get_mutex_max_handovers();
     p_newattr->max_wakeups = ABTI_global_get_mutex_max_wakeups();
 
@@ -138,11 +138,11 @@ void ABTI_mutex_attr_get_str(ABTI_mutex_attr *p_attr, char *p_buf)
         "["
         "attrs:%x "
         "nesting_cnt:%u "
-        "p_owner:%p "
+        "owner_id:%p "
         "]",
         p_attr->attrs,
         p_attr->nesting_cnt,
-        (void *)p_attr->p_owner
+        (void *)p_attr->owner_id
     );
 }
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -513,7 +513,7 @@ size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
     int p;
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-    ABTI_xstream *p_xstream = p_local->p_xstream;
+    ABTI_native_thread_id self_id = ABTI_self_get_native_thread_id(p_local);
 #endif
 
     for (p = 0; p < p_sched->num_pools; p++) {
@@ -534,7 +534,7 @@ size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
                     pool_size += p_pool->num_blocked;
                 }
 #else
-                if (p_pool->num_scheds == 1 && p_pool->consumer == p_xstream) {
+                if (p_pool->num_scheds == 1 && p_pool->consumer_id == self_id) {
                     pool_size += p_pool->num_blocked;
                 }
 #endif

--- a/src/stream.c
+++ b/src/stream.c
@@ -1289,7 +1289,8 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
 
     /* Wait until the target ES terminates */
     if (is_blockable == ABT_TRUE) {
-        ABTI_POOL_SET_CONSUMER(p_thread->p_pool, p_local->p_xstream);
+        ABTI_POOL_SET_CONSUMER(p_thread->p_pool,
+                               ABTI_self_get_native_thread_id(p_local));
 
         /* Save the caller ULT to set it ready when the ES is terminated */
         p_xstream->p_req_arg = (void *)p_thread;
@@ -1523,7 +1524,7 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
         /* The ULT did not finish its execution.
          * Change the state of current running ULT and
          * add it to the pool again. */
-        ABTI_POOL_ADD_THREAD(p_thread, p_xstream);
+        ABTI_POOL_ADD_THREAD(p_thread, ABTI_self_get_native_thread_id(p_local));
     } else if (p_thread->request & ABTI_THREAD_REQ_BLOCK) {
         LOG_EVENT("[U%" PRIu64 ":E%d] check blocked\n",
                   ABTI_thread_get_id(p_thread), p_xstream->rank);
@@ -1648,15 +1649,16 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
                 ABTI_THREAD_REQ_MIGRATE);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
-        LOG_EVENT("[U%" PRIu64 "] migration: E%d -> E%d\n",
+        LOG_EVENT("[U%" PRIu64 "] migration: E%d -> NT %p\n",
                 ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
-                p_pool->consumer ? p_pool->consumer->rank : -1);
+                (void *)p_pool->consumer_id);
 
         /* Change the associated pool */
         p_thread->p_pool = p_pool;
 
         /* Add the unit to the scheduler's pool */
-        ABTI_POOL_PUSH(p_pool, p_thread->unit, p_local->p_xstream);
+        ABTI_POOL_PUSH(p_pool, p_thread->unit,
+                       ABTI_self_get_native_thread_id(p_local));
     }
     ABTI_spinlock_release(&p_thread->lock);
 
@@ -1686,9 +1688,11 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     /* We check that from the pool set of the scheduler we do not find a pool
      * with another associated pool, and set the right value if it is okay  */
+    ABTI_native_thread_id consumer_id
+        = ABTI_xstream_get_native_thread_id(p_xstream);
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
-        abt_errno = ABTI_pool_set_consumer(p_pool, p_xstream);
+        abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);
         ABTI_CHECK_ERROR(abt_errno);
     }
 #endif
@@ -1738,7 +1742,8 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
          * it is freed in ABT_finalize. */
         p_sched->automatic = ABT_TRUE;
 
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit, p_xstream);
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit,
+                       ABTI_self_get_native_thread_id(*pp_local));
 
         /* Pop the top scheduler */
         ABTI_xstream_pop_sched(p_xstream);
@@ -1764,7 +1769,8 @@ int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
          * the new scheduler starts (see below), it can be scheduled by the new
          * scheduler. When the current ULT resumes its execution, it will free
          * the current main scheduler (see below). */
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit, p_xstream);
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit,
+                       ABTI_self_get_native_thread_id(*pp_local));
 
         /* Set the scheduler */
         p_xstream->p_main_sched = p_sched;

--- a/src/task.c
+++ b/src/task.c
@@ -778,7 +778,7 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_pool_push(p_pool, p_newtask->unit);
 #else
     abt_errno = ABTI_pool_push(p_pool, p_newtask->unit,
-                               ABTI_xstream_self(p_local));
+                               ABTI_self_get_native_thread_id(p_local));
     if (abt_errno != ABT_SUCCESS) {
         ABTI_task_free(p_local, p_newtask);
         goto fn_fail;
@@ -832,7 +832,7 @@ static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_pool_push(p_pool, p_task->unit);
 #else
     abt_errno = ABTI_pool_push(p_pool, p_task->unit,
-                               ABTI_xstream_self(p_local));
+                               ABTI_self_get_native_thread_id(p_local));
     ABTI_CHECK_ERROR(abt_errno);
 #endif
 


### PR DESCRIPTION
### Problems

Currently, `ABTI_unit *` is used to distinguish ULTs, tasklets, and external threads, and 'ABTI_xstream *' is used to distinguish ESs and external threads. In both cases, external threads (i.e., Pthreads) do not have an entity of `ABTI_unit` and `ABTI_xstream`, so its `pthread_t` is cast to a pointer type (`ABTI_unit *` and 'ABTI_xstream *') and assigned.

For example, `p_owner` points to either`p_thread/p_task->unit_def` (real `ABT_unit`) or `pthread_t` in the following case.
```c
struct ABTI_mutex_attr {
   ABTI_unit *p_owner;
};
int ABT_mutex_lock(...) {
  // get local unit
  ABTI_unit *p_self;
  if (!lp_ABTI_local)              p_self = (ABTI_unit *)pthread_self();
  else if(lp_ABTI_local->p_thread) p_self = &p_thread->unit_def;
  else if(lp_ABTI_local->p_task)   p_self = &p_task->unit_def;
  if (p_mutex->p_owner == p_self)
    [...]; // if the caller is an owner of this mutex, increment the nest level and return.
}
```
This design has several problems.
1. The developers might think `p_owner` really points to `ABTI_unit`, while it does not in the case of an external thread.
2. This is not portable. A `pthread_t` value might be longer than the pointer size.
3. Values are not unique. There's no guarantee that a `pthread_t` value is different from values of any `&p_thread->unit_def` and `&p_task->unit_def`.

### Solution

This PR fixes them by introducing `void *`-type ID, which uses `&lp_ABTI_local` (the address of the TLS value) to identify external threads.
```c
typedef void *ABTI_unit_id;
struct ABTI_mutex_attr {
   ABTI_unit_id owner_id;
};
int ABT_mutex_lock(...) {
  // get local unit_id
  ABTI_unit_id self_id;  
  if (!lp_ABTI_local)              self_id = (ABTI_unit_id)&lp_ABTI_local;
  else if(lp_ABTI_local->p_thread) self_id = (ABTI_unit_id)&p_thread;
  else if(lp_ABTI_local->p_task)   self_id = (ABTI_unit_id)&p_task;
  if (p_mutex->owner_id == self_id)
    [...]; // if the caller is an owner of this mutex, increment the nest level and return.
}
```
This solution 1. forbids dereference of `p_owner` because `ABTI_unit_id` is an opaque pointer, 2. is portable because it relies on only pointers, and 3. guarantees uniqueness of IDs because each value points to a real memory address.

Specifically, this PR adds two new types: `ABTI_unit_id` and `ABTI_native_thread_id`. `ABTI_unit_id` is to distinguish ULTs, tasklets, and external threads, while `ABTI_native_thread_id` is designed for execution streams and external threads.

### Performance

This change does not affect performance in the critical path if producer/consumer-check is disabled. Otherwise, there might be a slight performance difference though it should be almost negligible.
  