### PR TITLE
Add ABT_xstream_revive()

### DIFF
--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -131,13 +131,13 @@ void ABTD_affinity_finalize(void)
 #endif
 }
 
-int ABTD_affinity_set(ABTD_xstream_context ctx, int rank)
+int ABTD_affinity_set(ABTD_xstream_context *p_ctx, int rank)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
     int abt_errno;
 
     cpu_set_t cpuset = ABTD_affinity_get_cpuset_for_rank(rank);
-    if (!pthread_setaffinity_np(ctx, sizeof(cpu_set_t), &cpuset)) {
+    if (!pthread_setaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset)) {
         abt_errno = ABT_SUCCESS;
     } else {
         abt_errno = ABT_ERR_OTHER;
@@ -146,7 +146,7 @@ int ABTD_affinity_set(ABTD_xstream_context ctx, int rank)
 
 #if 0
     /* For debugging and verification */
-    int ret = pthread_getaffinity_np(ctx, sizeof(cpu_set_t), &cpuset);
+    int ret = pthread_getaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset);
     ABTI_CHECK_TRUE(!ret, ABT_ERR_OTHER);
     int i;
     for (i = 0; i < CPU_SETSIZE; i++) {
@@ -167,7 +167,7 @@ int ABTD_affinity_set(ABTD_xstream_context ctx, int rank)
 #endif
 }
 
-int ABTD_affinity_set_cpuset(ABTD_xstream_context ctx, int cpuset_size,
+int ABTD_affinity_set_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
                              int *p_cpuset)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
@@ -181,7 +181,7 @@ int ABTD_affinity_set_cpuset(ABTD_xstream_context ctx, int cpuset_size,
         CPU_SET(p_cpuset[i], &cpuset);
     }
 
-    i = pthread_setaffinity_np(ctx, sizeof(cpu_set_t), &cpuset);
+    i = pthread_setaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset);
     ABTI_CHECK_TRUE(!i, ABT_ERR_OTHER);
 
   fn_exit:
@@ -195,7 +195,7 @@ int ABTD_affinity_set_cpuset(ABTD_xstream_context ctx, int cpuset_size,
 #endif
 }
 
-int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
+int ABTD_affinity_get_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
                              int *p_cpuset, int *p_num_cpus)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
@@ -204,7 +204,7 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
     cpu_set_t cpuset;
     int num_cpus = 0;
 
-    i = pthread_getaffinity_np(ctx, sizeof(cpu_set_t), &cpuset);
+    i = pthread_getaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset);
     ABTI_CHECK_TRUE(!i, ABT_ERR_OTHER);
 
     if (p_cpuset != NULL) {

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -126,7 +126,7 @@ void ABTD_affinity_init(void)
 void ABTD_affinity_finalize(void)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
-    ABTD_xstream_context ctx = pthread_self();
+    pthread_t ctx = pthread_self();
     pthread_setaffinity_np(ctx, sizeof(cpu_set_t), &g_initial_cpuset);
 #endif
 }
@@ -137,7 +137,8 @@ int ABTD_affinity_set(ABTD_xstream_context *p_ctx, int rank)
     int abt_errno;
 
     cpu_set_t cpuset = ABTD_affinity_get_cpuset_for_rank(rank);
-    if (!pthread_setaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset)) {
+    if (!pthread_setaffinity_np(p_ctx->native_thread, sizeof(cpu_set_t),
+                                &cpuset)) {
         abt_errno = ABT_SUCCESS;
     } else {
         abt_errno = ABT_ERR_OTHER;
@@ -181,7 +182,8 @@ int ABTD_affinity_set_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
         CPU_SET(p_cpuset[i], &cpuset);
     }
 
-    i = pthread_setaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset);
+    i = pthread_setaffinity_np(p_ctx->native_thread, sizeof(cpu_set_t),
+                               &cpuset);
     ABTI_CHECK_TRUE(!i, ABT_ERR_OTHER);
 
   fn_exit:
@@ -204,7 +206,8 @@ int ABTD_affinity_get_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
     cpu_set_t cpuset;
     int num_cpus = 0;
 
-    i = pthread_getaffinity_np(*p_ctx, sizeof(cpu_set_t), &cpuset);
+    i = pthread_getaffinity_np(p_ctx->native_thread, sizeof(cpu_set_t),
+                               &cpuset);
     ABTI_CHECK_TRUE(!i, ABT_ERR_OTHER);
 
     if (p_cpuset != NULL) {

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -9,7 +9,7 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = pthread_create(p_ctx, NULL, f_xstream, p_arg);
+    int ret = pthread_create(&p_ctx->native_thread, NULL, f_xstream, p_arg);
     if (ret != 0) {
         HANDLE_ERROR("pthread_create");
         abt_errno = ABT_ERR_XSTREAM;
@@ -28,7 +28,7 @@ int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
 int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = pthread_join(*p_ctx, NULL);
+    int ret = pthread_join(p_ctx->native_thread, NULL);
     if (ret != 0) {
         HANDLE_ERROR("pthread_join");
         abt_errno = ABT_ERR_XSTREAM;
@@ -45,7 +45,7 @@ int ABTD_xstream_context_exit(void)
 int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    *p_ctx = pthread_self();
+    p_ctx->native_thread = pthread_self();
     return abt_errno;
 }
 

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -5,11 +5,23 @@
 
 #include "abti.h"
 
+static void *ABTDI_xstream_context_thread_func(void *arg)
+{
+    ABTD_xstream_context *p_ctx = (ABTD_xstream_context *)arg;
+    void *(*thread_f)(void *) = p_ctx->thread_f;
+    void *p_arg = p_ctx->p_arg;
+    thread_f(p_arg);
+    return NULL;
+}
+
 int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = pthread_create(&p_ctx->native_thread, NULL, f_xstream, p_arg);
+    p_ctx->thread_f = f_xstream;
+    p_ctx->p_arg = p_arg;
+    int ret = pthread_create(&p_ctx->native_thread, NULL,
+                             ABTDI_xstream_context_thread_func, p_ctx);
     if (ret != 0) {
         HANDLE_ERROR("pthread_create");
         abt_errno = ABT_ERR_XSTREAM;

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -25,10 +25,10 @@ int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
     return abt_errno;
 }
 
-int ABTD_xstream_context_join(ABTD_xstream_context ctx)
+int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = pthread_join(ctx, NULL);
+    int ret = pthread_join(*p_ctx, NULL);
     if (ret != 0) {
         HANDLE_ERROR("pthread_join");
         abt_errno = ABT_ERR_XSTREAM;

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -48,12 +48,6 @@ int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
     return abt_errno;
 }
 
-int ABTD_xstream_context_exit(void)
-{
-    pthread_exit(NULL);
-    return ABT_SUCCESS;
-}
-
 int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -113,7 +113,7 @@ int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx)
     return abt_errno;
 }
 
-int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx)
+int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
     p_ctx->native_thread = pthread_self();

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -10,7 +10,38 @@ static void *ABTDI_xstream_context_thread_func(void *arg)
     ABTD_xstream_context *p_ctx = (ABTD_xstream_context *)arg;
     void *(*thread_f)(void *) = p_ctx->thread_f;
     void *p_arg = p_ctx->p_arg;
-    thread_f(p_arg);
+    ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING);
+    while (1) {
+        /* Execute a main execution stream function. */
+        thread_f(p_arg);
+        /* This thread has finished. */
+        ABT_bool restart;
+        pthread_mutex_lock(&p_ctx->state_lock);
+        /* If another execution stream is waiting for this thread completion,
+         * let's wake it up. */
+        if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN) {
+            pthread_cond_signal(&p_ctx->state_cond);
+        }
+        p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_WAITING;
+        /* Wait for a request from ABTD_xstream_context_free() or
+         * ABTD_xstream_context_restart().
+         * The following loop is to deal with spurious wakeup. */
+        do {
+            pthread_cond_wait(&p_ctx->state_cond, &p_ctx->state_lock);
+        } while (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
+        if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_TERMINATE) {
+            /* ABTD_xstream_context_free() terminates this thread. */
+            restart = ABT_FALSE;
+        } else {
+            /* ABTD_xstream_context_restart() restarts this thread */
+            ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING
+                        || p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN);
+            restart = ABT_TRUE;
+        }
+        pthread_mutex_unlock(&p_ctx->state_lock);
+        if (!restart)
+            break;
+    }
     return NULL;
 }
 
@@ -20,6 +51,9 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
     int abt_errno = ABT_SUCCESS;
     p_ctx->thread_f = f_xstream;
     p_ctx->p_arg = p_arg;
+    p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_RUNNING;
+    pthread_mutex_init(&p_ctx->state_lock, NULL);
+    pthread_cond_init(&p_ctx->state_cond, NULL);
     int ret = pthread_create(&p_ctx->native_thread, NULL,
                              ABTDI_xstream_context_thread_func, p_ctx);
     if (ret != 0) {
@@ -31,20 +65,51 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
 
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
 {
-    ABTI_UNUSED(p_ctx);
     int abt_errno = ABT_SUCCESS;
-    /* Currently, nothing to do */
+    /* Request termination */
+    pthread_mutex_lock(&p_ctx->state_lock);
+    ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
+    p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_REQ_TERMINATE;
+    pthread_cond_signal(&p_ctx->state_cond);
+    pthread_mutex_unlock(&p_ctx->state_lock);
+    /* Join the target thread. */
+    int ret = pthread_join(p_ctx->native_thread, NULL);
+    if (ret != 0) {
+        HANDLE_ERROR("pthread_join");
+        abt_errno = ABT_ERR_XSTREAM;
+    }
+    pthread_cond_destroy(&p_ctx->state_cond);
+    pthread_mutex_destroy(&p_ctx->state_lock);
     return abt_errno;
 }
 
 int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = pthread_join(p_ctx->native_thread, NULL);
-    if (ret != 0) {
-        HANDLE_ERROR("pthread_join");
-        abt_errno = ABT_ERR_XSTREAM;
+    /* If not finished, sleep this thread. */
+    pthread_mutex_lock(&p_ctx->state_lock);
+    if (p_ctx->state != ABTD_XSTREAM_CONTEXT_STATE_WAITING) {
+        ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING);
+        p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN;
+        /* The following loop is to deal with spurious wakeup. */
+        do {
+            pthread_cond_wait(&p_ctx->state_cond, &p_ctx->state_lock);
+        } while (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN);
     }
+    ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
+    pthread_mutex_unlock(&p_ctx->state_lock);
+    return abt_errno;
+}
+
+int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx)
+{
+    int abt_errno = ABT_SUCCESS;
+    /* Request restart */
+    pthread_mutex_lock(&p_ctx->state_lock);
+    ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
+    p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_RUNNING;
+    pthread_cond_signal(&p_ctx->state_cond);
+    pthread_mutex_unlock(&p_ctx->state_lock);
     return abt_errno;
 }
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -454,6 +454,7 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
 int ABT_xstream_start(ABT_xstream xstream) ABT_API_PUBLIC ABT_DEPRECATED;
 int ABT_xstream_free(ABT_xstream *xstream) ABT_API_PUBLIC;
 int ABT_xstream_join(ABT_xstream xstream) ABT_API_PUBLIC;
+int ABT_xstream_revive(ABT_xstream xstream) ABT_API_PUBLIC;
 int ABT_xstream_exit(void) ABT_API_PUBLIC;
 int ABT_xstream_cancel(ABT_xstream xstream) ABT_API_PUBLIC;
 int ABT_xstream_self(ABT_xstream *xstream) ABT_API_PUBLIC;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -37,7 +37,6 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_exit(void);
 int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -16,6 +16,8 @@
 /* Data Types */
 typedef struct {
     pthread_t native_thread;
+    void *(*thread_f)(void *);
+    void *p_arg;
 } ABTD_xstream_context;
 typedef pthread_mutex_t     ABTD_xstream_mutex;
 #ifdef HAVE_PTHREAD_BARRIER_INIT

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -32,17 +32,17 @@ void ABTD_env_init(ABTI_global *p_global);
 int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_join(ABTD_xstream_context ctx);
+int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_exit(void);
 int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */
 void ABTD_affinity_init(void);
 void ABTD_affinity_finalize(void);
-int ABTD_affinity_set(ABTD_xstream_context ctx, int rank);
-int ABTD_affinity_set_cpuset(ABTD_xstream_context ctx, int cpuset_size,
+int ABTD_affinity_set(ABTD_xstream_context *p_ctx, int rank);
+int ABTD_affinity_set_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
                              int *p_cpuset);
-int ABTD_affinity_get_cpuset(ABTD_xstream_context ctx, int cpuset_size,
+int ABTD_affinity_get_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
                              int *p_cpuset, int *p_num_cpus);
 
 #include "abtd_stream.h"

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -14,10 +14,19 @@
 #include "abtd_atomic.h"
 
 /* Data Types */
-typedef struct {
+typedef enum {
+    ABTD_XSTREAM_CONTEXT_STATE_RUNNING,
+    ABTD_XSTREAM_CONTEXT_STATE_WAITING,
+    ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN,
+    ABTD_XSTREAM_CONTEXT_STATE_REQ_TERMINATE,
+} ABTD_xstream_context_state;
+typedef struct ABTD_xstream_context {
     pthread_t native_thread;
     void *(*thread_f)(void *);
     void *p_arg;
+    ABTD_xstream_context_state state;
+    pthread_mutex_t state_lock;
+    pthread_cond_t state_cond;
 } ABTD_xstream_context;
 typedef pthread_mutex_t     ABTD_xstream_mutex;
 #ifdef HAVE_PTHREAD_BARRIER_INIT
@@ -37,6 +46,7 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
+int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -47,7 +47,7 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
 int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_self(ABTD_xstream_context *p_ctx);
+int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */
 void ABTD_affinity_init(void);

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -14,7 +14,9 @@
 #include "abtd_atomic.h"
 
 /* Data Types */
-typedef pthread_t           ABTD_xstream_context;
+typedef struct {
+    pthread_t native_thread;
+} ABTD_xstream_context;
 typedef pthread_mutex_t     ABTD_xstream_mutex;
 #ifdef HAVE_PTHREAD_BARRIER_INIT
 typedef pthread_barrier_t   ABTD_xstream_barrier;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1909,10 +1909,13 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     ABTI_CHECK_ERROR(abt_errno);
     p_local->p_xstream = p_xstream;
 
+    /* Create the main sched ULT if not created yet */
     ABTI_sched *p_sched = p_xstream->p_main_sched;
-    abt_errno = ABTI_thread_create_main_sched(p_local, p_xstream, p_sched);
-    ABTI_CHECK_ERROR(abt_errno);
-    p_sched->p_thread->p_last_xstream = p_xstream;
+    if (!p_sched->p_thread) {
+        abt_errno = ABTI_thread_create_main_sched(p_local, p_xstream, p_sched);
+        ABTI_CHECK_ERROR(abt_errno);
+        p_sched->p_thread->p_last_xstream = p_xstream;
+    }
 
     /* Set the sched ULT as the current ULT */
     p_local->p_thread = p_sched->p_thread;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1351,9 +1351,11 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream)
     /* Free the array of sched contexts */
     ABTU_free(p_xstream->scheds);
 
-    /* Free the context */
-    abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
-    ABTI_CHECK_ERROR(abt_errno);
+    /* Free the context if a given xstream is secondary. */
+    if (p_xstream->type == ABTI_XSTREAM_TYPE_SECONDARY) {
+        abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
+        ABTI_CHECK_ERROR(abt_errno);
+    }
 
     ABTU_free(p_xstream);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -312,7 +312,7 @@ int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
-        ABTD_affinity_set(p_xstream->ctx, p_xstream->rank);
+        ABTD_affinity_set(&p_xstream->ctx, p_xstream->rank);
     }
 
   fn_exit:
@@ -344,7 +344,7 @@ int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream, A
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
-        ABTD_affinity_set(p_xstream->ctx, p_xstream->rank);
+        ABTD_affinity_set(&p_xstream->ctx, p_xstream->rank);
     }
 
     /* Create the main sched ULT */
@@ -645,7 +645,7 @@ int ABT_xstream_set_rank(ABT_xstream xstream, const int rank)
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
-        ABTD_affinity_set(p_xstream->ctx, p_xstream->rank);
+        ABTD_affinity_set(&p_xstream->ctx, p_xstream->rank);
     }
 
   fn_exit:
@@ -1130,7 +1130,7 @@ int ABT_xstream_set_cpubind(ABT_xstream xstream, int cpuid)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    abt_errno = ABTD_affinity_set_cpuset(p_xstream->ctx, 1, &cpuid);
+    abt_errno = ABTD_affinity_set_cpuset(&p_xstream->ctx, 1, &cpuid);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
@@ -1160,7 +1160,7 @@ int ABT_xstream_get_cpubind(ABT_xstream xstream, int *cpuid)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    abt_errno = ABTD_affinity_get_cpuset(p_xstream->ctx, 1, cpuid, NULL);
+    abt_errno = ABTD_affinity_get_cpuset(&p_xstream->ctx, 1, cpuid, NULL);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
@@ -1191,7 +1191,7 @@ int ABT_xstream_set_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    abt_errno = ABTD_affinity_set_cpuset(p_xstream->ctx, cpuset_size, cpuset);
+    abt_errno = ABTD_affinity_set_cpuset(&p_xstream->ctx, cpuset_size, cpuset);
     ABTI_CHECK_ERROR(abt_errno);
 
   fn_exit:
@@ -1233,7 +1233,7 @@ int ABT_xstream_get_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset,
         goto fn_exit;
     }
 
-    abt_errno = ABTD_affinity_get_cpuset(p_xstream->ctx, cpuset_size, cpuset,
+    abt_errno = ABTD_affinity_get_cpuset(&p_xstream->ctx, cpuset_size, cpuset,
                                          num_cpus);
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -1320,7 +1320,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
 
   fn_join:
     /* Normal join request */
-    abt_errno = ABTD_xstream_context_join(p_xstream->ctx);
+    abt_errno = ABTD_xstream_context_join(&p_xstream->ctx);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_join");
 
   fn_exit:

--- a/src/stream.c
+++ b/src/stream.c
@@ -293,8 +293,8 @@ int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
         LOG_EVENT("[E%d] start\n", p_xstream->rank);
 
-        abt_errno = ABTD_xstream_context_self(&p_xstream->ctx);
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_self");
+        abt_errno = ABTD_xstream_context_set_self(&p_xstream->ctx);
+        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_set_self");
 
         /* Create the main sched ULT */
         ABTI_sched *p_sched = p_xstream->p_main_sched;
@@ -367,8 +367,8 @@ int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream, A
 
     LOG_EVENT("[E%d] start\n", p_xstream->rank);
 
-    abt_errno = ABTD_xstream_context_self(&p_xstream->ctx);
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_self");
+    abt_errno = ABTD_xstream_context_set_self(&p_xstream->ctx);
+    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_set_self");
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -1898,8 +1898,6 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     /* Reset the current ES and its local info. */
     ABTI_local_finalize(&p_local);
 
-    ABTD_xstream_context_exit();
-
   fn_exit:
     return NULL;
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,6 +1,7 @@
 # basic
 basic/init_finalize
 basic/xstream_create
+basic/xstream_revive
 basic/xstream_affinity
 basic/xstream_barrier
 basic/xstream_rank

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -6,6 +6,7 @@
 TESTS = \
 	init_finalize \
 	xstream_create \
+	xstream_revive \
 	xstream_affinity \
 	xstream_barrier \
 	xstream_rank \
@@ -75,6 +76,7 @@ include $(top_srcdir)/test/Makefile.mk
 
 init_finalize_SOURCES = init_finalize.c
 xstream_create_SOURCES = xstream_create.c
+xstream_revive_SOURCES = xstream_revive.c
 xstream_affinity_SOURCES = xstream_affinity.c
 xstream_barrier_SOURCES = xstream_barrier.c
 xstream_rank_SOURCES = xstream_rank.c
@@ -132,6 +134,7 @@ info_stackdump2_SOURCES = info_stackdump2.c
 testing:
 	./init_finalize
 	./xstream_create
+	./xstream_revive
 	./xstream_affinity
 	./xstream_barrier
 	./xstream_rank

--- a/test/basic/xstream_revive.c
+++ b/test/basic/xstream_revive.c
@@ -1,0 +1,94 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS    4
+#define DEFAULT_NUM_THREADS     4
+
+void thread_func(void *arg)
+{
+    size_t my_id = (size_t)arg;
+    ATS_printf(1, "[TH%lu]: Hello, world!\n", my_id);
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j, step;
+    int ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1) num_xstreams = atoi(argv[1]);
+    assert(num_xstreams >= 0);
+    if (argc > 2) num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    ABT_xstream *xstreams;
+    xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools+i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (step = 0; step < 5; step++) {
+        if (step != 0) {
+            /* Revive Execution Streams */
+            for (i = 1; i < num_xstreams; i++) {
+                ret = ABT_xstream_revive(xstreams[i]);
+                ATS_ERROR(ret, "ABT_xstream_revive");
+            }
+        }
+        /* Create threads */
+        for (i = 0; i < num_xstreams; i++) {
+            for (j = 0; j < num_threads; j++) {
+                size_t tid = i * num_threads + j + 1;
+                ret = ABT_thread_create(pools[i],
+                        thread_func, (void *)tid, ABT_THREAD_ATTR_NULL,
+                        NULL);
+                ATS_ERROR(ret, "ABT_thread_create");
+            }
+        }
+        /* Join Execution Streams */
+        for (i = 1; i < num_xstreams; i++) {
+            ret = ABT_xstream_join(xstreams[i]);
+            ATS_ERROR(ret, "ABT_xstream_join");
+        }
+    }
+
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(pools);
+    free(xstreams);
+
+    return ret;
+}


### PR DESCRIPTION
This PR implements `ABT_xstream_revive()`, a function that restarts an execution stream that has been already joined. This PR addresses #146.

The interface is simple and does not assume that programmers change ES parameters (e.g., main scheduler) on reviving an ES.
```
int ABT_xstream_revive(ABT_xstream xstream);
```
See test/basic/xstream_revive.c to know how to use this function.

This join-revive mechanism uses `pthread_cond`, so it should not be terribly inefficient.

#147, #148, and #149 are prerequisite PRs.