### PR TITLE
atomic: force atomic-type variables

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -70,7 +70,7 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
         if (p_thread->p_last_xstream == p_joiner->p_last_xstream) {
             /* Only when the current ULT is on the same ES as p_joiner's,
              * we can jump to the joiner ULT. */
-            ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+            ABTD_atomic_store_int((int *)&p_thread->state,
                                      ABT_THREAD_STATE_TERMINATED);
             LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
                       ABTI_thread_get_id(p_thread),

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -63,7 +63,7 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
 {
     ABTD_thread_context *p_ctx = &p_thread->ctx;
     ABTD_thread_context *p_link =
-        (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ctx->p_link);
+        ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
     if (p_link) {
         /* If p_link is set, it means that other ULT has called the join. */
         ABTI_thread *p_joiner = (ABTI_thread *)p_link;
@@ -113,8 +113,7 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             do {
-                p_link = (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
-                    (ABTD_atomic_ptr *)&p_ctx->p_link);
+                p_link = ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
             } while (!p_link);
             ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
         }
@@ -178,9 +177,9 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
      * context switch to the joiner ULT and need to always wake it up. */
     ABTD_thread_context *p_ctx = &p_thread->ctx;
 
-    if (ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ctx->p_link)) {
+    if (ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link)) {
         /* If p_link is set, it means that other ULT has called the join. */
-        ABTI_thread *p_joiner = (ABTI_thread *)ABTD_atomic_relaxed_load_ptr((ABTD_atomic_ptr *)&p_ctx->p_link);
+        ABTI_thread *p_joiner = (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link);
         ABTI_thread_set_ready(p_local, p_joiner);
     } else {
         uint32_t req =
@@ -190,9 +189,9 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
-            while (ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ctx->p_link) == NULL)
+            while (ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link) == NULL)
                 ;
-            ABTI_thread *p_joiner = (ABTI_thread *)p_ctx->p_link;
+            ABTI_thread *p_joiner = (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link);
             ABTI_thread_set_ready(p_local, p_joiner);
         }
     }
@@ -204,7 +203,7 @@ void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
     ABTD_thread_context *p_ctx = &p_thread->ctx;
     fprintf(p_os, "%sp_ctx    : %p\n", prefix, p_ctx->p_ctx);
     fprintf(p_os, "%sp_arg    : %p\n", prefix, p_ctx->p_arg);
-    fprintf(p_os, "%sp_link   : %p\n", prefix, ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ctx->p_link));
+    fprintf(p_os, "%sp_link   : %p\n", prefix, (void *)ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link));
     fflush(p_os);
     ABTU_free(prefix);
 }

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -71,7 +71,7 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
             /* Only when the current ULT is on the same ES as p_joiner's,
              * we can jump to the joiner ULT. */
             ABTD_atomic_release_store_int(&p_thread->state,
-                                     ABT_THREAD_STATE_TERMINATED);
+                                          ABT_THREAD_STATE_TERMINATED);
             LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
                       ABTI_thread_get_id(p_thread),
                       p_thread->p_last_xstream->rank);
@@ -102,7 +102,7 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
             /* We don't need to use the atomic OR operation here because the ULT
              * will be terminated regardless of other requests. */
             ABTD_atomic_release_store_uint32(&p_thread->request,
-                                     ABTI_THREAD_REQ_TERMINATE);
+                                             ABTI_THREAD_REQ_TERMINATE);
         }
     } else {
         uint32_t req =
@@ -113,7 +113,8 @@ static inline void ABTDI_thread_terminate(ABTI_local *p_local,
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             do {
-                p_link = ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
+                p_link =
+                    ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
             } while (!p_link);
             ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
         }
@@ -179,7 +180,9 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
 
     if (ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link)) {
         /* If p_link is set, it means that other ULT has called the join. */
-        ABTI_thread *p_joiner = (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link);
+        ABTI_thread *p_joiner =
+            (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(
+                &p_ctx->p_link);
         ABTI_thread_set_ready(p_local, p_joiner);
     } else {
         uint32_t req =
@@ -189,9 +192,12 @@ void ABTD_thread_cancel(ABTI_local *p_local, ABTI_thread *p_thread)
         if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
-            while (ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link) == NULL)
+            while (ABTD_atomic_acquire_load_thread_context_ptr(
+                       &p_ctx->p_link) == NULL)
                 ;
-            ABTI_thread *p_joiner = (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link);
+            ABTI_thread *p_joiner =
+                (ABTI_thread *)ABTD_atomic_relaxed_load_thread_context_ptr(
+                    &p_ctx->p_link);
             ABTI_thread_set_ready(p_local, p_joiner);
         }
     }
@@ -203,7 +209,9 @@ void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
     ABTD_thread_context *p_ctx = &p_thread->ctx;
     fprintf(p_os, "%sp_ctx    : %p\n", prefix, p_ctx->p_ctx);
     fprintf(p_os, "%sp_arg    : %p\n", prefix, p_ctx->p_arg);
-    fprintf(p_os, "%sp_link   : %p\n", prefix, (void *)ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link));
+    fprintf(p_os, "%sp_link   : %p\n", prefix,
+            (void *)ABTD_atomic_acquire_load_thread_context_ptr(
+                &p_ctx->p_link));
     fflush(p_os);
     ABTU_free(prefix);
 }

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -158,7 +158,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
     if (p_barrier->counter < p_barrier->num_waiters) {
         ABTI_thread *p_thread;
         ABT_unit_type type;
-        int32_t ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = 0;
 
         if (p_local != NULL) {
             p_thread = p_local->p_thread;
@@ -202,7 +202,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
                 ABTI_thread_set_ready(p_local, p_thread);
             } else {
                 /* When p_cur is an external thread */
-                int32_t *p_ext_signal = (int32_t *)p_thread;
+                ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_thread;
                 ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -158,7 +158,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
     if (p_barrier->counter < p_barrier->num_waiters) {
         ABTI_thread *p_thread;
         ABT_unit_type type;
-        ABTD_atomic_int32 ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local != NULL) {
             p_thread = p_local->p_thread;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -169,6 +169,8 @@ int ABT_barrier_wait(ABT_barrier barrier)
             type = ABT_UNIT_TYPE_THREAD;
         } else {
             /* external thread */
+            /* Check size if ext_signal can be stored in p_thread. */
+            ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_thread));
             p_thread = (ABTI_thread *)&ext_signal;
             type = ABT_UNIT_TYPE_EXT;
         }

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -190,7 +190,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         } else {
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal))
+            while (!ABTD_atomic_acquire_load_int32(&ext_signal))
                 ;
         }
     } else {
@@ -203,7 +203,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
             } else {
                 /* When p_cur is an external thread */
                 int32_t *p_ext_signal = (int32_t *)p_thread;
-                ABTD_atomic_store_int32(p_ext_signal, 1);
+                ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 
             p_barrier->waiters[i] = NULL;

--- a/src/cond.c
+++ b/src/cond.c
@@ -186,7 +186,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     double tar_time = convert_timespec_to_sec(abstime);
 
     ABTI_unit *p_unit;
-    ABTD_atomic_int32 ext_signal = 0;
+    ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
     p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
     p_unit->pool = (ABT_pool)&ext_signal;

--- a/src/cond.c
+++ b/src/cond.c
@@ -226,7 +226,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     /* Unlock the mutex that the calling ULT is holding */
     ABTI_mutex_unlock(p_local, p_mutex);
 
-    while (!ABTD_atomic_load_int32(&ext_signal)) {
+    while (!ABTD_atomic_acquire_load_int32(&ext_signal)) {
         double cur_time = ABTI_get_wtime();
         if (cur_time >= tar_time) {
             remove_unit(p_cond, p_unit);
@@ -304,7 +304,7 @@ int ABT_cond_signal(ABT_cond cond)
     } else {
         /* When the head is an external thread */
         int32_t *p_ext_signal = (int32_t *)p_unit->pool;
-        ABTD_atomic_store_int32(p_ext_signal, 1);
+        ABTD_atomic_release_store_int32(p_ext_signal, 1);
     }
 
     ABTI_spinlock_release(&p_cond->lock);

--- a/src/cond.c
+++ b/src/cond.c
@@ -186,7 +186,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     double tar_time = convert_timespec_to_sec(abstime);
 
     ABTI_unit *p_unit;
-    int32_t ext_signal = 0;
+    ABTD_atomic_int32 ext_signal = 0;
 
     p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
     p_unit->pool = (ABT_pool)&ext_signal;
@@ -303,7 +303,7 @@ int ABT_cond_signal(ABT_cond cond)
         ABTI_thread_set_ready(p_local, p_thread);
     } else {
         /* When the head is an external thread */
-        int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+        ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
         ABTD_atomic_release_store_int32(p_ext_signal, 1);
     }
 

--- a/src/cond.c
+++ b/src/cond.c
@@ -189,6 +189,8 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
     p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+    /* Check size if ext_signal can be stored in p_unit->pool. */
+    ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
     p_unit->pool = (ABT_pool)&ext_signal;
     p_unit->type = ABT_UNIT_TYPE_EXT;
 

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -153,7 +153,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal))
+            while (!ABTD_atomic_acquire_load_int32(&ext_signal))
                 ;
             ABTU_free(p_unit);
         }
@@ -262,7 +262,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
         } else {
             /* When the head is an external thread */
             int32_t *p_ext_signal = (int32_t *)p_unit->pool;
-            ABTD_atomic_store_int32(p_ext_signal, 1);
+            ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 
         /* Next ULT */

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -127,6 +127,8 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
             /* external thread */
             type = ABT_UNIT_TYPE_EXT;
             p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+            /* Check size if ext_signal can be stored in p_unit->pool. */
+            ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
             p_unit->pool = (ABT_pool)&ext_signal;
             p_unit->type = type;
         }

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -113,7 +113,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        ABTD_atomic_int32 ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local != NULL) {
             p_current = p_local->p_thread;

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -113,7 +113,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        int32_t ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = 0;
 
         if (p_local != NULL) {
             p_current = p_local->p_thread;
@@ -261,7 +261,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
             ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
-            int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+            ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
             ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -177,7 +177,7 @@ int ABT_future_wait(ABT_future future)
 
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */
-            while (!ABTD_atomic_load_int32(&ext_signal))
+            while (!ABTD_atomic_acquire_load_int32(&ext_signal))
                 ;
             ABTU_free(p_unit);
         }
@@ -278,7 +278,7 @@ int ABT_future_set(ABT_future future, void *value)
             } else {
                 /* When the head is an external thread */
                 int32_t *p_ext_signal = (int32_t *)p_unit->pool;
-                ABTD_atomic_store_int32(p_ext_signal, 1);
+                ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 
             /* Next ULT */

--- a/src/futures.c
+++ b/src/futures.c
@@ -279,7 +279,8 @@ int ABT_future_set(ABT_future future, void *value)
                 ABTI_thread_set_ready(p_local, p_thread);
             } else {
                 /* When the head is an external thread */
-                ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
+                ABTD_atomic_int32 *p_ext_signal =
+                    (ABTD_atomic_int32 *)p_unit->pool;
                 ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -137,7 +137,7 @@ int ABT_future_wait(ABT_future future)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        int32_t ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = 0;
 
         if (p_local != NULL) {
             p_current = p_local->p_thread;
@@ -277,7 +277,7 @@ int ABT_future_set(ABT_future future, void *value)
                 ABTI_thread_set_ready(p_local, p_thread);
             } else {
                 /* When the head is an external thread */
-                int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+                ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
                 ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -137,7 +137,7 @@ int ABT_future_wait(ABT_future future)
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
-        ABTD_atomic_int32 ext_signal = 0;
+        ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local != NULL) {
             p_current = p_local->p_thread;

--- a/src/futures.c
+++ b/src/futures.c
@@ -151,6 +151,8 @@ int ABT_future_wait(ABT_future future)
             /* external thread */
             type = ABT_UNIT_TYPE_EXT;
             p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+            /* Check size if ext_signal can be stored in p_unit->pool. */
+            ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
             p_unit->pool = (ABT_pool)&ext_signal;
             p_unit->type = type;
         }

--- a/src/global.c
+++ b/src/global.c
@@ -18,7 +18,7 @@ static uint32_t g_ABTI_num_inits = 0;
 /* A global lock protecting the initialization/finalization process */
 static ABTI_spinlock g_ABTI_init_lock = ABTI_SPINLOCK_STATIC_INITIALIZER();
 /* A flag whether Argobots has been initialized or not */
-static uint32_t g_ABTI_initialized = 0;
+static ABTD_atomic_uint32 g_ABTI_initialized = 0;
 
 /**
  * @ingroup ENV

--- a/src/global.c
+++ b/src/global.c
@@ -18,7 +18,8 @@ static uint32_t g_ABTI_num_inits = 0;
 /* A global lock protecting the initialization/finalization process */
 static ABTI_spinlock g_ABTI_init_lock = ABTI_SPINLOCK_STATIC_INITIALIZER();
 /* A flag whether Argobots has been initialized or not */
-static ABTD_atomic_uint32 g_ABTI_initialized = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
+static ABTD_atomic_uint32 g_ABTI_initialized =
+    ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
 /**
  * @ingroup ENV
@@ -88,7 +89,8 @@ int ABT_init(int argc, char **argv)
     ABTI_thread *p_main_thread;
     abt_errno = ABTI_thread_create_main(p_local, p_newxstream, &p_main_thread);
     /* Set as if p_newxstream is currently running the main thread. */
-    ABTD_atomic_relaxed_store_int(&p_main_thread->state, ABT_THREAD_STATE_RUNNING);
+    ABTD_atomic_relaxed_store_int(&p_main_thread->state,
+                                  ABT_THREAD_STATE_RUNNING);
     p_main_thread->p_last_xstream = p_newxstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
@@ -165,7 +167,8 @@ int ABT_finalize(void)
     ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
     /* We wait for the remaining jobs */
-    if (ABTD_atomic_acquire_load_int(&p_xstream->state) != ABT_XSTREAM_STATE_TERMINATED) {
+    if (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+        ABT_XSTREAM_STATE_TERMINATED) {
         /* Set the orphan request for the primary ULT */
         ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
 

--- a/src/global.c
+++ b/src/global.c
@@ -102,7 +102,7 @@ int ABT_init(int argc, char **argv)
     if (gp_ABTI_global->print_config == ABT_TRUE) {
         ABTI_info_print_config(stdout);
     }
-    ABTD_atomic_store_uint32(&g_ABTI_initialized, 1);
+    ABTD_atomic_release_store_uint32(&g_ABTI_initialized, 1);
 
 fn_exit:
     /* Unlock a global lock */
@@ -209,7 +209,7 @@ int ABT_finalize(void)
     /* Free the ABTI_global structure */
     ABTU_free(gp_ABTI_global);
     gp_ABTI_global = NULL;
-    ABTD_atomic_store_uint32(&g_ABTI_initialized, 0);
+    ABTD_atomic_release_store_uint32(&g_ABTI_initialized, 0);
 
 fn_exit:
     /* Unlock a global lock */
@@ -237,7 +237,7 @@ int ABT_initialized(void)
 {
     int abt_errno = ABT_SUCCESS;
 
-    if (ABTD_atomic_load_uint32(&g_ABTI_initialized) == 0) {
+    if (ABTD_atomic_acquire_load_uint32(&g_ABTI_initialized) == 0) {
         abt_errno = ABT_ERR_UNINITIALIZED;
     }
 

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -8,10 +8,8 @@
 
 #define __USE_GNU
 #include <pthread.h>
-#include "abtd_context.h"
-
-/* Atomic Functions */
 #include "abtd_atomic.h"
+#include "abtd_context.h"
 
 /* Data Types */
 typedef enum {

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -284,22 +284,6 @@ static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline double ABTD_atomic_fetch_add_double(double *ptr, double v)
-{
-    union value {
-        double d_val;
-        uint64_t u_val;
-    } oldv, newv;
-
-    do {
-        oldv.d_val = *ptr;
-        newv.d_val = oldv.d_val + v;
-    } while (!ABTD_atomic_bool_cas_weak_uint64((uint64_t *)ptr, oldv.u_val,
-                                               newv.u_val));
-
-    return oldv.d_val;
-}
-
 static inline int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -334,11 +318,6 @@ static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 #else
     return __sync_fetch_and_sub(ptr, v);
 #endif
-}
-
-static inline double ABTD_atomic_fetch_sub_double(double *ptr, double v)
-{
-    return ABTD_atomic_fetch_add_double(ptr, -v);
 }
 
 static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,9 +8,9 @@
 
 #include <stdint.h>
 
-typedef struct ABTD_atomic_uint8 {
+typedef struct ABTD_atomic_bool {
     uint8_t val;
-} ABTD_atomic_uint8;
+} ABTD_atomic_bool;
 
 typedef struct ABTD_atomic_int {
     int val;
@@ -36,7 +36,7 @@ typedef struct ABTD_atomic_ptr {
     void *val;
 } ABTD_atomic_ptr;
 
-#define ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(val)                              \
+#define ABTD_ATOMIC_BOOL_STATIC_INITIALIZER(val)                               \
     {                                                                          \
         (val)                                                                  \
     }
@@ -572,7 +572,7 @@ static inline uint64_t ABTD_atomic_fetch_xor_uint64(ABTD_atomic_uint64 *ptr, uin
 #endif
 }
 
-static inline uint16_t ABTD_atomic_test_and_set_uint8(ABTD_atomic_uint8 *ptr)
+static inline uint16_t ABTD_atomic_test_and_set_bool(ABTD_atomic_bool *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -582,7 +582,7 @@ static inline uint16_t ABTD_atomic_test_and_set_uint8(ABTD_atomic_uint8 *ptr)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_clear_uint8(ABTD_atomic_uint8 *ptr)
+static inline void ABTD_atomic_relaxed_clear_bool(ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(&ptr->val, __ATOMIC_RELAXED);
@@ -591,7 +591,7 @@ static inline void ABTD_atomic_relaxed_clear_uint8(ABTD_atomic_uint8 *ptr)
 #endif
 }
 
-static inline void ABTD_atomic_release_clear_uint8(ABTD_atomic_uint8 *ptr)
+static inline void ABTD_atomic_release_clear_bool(ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(&ptr->val, __ATOMIC_RELEASE);
@@ -600,12 +600,12 @@ static inline void ABTD_atomic_release_clear_uint8(ABTD_atomic_uint8 *ptr)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_relaxed_load_uint8(const ABTD_atomic_uint8 *ptr)
+static inline ABT_bool ABTD_atomic_relaxed_load_bool(const ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED) ? ABT_TRUE : ABT_FALSE;
 #else
-    return *(volatile uint8_t *)&ptr->val;
+    return (*(volatile uint8_t *)&ptr->val) ? ABT_TRUE : ABT_FALSE;
 #endif
 }
 
@@ -665,13 +665,13 @@ static inline void *ABTD_atomic_relaxed_load_ptr(const ABTD_atomic_ptr *ptr)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_acquire_load_uint8(const ABTD_atomic_uint8 *ptr)
+static inline ABT_bool ABTD_atomic_acquire_load_bool(const ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE) ? ABT_TRUE : ABT_FALSE;
 #else
     __sync_synchronize();
-    uint8_t val = *(volatile uint8_t *)&ptr->val;
+    ABT_bool val = *(volatile uint8_t *)&ptr->val ? ABT_TRUE : ABT_FALSE;
     __sync_synchronize();
     return val;
 #endif

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -525,7 +525,7 @@ static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline void ABTD_atomic_clear_uint8(uint8_t *ptr)
+static inline void ABTD_atomic_release_clear_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELEASE);
@@ -534,7 +534,7 @@ static inline void ABTD_atomic_clear_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_acquire_load_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -546,7 +546,7 @@ static inline uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline int ABTD_atomic_load_int(int *ptr)
+static inline int ABTD_atomic_acquire_load_int(int *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -558,7 +558,7 @@ static inline int ABTD_atomic_load_int(int *ptr)
 #endif
 }
 
-static inline int32_t ABTD_atomic_load_int32(int32_t *ptr)
+static inline int32_t ABTD_atomic_acquire_load_int32(int32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -570,7 +570,7 @@ static inline int32_t ABTD_atomic_load_int32(int32_t *ptr)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
+static inline uint32_t ABTD_atomic_acquire_load_uint32(uint32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -582,7 +582,7 @@ static inline uint32_t ABTD_atomic_load_uint32(uint32_t *ptr)
 #endif
 }
 
-static inline int64_t ABTD_atomic_load_int64(int64_t *ptr)
+static inline int64_t ABTD_atomic_acquire_load_int64(int64_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -594,7 +594,7 @@ static inline int64_t ABTD_atomic_load_int64(int64_t *ptr)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
+static inline uint64_t ABTD_atomic_acquire_load_uint64(uint64_t *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -607,7 +607,7 @@ static inline uint64_t ABTD_atomic_load_uint64(uint64_t *ptr)
 #endif
 }
 
-static inline void *ABTD_atomic_load_ptr(void **ptr)
+static inline void *ABTD_atomic_acquire_load_ptr(void **ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -620,7 +620,7 @@ static inline void *ABTD_atomic_load_ptr(void **ptr)
 #endif
 }
 
-static inline void ABTD_atomic_store_int(int *ptr, int val)
+static inline void ABTD_atomic_release_store_int(int *ptr, int val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -631,7 +631,7 @@ static inline void ABTD_atomic_store_int(int *ptr, int val)
 #endif
 }
 
-static inline void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
+static inline void ABTD_atomic_release_store_int32(int32_t *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -642,7 +642,7 @@ static inline void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
+static inline void ABTD_atomic_release_store_uint32(uint32_t *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -653,7 +653,7 @@ static inline void ABTD_atomic_store_uint32(uint32_t *ptr, uint32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
+static inline void ABTD_atomic_release_store_int64(int64_t *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -664,7 +664,7 @@ static inline void ABTD_atomic_store_int64(int64_t *ptr, int64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
+static inline void ABTD_atomic_release_store_uint64(uint64_t *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -675,7 +675,7 @@ static inline void ABTD_atomic_store_uint64(uint64_t *ptr, uint64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_store_ptr(void **ptr, void *val)
+static inline void ABTD_atomic_release_store_ptr(void **ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -693,7 +693,7 @@ static inline int ABTD_atomic_exchange_int(int *ptr, int v)
 #else
     int val;
     do {
-        val = ABTD_atomic_load_int(ptr);
+        val = ABTD_atomic_acquire_load_int(ptr);
     } while (!ABTD_atomic_bool_cas_weak_int(ptr, val, v));
     return val;
 #endif
@@ -706,7 +706,7 @@ static inline int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 #else
     int32_t val;
     do {
-        val = ABTD_atomic_load_int32(ptr);
+        val = ABTD_atomic_acquire_load_int32(ptr);
     } while (!ABTD_atomic_bool_cas_weak_int32(ptr, val, v));
     return val;
 #endif
@@ -719,7 +719,7 @@ static inline uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 #else
     uint32_t val;
     do {
-        val = ABTD_atomic_load_uint32(ptr);
+        val = ABTD_atomic_acquire_load_uint32(ptr);
     } while (!ABTD_atomic_bool_cas_weak_uint32(ptr, val, v));
     return val;
 #endif
@@ -732,7 +732,7 @@ static inline int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 #else
     int64_t val;
     do {
-        val = ABTD_atomic_load_int64(ptr);
+        val = ABTD_atomic_acquire_load_int64(ptr);
     } while (!ABTD_atomic_bool_cas_weak_int64(ptr, val, v));
     return val;
 #endif
@@ -745,7 +745,7 @@ static inline uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 #else
     uint64_t val;
     do {
-        val = ABTD_atomic_load_uint64(ptr);
+        val = ABTD_atomic_acquire_load_uint64(ptr);
     } while (!ABTD_atomic_bool_cas_weak_uint64(ptr, val, v));
     return val;
 #endif
@@ -758,7 +758,7 @@ static inline void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
 #else
     void *val;
     do {
-        val = ABTD_atomic_load_ptr(ptr);
+        val = ABTD_atomic_acquire_load_ptr(ptr);
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, val, v));
     return val;
 #endif

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,7 +8,29 @@
 
 #include <stdint.h>
 
-static inline int ABTDI_atomic_val_cas_int(int *ptr, int oldv, int newv, int weak)
+typedef uint8_t ABTD_atomic_uint8;
+
+typedef int ABTD_atomic_int;
+
+typedef int32_t ABTD_atomic_int32;
+
+typedef uint32_t ABTD_atomic_uint32;
+
+typedef int64_t ABTD_atomic_int64;
+
+typedef uint64_t ABTD_atomic_uint64;
+
+typedef void *ABTD_atomic_ptr;
+
+#define ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_INT_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_INT32_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_INT64_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_PTR_STATIC_INITIALIZER(val) (val)
+
+static inline int ABTDI_atomic_val_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int tmp_oldv = oldv;
@@ -20,7 +42,7 @@ static inline int ABTDI_atomic_val_cas_int(int *ptr, int oldv, int newv, int wea
 #endif
 }
 
-static inline int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv,
+static inline int32_t ABTDI_atomic_val_cas_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
                                                  int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -33,7 +55,7 @@ static inline int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv,
 #endif
 }
 
-static inline uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
+static inline uint32_t ABTDI_atomic_val_cas_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
                                                    uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -46,7 +68,7 @@ static inline uint32_t ABTDI_atomic_val_cas_uint32(uint32_t *ptr, uint32_t oldv,
 #endif
 }
 
-static inline int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv,
+static inline int64_t ABTDI_atomic_val_cas_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
                                                  int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -59,7 +81,7 @@ static inline int64_t ABTDI_atomic_val_cas_int64(int64_t *ptr, int64_t oldv,
 #endif
 }
 
-static inline uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
+static inline uint64_t ABTDI_atomic_val_cas_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
                                                    uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -72,7 +94,7 @@ static inline uint64_t ABTDI_atomic_val_cas_uint64(uint64_t *ptr, uint64_t oldv,
 #endif
 }
 
-static inline void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv,
+static inline void *ABTDI_atomic_val_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, void *newv,
                                              int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -85,7 +107,7 @@ static inline void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv,
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int(int *ptr, int oldv, int newv, int weak)
+static inline int ABTDI_atomic_bool_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
@@ -95,7 +117,7 @@ static inline int ABTDI_atomic_bool_cas_int(int *ptr, int oldv, int newv, int we
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv,
+static inline int ABTDI_atomic_bool_cas_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
                                               int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -106,7 +128,7 @@ static inline int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv,
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv,
+static inline int ABTDI_atomic_bool_cas_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
                                                uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -117,7 +139,7 @@ static inline int ABTDI_atomic_bool_cas_uint32(uint32_t *ptr, uint32_t oldv,
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv,
+static inline int ABTDI_atomic_bool_cas_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
                                               int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -128,7 +150,7 @@ static inline int ABTDI_atomic_bool_cas_int64(int64_t *ptr, int64_t oldv,
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv,
+static inline int ABTDI_atomic_bool_cas_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
                                                uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -139,7 +161,7 @@ static inline int ABTDI_atomic_bool_cas_uint64(uint64_t *ptr, uint64_t oldv,
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv,
+static inline int ABTDI_atomic_bool_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, void *newv,
                                             int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -150,147 +172,147 @@ static inline int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv,
 #endif
 }
 
-static inline int ABTD_atomic_val_cas_weak_int(int *ptr, int oldv,  int newv)
+static inline int ABTD_atomic_val_cas_weak_int(ABTD_atomic_int *ptr, int oldv, int newv)
 {
     return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 1);
 }
 
-static inline int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv,
+static inline int32_t ABTD_atomic_val_cas_weak_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
                                                      int32_t newv)
 {
     return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
 }
 
 static inline uint32_t
-ABTD_atomic_val_cas_weak_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
+ABTD_atomic_val_cas_weak_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
 {
     return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline int64_t ABTD_atomic_val_cas_weak_int64(int64_t *ptr, int64_t oldv,
+static inline int64_t ABTD_atomic_val_cas_weak_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
                                                      int64_t newv)
 {
     return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
 }
 
 static inline uint64_t
-ABTD_atomic_val_cas_weak_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
+ABTD_atomic_val_cas_weak_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
 {
     return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv,
+static inline void *ABTD_atomic_val_cas_weak_ptr(ABTD_atomic_ptr *ptr, void *oldv,
                                                  void *newv)
 {
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_val_cas_strong_int(int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_val_cas_strong_int(ABTD_atomic_int *ptr, int oldv, int newv)
 {
     return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 0);
 }
 
 static inline int32_t
-ABTD_atomic_val_cas_strong_int32(int32_t *ptr, int32_t oldv, int32_t newv)
+ABTD_atomic_val_cas_strong_int32(ABTD_atomic_int32 *ptr, int32_t oldv, int32_t newv)
 {
     return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
 }
 
 static inline uint32_t
-ABTD_atomic_val_cas_strong_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
+ABTD_atomic_val_cas_strong_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
 {
     return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
 }
 
 static inline int64_t
-ABTD_atomic_val_cas_strong_int64(int64_t *ptr, int64_t oldv, int64_t newv)
+ABTD_atomic_val_cas_strong_int64(ABTD_atomic_int64 *ptr, int64_t oldv, int64_t newv)
 {
     return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
 }
 
 static inline uint64_t
-ABTD_atomic_val_cas_strong_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
+ABTD_atomic_val_cas_strong_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
 {
     return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv,
+static inline void *ABTD_atomic_val_cas_strong_ptr(ABTD_atomic_ptr *ptr, void *oldv,
                                                    void *newv)
 {
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int(int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_bool_cas_weak_int(ABTD_atomic_int *ptr, int oldv, int newv)
 {
     return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv,
+static inline int ABTD_atomic_bool_cas_weak_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
                                                   int32_t newv)
 {
     return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_uint32(uint32_t *ptr, uint32_t oldv,
+static inline int ABTD_atomic_bool_cas_weak_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
                                                    uint32_t newv)
 {
     return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int64(int64_t *ptr, int64_t oldv,
+static inline int ABTD_atomic_bool_cas_weak_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
                                                   int64_t newv)
 {
     return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_uint64(uint64_t *ptr, uint64_t oldv,
+static inline int ABTD_atomic_bool_cas_weak_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
                                                    uint64_t newv)
 {
     return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv,
+static inline int ABTD_atomic_bool_cas_weak_ptr(ABTD_atomic_ptr *ptr, void *oldv,
                                                 void *newv)
 {
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int(int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_bool_cas_strong_int(ABTD_atomic_int *ptr, int oldv, int newv)
 {
     return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv,
+static inline int ABTD_atomic_bool_cas_strong_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
                                                     int32_t newv)
 {
     return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
 }
 
 static inline int
-ABTD_atomic_bool_cas_strong_uint32(uint32_t *ptr, uint32_t oldv, uint32_t newv)
+ABTD_atomic_bool_cas_strong_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
 {
     return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int64(int64_t *ptr, int64_t oldv,
+static inline int ABTD_atomic_bool_cas_strong_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
                                                     int64_t newv)
 {
     return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
 }
 
 static inline int
-ABTD_atomic_bool_cas_strong_uint64(uint64_t *ptr, uint64_t oldv, uint64_t newv)
+ABTD_atomic_bool_cas_strong_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
 {
     return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv,
+static inline int ABTD_atomic_bool_cas_strong_ptr(ABTD_atomic_ptr *ptr, void *oldv,
                                                   void *newv)
 {
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_fetch_add_int(int *ptr, int v)
+static inline int ABTD_atomic_fetch_add_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -299,7 +321,7 @@ static inline int ABTD_atomic_fetch_add_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_add_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -308,7 +330,7 @@ static inline int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_add_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -317,7 +339,7 @@ static inline uint32_t ABTD_atomic_fetch_add_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_add_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -326,7 +348,7 @@ static inline int64_t ABTD_atomic_fetch_add_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_add_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
@@ -335,7 +357,7 @@ static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline int ABTD_atomic_fetch_sub_int(int *ptr, int v)
+static inline int ABTD_atomic_fetch_sub_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -344,7 +366,7 @@ static inline int ABTD_atomic_fetch_sub_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_sub_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -353,7 +375,7 @@ static inline int32_t ABTD_atomic_fetch_sub_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_sub_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -362,7 +384,7 @@ static inline uint32_t ABTD_atomic_fetch_sub_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_sub_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -371,7 +393,7 @@ static inline int64_t ABTD_atomic_fetch_sub_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_sub_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
@@ -380,7 +402,7 @@ static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline int ABTD_atomic_fetch_and_int(int *ptr, int v)
+static inline int ABTD_atomic_fetch_and_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -389,7 +411,7 @@ static inline int ABTD_atomic_fetch_and_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_and_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -398,7 +420,7 @@ static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_and_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -407,7 +429,7 @@ static inline uint32_t ABTD_atomic_fetch_and_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_and_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -416,7 +438,7 @@ static inline int64_t ABTD_atomic_fetch_and_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_and_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
@@ -425,7 +447,7 @@ static inline uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline int ABTD_atomic_fetch_or_int(int *ptr, int v)
+static inline int ABTD_atomic_fetch_or_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -434,7 +456,7 @@ static inline int ABTD_atomic_fetch_or_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_or_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -443,7 +465,7 @@ static inline int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_or_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -452,7 +474,7 @@ static inline uint32_t ABTD_atomic_fetch_or_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_or_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -461,7 +483,7 @@ static inline int64_t ABTD_atomic_fetch_or_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_or_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
@@ -470,7 +492,7 @@ static inline uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline int ABTD_atomic_fetch_xor_int(int *ptr, int v)
+static inline int ABTD_atomic_fetch_xor_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -479,7 +501,7 @@ static inline int ABTD_atomic_fetch_xor_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_xor_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -488,7 +510,7 @@ static inline int32_t ABTD_atomic_fetch_xor_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_xor_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -497,7 +519,7 @@ static inline uint32_t ABTD_atomic_fetch_xor_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_xor_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -506,7 +528,7 @@ static inline int64_t ABTD_atomic_fetch_xor_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_xor_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
@@ -515,7 +537,7 @@ static inline uint64_t ABTD_atomic_fetch_xor_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_test_and_set_uint8(ABTD_atomic_uint8 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -525,7 +547,7 @@ static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_clear_uint8(uint8_t *ptr)
+static inline void ABTD_atomic_relaxed_clear_uint8(ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELAXED);
@@ -534,7 +556,7 @@ static inline void ABTD_atomic_relaxed_clear_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline void ABTD_atomic_release_clear_uint8(uint8_t *ptr)
+static inline void ABTD_atomic_release_clear_uint8(ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELEASE);
@@ -543,7 +565,7 @@ static inline void ABTD_atomic_release_clear_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_relaxed_load_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_relaxed_load_uint8(const ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -552,7 +574,7 @@ static inline uint16_t ABTD_atomic_relaxed_load_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline int ABTD_atomic_relaxed_load_int(int *ptr)
+static inline int ABTD_atomic_relaxed_load_int(const ABTD_atomic_int *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -561,7 +583,7 @@ static inline int ABTD_atomic_relaxed_load_int(int *ptr)
 #endif
 }
 
-static inline int32_t ABTD_atomic_relaxed_load_int32(int32_t *ptr)
+static inline int32_t ABTD_atomic_relaxed_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -570,7 +592,7 @@ static inline int32_t ABTD_atomic_relaxed_load_int32(int32_t *ptr)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_relaxed_load_uint32(uint32_t *ptr)
+static inline uint32_t ABTD_atomic_relaxed_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -579,7 +601,7 @@ static inline uint32_t ABTD_atomic_relaxed_load_uint32(uint32_t *ptr)
 #endif
 }
 
-static inline int64_t ABTD_atomic_relaxed_load_int64(int64_t *ptr)
+static inline int64_t ABTD_atomic_relaxed_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -588,7 +610,7 @@ static inline int64_t ABTD_atomic_relaxed_load_int64(int64_t *ptr)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_relaxed_load_uint64(uint64_t *ptr)
+static inline uint64_t ABTD_atomic_relaxed_load_uint64(const ABTD_atomic_uint64 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -598,7 +620,7 @@ static inline uint64_t ABTD_atomic_relaxed_load_uint64(uint64_t *ptr)
 #endif
 }
 
-static inline void *ABTD_atomic_relaxed_load_ptr(void **ptr)
+static inline void *ABTD_atomic_relaxed_load_ptr(const ABTD_atomic_ptr *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -608,7 +630,7 @@ static inline void *ABTD_atomic_relaxed_load_ptr(void **ptr)
 #endif
 }
 
-static inline uint16_t ABTD_atomic_acquire_load_uint8(uint8_t *ptr)
+static inline uint16_t ABTD_atomic_acquire_load_uint8(const ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -620,7 +642,7 @@ static inline uint16_t ABTD_atomic_acquire_load_uint8(uint8_t *ptr)
 #endif
 }
 
-static inline int ABTD_atomic_acquire_load_int(int *ptr)
+static inline int ABTD_atomic_acquire_load_int(const ABTD_atomic_int *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -632,7 +654,7 @@ static inline int ABTD_atomic_acquire_load_int(int *ptr)
 #endif
 }
 
-static inline int32_t ABTD_atomic_acquire_load_int32(int32_t *ptr)
+static inline int32_t ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -644,7 +666,7 @@ static inline int32_t ABTD_atomic_acquire_load_int32(int32_t *ptr)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_acquire_load_uint32(uint32_t *ptr)
+static inline uint32_t ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -656,7 +678,7 @@ static inline uint32_t ABTD_atomic_acquire_load_uint32(uint32_t *ptr)
 #endif
 }
 
-static inline int64_t ABTD_atomic_acquire_load_int64(int64_t *ptr)
+static inline int64_t ABTD_atomic_acquire_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
@@ -668,7 +690,7 @@ static inline int64_t ABTD_atomic_acquire_load_int64(int64_t *ptr)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_acquire_load_uint64(uint64_t *ptr)
+static inline uint64_t ABTD_atomic_acquire_load_uint64(const ABTD_atomic_uint64 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -681,7 +703,7 @@ static inline uint64_t ABTD_atomic_acquire_load_uint64(uint64_t *ptr)
 #endif
 }
 
-static inline void *ABTD_atomic_acquire_load_ptr(void **ptr)
+static inline void *ABTD_atomic_acquire_load_ptr(const ABTD_atomic_ptr *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -694,7 +716,7 @@ static inline void *ABTD_atomic_acquire_load_ptr(void **ptr)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_int(int *ptr, int val)
+static inline void ABTD_atomic_relaxed_store_int(ABTD_atomic_int *ptr, int val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -703,7 +725,7 @@ static inline void ABTD_atomic_relaxed_store_int(int *ptr, int val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_int32(int32_t *ptr, int32_t val)
+static inline void ABTD_atomic_relaxed_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -712,7 +734,7 @@ static inline void ABTD_atomic_relaxed_store_int32(int32_t *ptr, int32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_uint32(uint32_t *ptr, uint32_t val)
+static inline void ABTD_atomic_relaxed_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -721,7 +743,7 @@ static inline void ABTD_atomic_relaxed_store_uint32(uint32_t *ptr, uint32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_int64(int64_t *ptr, int64_t val)
+static inline void ABTD_atomic_relaxed_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -730,7 +752,7 @@ static inline void ABTD_atomic_relaxed_store_int64(int64_t *ptr, int64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_uint64(uint64_t *ptr, uint64_t val)
+static inline void ABTD_atomic_relaxed_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -739,7 +761,7 @@ static inline void ABTD_atomic_relaxed_store_uint64(uint64_t *ptr, uint64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_ptr(void **ptr, void *val)
+static inline void ABTD_atomic_relaxed_store_ptr(ABTD_atomic_ptr *ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
@@ -748,7 +770,7 @@ static inline void ABTD_atomic_relaxed_store_ptr(void **ptr, void *val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_int(int *ptr, int val)
+static inline void ABTD_atomic_release_store_int(ABTD_atomic_int *ptr, int val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -759,7 +781,7 @@ static inline void ABTD_atomic_release_store_int(int *ptr, int val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_int32(int32_t *ptr, int32_t val)
+static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -770,7 +792,7 @@ static inline void ABTD_atomic_release_store_int32(int32_t *ptr, int32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_uint32(uint32_t *ptr, uint32_t val)
+static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -781,7 +803,7 @@ static inline void ABTD_atomic_release_store_uint32(uint32_t *ptr, uint32_t val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_int64(int64_t *ptr, int64_t val)
+static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -792,7 +814,7 @@ static inline void ABTD_atomic_release_store_int64(int64_t *ptr, int64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_uint64(uint64_t *ptr, uint64_t val)
+static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -803,7 +825,7 @@ static inline void ABTD_atomic_release_store_uint64(uint64_t *ptr, uint64_t val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_ptr(void **ptr, void *val)
+static inline void ABTD_atomic_release_store_ptr(ABTD_atomic_ptr *ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
@@ -814,7 +836,7 @@ static inline void ABTD_atomic_release_store_ptr(void **ptr, void *val)
 #endif
 }
 
-static inline int ABTD_atomic_exchange_int(int *ptr, int v)
+static inline int ABTD_atomic_exchange_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -827,7 +849,7 @@ static inline int ABTD_atomic_exchange_int(int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
+static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -840,7 +862,7 @@ static inline int32_t ABTD_atomic_exchange_int32(int32_t *ptr, int32_t v)
 #endif
 }
 
-static inline uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -853,7 +875,7 @@ static inline uint32_t ABTD_atomic_exchange_uint32(uint32_t *ptr, uint32_t v)
 #endif
 }
 
-static inline int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
+static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -866,7 +888,7 @@ static inline int64_t ABTD_atomic_exchange_int64(int64_t *ptr, int64_t v)
 #endif
 }
 
-static inline uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_exchange_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
@@ -879,7 +901,7 @@ static inline uint64_t ABTD_atomic_exchange_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
-static inline void *ABTD_atomic_exchange_ptr(void **ptr, void *v)
+static inline void *ABTD_atomic_exchange_ptr(ABTD_atomic_ptr *ptr, void *v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,6 +8,18 @@
 
 #include <stdint.h>
 
+static inline int ABTDI_atomic_val_cas_int(int *ptr, int oldv, int newv, int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    int tmp_oldv = oldv;
+    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+                                          __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+    return ret ? tmp_oldv : oldv;
+#else
+    return __sync_val_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
 static inline int32_t ABTDI_atomic_val_cas_int32(int32_t *ptr, int32_t oldv,
                                                  int32_t newv, int weak)
 {
@@ -73,6 +85,16 @@ static inline void *ABTDI_atomic_val_cas_ptr(void **ptr, void *oldv, void *newv,
 #endif
 }
 
+static inline int ABTDI_atomic_bool_cas_int(int *ptr, int oldv, int newv, int weak)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+                                       __ATOMIC_ACQUIRE);
+#else
+    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+#endif
+}
+
 static inline int ABTDI_atomic_bool_cas_int32(int32_t *ptr, int32_t oldv,
                                               int32_t newv, int weak)
 {
@@ -128,6 +150,11 @@ static inline int ABTDI_atomic_bool_cas_ptr(void **ptr, void *oldv, void *newv,
 #endif
 }
 
+static inline int ABTD_atomic_val_cas_weak_int(int *ptr, int oldv,  int newv)
+{
+    return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 1);
+}
+
 static inline int32_t ABTD_atomic_val_cas_weak_int32(int32_t *ptr, int32_t oldv,
                                                      int32_t newv)
 {
@@ -156,6 +183,11 @@ static inline void *ABTD_atomic_val_cas_weak_ptr(void **ptr, void *oldv,
                                                  void *newv)
 {
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
+}
+
+static inline int ABTD_atomic_val_cas_strong_int(int *ptr, int oldv, int newv)
+{
+    return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 0);
 }
 
 static inline int32_t
@@ -188,6 +220,11 @@ static inline void *ABTD_atomic_val_cas_strong_ptr(void **ptr, void *oldv,
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
 }
 
+static inline int ABTD_atomic_bool_cas_weak_int(int *ptr, int oldv, int newv)
+{
+    return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 1);
+}
+
 static inline int ABTD_atomic_bool_cas_weak_int32(int32_t *ptr, int32_t oldv,
                                                   int32_t newv)
 {
@@ -218,6 +255,11 @@ static inline int ABTD_atomic_bool_cas_weak_ptr(void **ptr, void *oldv,
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
 }
 
+static inline int ABTD_atomic_bool_cas_strong_int(int *ptr, int oldv, int newv)
+{
+    return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 0);
+}
+
 static inline int ABTD_atomic_bool_cas_strong_int32(int32_t *ptr, int32_t oldv,
                                                     int32_t newv)
 {
@@ -246,6 +288,15 @@ static inline int ABTD_atomic_bool_cas_strong_ptr(void **ptr, void *oldv,
                                                   void *newv)
 {
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
+}
+
+static inline int ABTD_atomic_fetch_add_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    return __sync_fetch_and_add(ptr, v);
+#endif
 }
 
 static inline int32_t ABTD_atomic_fetch_add_int32(int32_t *ptr, int32_t v)
@@ -281,6 +332,15 @@ static inline uint64_t ABTD_atomic_fetch_add_uint64(uint64_t *ptr, uint64_t v)
     return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
 #else
     return __sync_fetch_and_add(ptr, v);
+#endif
+}
+
+static inline int ABTD_atomic_fetch_sub_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    return __sync_fetch_and_sub(ptr, v);
 #endif
 }
 
@@ -320,6 +380,15 @@ static inline uint64_t ABTD_atomic_fetch_sub_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
+static inline int ABTD_atomic_fetch_and_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    return __sync_fetch_and_and(ptr, v);
+#endif
+}
+
 static inline int32_t ABTD_atomic_fetch_and_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -356,6 +425,15 @@ static inline uint64_t ABTD_atomic_fetch_and_uint64(uint64_t *ptr, uint64_t v)
 #endif
 }
 
+static inline int ABTD_atomic_fetch_or_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    return __sync_fetch_and_or(ptr, v);
+#endif
+}
+
 static inline int32_t ABTD_atomic_fetch_or_int32(int32_t *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -389,6 +467,15 @@ static inline uint64_t ABTD_atomic_fetch_or_uint64(uint64_t *ptr, uint64_t v)
     return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
 #else
     return __sync_fetch_and_or(ptr, v);
+#endif
+}
+
+static inline int ABTD_atomic_fetch_xor_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    return __sync_fetch_and_xor(ptr, v);
 #endif
 }
 
@@ -459,6 +546,18 @@ static inline uint16_t ABTD_atomic_load_uint8(uint8_t *ptr)
 #endif
 }
 
+static inline int ABTD_atomic_load_int(int *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
+    __sync_synchronize();
+    int val = *(volatile int *)ptr;
+    __sync_synchronize();
+    return val;
+#endif
+}
+
 static inline int32_t ABTD_atomic_load_int32(int32_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -521,6 +620,17 @@ static inline void *ABTD_atomic_load_ptr(void **ptr)
 #endif
 }
 
+static inline void ABTD_atomic_store_int(int *ptr, int val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
+    *(volatile int *)ptr = val;
+    __sync_synchronize();
+#endif
+}
+
 static inline void ABTD_atomic_store_int32(int32_t *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -573,6 +683,19 @@ static inline void ABTD_atomic_store_ptr(void **ptr, void *val)
     __sync_synchronize();
     *(void *volatile *)ptr = val;
     __sync_synchronize();
+#endif
+}
+
+static inline int ABTD_atomic_exchange_int(int *ptr, int v)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+#else
+    int val;
+    do {
+        val = ABTD_atomic_load_int(ptr);
+    } while (!ABTD_atomic_bool_cas_weak_int(ptr, val, v));
+    return val;
 #endif
 }
 

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -8,37 +8,72 @@
 
 #include <stdint.h>
 
-typedef uint8_t ABTD_atomic_uint8;
+typedef struct ABTD_atomic_uint8 {
+    uint8_t val;
+} ABTD_atomic_uint8;
 
-typedef int ABTD_atomic_int;
+typedef struct ABTD_atomic_int {
+    int val;
+} ABTD_atomic_int;
 
-typedef int32_t ABTD_atomic_int32;
+typedef struct ABTD_atomic_int32 {
+    int32_t val;
+} ABTD_atomic_int32;
 
-typedef uint32_t ABTD_atomic_uint32;
+typedef struct ABTD_atomic_uint32 {
+    uint32_t val;
+} ABTD_atomic_uint32;
 
-typedef int64_t ABTD_atomic_int64;
+typedef struct ABTD_atomic_int64 {
+    int64_t val;
+} ABTD_atomic_int64;
 
-typedef uint64_t ABTD_atomic_uint64;
+typedef struct ABTD_atomic_uint64 {
+    uint64_t val;
+} ABTD_atomic_uint64;
 
-typedef void *ABTD_atomic_ptr;
+typedef struct ABTD_atomic_ptr {
+    void *val;
+} ABTD_atomic_ptr;
 
-#define ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_INT_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_INT32_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_INT64_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(val) (val)
-#define ABTD_ATOMIC_PTR_STATIC_INITIALIZER(val) (val)
+#define ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(val)                              \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_INT_STATIC_INITIALIZER(val)                                \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_INT32_STATIC_INITIALIZER(val)                              \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(val)                             \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_INT64_STATIC_INITIALIZER(val)                              \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(val)                             \
+    {                                                                          \
+        (val)                                                                  \
+    }
+#define ABTD_ATOMIC_PTR_STATIC_INITIALIZER(val)                                \
+    {                                                                          \
+        (val)                                                                  \
+    }
 
 static inline int ABTDI_atomic_val_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -47,11 +82,11 @@ static inline int32_t ABTDI_atomic_val_cas_int32(ABTD_atomic_int32 *ptr, int32_t
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int32_t tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -60,11 +95,11 @@ static inline uint32_t ABTDI_atomic_val_cas_uint32(ABTD_atomic_uint32 *ptr, uint
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint32_t tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -73,11 +108,11 @@ static inline int64_t ABTDI_atomic_val_cas_int64(ABTD_atomic_int64 *ptr, int64_t
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int64_t tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -86,11 +121,11 @@ static inline uint64_t ABTDI_atomic_val_cas_uint64(ABTD_atomic_uint64 *ptr, uint
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint64_t tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -99,21 +134,21 @@ static inline void *ABTDI_atomic_val_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, v
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     void *tmp_oldv = oldv;
-    int ret = __atomic_compare_exchange_n(ptr, &oldv, newv, weak,
+    int ret = __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
                                           __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
     return ret ? tmp_oldv : oldv;
 #else
-    return __sync_val_compare_and_swap(ptr, oldv, newv);
+    return __sync_val_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
 static inline int ABTDI_atomic_bool_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -121,10 +156,10 @@ static inline int ABTDI_atomic_bool_cas_int32(ABTD_atomic_int32 *ptr, int32_t ol
                                               int32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -132,10 +167,10 @@ static inline int ABTDI_atomic_bool_cas_uint32(ABTD_atomic_uint32 *ptr, uint32_t
                                                uint32_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -143,10 +178,10 @@ static inline int ABTDI_atomic_bool_cas_int64(ABTD_atomic_int64 *ptr, int64_t ol
                                               int64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -154,10 +189,10 @@ static inline int ABTDI_atomic_bool_cas_uint64(ABTD_atomic_uint64 *ptr, uint64_t
                                                uint64_t newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -165,10 +200,10 @@ static inline int ABTDI_atomic_bool_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, vo
                                             int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(ptr, &oldv, newv, weak, __ATOMIC_ACQ_REL,
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
                                        __ATOMIC_ACQUIRE);
 #else
-    return __sync_bool_compare_and_swap(ptr, oldv, newv);
+    return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
@@ -315,225 +350,225 @@ static inline int ABTD_atomic_bool_cas_strong_ptr(ABTD_atomic_ptr *ptr, void *ol
 static inline int ABTD_atomic_fetch_add_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_add(ptr, v);
+    return __sync_fetch_and_add(&ptr->val, v);
 #endif
 }
 
 static inline int32_t ABTD_atomic_fetch_add_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_add(ptr, v);
+    return __sync_fetch_and_add(&ptr->val, v);
 #endif
 }
 
 static inline uint32_t ABTD_atomic_fetch_add_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_add(ptr, v);
+    return __sync_fetch_and_add(&ptr->val, v);
 #endif
 }
 
 static inline int64_t ABTD_atomic_fetch_add_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_add(ptr, v);
+    return __sync_fetch_and_add(&ptr->val, v);
 #endif
 }
 
 static inline uint64_t ABTD_atomic_fetch_add_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_add(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_add(ptr, v);
+    return __sync_fetch_and_add(&ptr->val, v);
 #endif
 }
 
 static inline int ABTD_atomic_fetch_sub_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_sub(ptr, v);
+    return __sync_fetch_and_sub(&ptr->val, v);
 #endif
 }
 
 static inline int32_t ABTD_atomic_fetch_sub_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_sub(ptr, v);
+    return __sync_fetch_and_sub(&ptr->val, v);
 #endif
 }
 
 static inline uint32_t ABTD_atomic_fetch_sub_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_sub(ptr, v);
+    return __sync_fetch_and_sub(&ptr->val, v);
 #endif
 }
 
 static inline int64_t ABTD_atomic_fetch_sub_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_sub(ptr, v);
+    return __sync_fetch_and_sub(&ptr->val, v);
 #endif
 }
 
 static inline uint64_t ABTD_atomic_fetch_sub_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_sub(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_sub(ptr, v);
+    return __sync_fetch_and_sub(&ptr->val, v);
 #endif
 }
 
 static inline int ABTD_atomic_fetch_and_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_and(ptr, v);
+    return __sync_fetch_and_and(&ptr->val, v);
 #endif
 }
 
 static inline int32_t ABTD_atomic_fetch_and_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_and(ptr, v);
+    return __sync_fetch_and_and(&ptr->val, v);
 #endif
 }
 
 static inline uint32_t ABTD_atomic_fetch_and_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_and(ptr, v);
+    return __sync_fetch_and_and(&ptr->val, v);
 #endif
 }
 
 static inline int64_t ABTD_atomic_fetch_and_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_and(ptr, v);
+    return __sync_fetch_and_and(&ptr->val, v);
 #endif
 }
 
 static inline uint64_t ABTD_atomic_fetch_and_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_and(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_and(ptr, v);
+    return __sync_fetch_and_and(&ptr->val, v);
 #endif
 }
 
 static inline int ABTD_atomic_fetch_or_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_or(ptr, v);
+    return __sync_fetch_and_or(&ptr->val, v);
 #endif
 }
 
 static inline int32_t ABTD_atomic_fetch_or_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_or(ptr, v);
+    return __sync_fetch_and_or(&ptr->val, v);
 #endif
 }
 
 static inline uint32_t ABTD_atomic_fetch_or_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_or(ptr, v);
+    return __sync_fetch_and_or(&ptr->val, v);
 #endif
 }
 
 static inline int64_t ABTD_atomic_fetch_or_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_or(ptr, v);
+    return __sync_fetch_and_or(&ptr->val, v);
 #endif
 }
 
 static inline uint64_t ABTD_atomic_fetch_or_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_or(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_or(ptr, v);
+    return __sync_fetch_and_or(&ptr->val, v);
 #endif
 }
 
 static inline int ABTD_atomic_fetch_xor_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_xor(ptr, v);
+    return __sync_fetch_and_xor(&ptr->val, v);
 #endif
 }
 
 static inline int32_t ABTD_atomic_fetch_xor_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_xor(ptr, v);
+    return __sync_fetch_and_xor(&ptr->val, v);
 #endif
 }
 
 static inline uint32_t ABTD_atomic_fetch_xor_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_xor(ptr, v);
+    return __sync_fetch_and_xor(&ptr->val, v);
 #endif
 }
 
 static inline int64_t ABTD_atomic_fetch_xor_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_xor(ptr, v);
+    return __sync_fetch_and_xor(&ptr->val, v);
 #endif
 }
 
 static inline uint64_t ABTD_atomic_fetch_xor_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_fetch_xor(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
-    return __sync_fetch_and_xor(ptr, v);
+    return __sync_fetch_and_xor(&ptr->val, v);
 #endif
 }
 
@@ -541,72 +576,72 @@ static inline uint16_t ABTD_atomic_test_and_set_uint8(ABTD_atomic_uint8 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_test_and_set(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_test_and_set(&ptr->val, __ATOMIC_ACQUIRE);
 #else
-    return __sync_lock_test_and_set(ptr, 1);
+    return __sync_lock_test_and_set(&ptr->val, 1);
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_clear_uint8(ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_clear(ptr, __ATOMIC_RELAXED);
+    __atomic_clear(&ptr->val, __ATOMIC_RELAXED);
 #else
-    *(volatile uint8_t *)ptr = 0;
+    *(volatile uint8_t *)&ptr->val = 0;
 #endif
 }
 
 static inline void ABTD_atomic_release_clear_uint8(ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_clear(ptr, __ATOMIC_RELEASE);
+    __atomic_clear(&ptr->val, __ATOMIC_RELEASE);
 #else
-    __sync_lock_release(ptr);
+    __sync_lock_release(&ptr->val);
 #endif
 }
 
 static inline uint16_t ABTD_atomic_relaxed_load_uint8(const ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile uint8_t *)ptr;
+    return *(volatile uint8_t *)&ptr->val;
 #endif
 }
 
 static inline int ABTD_atomic_relaxed_load_int(const ABTD_atomic_int *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile int *)ptr;
+    return *(volatile int *)&ptr->val;
 #endif
 }
 
 static inline int32_t ABTD_atomic_relaxed_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile int32_t *)ptr;
+    return *(volatile int32_t *)&ptr->val;
 #endif
 }
 
 static inline uint32_t ABTD_atomic_relaxed_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile uint32_t *)ptr;
+    return *(volatile uint32_t *)&ptr->val;
 #endif
 }
 
 static inline int64_t ABTD_atomic_relaxed_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile int64_t *)ptr;
+    return *(volatile int64_t *)&ptr->val;
 #endif
 }
 
@@ -614,9 +649,9 @@ static inline uint64_t ABTD_atomic_relaxed_load_uint64(const ABTD_atomic_uint64 
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(volatile uint64_t *)ptr;
+    return *(volatile uint64_t *)&ptr->val;
 #endif
 }
 
@@ -624,19 +659,19 @@ static inline void *ABTD_atomic_relaxed_load_ptr(const ABTD_atomic_ptr *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+    return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
 #else
-    return *(void *volatile *)ptr;
+    return *(void *volatile *)&ptr->val;
 #endif
 }
 
 static inline uint16_t ABTD_atomic_acquire_load_uint8(const ABTD_atomic_uint8 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    uint8_t val = *(volatile uint8_t *)ptr;
+    uint8_t val = *(volatile uint8_t *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -645,10 +680,10 @@ static inline uint16_t ABTD_atomic_acquire_load_uint8(const ABTD_atomic_uint8 *p
 static inline int ABTD_atomic_acquire_load_int(const ABTD_atomic_int *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    int val = *(volatile int *)ptr;
+    int val = *(volatile int *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -657,10 +692,10 @@ static inline int ABTD_atomic_acquire_load_int(const ABTD_atomic_int *ptr)
 static inline int32_t ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    int32_t val = *(volatile int32_t *)ptr;
+    int32_t val = *(volatile int32_t *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -669,10 +704,10 @@ static inline int32_t ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *pt
 static inline uint32_t ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    uint32_t val = *(volatile uint32_t *)ptr;
+    uint32_t val = *(volatile uint32_t *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -681,10 +716,10 @@ static inline uint32_t ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 
 static inline int64_t ABTD_atomic_acquire_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    int64_t val = *(volatile int64_t *)ptr;
+    int64_t val = *(volatile int64_t *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -694,10 +729,10 @@ static inline uint64_t ABTD_atomic_acquire_load_uint64(const ABTD_atomic_uint64 
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    uint64_t val = *(volatile uint64_t *)ptr;
+    uint64_t val = *(volatile uint64_t *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -707,10 +742,10 @@ static inline void *ABTD_atomic_acquire_load_ptr(const ABTD_atomic_ptr *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+    return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
 #else
     __sync_synchronize();
-    void *val = *(void *volatile *)ptr;
+    void *val = *(void *volatile *)&ptr->val;
     __sync_synchronize();
     return val;
 #endif
@@ -719,64 +754,64 @@ static inline void *ABTD_atomic_acquire_load_ptr(const ABTD_atomic_ptr *ptr)
 static inline void ABTD_atomic_relaxed_store_int(ABTD_atomic_int *ptr, int val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(volatile int *)ptr = val;
+    *(volatile int *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(volatile int32_t *)ptr = val;
+    *(volatile int32_t *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(volatile uint32_t *)ptr = val;
+    *(volatile uint32_t *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(volatile int64_t *)ptr = val;
+    *(volatile int64_t *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(volatile uint64_t *)ptr = val;
+    *(volatile uint64_t *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_relaxed_store_ptr(ABTD_atomic_ptr *ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
 #else
-    *(void *volatile *)ptr = val;
+    *(void *volatile *)&ptr->val = val;
 #endif
 }
 
 static inline void ABTD_atomic_release_store_int(ABTD_atomic_int *ptr, int val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(volatile int *)ptr = val;
+    *(volatile int *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -784,10 +819,10 @@ static inline void ABTD_atomic_release_store_int(ABTD_atomic_int *ptr, int val)
 static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(volatile int32_t *)ptr = val;
+    *(volatile int32_t *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -795,10 +830,10 @@ static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr, int32
 static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(volatile uint32_t *)ptr = val;
+    *(volatile uint32_t *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -806,10 +841,10 @@ static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr, uin
 static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(volatile int64_t *)ptr = val;
+    *(volatile int64_t *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -817,10 +852,10 @@ static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr, int64
 static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(volatile uint64_t *)ptr = val;
+    *(volatile uint64_t *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -828,10 +863,10 @@ static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr, uin
 static inline void ABTD_atomic_release_store_ptr(ABTD_atomic_ptr *ptr, void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    __atomic_store_n(ptr, val, __ATOMIC_RELEASE);
+    __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
 #else
     __sync_synchronize();
-    *(void *volatile *)ptr = val;
+    *(void *volatile *)&ptr->val = val;
     __sync_synchronize();
 #endif
 }
@@ -839,7 +874,7 @@ static inline void ABTD_atomic_release_store_ptr(ABTD_atomic_ptr *ptr, void *val
 static inline int ABTD_atomic_exchange_int(ABTD_atomic_int *ptr, int v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     int val;
     do {
@@ -852,7 +887,7 @@ static inline int ABTD_atomic_exchange_int(ABTD_atomic_int *ptr, int v)
 static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr, int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     int32_t val;
     do {
@@ -865,7 +900,7 @@ static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr, int32_t
 static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     uint32_t val;
     do {
@@ -878,7 +913,7 @@ static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr, uint
 static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr, int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     int64_t val;
     do {
@@ -891,7 +926,7 @@ static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr, int64_t
 static inline uint64_t ABTD_atomic_exchange_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     uint64_t val;
     do {
@@ -904,7 +939,7 @@ static inline uint64_t ABTD_atomic_exchange_uint64(ABTD_atomic_uint64 *ptr, uint
 static inline void *ABTD_atomic_exchange_ptr(ABTD_atomic_ptr *ptr, void *v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_exchange_n(ptr, v, __ATOMIC_ACQ_REL);
+    return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
 #else
     void *val;
     do {

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -65,7 +65,8 @@ typedef struct ABTD_atomic_ptr {
         (val)                                                                  \
     }
 
-static inline int ABTDI_atomic_val_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
+static inline int ABTDI_atomic_val_cas_int(ABTD_atomic_int *ptr, int oldv,
+                                           int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int tmp_oldv = oldv;
@@ -77,8 +78,9 @@ static inline int ABTDI_atomic_val_cas_int(ABTD_atomic_int *ptr, int oldv, int n
 #endif
 }
 
-static inline int32_t ABTDI_atomic_val_cas_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
-                                                 int32_t newv, int weak)
+static inline int32_t ABTDI_atomic_val_cas_int32(ABTD_atomic_int32 *ptr,
+                                                 int32_t oldv, int32_t newv,
+                                                 int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int32_t tmp_oldv = oldv;
@@ -90,8 +92,9 @@ static inline int32_t ABTDI_atomic_val_cas_int32(ABTD_atomic_int32 *ptr, int32_t
 #endif
 }
 
-static inline uint32_t ABTDI_atomic_val_cas_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
-                                                   uint32_t newv, int weak)
+static inline uint32_t ABTDI_atomic_val_cas_uint32(ABTD_atomic_uint32 *ptr,
+                                                   uint32_t oldv, uint32_t newv,
+                                                   int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint32_t tmp_oldv = oldv;
@@ -103,8 +106,9 @@ static inline uint32_t ABTDI_atomic_val_cas_uint32(ABTD_atomic_uint32 *ptr, uint
 #endif
 }
 
-static inline int64_t ABTDI_atomic_val_cas_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
-                                                 int64_t newv, int weak)
+static inline int64_t ABTDI_atomic_val_cas_int64(ABTD_atomic_int64 *ptr,
+                                                 int64_t oldv, int64_t newv,
+                                                 int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     int64_t tmp_oldv = oldv;
@@ -116,8 +120,9 @@ static inline int64_t ABTDI_atomic_val_cas_int64(ABTD_atomic_int64 *ptr, int64_t
 #endif
 }
 
-static inline uint64_t ABTDI_atomic_val_cas_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
-                                                   uint64_t newv, int weak)
+static inline uint64_t ABTDI_atomic_val_cas_uint64(ABTD_atomic_uint64 *ptr,
+                                                   uint64_t oldv, uint64_t newv,
+                                                   int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     uint64_t tmp_oldv = oldv;
@@ -129,8 +134,8 @@ static inline uint64_t ABTDI_atomic_val_cas_uint64(ABTD_atomic_uint64 *ptr, uint
 #endif
 }
 
-static inline void *ABTDI_atomic_val_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, void *newv,
-                                             int weak)
+static inline void *ABTDI_atomic_val_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv,
+                                             void *newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     void *tmp_oldv = oldv;
@@ -142,207 +147,224 @@ static inline void *ABTDI_atomic_val_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, v
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int(ABTD_atomic_int *ptr, int oldv, int newv, int weak)
+static inline int ABTDI_atomic_bool_cas_int(ABTD_atomic_int *ptr, int oldv,
+                                            int newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
-                                              int32_t newv, int weak)
+static inline int ABTDI_atomic_bool_cas_int32(ABTD_atomic_int32 *ptr,
+                                              int32_t oldv, int32_t newv,
+                                              int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
-                                               uint32_t newv, int weak)
+static inline int ABTDI_atomic_bool_cas_uint32(ABTD_atomic_uint32 *ptr,
+                                               uint32_t oldv, uint32_t newv,
+                                               int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
-                                              int64_t newv, int weak)
+static inline int ABTDI_atomic_bool_cas_int64(ABTD_atomic_int64 *ptr,
+                                              int64_t oldv, int64_t newv,
+                                              int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
-                                               uint64_t newv, int weak)
+static inline int ABTDI_atomic_bool_cas_uint64(ABTD_atomic_uint64 *ptr,
+                                               uint64_t oldv, uint64_t newv,
+                                               int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTDI_atomic_bool_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv, void *newv,
-                                            int weak)
+static inline int ABTDI_atomic_bool_cas_ptr(ABTD_atomic_ptr *ptr, void *oldv,
+                                            void *newv, int weak)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
-    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak, __ATOMIC_ACQ_REL,
-                                       __ATOMIC_ACQUIRE);
+    return __atomic_compare_exchange_n(&ptr->val, &oldv, newv, weak,
+                                       __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
 #else
     return __sync_bool_compare_and_swap(&ptr->val, oldv, newv);
 #endif
 }
 
-static inline int ABTD_atomic_val_cas_weak_int(ABTD_atomic_int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_val_cas_weak_int(ABTD_atomic_int *ptr, int oldv,
+                                               int newv)
 {
     return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 1);
 }
 
-static inline int32_t ABTD_atomic_val_cas_weak_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
-                                                     int32_t newv)
+static inline int32_t ABTD_atomic_val_cas_weak_int32(ABTD_atomic_int32 *ptr,
+                                                     int32_t oldv, int32_t newv)
 {
     return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline uint32_t
-ABTD_atomic_val_cas_weak_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
+static inline uint32_t ABTD_atomic_val_cas_weak_uint32(ABTD_atomic_uint32 *ptr,
+                                                       uint32_t oldv,
+                                                       uint32_t newv)
 {
     return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline int64_t ABTD_atomic_val_cas_weak_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
-                                                     int64_t newv)
+static inline int64_t ABTD_atomic_val_cas_weak_int64(ABTD_atomic_int64 *ptr,
+                                                     int64_t oldv, int64_t newv)
 {
     return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline uint64_t
-ABTD_atomic_val_cas_weak_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
+static inline uint64_t ABTD_atomic_val_cas_weak_uint64(ABTD_atomic_uint64 *ptr,
+                                                       uint64_t oldv,
+                                                       uint64_t newv)
 {
     return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline void *ABTD_atomic_val_cas_weak_ptr(ABTD_atomic_ptr *ptr, void *oldv,
-                                                 void *newv)
+static inline void *ABTD_atomic_val_cas_weak_ptr(ABTD_atomic_ptr *ptr,
+                                                 void *oldv, void *newv)
 {
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_val_cas_strong_int(ABTD_atomic_int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_val_cas_strong_int(ABTD_atomic_int *ptr, int oldv,
+                                                 int newv)
 {
     return ABTDI_atomic_val_cas_int(ptr, oldv, newv, 0);
 }
 
-static inline int32_t
-ABTD_atomic_val_cas_strong_int32(ABTD_atomic_int32 *ptr, int32_t oldv, int32_t newv)
+static inline int32_t ABTD_atomic_val_cas_strong_int32(ABTD_atomic_int32 *ptr,
+                                                       int32_t oldv,
+                                                       int32_t newv)
 {
     return ABTDI_atomic_val_cas_int32(ptr, oldv, newv, 0);
 }
 
 static inline uint32_t
-ABTD_atomic_val_cas_strong_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
+ABTD_atomic_val_cas_strong_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
+                                  uint32_t newv)
 {
     return ABTDI_atomic_val_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline int64_t
-ABTD_atomic_val_cas_strong_int64(ABTD_atomic_int64 *ptr, int64_t oldv, int64_t newv)
+static inline int64_t ABTD_atomic_val_cas_strong_int64(ABTD_atomic_int64 *ptr,
+                                                       int64_t oldv,
+                                                       int64_t newv)
 {
     return ABTDI_atomic_val_cas_int64(ptr, oldv, newv, 0);
 }
 
 static inline uint64_t
-ABTD_atomic_val_cas_strong_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
+ABTD_atomic_val_cas_strong_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
+                                  uint64_t newv)
 {
     return ABTDI_atomic_val_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline void *ABTD_atomic_val_cas_strong_ptr(ABTD_atomic_ptr *ptr, void *oldv,
-                                                   void *newv)
+static inline void *ABTD_atomic_val_cas_strong_ptr(ABTD_atomic_ptr *ptr,
+                                                   void *oldv, void *newv)
 {
     return ABTDI_atomic_val_cas_ptr(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int(ABTD_atomic_int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_bool_cas_weak_int(ABTD_atomic_int *ptr, int oldv,
+                                                int newv)
 {
     return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
-                                                  int32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int32(ABTD_atomic_int32 *ptr,
+                                                  int32_t oldv, int32_t newv)
 {
     return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv,
-                                                   uint32_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint32(ABTD_atomic_uint32 *ptr,
+                                                   uint32_t oldv, uint32_t newv)
 {
     return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
-                                                  int64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_int64(ABTD_atomic_int64 *ptr,
+                                                  int64_t oldv, int64_t newv)
 {
     return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv,
-                                                   uint64_t newv)
+static inline int ABTD_atomic_bool_cas_weak_uint64(ABTD_atomic_uint64 *ptr,
+                                                   uint64_t oldv, uint64_t newv)
 {
     return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_weak_ptr(ABTD_atomic_ptr *ptr, void *oldv,
-                                                void *newv)
+static inline int ABTD_atomic_bool_cas_weak_ptr(ABTD_atomic_ptr *ptr,
+                                                void *oldv, void *newv)
 {
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 1);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int(ABTD_atomic_int *ptr, int oldv, int newv)
+static inline int ABTD_atomic_bool_cas_strong_int(ABTD_atomic_int *ptr,
+                                                  int oldv, int newv)
 {
     return ABTDI_atomic_bool_cas_int(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int32(ABTD_atomic_int32 *ptr, int32_t oldv,
-                                                    int32_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int32(ABTD_atomic_int32 *ptr,
+                                                    int32_t oldv, int32_t newv)
 {
     return ABTDI_atomic_bool_cas_int32(ptr, oldv, newv, 0);
 }
 
-static inline int
-ABTD_atomic_bool_cas_strong_uint32(ABTD_atomic_uint32 *ptr, uint32_t oldv, uint32_t newv)
+static inline int ABTD_atomic_bool_cas_strong_uint32(ABTD_atomic_uint32 *ptr,
+                                                     uint32_t oldv,
+                                                     uint32_t newv)
 {
     return ABTDI_atomic_bool_cas_uint32(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_int64(ABTD_atomic_int64 *ptr, int64_t oldv,
-                                                    int64_t newv)
+static inline int ABTD_atomic_bool_cas_strong_int64(ABTD_atomic_int64 *ptr,
+                                                    int64_t oldv, int64_t newv)
 {
     return ABTDI_atomic_bool_cas_int64(ptr, oldv, newv, 0);
 }
 
-static inline int
-ABTD_atomic_bool_cas_strong_uint64(ABTD_atomic_uint64 *ptr, uint64_t oldv, uint64_t newv)
+static inline int ABTD_atomic_bool_cas_strong_uint64(ABTD_atomic_uint64 *ptr,
+                                                     uint64_t oldv,
+                                                     uint64_t newv)
 {
     return ABTDI_atomic_bool_cas_uint64(ptr, oldv, newv, 0);
 }
 
-static inline int ABTD_atomic_bool_cas_strong_ptr(ABTD_atomic_ptr *ptr, void *oldv,
-                                                  void *newv)
+static inline int ABTD_atomic_bool_cas_strong_ptr(ABTD_atomic_ptr *ptr,
+                                                  void *oldv, void *newv)
 {
     return ABTDI_atomic_bool_cas_ptr(ptr, oldv, newv, 0);
 }
@@ -356,7 +378,8 @@ static inline int ABTD_atomic_fetch_add_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_add_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_add_int32(ABTD_atomic_int32 *ptr,
+                                                  int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -365,7 +388,8 @@ static inline int32_t ABTD_atomic_fetch_add_int32(ABTD_atomic_int32 *ptr, int32_
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_add_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_add_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -374,7 +398,8 @@ static inline uint32_t ABTD_atomic_fetch_add_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_add_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_add_int64(ABTD_atomic_int64 *ptr,
+                                                  int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -383,7 +408,8 @@ static inline int64_t ABTD_atomic_fetch_add_int64(ABTD_atomic_int64 *ptr, int64_
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_add_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_add_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_add(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -401,7 +427,8 @@ static inline int ABTD_atomic_fetch_sub_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_sub_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_sub_int32(ABTD_atomic_int32 *ptr,
+                                                  int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -410,7 +437,8 @@ static inline int32_t ABTD_atomic_fetch_sub_int32(ABTD_atomic_int32 *ptr, int32_
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_sub_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_sub_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -419,7 +447,8 @@ static inline uint32_t ABTD_atomic_fetch_sub_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_sub_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_sub_int64(ABTD_atomic_int64 *ptr,
+                                                  int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -428,7 +457,8 @@ static inline int64_t ABTD_atomic_fetch_sub_int64(ABTD_atomic_int64 *ptr, int64_
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_sub_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_sub_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_sub(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -446,7 +476,8 @@ static inline int ABTD_atomic_fetch_and_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_and_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_and_int32(ABTD_atomic_int32 *ptr,
+                                                  int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -455,7 +486,8 @@ static inline int32_t ABTD_atomic_fetch_and_int32(ABTD_atomic_int32 *ptr, int32_
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_and_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_and_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -464,7 +496,8 @@ static inline uint32_t ABTD_atomic_fetch_and_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_and_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_and_int64(ABTD_atomic_int64 *ptr,
+                                                  int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -473,7 +506,8 @@ static inline int64_t ABTD_atomic_fetch_and_int64(ABTD_atomic_int64 *ptr, int64_
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_and_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_and_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_and(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -491,7 +525,8 @@ static inline int ABTD_atomic_fetch_or_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_or_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_or_int32(ABTD_atomic_int32 *ptr,
+                                                 int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -500,7 +535,8 @@ static inline int32_t ABTD_atomic_fetch_or_int32(ABTD_atomic_int32 *ptr, int32_t
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_or_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_or_uint32(ABTD_atomic_uint32 *ptr,
+                                                   uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -509,7 +545,8 @@ static inline uint32_t ABTD_atomic_fetch_or_uint32(ABTD_atomic_uint32 *ptr, uint
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_or_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_or_int64(ABTD_atomic_int64 *ptr,
+                                                 int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -518,7 +555,8 @@ static inline int64_t ABTD_atomic_fetch_or_int64(ABTD_atomic_int64 *ptr, int64_t
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_or_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_or_uint64(ABTD_atomic_uint64 *ptr,
+                                                   uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_or(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -536,7 +574,8 @@ static inline int ABTD_atomic_fetch_xor_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_fetch_xor_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_fetch_xor_int32(ABTD_atomic_int32 *ptr,
+                                                  int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -545,7 +584,8 @@ static inline int32_t ABTD_atomic_fetch_xor_int32(ABTD_atomic_int32 *ptr, int32_
 #endif
 }
 
-static inline uint32_t ABTD_atomic_fetch_xor_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_fetch_xor_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -554,7 +594,8 @@ static inline uint32_t ABTD_atomic_fetch_xor_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline int64_t ABTD_atomic_fetch_xor_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_fetch_xor_int64(ABTD_atomic_int64 *ptr,
+                                                  int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -563,7 +604,8 @@ static inline int64_t ABTD_atomic_fetch_xor_int64(ABTD_atomic_int64 *ptr, int64_
 #endif
 }
 
-static inline uint64_t ABTD_atomic_fetch_xor_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_fetch_xor_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_fetch_xor(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -600,7 +642,8 @@ static inline void ABTD_atomic_release_clear_bool(ABTD_atomic_bool *ptr)
 #endif
 }
 
-static inline ABT_bool ABTD_atomic_relaxed_load_bool(const ABTD_atomic_bool *ptr)
+static inline ABT_bool
+ABTD_atomic_relaxed_load_bool(const ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED) ? ABT_TRUE : ABT_FALSE;
@@ -618,7 +661,8 @@ static inline int ABTD_atomic_relaxed_load_int(const ABTD_atomic_int *ptr)
 #endif
 }
 
-static inline int32_t ABTD_atomic_relaxed_load_int32(const ABTD_atomic_int32 *ptr)
+static inline int32_t
+ABTD_atomic_relaxed_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
@@ -627,7 +671,8 @@ static inline int32_t ABTD_atomic_relaxed_load_int32(const ABTD_atomic_int32 *pt
 #endif
 }
 
-static inline uint32_t ABTD_atomic_relaxed_load_uint32(const ABTD_atomic_uint32 *ptr)
+static inline uint32_t
+ABTD_atomic_relaxed_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
@@ -636,7 +681,8 @@ static inline uint32_t ABTD_atomic_relaxed_load_uint32(const ABTD_atomic_uint32 
 #endif
 }
 
-static inline int64_t ABTD_atomic_relaxed_load_int64(const ABTD_atomic_int64 *ptr)
+static inline int64_t
+ABTD_atomic_relaxed_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_RELAXED);
@@ -645,7 +691,8 @@ static inline int64_t ABTD_atomic_relaxed_load_int64(const ABTD_atomic_int64 *pt
 #endif
 }
 
-static inline uint64_t ABTD_atomic_relaxed_load_uint64(const ABTD_atomic_uint64 *ptr)
+static inline uint64_t
+ABTD_atomic_relaxed_load_uint64(const ABTD_atomic_uint64 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -665,7 +712,8 @@ static inline void *ABTD_atomic_relaxed_load_ptr(const ABTD_atomic_ptr *ptr)
 #endif
 }
 
-static inline ABT_bool ABTD_atomic_acquire_load_bool(const ABTD_atomic_bool *ptr)
+static inline ABT_bool
+ABTD_atomic_acquire_load_bool(const ABTD_atomic_bool *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE) ? ABT_TRUE : ABT_FALSE;
@@ -689,7 +737,8 @@ static inline int ABTD_atomic_acquire_load_int(const ABTD_atomic_int *ptr)
 #endif
 }
 
-static inline int32_t ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *ptr)
+static inline int32_t
+ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
@@ -701,7 +750,8 @@ static inline int32_t ABTD_atomic_acquire_load_int32(const ABTD_atomic_int32 *pt
 #endif
 }
 
-static inline uint32_t ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 *ptr)
+static inline uint32_t
+ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
@@ -713,7 +763,8 @@ static inline uint32_t ABTD_atomic_acquire_load_uint32(const ABTD_atomic_uint32 
 #endif
 }
 
-static inline int64_t ABTD_atomic_acquire_load_int64(const ABTD_atomic_int64 *ptr)
+static inline int64_t
+ABTD_atomic_acquire_load_int64(const ABTD_atomic_int64 *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_load_n(&ptr->val, __ATOMIC_ACQUIRE);
@@ -725,7 +776,8 @@ static inline int64_t ABTD_atomic_acquire_load_int64(const ABTD_atomic_int64 *pt
 #endif
 }
 
-static inline uint64_t ABTD_atomic_acquire_load_uint64(const ABTD_atomic_uint64 *ptr)
+static inline uint64_t
+ABTD_atomic_acquire_load_uint64(const ABTD_atomic_uint64 *ptr)
 {
     /* return 0 if this test_and_set succeeds to set a value. */
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
@@ -760,7 +812,8 @@ static inline void ABTD_atomic_relaxed_store_int(ABTD_atomic_int *ptr, int val)
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
+static inline void ABTD_atomic_relaxed_store_int32(ABTD_atomic_int32 *ptr,
+                                                   int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
@@ -769,7 +822,8 @@ static inline void ABTD_atomic_relaxed_store_int32(ABTD_atomic_int32 *ptr, int32
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
+static inline void ABTD_atomic_relaxed_store_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
@@ -778,7 +832,8 @@ static inline void ABTD_atomic_relaxed_store_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
+static inline void ABTD_atomic_relaxed_store_int64(ABTD_atomic_int64 *ptr,
+                                                   int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
@@ -787,7 +842,8 @@ static inline void ABTD_atomic_relaxed_store_int64(ABTD_atomic_int64 *ptr, int64
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
+static inline void ABTD_atomic_relaxed_store_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
@@ -796,7 +852,8 @@ static inline void ABTD_atomic_relaxed_store_uint64(ABTD_atomic_uint64 *ptr, uin
 #endif
 }
 
-static inline void ABTD_atomic_relaxed_store_ptr(ABTD_atomic_ptr *ptr, void *val)
+static inline void ABTD_atomic_relaxed_store_ptr(ABTD_atomic_ptr *ptr,
+                                                 void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELAXED);
@@ -816,7 +873,8 @@ static inline void ABTD_atomic_release_store_int(ABTD_atomic_int *ptr, int val)
 #endif
 }
 
-static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr, int32_t val)
+static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr,
+                                                   int32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
@@ -827,7 +885,8 @@ static inline void ABTD_atomic_release_store_int32(ABTD_atomic_int32 *ptr, int32
 #endif
 }
 
-static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr, uint32_t val)
+static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr,
+                                                    uint32_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
@@ -838,7 +897,8 @@ static inline void ABTD_atomic_release_store_uint32(ABTD_atomic_uint32 *ptr, uin
 #endif
 }
 
-static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr, int64_t val)
+static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr,
+                                                   int64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
@@ -849,7 +909,8 @@ static inline void ABTD_atomic_release_store_int64(ABTD_atomic_int64 *ptr, int64
 #endif
 }
 
-static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr, uint64_t val)
+static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr,
+                                                    uint64_t val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
@@ -860,7 +921,8 @@ static inline void ABTD_atomic_release_store_uint64(ABTD_atomic_uint64 *ptr, uin
 #endif
 }
 
-static inline void ABTD_atomic_release_store_ptr(ABTD_atomic_ptr *ptr, void *val)
+static inline void ABTD_atomic_release_store_ptr(ABTD_atomic_ptr *ptr,
+                                                 void *val)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_store_n(&ptr->val, val, __ATOMIC_RELEASE);
@@ -884,7 +946,8 @@ static inline int ABTD_atomic_exchange_int(ABTD_atomic_int *ptr, int v)
 #endif
 }
 
-static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr, int32_t v)
+static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr,
+                                                 int32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -897,7 +960,8 @@ static inline int32_t ABTD_atomic_exchange_int32(ABTD_atomic_int32 *ptr, int32_t
 #endif
 }
 
-static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr, uint32_t v)
+static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr,
+                                                   uint32_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -910,7 +974,8 @@ static inline uint32_t ABTD_atomic_exchange_uint32(ABTD_atomic_uint32 *ptr, uint
 #endif
 }
 
-static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr, int64_t v)
+static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr,
+                                                 int64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);
@@ -923,7 +988,8 @@ static inline int64_t ABTD_atomic_exchange_int64(ABTD_atomic_int64 *ptr, int64_t
 #endif
 }
 
-static inline uint64_t ABTD_atomic_exchange_uint64(ABTD_atomic_uint64 *ptr, uint64_t v)
+static inline uint64_t ABTD_atomic_exchange_uint64(ABTD_atomic_uint64 *ptr,
+                                                   uint64_t v)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     return __atomic_exchange_n(&ptr->val, v, __ATOMIC_ACQ_REL);

--- a/src/include/abtd_atomic.h
+++ b/src/include/abtd_atomic.h
@@ -525,12 +525,86 @@ static inline uint16_t ABTD_atomic_test_and_set_uint8(uint8_t *ptr)
 #endif
 }
 
+static inline void ABTD_atomic_relaxed_clear_uint8(uint8_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_clear(ptr, __ATOMIC_RELAXED);
+#else
+    *(volatile uint8_t *)ptr = 0;
+#endif
+}
+
 static inline void ABTD_atomic_release_clear_uint8(uint8_t *ptr)
 {
 #ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
     __atomic_clear(ptr, __ATOMIC_RELEASE);
 #else
     __sync_lock_release(ptr);
+#endif
+}
+
+static inline uint16_t ABTD_atomic_relaxed_load_uint8(uint8_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile uint8_t *)ptr;
+#endif
+}
+
+static inline int ABTD_atomic_relaxed_load_int(int *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile int *)ptr;
+#endif
+}
+
+static inline int32_t ABTD_atomic_relaxed_load_int32(int32_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile int32_t *)ptr;
+#endif
+}
+
+static inline uint32_t ABTD_atomic_relaxed_load_uint32(uint32_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile uint32_t *)ptr;
+#endif
+}
+
+static inline int64_t ABTD_atomic_relaxed_load_int64(int64_t *ptr)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile int64_t *)ptr;
+#endif
+}
+
+static inline uint64_t ABTD_atomic_relaxed_load_uint64(uint64_t *ptr)
+{
+    /* return 0 if this test_and_set succeeds to set a value. */
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(volatile uint64_t *)ptr;
+#endif
+}
+
+static inline void *ABTD_atomic_relaxed_load_ptr(void **ptr)
+{
+    /* return 0 if this test_and_set succeeds to set a value. */
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *(void *volatile *)ptr;
 #endif
 }
 
@@ -617,6 +691,60 @@ static inline void *ABTD_atomic_acquire_load_ptr(void **ptr)
     void *val = *(void *volatile *)ptr;
     __sync_synchronize();
     return val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_int(int *ptr, int val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(volatile int *)ptr = val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_int32(int32_t *ptr, int32_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(volatile int32_t *)ptr = val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_uint32(uint32_t *ptr, uint32_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(volatile uint32_t *)ptr = val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_int64(int64_t *ptr, int64_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(volatile int64_t *)ptr = val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_uint64(uint64_t *ptr, uint64_t val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(volatile uint64_t *)ptr = val;
+#endif
+}
+
+static inline void ABTD_atomic_relaxed_store_ptr(void **ptr, void *val)
+{
+#ifdef ABT_CONFIG_HAVE_ATOMIC_BUILTIN
+    __atomic_store_n(ptr, val, __ATOMIC_RELAXED);
+#else
+    *(void *volatile *)ptr = val;
 #endif
 }
 

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -44,10 +44,10 @@ static inline void ABTD_atomic_release_store_thread_context_ptr(
 }
 
 struct ABTD_thread_context {
-    void *p_ctx;                        /* actual context of fcontext, or a
-                                         * pointer to uctx */
-    void (*f_thread)(void *);           /* ULT function */
-    void *p_arg;                        /* ULT function argument */
+    void *p_ctx;                           /* actual context of fcontext, or a
+                                            * pointer to uctx */
+    void (*f_thread)(void *);              /* ULT function */
+    void *p_arg;                           /* ULT function argument */
     ABTD_thread_context_atomic_ptr p_link; /* pointer to scheduler context */
 #ifndef ABT_CONFIG_USE_FCONTEXT
     ucontext_t uctx;               /* ucontext entity pointed by p_ctx */

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -35,7 +35,7 @@ static inline int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     ABTD_thread_context_make(p_newctx, p_stacktop, stacksize, f_wrapper);
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
-    p_newctx->p_link = p_link;
+    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, p_link);
 
     return abt_errno;
 }
@@ -70,7 +70,7 @@ static inline int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 #endif
     p_newctx->f_thread = NULL;
     p_newctx->p_arg = NULL;
-    p_newctx->p_link = NULL;
+    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, NULL);
     return abt_errno;
 }
 
@@ -84,7 +84,7 @@ static inline int ABTD_thread_context_init(ABTD_thread_context *p_link,
     p_newctx->p_ctx = NULL;
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
-    p_newctx->p_link = p_link;
+    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, p_link);
     return abt_errno;
 }
 
@@ -163,7 +163,7 @@ static inline void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
 static inline void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
                                                    ABTD_thread_context *p_link)
 {
-    ABTD_atomic_release_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
+    ABTD_atomic_release_store_ptr((ABTD_atomic_ptr *)&p_ctx->p_link, (void *)p_link);
 }
 
 static inline void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx,

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -163,7 +163,7 @@ static inline void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
 static inline void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
                                                    ABTD_thread_context *p_link)
 {
-    ABTD_atomic_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
+    ABTD_atomic_release_store_ptr((void **)&p_ctx->p_link, (void *)p_link);
 }
 
 static inline void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx,

--- a/src/include/abtd_thread.h
+++ b/src/include/abtd_thread.h
@@ -35,7 +35,7 @@ static inline int ABTDI_thread_context_create(ABTD_thread_context *p_link,
     ABTD_thread_context_make(p_newctx, p_stacktop, stacksize, f_wrapper);
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
-    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, p_link);
+    ABTD_atomic_relaxed_store_thread_context_ptr(&p_newctx->p_link, p_link);
 
     return abt_errno;
 }
@@ -70,7 +70,7 @@ static inline int ABTD_thread_context_invalidate(ABTD_thread_context *p_newctx)
 #endif
     p_newctx->f_thread = NULL;
     p_newctx->p_arg = NULL;
-    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, NULL);
+    ABTD_atomic_relaxed_store_thread_context_ptr(&p_newctx->p_link, NULL);
     return abt_errno;
 }
 
@@ -84,7 +84,7 @@ static inline int ABTD_thread_context_init(ABTD_thread_context *p_link,
     p_newctx->p_ctx = NULL;
     p_newctx->f_thread = f_thread;
     p_newctx->p_arg = p_arg;
-    ABTD_atomic_relaxed_store_ptr((ABTD_atomic_ptr *)&p_newctx->p_link, p_link);
+    ABTD_atomic_relaxed_store_thread_context_ptr(&p_newctx->p_link, p_link);
     return abt_errno;
 }
 
@@ -159,12 +159,6 @@ static inline void ABTD_thread_context_dynamic_promote_thread(void *p_stacktop)
     ABTDI_thread_context_dynamic_promote(p_stacktop, jump_f);
 }
 #endif
-
-static inline void ABTD_thread_context_change_link(ABTD_thread_context *p_ctx,
-                                                   ABTD_thread_context *p_link)
-{
-    ABTD_atomic_release_store_ptr((ABTD_atomic_ptr *)&p_ctx->p_link, (void *)p_link);
-}
 
 static inline void ABTD_thread_context_set_arg(ABTD_thread_context *p_ctx,
                                                void *arg)

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -259,15 +259,15 @@ struct ABTI_sched {
 struct ABTI_pool {
     ABT_pool_access access; /* Access mode */
     ABT_bool automatic;     /* To know if automatic data free */
-    int32_t num_scheds;     /* Number of associated schedulers */
-                            /* NOTE: int32_t to check if still positive */
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     ABTI_native_thread_id consumer_id; /* Associated consumer ID */
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
     ABTI_native_thread_id producer_id; /* Associated producer ID */
 #endif
-    uint32_t num_blocked;   /* Number of blocked ULTs */
+    /* NOTE: int32_t to check if still positive */
+    int32_t num_scheds;     /* Number of associated schedulers */
+    int32_t num_blocked;    /* Number of blocked ULTs */
     int32_t num_migrations; /* Number of migrating ULTs */
     void *data;             /* Specific data */
     uint64_t id;            /* ID */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -150,7 +150,7 @@ struct ABTI_mutex_attr {
 };
 
 struct ABTI_mutex {
-    uint32_t val;                 /* 0: unlocked, 1: locked */
+    ABTD_atomic_uint32 val;       /* 0: unlocked, 1: locked */
     ABTI_mutex_attr attr;         /* attributes */
     ABTI_thread_htable *p_htable; /* a set of queues */
     ABTI_thread *p_handover;      /* next ULT for the mutex handover */
@@ -218,13 +218,13 @@ struct ABTI_local {
 struct ABTI_xstream {
     int rank;                         /* Rank */
     ABTI_xstream_type type;           /* Type */
-    volatile ABT_xstream_state state; /* State */
+    ABTD_atomic_int state;            /* State (ABT_xstream_state) */
     ABTI_sched **scheds;              /* Stack of running schedulers */
     int max_scheds;                   /* Allocation size of the array scheds */
     int num_scheds;                   /* Number of scheds */
     ABTI_spinlock sched_lock;         /* Lock for the scheduler management */
 
-    uint32_t request;         /* Request */
+    ABTD_atomic_uint32 request; /* Request */
     void *p_req_arg;          /* Request argument */
     ABTI_sched *p_main_sched; /* Main scheduler */
 
@@ -237,7 +237,7 @@ struct ABTI_sched {
     ABTI_sched_kind kind;       /* Kind of the scheduler  */
     ABT_sched_type type;        /* Can yield or not (ULT or task) */
     ABT_sched_state state;      /* State */
-    uint32_t request;           /* Request */
+    ABTD_atomic_uint32 request; /* Request */
     ABT_pool *pools;            /* Work unit pools */
     int num_pools;              /* Number of work unit pools */
     ABTI_thread *p_thread;      /* Associated ULT */
@@ -266,9 +266,9 @@ struct ABTI_pool {
     ABTI_native_thread_id producer_id; /* Associated producer ID */
 #endif
     /* NOTE: int32_t to check if still positive */
-    int32_t num_scheds;     /* Number of associated schedulers */
-    int32_t num_blocked;    /* Number of blocked ULTs */
-    int32_t num_migrations; /* Number of migrating ULTs */
+    ABTD_atomic_int32 num_scheds;     /* Number of associated schedulers */
+    ABTD_atomic_int32 num_blocked;    /* Number of blocked ULTs */
+    ABTD_atomic_int32 num_migrations; /* Number of migrating ULTs */
     void *data;             /* Specific data */
     uint64_t id;            /* ID */
 
@@ -317,8 +317,8 @@ struct ABTI_thread_attr {
 struct ABTI_thread {
     ABTD_thread_context ctx;      /* Context */
     ABTI_unit unit_def;           /* Internal unit definition */
-    ABT_thread_state state;       /* State */
-    uint32_t request;             /* Request */
+    ABTD_atomic_int state;        /* State (ABT_thread_state) */
+    ABTD_atomic_uint32 request;   /* Request */
     ABTI_xstream *p_last_xstream; /* Last ES where it ran */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
@@ -357,8 +357,8 @@ struct ABTI_thread_entry {
 
 struct ABTI_task {
     ABTI_xstream *p_xstream; /* Associated ES */
-    ABT_task_state state;    /* State */
-    uint32_t request;        /* Request */
+    ABTD_atomic_int state;   /* State (ABT_task_state) */
+    ABTD_atomic_uint32 request; /* Request */
     void (*f_task)(void *);  /* Task function */
     void *p_arg;             /* Task arguments */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
@@ -378,7 +378,7 @@ struct ABTI_task {
 struct ABTI_key {
     void (*f_destructor)(void *value);
     uint32_t id;
-    uint32_t refcount; /* Reference count */
+    ABTD_atomic_uint32 refcount; /* Reference count */
     ABT_bool freed;    /* TRUE: freed, FALSE: not */
 };
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -216,17 +216,17 @@ struct ABTI_local {
 };
 
 struct ABTI_xstream {
-    int rank;                         /* Rank */
-    ABTI_xstream_type type;           /* Type */
-    ABTD_atomic_int state;            /* State (ABT_xstream_state) */
-    ABTI_sched **scheds;              /* Stack of running schedulers */
-    int max_scheds;                   /* Allocation size of the array scheds */
-    int num_scheds;                   /* Number of scheds */
-    ABTI_spinlock sched_lock;         /* Lock for the scheduler management */
+    int rank;                 /* Rank */
+    ABTI_xstream_type type;   /* Type */
+    ABTD_atomic_int state;    /* State (ABT_xstream_state) */
+    ABTI_sched **scheds;      /* Stack of running schedulers */
+    int max_scheds;           /* Allocation size of the array scheds */
+    int num_scheds;           /* Number of scheds */
+    ABTI_spinlock sched_lock; /* Lock for the scheduler management */
 
     ABTD_atomic_uint32 request; /* Request */
-    void *p_req_arg;          /* Request argument */
-    ABTI_sched *p_main_sched; /* Main scheduler */
+    void *p_req_arg;            /* Request argument */
+    ABTI_sched *p_main_sched;   /* Main scheduler */
 
     ABTD_xstream_context ctx; /* ES context */
 };
@@ -269,8 +269,8 @@ struct ABTI_pool {
     ABTD_atomic_int32 num_scheds;     /* Number of associated schedulers */
     ABTD_atomic_int32 num_blocked;    /* Number of blocked ULTs */
     ABTD_atomic_int32 num_migrations; /* Number of migrating ULTs */
-    void *data;             /* Specific data */
-    uint64_t id;            /* ID */
+    void *data;                       /* Specific data */
+    uint64_t id;                      /* ID */
 
     /* Functions to manage units */
     ABT_unit_get_type_fn u_get_type;
@@ -356,11 +356,11 @@ struct ABTI_thread_entry {
 };
 
 struct ABTI_task {
-    ABTI_xstream *p_xstream; /* Associated ES */
-    ABTD_atomic_int state;   /* State (ABT_task_state) */
+    ABTI_xstream *p_xstream;    /* Associated ES */
+    ABTD_atomic_int state;      /* State (ABT_task_state) */
     ABTD_atomic_uint32 request; /* Request */
-    void (*f_task)(void *);  /* Task function */
-    void *p_arg;             /* Task arguments */
+    void (*f_task)(void *);     /* Task function */
+    void *p_arg;                /* Task arguments */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
 #endif
@@ -379,7 +379,7 @@ struct ABTI_key {
     void (*f_destructor)(void *value);
     uint32_t id;
     ABTD_atomic_uint32 refcount; /* Reference count */
-    ABT_bool freed;    /* TRUE: freed, FALSE: not */
+    ABT_bool freed;              /* TRUE: freed, FALSE: not */
 };
 
 struct ABTI_ktelem {

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -66,7 +66,7 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
     ABTI_thread *p_thread;
     ABTI_unit *p_unit;
     ABT_unit_type type;
-    int32_t ext_signal = 0;
+    ABTD_atomic_int32 ext_signal = 0;
 
     if (p_local != NULL) {
         p_thread = p_local->p_thread;
@@ -172,7 +172,7 @@ static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
             ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
-            int32_t *p_ext_signal = (int32_t *)p_unit->pool;
+            ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
             ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -66,7 +66,7 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
     ABTI_thread *p_thread;
     ABTI_unit *p_unit;
     ABT_unit_type type;
-    ABTD_atomic_int32 ext_signal = 0;
+    ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
     if (p_local != NULL) {
         p_thread = p_local->p_thread;

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -133,7 +133,7 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
 
         /* External thread is waiting here polling ext_signal. */
         /* FIXME: need a better implementation */
-        while (!ABTD_atomic_load_int32(&ext_signal))
+        while (!ABTD_atomic_acquire_load_int32(&ext_signal))
             ;
         ABTU_free(p_unit);
     }
@@ -173,7 +173,7 @@ static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
         } else {
             /* When the head is an external thread */
             int32_t *p_ext_signal = (int32_t *)p_unit->pool;
-            ABTD_atomic_store_int32(p_ext_signal, 1);
+            ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 
         /* Next ULT */

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -80,6 +80,8 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
         /* external thread */
         type = ABT_UNIT_TYPE_EXT;
         p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+        /* Check size if ext_signal can be stored in p_unit->pool. */
+        ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
         p_unit->pool = (ABT_pool)&ext_signal;
         p_unit->type = type;
     }

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -27,13 +27,13 @@ enum {
 };
 
 struct ABTI_sp_header {
-    uint32_t num_total_stacks; /* Number of total stacks */
+    uint32_t num_total_stacks;           /* Number of total stacks */
     ABTD_atomic_uint32 num_empty_stacks; /* Number of empty stacks */
-    size_t stacksize;          /* Stack size */
-    uint64_t id;               /* ID */
-    ABT_bool is_mmapped;       /* ABT_TRUE if it is mmapped */
-    void *p_sp;                /* Pointer to the allocated stack page */
-    ABTI_sp_header *p_next;    /* Next stack page header */
+    size_t stacksize;                    /* Stack size */
+    uint64_t id;                         /* ID */
+    ABT_bool is_mmapped;                 /* ABT_TRUE if it is mmapped */
+    void *p_sp;             /* Pointer to the allocated stack page */
+    ABTI_sp_header *p_next; /* Next stack page header */
 };
 
 struct ABTI_stack_header {
@@ -43,16 +43,16 @@ struct ABTI_stack_header {
 };
 
 struct ABTI_page_header {
-    uint32_t blk_size;              /* Block size in bytes */
-    uint32_t num_total_blks;        /* Number of total blocks */
-    uint32_t num_empty_blks;        /* Number of empty blocks */
-    ABTD_atomic_uint32 num_remote_free;       /* Number of remote free blocks */
-    ABTI_blk_header *p_head;        /* First empty block */
-    ABTI_blk_header *p_free;        /* For remote free */
-    ABTI_native_thread_id owner_id; /* Owner's ID */
-    ABTI_page_header *p_prev;       /* Prev page header */
-    ABTI_page_header *p_next;       /* Next page header */
-    ABT_bool is_mmapped;            /* ABT_TRUE if it is mmapped */
+    uint32_t blk_size;                  /* Block size in bytes */
+    uint32_t num_total_blks;            /* Number of total blocks */
+    uint32_t num_empty_blks;            /* Number of empty blocks */
+    ABTD_atomic_uint32 num_remote_free; /* Number of remote free blocks */
+    ABTI_blk_header *p_head;            /* First empty block */
+    ABTI_blk_header *p_free;            /* For remote free */
+    ABTI_native_thread_id owner_id;     /* Owner's ID */
+    ABTI_page_header *p_prev;           /* Prev page header */
+    ABTI_page_header *p_next;           /* Next page header */
+    ABT_bool is_mmapped;                /* ABT_TRUE if it is mmapped */
 };
 
 struct ABTI_blk_header {

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -28,7 +28,7 @@ enum {
 
 struct ABTI_sp_header {
     uint32_t num_total_stacks; /* Number of total stacks */
-    uint32_t num_empty_stacks; /* Number of empty stacks */
+    ABTD_atomic_uint32 num_empty_stacks; /* Number of empty stacks */
     size_t stacksize;          /* Stack size */
     uint64_t id;               /* ID */
     ABT_bool is_mmapped;       /* ABT_TRUE if it is mmapped */
@@ -46,7 +46,7 @@ struct ABTI_page_header {
     uint32_t blk_size;              /* Block size in bytes */
     uint32_t num_total_blks;        /* Number of total blocks */
     uint32_t num_empty_blks;        /* Number of empty blocks */
-    uint32_t num_remote_free;       /* Number of remote free blocks */
+    ABTD_atomic_uint32 num_remote_free;       /* Number of remote free blocks */
     ABTI_blk_header *p_head;        /* First empty block */
     ABTI_blk_header *p_free;        /* For remote free */
     ABTI_native_thread_id owner_id; /* Owner's ID */

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -38,7 +38,7 @@ static inline ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 
 static inline void ABTI_mutex_init(ABTI_mutex *p_mutex)
 {
-    p_mutex->val = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_mutex->val, 0);
     p_mutex->attr.attrs = ABTI_MUTEX_ATTR_NONE;
     p_mutex->attr.max_handovers = ABTI_global_get_mutex_max_handovers();
     p_mutex->attr.max_wakeups = ABTI_global_get_mutex_max_wakeups();
@@ -107,11 +107,11 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                     ABTI_thread *p_self = (*pp_local)->p_thread;
                     if (p_self == p_mutex->p_handover) {
                         p_mutex->p_handover = NULL;
-                        p_mutex->val = 2;
+                        ABTD_atomic_release_store_uint32(&p_mutex->val, 2);
 
                         /* Push the previous ULT to its pool */
                         ABTI_thread *p_giver = p_mutex->p_giver;
-                        p_giver->state = ABT_THREAD_STATE_READY;
+                        ABTD_atomic_release_store_int(&p_giver->state, ABT_THREAD_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local));
@@ -148,7 +148,7 @@ static inline void ABTI_mutex_unlock(ABTI_local *p_local, ABTI_mutex *p_mutex)
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTD_atomic_mem_barrier();
-    *(volatile uint32_t *)&p_mutex->val = 0;
+    ABTD_atomic_release_store_uint32(&p_mutex->val, 0);
     LOG_EVENT("%p: unlock w/o wake\n", p_mutex);
 #else
     if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1) != 1) {

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -111,7 +111,8 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
 
                         /* Push the previous ULT to its pool */
                         ABTI_thread *p_giver = p_mutex->p_giver;
-                        ABTD_atomic_release_store_int(&p_giver->state, ABT_THREAD_STATE_READY);
+                        ABTD_atomic_release_store_int(&p_giver->state,
+                                                      ABT_THREAD_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local));

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -63,7 +63,7 @@ static inline void ABTI_mutex_spinlock(ABTI_mutex *p_mutex)
     /* ABTI_spinlock_ functions cannot be used since p_mutex->val can take
      * other values (i.e., not UNLOCKED nor LOCKED.) */
     while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-        while (ABTD_atomic_load_uint32(&p_mutex->val) != 0)
+        while (ABTD_atomic_acquire_load_uint32(&p_mutex->val) != 0)
             ;
     }
     LOG_EVENT("%p: spinlock\n", p_mutex);
@@ -152,7 +152,7 @@ static inline void ABTI_mutex_unlock(ABTI_local *p_local, ABTI_mutex *p_mutex)
     LOG_EVENT("%p: unlock w/o wake\n", p_mutex);
 #else
     if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1) != 1) {
-        ABTD_atomic_store_uint32(&p_mutex->val, 0);
+        ABTD_atomic_release_store_uint32(&p_mutex->val, 0);
         LOG_EVENT("%p: unlock with wake\n", p_mutex);
         ABTI_mutex_wake_de(p_local, p_mutex);
     } else {

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -41,13 +41,13 @@ static inline ABT_pool ABTI_pool_get_handle(ABTI_pool *p_pool)
 /* A ULT is blocked and is waiting for going back to this pool */
 static inline void ABTI_pool_inc_num_blocked(ABTI_pool *p_pool)
 {
-    ABTD_atomic_fetch_add_uint32(&p_pool->num_blocked, 1);
+    ABTD_atomic_fetch_add_int32(&p_pool->num_blocked, 1);
 }
 
 /* A blocked ULT is back in the pool */
 static inline void ABTI_pool_dec_num_blocked(ABTI_pool *p_pool)
 {
-    ABTD_atomic_fetch_sub_uint32(&p_pool->num_blocked, 1);
+    ABTD_atomic_fetch_sub_int32(&p_pool->num_blocked, 1);
 }
 
 /* The pool will receive a migrated ULT */

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -7,7 +7,7 @@
 #define ABTI_SPINLOCK_H_INCLUDED
 
 struct ABTI_spinlock {
-    uint8_t val;
+    ABTD_atomic_uint8 val;
 };
 
 #define ABTI_SPINLOCK_STATIC_INITIALIZER()                                     \

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -12,25 +12,25 @@ struct ABTI_spinlock {
 
 #define ABTI_SPINLOCK_STATIC_INITIALIZER()                                     \
     {                                                                          \
-        0                                                                      \
+        ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(0)                                \
     }
 
 static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 {
-    p_lock->val = 0;
+    ABTD_atomic_relaxed_clear_uint8(&p_lock->val);
 }
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_lock->val)) {
-        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_lock->val) != 0)
+    while (ABTD_atomic_test_and_set_uint8(&p_lock->val)) {
+        while (ABTD_atomic_acquire_load_uint8(&p_lock->val) != 0)
             ;
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    ABTD_atomic_release_clear_uint8((uint8_t *)&p_lock->val);
+    ABTD_atomic_release_clear_uint8(&p_lock->val);
 }
 
 #endif /* ABTI_SPINLOCK_H_INCLUDED */

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -23,14 +23,14 @@ static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_lock->val)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_lock->val) != 0)
+        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_lock->val) != 0)
             ;
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    ABTD_atomic_clear_uint8((uint8_t *)&p_lock->val);
+    ABTD_atomic_release_clear_uint8((uint8_t *)&p_lock->val);
 }
 
 #endif /* ABTI_SPINLOCK_H_INCLUDED */

--- a/src/include/abti_spinlock.h
+++ b/src/include/abti_spinlock.h
@@ -7,30 +7,30 @@
 #define ABTI_SPINLOCK_H_INCLUDED
 
 struct ABTI_spinlock {
-    ABTD_atomic_uint8 val;
+    ABTD_atomic_bool val;
 };
 
 #define ABTI_SPINLOCK_STATIC_INITIALIZER()                                     \
     {                                                                          \
-        ABTD_ATOMIC_UINT8_STATIC_INITIALIZER(0)                                \
+        ABTD_ATOMIC_BOOL_STATIC_INITIALIZER(0)                                 \
     }
 
 static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
 {
-    ABTD_atomic_relaxed_clear_uint8(&p_lock->val);
+    ABTD_atomic_relaxed_clear_bool(&p_lock->val);
 }
 
 static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
 {
-    while (ABTD_atomic_test_and_set_uint8(&p_lock->val)) {
-        while (ABTD_atomic_acquire_load_uint8(&p_lock->val) != 0)
+    while (ABTD_atomic_test_and_set_bool(&p_lock->val)) {
+        while (ABTD_atomic_acquire_load_bool(&p_lock->val) != ABT_FALSE)
             ;
     }
 }
 
 static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
 {
-    ABTD_atomic_release_clear_uint8(&p_lock->val);
+    ABTD_atomic_release_clear_bool(&p_lock->val);
 }
 
 #endif /* ABTI_SPINLOCK_H_INCLUDED */

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -116,13 +116,13 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
     LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
-        ABTD_atomic_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_thread->is_sched);
 #endif
@@ -131,7 +131,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        ABTD_atomic_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
     }
 }
@@ -142,13 +142,13 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
     LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
-        ABTD_atomic_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_task->is_sched);
 #endif
@@ -157,7 +157,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        ABTD_atomic_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
     }
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -116,13 +116,13 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
     LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
-        ABTD_atomic_release_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int(&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_release_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int(&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_thread->is_sched);
 #endif
@@ -131,7 +131,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int((int *)&p_thread->state,
+        ABTD_atomic_release_store_int(&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
     }
 }
@@ -142,13 +142,13 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
     LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
-        ABTD_atomic_release_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int(&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_release_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int(&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_task->is_sched);
 #endif
@@ -157,7 +157,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int((int *)&p_task->state,
+        ABTD_atomic_release_store_int(&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
     }
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -116,13 +116,13 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
     LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
-        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+        ABTD_atomic_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+        ABTD_atomic_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_thread->is_sched);
 #endif
@@ -131,7 +131,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        ABTD_atomic_store_uint32((uint32_t *)&p_thread->state,
+        ABTD_atomic_store_int((int *)&p_thread->state,
                                  ABT_THREAD_STATE_TERMINATED);
     }
 }
@@ -142,13 +142,13 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
     LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
-        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+        ABTD_atomic_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+        ABTD_atomic_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_task->is_sched);
 #endif
@@ -157,7 +157,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        ABTD_atomic_store_uint32((uint32_t *)&p_task->state,
+        ABTD_atomic_store_int((int *)&p_task->state,
                                  ABT_TASK_STATE_TERMINATED);
     }
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -117,13 +117,13 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
               p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
         ABTD_atomic_release_store_int(&p_thread->state,
-                                 ABT_THREAD_STATE_TERMINATED);
+                                      ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_thread->is_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
         ABTD_atomic_release_store_int(&p_thread->state,
-                                 ABT_THREAD_STATE_TERMINATED);
+                                      ABT_THREAD_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_thread->is_sched);
 #endif
     } else {
@@ -132,7 +132,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
         ABTD_atomic_release_store_int(&p_thread->state,
-                                 ABT_THREAD_STATE_TERMINATED);
+                                      ABT_THREAD_STATE_TERMINATED);
     }
 }
 
@@ -143,13 +143,13 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
               p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
         ABTD_atomic_release_store_int(&p_task->state,
-                                 ABT_TASK_STATE_TERMINATED);
+                                      ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     } else if (p_task->is_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
         ABTD_atomic_release_store_int(&p_task->state,
-                                 ABT_TASK_STATE_TERMINATED);
+                                      ABT_TASK_STATE_TERMINATED);
         ABTI_sched_discard_and_free(p_local, p_task->is_sched);
 #endif
     } else {
@@ -158,7 +158,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_local *p_local,
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
         ABTD_atomic_release_store_int(&p_task->state,
-                                 ABT_TASK_STATE_TERMINATED);
+                                      ABT_TASK_STATE_TERMINATED);
     }
 }
 

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -214,7 +214,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
              * TODO: avoid making a copy of the code. */
             ABTD_thread_context *p_ctx = &p_prev->ctx;
             ABTD_thread_context *p_link =
-                (ABTD_thread_context *)ABTD_atomic_load_ptr(
+                (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
                     (void **)&p_ctx->p_link);
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
@@ -226,7 +226,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
 
                 /* We don't need to use the atomic OR operation here because
                  * the ULT will be terminated regardless of other requests. */
-                ABTD_atomic_store_uint32(&p_prev->request,
+                ABTD_atomic_release_store_uint32(&p_prev->request,
                                          ABTI_THREAD_REQ_TERMINATE);
             } else {
                 uint32_t req =
@@ -238,7 +238,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                      * joiner has blocked.  We have to wake up the joiner ULT.
                      */
                     do {
-                        p_link = (ABTD_thread_context *)ABTD_atomic_load_ptr(
+                        p_link = (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
                             (void **)&p_ctx->p_link);
                     } while (!p_link);
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -226,7 +226,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                 /* We don't need to use the atomic OR operation here because
                  * the ULT will be terminated regardless of other requests. */
                 ABTD_atomic_release_store_uint32(&p_prev->request,
-                                         ABTI_THREAD_REQ_TERMINATE);
+                                                 ABTI_THREAD_REQ_TERMINATE);
             } else {
                 uint32_t req =
                     ABTD_atomic_fetch_or_uint32(&p_prev->request,

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -214,8 +214,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
              * TODO: avoid making a copy of the code. */
             ABTD_thread_context *p_ctx = &p_prev->ctx;
             ABTD_thread_context *p_link =
-                (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
-                    (ABTD_atomic_ptr *)&p_ctx->p_link);
+                ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
                  * join. */
@@ -238,8 +237,8 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                      * joiner has blocked.  We have to wake up the joiner ULT.
                      */
                     do {
-                        p_link = (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
-                            (ABTD_atomic_ptr *)&p_ctx->p_link);
+                        p_link = ABTD_atomic_acquire_load_thread_context_ptr(
+                            &p_ctx->p_link);
                     } while (!p_link);
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -215,7 +215,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
             ABTD_thread_context *p_ctx = &p_prev->ctx;
             ABTD_thread_context *p_link =
                 (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
-                    (void **)&p_ctx->p_link);
+                    (ABTD_atomic_ptr *)&p_ctx->p_link);
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
                  * join. */
@@ -239,7 +239,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                      */
                     do {
                         p_link = (ABTD_thread_context *)ABTD_atomic_acquire_load_ptr(
-                            (void **)&p_ctx->p_link);
+                            (ABTD_atomic_ptr *)&p_ctx->p_link);
                     } while (!p_link);
                     ABTI_thread_set_ready(p_local, (ABTI_thread *)p_link);
                 }
@@ -352,7 +352,7 @@ static inline void ABTI_thread_yield(ABTI_local **pp_local,
               p_thread->p_last_xstream->rank);
 
     /* Change the state of current running thread */
-    p_thread->state = ABT_THREAD_STATE_READY;
+    ABTD_atomic_release_store_int(&p_thread->state, ABT_THREAD_STATE_READY);
 
     /* Switch to the top scheduler */
     p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -75,21 +75,21 @@ struct ABTI_thread_htable {
 static inline void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue)
 {
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->mutex)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->mutex) != 0)
+        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_queue->mutex) != 0)
             ;
     }
 }
 
 static inline void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue)
 {
-    ABTD_atomic_clear_uint8((uint8_t *)&p_queue->mutex);
+    ABTD_atomic_release_clear_uint8((uint8_t *)&p_queue->mutex);
 }
 
 static inline void
 ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
 {
     while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->low_mutex)) {
-        while (ABTD_atomic_load_uint8((uint8_t *)&p_queue->low_mutex) != 0)
+        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_queue->low_mutex) != 0)
             ;
     }
 }
@@ -97,7 +97,7 @@ ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
 static inline void
 ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue)
 {
-    ABTD_atomic_clear_uint8((uint8_t *)&p_queue->low_mutex);
+    ABTD_atomic_release_clear_uint8((uint8_t *)&p_queue->low_mutex);
 }
 
 static inline void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -74,22 +74,22 @@ struct ABTI_thread_htable {
 
 static inline void ABTI_thread_queue_acquire_mutex(ABTI_thread_queue *p_queue)
 {
-    while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->mutex)) {
-        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_queue->mutex) != 0)
+    while (!ABTD_atomic_bool_cas_weak_uint32(&p_queue->mutex, 0, 1)) {
+        while (ABTD_atomic_acquire_load_uint32(&p_queue->mutex) != 0)
             ;
     }
 }
 
 static inline void ABTI_thread_queue_release_mutex(ABTI_thread_queue *p_queue)
 {
-    ABTD_atomic_release_clear_uint8((uint8_t *)&p_queue->mutex);
+    ABTD_atomic_release_store_uint32(&p_queue->mutex, 0);
 }
 
 static inline void
 ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
 {
-    while (ABTD_atomic_test_and_set_uint8((uint8_t *)&p_queue->low_mutex)) {
-        while (ABTD_atomic_acquire_load_uint8((uint8_t *)&p_queue->low_mutex) != 0)
+    while (!ABTD_atomic_bool_cas_weak_uint32(&p_queue->low_mutex, 0, 1)) {
+        while (ABTD_atomic_acquire_load_uint32(&p_queue->low_mutex) != 0)
             ;
     }
 }
@@ -97,7 +97,7 @@ ABTI_thread_queue_acquire_low_mutex(ABTI_thread_queue *p_queue)
 static inline void
 ABTI_thread_queue_release_low_mutex(ABTI_thread_queue *p_queue)
 {
-    ABTD_atomic_release_clear_uint8((uint8_t *)&p_queue->low_mutex);
+    ABTD_atomic_release_store_uint32(&p_queue->low_mutex, 0);
 }
 
 static inline void ABTI_thread_htable_add_h_node(ABTI_thread_htable *p_htable,

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -23,14 +23,16 @@ struct ABTI_thread_queue {
     uint32_t pad0;
     ABTI_thread *head;
     ABTI_thread *tail;
-    char pad1[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) * 3 - sizeof(ABTI_thread *) * 2];
+    char pad1[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) * 3 -
+              sizeof(ABTI_thread *) * 2];
 
     /* low priority queue */
     ABTD_atomic_uint32 low_mutex; /* can be initialized by just assigning 0*/
     uint32_t low_num_threads;
     ABTI_thread *low_head;
     ABTI_thread *low_tail;
-    char pad2[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) - sizeof(ABTI_thread *) * 2];
+    char pad2[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) -
+              sizeof(ABTI_thread *) * 2];
 
     /* two doubly-linked lists */
     ABTI_thread_queue *p_h_next;

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -17,20 +17,20 @@
 #endif
 
 struct ABTI_thread_queue {
-    uint32_t mutex; /* can be initialized by just assigning 0*/
+    ABTD_atomic_uint32 mutex; /* can be initialized by just assigning 0*/
     uint32_t num_handovers;
     uint32_t num_threads;
     uint32_t pad0;
     ABTI_thread *head;
     ABTI_thread *tail;
-    char pad1[64 - sizeof(uint32_t) * 4 - sizeof(ABTI_thread *) * 2];
+    char pad1[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) * 3 - sizeof(ABTI_thread *) * 2];
 
     /* low priority queue */
-    uint32_t low_mutex; /* can be initialized by just assigning 0*/
+    ABTD_atomic_uint32 low_mutex; /* can be initialized by just assigning 0*/
     uint32_t low_num_threads;
     ABTI_thread *low_head;
     ABTI_thread *low_tail;
-    char pad2[64 - sizeof(uint32_t) * 2 - sizeof(ABTI_thread *) * 2];
+    char pad2[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) - sizeof(ABTI_thread *) * 2];
 
     /* two doubly-linked lists */
     ABTI_thread_queue *p_h_next;
@@ -50,7 +50,7 @@ struct ABTI_thread_htable {
 #else
     ABTI_spinlock mutex; /* To protect table */
 #endif
-    uint32_t num_elems;
+    ABTD_atomic_uint32 num_elems;
     uint32_t num_rows;
     ABTI_thread_queue *queue;
 

--- a/src/info.c
+++ b/src/info.c
@@ -632,12 +632,12 @@ static inline void ABTI_info_add_pool_set(ABT_pool pool,
 #define PRINT_STACK_FLAG_WAIT 2
 #define PRINT_STACK_FLAG_FINALIZE 3
 
-static ABTD_atomic_uint32 print_stack_flag = PRINT_STACK_FLAG_UNSET;
+static ABTD_atomic_uint32 print_stack_flag = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(PRINT_STACK_FLAG_UNSET);
 static FILE *print_stack_fp = NULL;
 static double print_stack_timeout = 0.0;
 static void (*print_cb_func)(ABT_bool, void *) = NULL;
 static void *print_arg = NULL;
-static ABTD_atomic_uint32 print_stack_barrier = 0;
+static ABTD_atomic_uint32 print_stack_barrier = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
 /**
  * @ingroup INFO
@@ -738,7 +738,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
             fprintf(fp,
                     "ABT_info_trigger_print_all_thread_stacks: "
                     "timeout (only %d ESs stop)\n",
-                    (int)print_stack_barrier);
+                    (int)ABTD_atomic_acquire_load_uint32(&print_stack_barrier));
         }
         for (i = 0; i < gp_ABTI_global->num_xstreams; i++) {
             ABTI_xstream *p_xstream = gp_ABTI_global->p_xstreams[i];

--- a/src/info.c
+++ b/src/info.c
@@ -632,12 +632,14 @@ static inline void ABTI_info_add_pool_set(ABT_pool pool,
 #define PRINT_STACK_FLAG_WAIT 2
 #define PRINT_STACK_FLAG_FINALIZE 3
 
-static ABTD_atomic_uint32 print_stack_flag = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(PRINT_STACK_FLAG_UNSET);
+static ABTD_atomic_uint32 print_stack_flag =
+    ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(PRINT_STACK_FLAG_UNSET);
 static FILE *print_stack_fp = NULL;
 static double print_stack_timeout = 0.0;
 static void (*print_cb_func)(ABT_bool, void *) = NULL;
 static void *print_arg = NULL;
-static ABTD_atomic_uint32 print_stack_barrier = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
+static ABTD_atomic_uint32 print_stack_barrier =
+    ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
 /**
  * @ingroup INFO
@@ -681,7 +683,8 @@ int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
 {
     /* This function is signal-safe, so it may not call other functions unless
      * you really know what the called functions do. */
-    if (ABTD_atomic_acquire_load_uint32(&print_stack_flag) == PRINT_STACK_FLAG_UNSET) {
+    if (ABTD_atomic_acquire_load_uint32(&print_stack_flag) ==
+        PRINT_STACK_FLAG_UNSET) {
         if (ABTD_atomic_bool_cas_strong_uint32(&print_stack_flag,
                                                PRINT_STACK_FLAG_UNSET,
                                                PRINT_STACK_FLAG_INITIALIZE)) {
@@ -691,8 +694,10 @@ int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
             print_cb_func = cb_func;
             print_arg = arg;
             /* Here print_stack_barrier must be 0. */
-            ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&print_stack_barrier) == 0);
-            ABTD_atomic_release_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_WAIT);
+            ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&print_stack_barrier) ==
+                        0);
+            ABTD_atomic_release_store_uint32(&print_stack_flag,
+                                             PRINT_STACK_FLAG_WAIT);
         }
     }
     return ABT_SUCCESS;
@@ -700,7 +705,8 @@ int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
 
 void ABTI_info_check_print_all_thread_stacks(void)
 {
-    if (ABTD_atomic_acquire_load_uint32(&print_stack_flag) != PRINT_STACK_FLAG_WAIT)
+    if (ABTD_atomic_acquire_load_uint32(&print_stack_flag) !=
+        PRINT_STACK_FLAG_WAIT)
         return;
 
     /* Wait for the other execution streams using a barrier mechanism. */
@@ -769,7 +775,8 @@ void ABTI_info_check_print_all_thread_stacks(void)
             print_cb_func(force_print, print_arg);
         ABTI_info_finalize_pool_set(&pool_set);
         /* Update print_stack_flag to 3. */
-        ABTD_atomic_release_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_FINALIZE);
+        ABTD_atomic_release_store_uint32(&print_stack_flag,
+                                         PRINT_STACK_FLAG_FINALIZE);
     } else {
         /* Wait for the master's work. */
         while (ABTD_atomic_acquire_load_uint32(&print_stack_flag) !=
@@ -783,7 +790,8 @@ void ABTI_info_check_print_all_thread_stacks(void)
     uint32_t dec_value = ABTD_atomic_fetch_sub_uint32(&print_stack_barrier, 1);
     if (dec_value == 0) {
         /* The last execution stream resets the flag. */
-        ABTD_atomic_release_store_uint32(&print_stack_flag, PRINT_STACK_FLAG_UNSET);
+        ABTD_atomic_release_store_uint32(&print_stack_flag,
+                                         PRINT_STACK_FLAG_UNSET);
     }
 }
 

--- a/src/info.c
+++ b/src/info.c
@@ -632,12 +632,12 @@ static inline void ABTI_info_add_pool_set(ABT_pool pool,
 #define PRINT_STACK_FLAG_WAIT 2
 #define PRINT_STACK_FLAG_FINALIZE 3
 
-static uint32_t print_stack_flag = PRINT_STACK_FLAG_UNSET;
+static ABTD_atomic_uint32 print_stack_flag = PRINT_STACK_FLAG_UNSET;
 static FILE *print_stack_fp = NULL;
 static double print_stack_timeout = 0.0;
 static void (*print_cb_func)(ABT_bool, void *) = NULL;
 static void *print_arg = NULL;
-static uint32_t print_stack_barrier = 0;
+static ABTD_atomic_uint32 print_stack_barrier = 0;
 
 /**
  * @ingroup INFO

--- a/src/key.c
+++ b/src/key.c
@@ -15,7 +15,7 @@ static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
 void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key);
 
-static uint32_t g_key_id = 0;
+static ABTD_atomic_uint32 g_key_id = 0;
 
 /**
  * @ingroup KEY

--- a/src/key.c
+++ b/src/key.c
@@ -15,7 +15,7 @@ static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
 void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key);
 
-static ABTD_atomic_uint32 g_key_id = 0;
+static ABTD_atomic_uint32 g_key_id = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
 /**
  * @ingroup KEY
@@ -51,7 +51,7 @@ int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
     p_newkey = (ABTI_key *)ABTU_malloc(sizeof(ABTI_key));
     p_newkey->f_destructor = destructor;
     p_newkey->id = ABTD_atomic_fetch_add_uint32(&g_key_id, 1);
-    p_newkey->refcount = 1;
+    ABTD_atomic_relaxed_store_uint32(&p_newkey->refcount, 1);
     p_newkey->freed = ABT_FALSE;
 
     /* Return value */

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -100,7 +100,9 @@ void ABTI_mem_finalize_local(ABTI_local *p_local)
         ABTI_page_header *p_tmp = p_cur;
         p_cur = p_cur->p_next;
 
-        size_t num_free_blks = p_tmp->num_empty_blks + ABTD_atomic_acquire_load_uint32(&p_tmp->num_remote_free);
+        size_t num_free_blks =
+            p_tmp->num_empty_blks +
+            ABTD_atomic_acquire_load_uint32(&p_tmp->num_remote_free);
         if (num_free_blks == p_tmp->num_total_blks) {
             if (p_tmp->is_mmapped == ABT_TRUE) {
                 munmap(p_tmp, gp_ABTI_global->mem_page_size);
@@ -440,7 +442,9 @@ void ABTI_mem_free_page(ABTI_local *p_local, ABTI_page_header *p_ph)
     if (p_local->p_mem_task_head == p_local->p_mem_task_tail)
         return;
 
-    uint32_t num_free_blks = p_ph->num_empty_blks + ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
+    uint32_t num_free_blks =
+        p_ph->num_empty_blks +
+        ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
     if (num_free_blks == p_ph->num_total_blks) {
         /* All blocks in the page have been freed */
         /* Remove from the list and free the page */
@@ -466,7 +470,8 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
      * accurate as long as their sum is the same as the actual number of free
      * blocks. We keep these variables to avoid chasing the linked list to count
      * the number of free blocks. */
-    uint32_t num_remote_free = ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
+    uint32_t num_remote_free =
+        ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
     ABTD_atomic_ptr *ptr;
     void *old;
 
@@ -476,7 +481,8 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
     /* Take the remote free pointer */
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr(
+                (ABTD_atomic_ptr *)&p_ph->p_free);
         p_ph->p_head = p_free;
         ptr = (ABTD_atomic_ptr *)&p_ph->p_free;
         old = (void *)p_free;
@@ -489,7 +495,8 @@ void ABTI_mem_free_remote(ABTI_page_header *p_ph, ABTI_blk_header *p_bh)
     void *old, *new;
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr(
+                (ABTD_atomic_ptr *)&p_ph->p_free);
         p_bh->p_next = p_free;
         ptr = (ABTD_atomic_ptr *)&p_ph->p_free;
         old = (void *)p_free;
@@ -533,9 +540,11 @@ static inline void ABTI_mem_free_sph_list(ABTI_sp_header *p_sph)
         p_tmp = p_cur;
         p_cur = p_cur->p_next;
 
-        if (p_tmp->num_total_stacks != ABTD_atomic_acquire_load_uint32(&p_tmp->num_empty_stacks)) {
+        if (p_tmp->num_total_stacks !=
+            ABTD_atomic_acquire_load_uint32(&p_tmp->num_empty_stacks)) {
             LOG_DEBUG("%u ULTs are not freed\n",
-                      p_tmp->num_total_stacks - ABTD_atomic_acquire_load_uint32(&p_tmp->num_empty_stacks));
+                      p_tmp->num_total_stacks - ABTD_atomic_acquire_load_uint32(
+                                                    &p_tmp->num_empty_stacks));
         }
 
         if (p_tmp->is_mmapped == ABT_TRUE) {

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -269,7 +269,7 @@ char *ABTI_mem_take_global_stack(ABTI_local *p_local)
     void **ptr;
     void *old;
     do {
-        p_sh = (ABTI_stack_header *)ABTD_atomic_load_ptr(
+        p_sh = (ABTI_stack_header *)ABTD_atomic_acquire_load_ptr(
             (void **)&p_global->p_mem_stack);
         ptr = (void **)&p_global->p_mem_stack;
         old = (void *)p_sh;
@@ -303,7 +303,7 @@ void ABTI_mem_add_stack_to_global(ABTI_stack_header *p_sh)
 
     do {
         ABTI_stack_header *p_mem_stack =
-            (ABTI_stack_header *)ABTD_atomic_load_ptr(
+            (ABTI_stack_header *)ABTD_atomic_acquire_load_ptr(
                 (void **)&p_global->p_mem_stack);
         p_sh->p_next = p_mem_stack;
         ptr = (void **)&p_global->p_mem_stack;
@@ -476,7 +476,7 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
     /* Take the remote free pointer */
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_load_ptr((void **)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((void **)&p_ph->p_free);
         p_ph->p_head = p_free;
         ptr = (void **)&p_ph->p_free;
         old = (void *)p_free;
@@ -489,7 +489,7 @@ void ABTI_mem_free_remote(ABTI_page_header *p_ph, ABTI_blk_header *p_bh)
     void *old, *new;
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_load_ptr((void **)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((void **)&p_ph->p_free);
         p_bh->p_next = p_free;
         ptr = (void **)&p_ph->p_free;
         old = (void *)p_free;
@@ -621,7 +621,7 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
     void **ptr = (void **)&gp_ABTI_global->p_mem_sph;
     void *old;
     do {
-        p_sph->p_next = (ABTI_sp_header *)ABTD_atomic_load_ptr(ptr);
+        p_sph->p_next = (ABTI_sp_header *)ABTD_atomic_acquire_load_ptr(ptr);
         old = (void *)p_sph->p_next;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, (void *)p_sph));
 

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -47,7 +47,7 @@ static inline void ABTI_mem_add_page(ABTI_local *p_local,
 static inline void ABTI_mem_add_pages_to_global(ABTI_page_header *p_head,
                                                 ABTI_page_header *p_tail);
 static inline void ABTI_mem_free_sph_list(ABTI_sp_header *p_sph);
-static ABTD_atomic_uint64 g_sp_id = 0;
+static ABTD_atomic_uint64 g_sp_id = ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);
 
 void ABTI_mem_init(ABTI_global *p_global)
 {
@@ -56,7 +56,7 @@ void ABTI_mem_init(ABTI_global *p_global)
     p_global->p_mem_task = NULL;
     p_global->p_mem_sph = NULL;
 
-    g_sp_id = 0;
+    ABTD_atomic_relaxed_store_uint64(&g_sp_id, 0);
 }
 
 void ABTI_mem_init_local(ABTI_local *p_local)
@@ -100,7 +100,7 @@ void ABTI_mem_finalize_local(ABTI_local *p_local)
         ABTI_page_header *p_tmp = p_cur;
         p_cur = p_cur->p_next;
 
-        size_t num_free_blks = p_tmp->num_empty_blks + p_tmp->num_remote_free;
+        size_t num_free_blks = p_tmp->num_empty_blks + ABTD_atomic_acquire_load_uint32(&p_tmp->num_remote_free);
         if (num_free_blks == p_tmp->num_total_blks) {
             if (p_tmp->is_mmapped == ABT_TRUE) {
                 munmap(p_tmp, gp_ABTI_global->mem_page_size);
@@ -270,8 +270,8 @@ char *ABTI_mem_take_global_stack(ABTI_local *p_local)
     void *old;
     do {
         p_sh = (ABTI_stack_header *)ABTD_atomic_acquire_load_ptr(
-            (void **)&p_global->p_mem_stack);
-        ptr = (void **)&p_global->p_mem_stack;
+            (ABTD_atomic_ptr *)&p_global->p_mem_stack);
+        ptr = (ABTD_atomic_ptr *)&p_global->p_mem_stack;
         old = (void *)p_sh;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, NULL));
 
@@ -304,9 +304,9 @@ void ABTI_mem_add_stack_to_global(ABTI_stack_header *p_sh)
     do {
         ABTI_stack_header *p_mem_stack =
             (ABTI_stack_header *)ABTD_atomic_acquire_load_ptr(
-                (void **)&p_global->p_mem_stack);
+                (ABTD_atomic_ptr *)&p_global->p_mem_stack);
         p_sh->p_next = p_mem_stack;
-        ptr = (void **)&p_global->p_mem_stack;
+        ptr = (ABTD_atomic_ptr *)&p_global->p_mem_stack;
         old = (void *)p_mem_stack;
         new = (void *)p_sh;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, new));
@@ -415,7 +415,7 @@ ABTI_page_header *ABTI_mem_alloc_page(ABTI_local *p_local, size_t blk_size)
     p_ph->blk_size = blk_size;
     p_ph->num_total_blks = num_blks;
     p_ph->num_empty_blks = num_blks;
-    p_ph->num_remote_free = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_ph->num_remote_free, 0);
     p_ph->p_head = (ABTI_blk_header *)(p_page + ph_size);
     p_ph->p_free = NULL;
     ABTI_mem_add_page(p_local, p_ph);
@@ -440,7 +440,7 @@ void ABTI_mem_free_page(ABTI_local *p_local, ABTI_page_header *p_ph)
     if (p_local->p_mem_task_head == p_local->p_mem_task_tail)
         return;
 
-    uint32_t num_free_blks = p_ph->num_empty_blks + p_ph->num_remote_free;
+    uint32_t num_free_blks = p_ph->num_empty_blks + ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
     if (num_free_blks == p_ph->num_total_blks) {
         /* All blocks in the page have been freed */
         /* Remove from the list and free the page */
@@ -466,7 +466,7 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
      * accurate as long as their sum is the same as the actual number of free
      * blocks. We keep these variables to avoid chasing the linked list to count
      * the number of free blocks. */
-    uint32_t num_remote_free = p_ph->num_remote_free;
+    uint32_t num_remote_free = ABTD_atomic_acquire_load_uint32(&p_ph->num_remote_free);
     ABTD_atomic_ptr *ptr;
     void *old;
 
@@ -476,9 +476,9 @@ void ABTI_mem_take_free(ABTI_page_header *p_ph)
     /* Take the remote free pointer */
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((void **)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ph->p_free);
         p_ph->p_head = p_free;
-        ptr = (void **)&p_ph->p_free;
+        ptr = (ABTD_atomic_ptr *)&p_ph->p_free;
         old = (void *)p_free;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, NULL));
 }
@@ -489,9 +489,9 @@ void ABTI_mem_free_remote(ABTI_page_header *p_ph, ABTI_blk_header *p_bh)
     void *old, *new;
     do {
         ABTI_blk_header *p_free =
-            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((void **)&p_ph->p_free);
+            (ABTI_blk_header *)ABTD_atomic_acquire_load_ptr((ABTD_atomic_ptr *)&p_ph->p_free);
         p_bh->p_next = p_free;
-        ptr = (void **)&p_ph->p_free;
+        ptr = (ABTD_atomic_ptr *)&p_ph->p_free;
         old = (void *)p_free;
         new = (void *)p_bh;
     } while (!ABTD_atomic_bool_cas_weak_ptr(ptr, old, new));
@@ -533,9 +533,9 @@ static inline void ABTI_mem_free_sph_list(ABTI_sp_header *p_sph)
         p_tmp = p_cur;
         p_cur = p_cur->p_next;
 
-        if (p_tmp->num_total_stacks != p_tmp->num_empty_stacks) {
+        if (p_tmp->num_total_stacks != ABTD_atomic_acquire_load_uint32(&p_tmp->num_empty_stacks)) {
             LOG_DEBUG("%u ULTs are not freed\n",
-                      p_tmp->num_total_stacks - p_tmp->num_empty_stacks);
+                      p_tmp->num_total_stacks - ABTD_atomic_acquire_load_uint32(&p_tmp->num_empty_stacks));
         }
 
         if (p_tmp->is_mmapped == ABT_TRUE) {
@@ -568,7 +568,7 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
     p_sph = (ABTI_sp_header *)ABTU_malloc(sizeof(ABTI_sp_header));
     num_stacks = sp_size / stacksize;
     p_sph->num_total_stacks = num_stacks;
-    p_sph->num_empty_stacks = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_sph->num_empty_stacks, 0);
     p_sph->stacksize = stacksize;
     p_sph->id = ABTD_atomic_fetch_add_uint64(&g_sp_id, 1);
 
@@ -618,7 +618,7 @@ char *ABTI_mem_alloc_sp(ABTI_local *p_local, size_t stacksize)
     }
 
     /* Add this stack page to the global stack page list */
-    ABTD_atomic_ptr *ptr = (void **)&gp_ABTI_global->p_mem_sph;
+    ABTD_atomic_ptr *ptr = (ABTD_atomic_ptr *)&gp_ABTI_global->p_mem_sph;
     void *old;
     do {
         p_sph->p_next = (ABTI_sp_header *)ABTD_atomic_acquire_load_ptr(ptr);

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -235,7 +235,8 @@ static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
 
                         /* Push the previous ULT to its pool */
                         ABTI_thread *p_giver = p_mutex->p_giver;
-                        ABTD_atomic_release_store_int(&p_giver->state, ABT_THREAD_STATE_READY);
+                        ABTD_atomic_release_store_int(&p_giver->state,
+                                                      ABT_THREAD_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local));
@@ -566,7 +567,8 @@ handover:
               ABTI_thread_get_id(p_next));
 
     /* yield_to the next ULT */
-    while (ABTD_atomic_acquire_load_uint32(&p_next->request) & ABTI_THREAD_REQ_BLOCK)
+    while (ABTD_atomic_acquire_load_uint32(&p_next->request) &
+           ABTI_THREAD_REQ_BLOCK)
         ;
     ABTI_pool_dec_num_blocked(p_next->p_pool);
     ABTD_atomic_release_store_int(&p_next->state, ABT_THREAD_STATE_RUNNING);

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -682,7 +682,7 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
             "%sproducer ID   : %p\n"
 #endif
             "%ssize          : %zu\n"
-            "%snum_blocked   : %u\n"
+            "%snum_blocked   : %d\n"
             "%snum_migrations: %d\n"
             "%sdata          : %p\n",
             prefix, (void *)p_pool, prefix, p_pool->id, prefix, access, prefix,

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -694,8 +694,10 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
             prefix, (void *)p_pool->producer_id,
 #endif
-            prefix, ABTI_pool_get_size(p_pool), prefix, ABTD_atomic_acquire_load_int32(&p_pool->num_blocked),
-            prefix, ABTD_atomic_acquire_load_int32(&p_pool->num_migrations), prefix, p_pool->data);
+            prefix, ABTI_pool_get_size(p_pool), prefix,
+            ABTD_atomic_acquire_load_int32(&p_pool->num_blocked), prefix,
+            ABTD_atomic_acquire_load_int32(&p_pool->num_migrations), prefix,
+            p_pool->data);
 
 fn_exit:
     fflush(p_os);

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -841,7 +841,7 @@ int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source)
 #endif
 }
 
-static uint64_t g_pool_id = 0;
+static ABTD_atomic_uint64 g_pool_id = 0;
 void ABTI_pool_reset_id(void)
 {
     g_pool_id = 0;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -550,15 +550,15 @@ int ABTI_pool_create(ABT_pool_def *def, ABT_pool_config config,
     p_pool = (ABTI_pool *)ABTU_malloc(sizeof(ABTI_pool));
     p_pool->access = def->access;
     p_pool->automatic = automatic;
-    p_pool->num_scheds = 0;
+    ABTD_atomic_release_store_int32(&p_pool->num_scheds, 0);
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
     p_pool->consumer_id = 0;
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
     p_pool->producer_id = 0;
 #endif
-    p_pool->num_blocked = 0;
-    p_pool->num_migrations = 0;
+    ABTD_atomic_release_store_int32(&p_pool->num_blocked, 0);
+    ABTD_atomic_release_store_int32(&p_pool->num_migrations, 0);
     p_pool->data = NULL;
 
     /* Set up the pool functions from def */
@@ -687,15 +687,15 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)
             "%sdata          : %p\n",
             prefix, (void *)p_pool, prefix, p_pool->id, prefix, access, prefix,
             (p_pool->automatic == ABT_TRUE) ? "TRUE" : "FALSE", prefix,
-            p_pool->num_scheds,
+            ABTD_atomic_acquire_load_int32(&p_pool->num_scheds),
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
             prefix, (void *)p_pool->consumer_id,
 #endif
 #ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
             prefix, (void *)p_pool->producer_id,
 #endif
-            prefix, ABTI_pool_get_size(p_pool), prefix, p_pool->num_blocked,
-            prefix, p_pool->num_migrations, prefix, p_pool->data);
+            prefix, ABTI_pool_get_size(p_pool), prefix, ABTD_atomic_acquire_load_int32(&p_pool->num_blocked),
+            prefix, ABTD_atomic_acquire_load_int32(&p_pool->num_migrations), prefix, p_pool->data);
 
 fn_exit:
     fflush(p_os);
@@ -712,7 +712,7 @@ int ABTI_pool_set_consumer(ABTI_pool *p_pool, ABTI_native_thread_id consumer_id)
 {
     int abt_errno = ABT_SUCCESS;
 
-    if (p_pool->num_scheds == 0) {
+    if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 0) {
         return abt_errno;
     }
 
@@ -768,7 +768,7 @@ int ABTI_pool_set_producer(ABTI_pool *p_pool, ABTI_native_thread_id producer_id)
 {
     int abt_errno = ABT_SUCCESS;
 
-    if (p_pool->num_scheds == 0) {
+    if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 0) {
         return abt_errno;
     }
 
@@ -841,10 +841,10 @@ int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source)
 #endif
 }
 
-static ABTD_atomic_uint64 g_pool_id = 0;
+static ABTD_atomic_uint64 g_pool_id = ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);
 void ABTI_pool_reset_id(void)
 {
-    g_pool_id = 0;
+    ABTD_atomic_release_store_uint64(&g_pool_id, 0);
 }
 
 /*****************************************************************************/

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -993,7 +993,7 @@ fn_exit:
     ABTU_free(prefix);
 }
 
-static uint64_t g_sched_id = 0;
+static ABTD_atomic_uint64 g_sched_id = 0;
 void ABTI_sched_reset_id(void)
 {
     g_sched_id = 0;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -317,7 +317,8 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched,
     size_t size;
 
     /* Check exit request */
-    if (ABTD_atomic_acquire_load_uint32(&p_sched->request) & ABTI_SCHED_REQ_EXIT) {
+    if (ABTD_atomic_acquire_load_uint32(&p_sched->request) &
+        ABTI_SCHED_REQ_EXIT) {
         ABTI_spinlock_acquire(&p_xstream->sched_lock);
         p_sched->state = ABT_SCHED_STATE_TERMINATED;
         stop = ABT_TRUE;
@@ -326,7 +327,8 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched,
 
     size = ABTI_sched_get_effective_size(*pp_local, p_sched);
     if (size == 0) {
-        if (ABTD_atomic_acquire_load_uint32(&p_sched->request) & ABTI_SCHED_REQ_FINISH) {
+        if (ABTD_atomic_acquire_load_uint32(&p_sched->request) &
+            ABTI_SCHED_REQ_FINISH) {
             /* Check join request */
             /* We need to lock in case someone wants to migrate to this
              * scheduler */
@@ -523,7 +525,8 @@ size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
         pool_size += ABTD_atomic_acquire_load_int32(&p_pool->num_migrations);
         switch (p_pool->access) {
             case ABT_POOL_ACCESS_PRIV:
-                pool_size += ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
+                pool_size +=
+                    ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
                 break;
             case ABT_POOL_ACCESS_SPSC:
             case ABT_POOL_ACCESS_MPSC:
@@ -531,11 +534,14 @@ size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
             case ABT_POOL_ACCESS_MPMC:
 #ifdef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
                 if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 1) {
-                    pool_size += ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
+                    pool_size +=
+                        ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
                 }
 #else
-                if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 1 && p_pool->consumer_id == self_id) {
-                    pool_size += ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
+                if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 1 &&
+                    p_pool->consumer_id == self_id) {
+                    pool_size +=
+                        ABTD_atomic_acquire_load_int32(&p_pool->num_blocked);
                 }
 #endif
                 break;
@@ -976,8 +982,9 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
             prefix, p_sched->kind, kind_str, prefix, type, prefix, state,
             prefix, used, prefix,
             (p_sched->automatic == ABT_TRUE) ? "TRUE" : "FALSE", prefix,
-            ABTD_atomic_acquire_load_uint32(&p_sched->request), prefix, p_sched->num_pools, prefix, pools_str,
-            prefix, ABTI_sched_get_size(p_sched), prefix,
+            ABTD_atomic_acquire_load_uint32(&p_sched->request), prefix,
+            p_sched->num_pools, prefix, pools_str, prefix,
+            ABTI_sched_get_size(p_sched), prefix,
             ABTI_sched_get_total_size(p_sched), prefix, p_sched->data);
     ABTU_free(pools_str);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -528,7 +528,7 @@ int ABT_xstream_exit(void)
         }
 #endif
         ABTI_thread_yield(&p_local, p_local->p_thread);
-    } while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) !=
+    } while (ABTD_atomic_load_int((int *)&p_xstream->state) !=
              ABT_XSTREAM_STATE_TERMINATED);
 
 fn_exit:
@@ -1310,7 +1310,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-    if (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) ==
+    if (ABTD_atomic_load_int((int *)&p_xstream->state) ==
         ABT_XSTREAM_STATE_TERMINATED) {
         goto fn_join;
     }
@@ -1333,7 +1333,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         /* Set the join request */
         ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        while (ABTD_atomic_load_uint32((uint32_t *)&p_xstream->state) !=
+        while (ABTD_atomic_load_int((int *)&p_xstream->state) !=
                ABT_XSTREAM_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
             if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
@@ -1445,7 +1445,7 @@ void ABTI_xstream_schedule(void *p_arg)
     }
 
     /* Set the ES's state as TERMINATED */
-    ABTD_atomic_store_uint32((uint32_t *)&p_xstream->state,
+    ABTD_atomic_store_int((int *)&p_xstream->state,
                              ABT_XSTREAM_STATE_TERMINATED);
     LOG_EVENT("[E%d] terminated\n", p_xstream->rank);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -528,7 +528,7 @@ int ABT_xstream_exit(void)
         }
 #endif
         ABTI_thread_yield(&p_local, p_local->p_thread);
-    } while (ABTD_atomic_load_int((int *)&p_xstream->state) !=
+    } while (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) !=
              ABT_XSTREAM_STATE_TERMINATED);
 
 fn_exit:
@@ -1310,7 +1310,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-    if (ABTD_atomic_load_int((int *)&p_xstream->state) ==
+    if (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) ==
         ABT_XSTREAM_STATE_TERMINATED) {
         goto fn_join;
     }
@@ -1333,7 +1333,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         /* Set the join request */
         ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        while (ABTD_atomic_load_int((int *)&p_xstream->state) !=
+        while (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) !=
                ABT_XSTREAM_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
             if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
@@ -1419,7 +1419,7 @@ void ABTI_xstream_schedule(void *p_arg)
 
         ABTI_spinlock_release(&p_xstream->sched_lock);
 
-        request = ABTD_atomic_load_uint32(&p_xstream->request);
+        request = ABTD_atomic_acquire_load_uint32(&p_xstream->request);
 
         /* If there is an exit or a cancel request, the ES terminates
          * regardless of remaining work units. */
@@ -1445,7 +1445,7 @@ void ABTI_xstream_schedule(void *p_arg)
     }
 
     /* Set the ES's state as TERMINATED */
-    ABTD_atomic_store_int((int *)&p_xstream->state,
+    ABTD_atomic_release_store_int((int *)&p_xstream->state,
                              ABT_XSTREAM_STATE_TERMINATED);
     LOG_EVENT("[E%d] terminated\n", p_xstream->rank);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -71,11 +71,11 @@ int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
     ABTI_xstream_set_new_rank(p_newxstream);
 
     p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state = ABT_XSTREAM_STATE_RUNNING;
+    ABTD_atomic_relaxed_store_int(&p_newxstream->state, ABT_XSTREAM_STATE_RUNNING);
     p_newxstream->scheds = NULL;
     p_newxstream->num_scheds = 0;
     p_newxstream->max_scheds = 0;
-    p_newxstream->request = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_newxstream->request, 0);
     p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
@@ -215,11 +215,11 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     }
 
     p_newxstream->type = ABTI_XSTREAM_TYPE_SECONDARY;
-    p_newxstream->state = ABT_XSTREAM_STATE_RUNNING;
+    ABTD_atomic_relaxed_store_int(&p_newxstream->state, ABT_XSTREAM_STATE_RUNNING);
     p_newxstream->scheds = NULL;
     p_newxstream->num_scheds = 0;
     p_newxstream->max_scheds = 0;
-    p_newxstream->request = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_newxstream->request, 0);
     p_newxstream->p_req_arg = NULL;
     p_newxstream->p_main_sched = NULL;
 
@@ -284,7 +284,7 @@ int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
     int abt_errno = ABT_SUCCESS;
 
     /* The ES's state must be RUNNING */
-    ABTI_ASSERT(p_xstream->state == ABT_XSTREAM_STATE_RUNNING);
+    ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING);
 
     /* Add the main scheduler to the stack of schedulers */
     ABTI_xstream_push_sched(p_xstream, p_xstream->p_main_sched);
@@ -336,8 +336,8 @@ int ABT_xstream_revive(ABT_xstream xstream)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    p_xstream->state = ABT_XSTREAM_STATE_RUNNING;
-    p_xstream->request = 0;
+    ABTD_atomic_relaxed_store_int(&p_xstream->state, ABT_XSTREAM_STATE_RUNNING);
+    ABTD_atomic_relaxed_store_uint32(&p_xstream->request, 0);
     p_xstream->p_req_arg = NULL;
     abt_errno = ABTD_xstream_context_revive(&p_xstream->ctx);
     ABTI_CHECK_ERROR(abt_errno);
@@ -363,7 +363,7 @@ int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     ABTI_xstream_push_sched(p_xstream, p_xstream->p_main_sched);
 
     /* The ES's state must be running here. */
-    ABTI_ASSERT(p_xstream->state == ABT_XSTREAM_STATE_RUNNING);
+    ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING);
 
     LOG_EVENT("[E%d] start\n", p_xstream->rank);
 
@@ -433,7 +433,7 @@ int ABT_xstream_free(ABT_xstream *xstream)
                         "The primary xstream cannot be freed explicitly.");
 
     /* Wait until xstream terminates */
-    if (p_xstream->state != ABT_XSTREAM_STATE_TERMINATED) {
+    if (ABTD_atomic_acquire_load_int(&p_xstream->state) != ABT_XSTREAM_STATE_TERMINATED) {
         abt_errno = ABTI_xstream_join(&p_local, p_xstream);
         ABTI_CHECK_ERROR(abt_errno);
     }
@@ -528,7 +528,7 @@ int ABT_xstream_exit(void)
         }
 #endif
         ABTI_thread_yield(&p_local, p_local->p_thread);
-    } while (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) !=
+    } while (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
              ABT_XSTREAM_STATE_TERMINATED);
 
 fn_exit:
@@ -756,7 +756,7 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
     /* TODO: a new state representing that the scheduler is changed is needed
      * to avoid running xstreams while the scheduler is changed in this
      * function. */
-    if (p_xstream->state == ABT_XSTREAM_STATE_RUNNING) {
+    if (ABTD_atomic_acquire_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING) {
         if (p_thread->p_last_xstream != p_xstream) {
             abt_errno = ABT_ERR_XSTREAM_STATE;
             goto fn_fail;
@@ -913,7 +913,7 @@ int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state)
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     /* Return value */
-    *state = p_xstream->state;
+    *state = (ABT_xstream_state)ABTD_atomic_acquire_load_int(&p_xstream->state);
 
 fn_exit:
     return abt_errno;
@@ -1123,12 +1123,13 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
 
     ABTI_info_check_print_all_thread_stacks();
 
-    if (p_xstream->request & ABTI_XSTREAM_REQ_JOIN) {
+    uint32_t request = ABTD_atomic_acquire_load_uint32(&p_xstream->request);
+    if (request & ABTI_XSTREAM_REQ_JOIN) {
         ABTI_sched_finish(p_sched);
     }
 
-    if ((p_xstream->request & ABTI_XSTREAM_REQ_EXIT) ||
-        (p_xstream->request & ABTI_XSTREAM_REQ_CANCEL)) {
+    if ((request & ABTI_XSTREAM_REQ_EXIT) ||
+        (request & ABTI_XSTREAM_REQ_CANCEL)) {
         ABTI_sched_exit(p_sched);
     }
 
@@ -1310,7 +1311,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-    if (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) ==
+    if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
         ABT_XSTREAM_STATE_TERMINATED) {
         goto fn_join;
     }
@@ -1333,7 +1334,7 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         /* Set the join request */
         ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        while (ABTD_atomic_acquire_load_int((int *)&p_xstream->state) !=
+        while (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
                ABT_XSTREAM_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
             if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
@@ -1401,7 +1402,7 @@ void ABTI_xstream_schedule(void *p_arg)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = (ABTI_xstream *)p_arg;
 
-    ABTI_ASSERT(p_xstream->state == ABT_XSTREAM_STATE_RUNNING);
+    ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING);
     while (1) {
         uint32_t request;
 
@@ -1445,7 +1446,7 @@ void ABTI_xstream_schedule(void *p_arg)
     }
 
     /* Set the ES's state as TERMINATED */
-    ABTD_atomic_release_store_int((int *)&p_xstream->state,
+    ABTD_atomic_release_store_int(&p_xstream->state,
                              ABT_XSTREAM_STATE_TERMINATED);
     LOG_EVENT("[E%d] terminated\n", p_xstream->rank);
 }
@@ -1457,7 +1458,7 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     ABTI_local *p_local = *pp_local;
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->request) & ABTI_THREAD_REQ_CANCEL) {
         LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
                   p_xstream->rank);
         ABTD_thread_cancel(p_local, p_thread);
@@ -1467,7 +1468,7 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    if (p_thread->request & ABTI_THREAD_REQ_MIGRATE) {
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->request) & ABTI_THREAD_REQ_MIGRATE) {
         abt_errno = ABTI_xstream_migrate_thread(p_local, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
@@ -1487,7 +1488,7 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     p_thread->p_last_xstream = p_xstream;
 
     /* Change the ULT state */
-    p_thread->state = ABT_THREAD_STATE_RUNNING;
+    ABTD_atomic_release_store_int(&p_thread->state, ABT_THREAD_STATE_RUNNING);
 
     /* Switch the context */
     LOG_EVENT("[U%" PRIu64 ":E%d] start running\n",
@@ -1532,39 +1533,40 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
     /* We do not need to acquire-load request since all critical requests
      * (BLOCK, ORPHAN, STOP, and NOPUSH) are written by p_thread. CANCEL might
      * be delayed. */
-    if (p_thread->request & ABTI_THREAD_REQ_STOP) {
+    uint32_t request = ABTD_atomic_acquire_load_uint32(&p_thread->request);
+    if (request & ABTI_THREAD_REQ_STOP) {
         /* The ULT has completed its execution or it called the exit request. */
         LOG_EVENT("[U%" PRIu64 ":E%d] %s\n", ABTI_thread_get_id(p_thread),
                   p_xstream->rank,
-                  (p_thread->request & ABTI_THREAD_REQ_TERMINATE
+                  (request & ABTI_THREAD_REQ_TERMINATE
                        ? "finished"
-                       : ((p_thread->request & ABTI_THREAD_REQ_EXIT)
+                       : ((request & ABTI_THREAD_REQ_EXIT)
                               ? "exit called"
                               : "UNKNOWN")));
         ABTI_xstream_terminate_thread(p_local, p_thread);
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    } else if (p_thread->request & ABTI_THREAD_REQ_CANCEL) {
+    } else if (request & ABTI_THREAD_REQ_CANCEL) {
         LOG_EVENT("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
                   p_xstream->rank);
         ABTD_thread_cancel(p_local, p_thread);
         ABTI_xstream_terminate_thread(p_local, p_thread);
 #endif
-    } else if (!(p_thread->request & ABTI_THREAD_REQ_NON_YIELD)) {
+    } else if (!(request & ABTI_THREAD_REQ_NON_YIELD)) {
         /* The ULT did not finish its execution.
          * Change the state of current running ULT and
          * add it to the pool again. */
         ABTI_POOL_ADD_THREAD(p_thread, ABTI_self_get_native_thread_id(p_local));
-    } else if (p_thread->request & ABTI_THREAD_REQ_BLOCK) {
+    } else if (request & ABTI_THREAD_REQ_BLOCK) {
         LOG_EVENT("[U%" PRIu64 ":E%d] check blocked\n",
                   ABTI_thread_get_id(p_thread), p_xstream->rank);
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_BLOCK);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    } else if (p_thread->request & ABTI_THREAD_REQ_MIGRATE) {
+    } else if (request & ABTI_THREAD_REQ_MIGRATE) {
         /* This is the case when the ULT requests migration of itself. */
         abt_errno = ABTI_xstream_migrate_thread(p_local, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
 #endif
-    } else if (p_thread->request & ABTI_THREAD_REQ_ORPHAN) {
+    } else if (request & ABTI_THREAD_REQ_ORPHAN) {
         /* The ULT is not pushed back to the pool and is disconnected from any
          * pool. */
         LOG_EVENT("[U%" PRIu64 ":E%d] orphaned\n", ABTI_thread_get_id(p_thread),
@@ -1572,7 +1574,7 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
         ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
         p_thread->p_pool->u_free(&p_thread->unit);
         p_thread->p_pool = NULL;
-    } else if (p_thread->request & ABTI_THREAD_REQ_NOPUSH) {
+    } else if (request & ABTI_THREAD_REQ_NOPUSH) {
         /* The ULT is not pushed back to the pool */
         LOG_EVENT("[U%" PRIu64 ":E%d] not pushed\n",
                   ABTI_thread_get_id(p_thread), p_xstream->rank);
@@ -1594,7 +1596,7 @@ void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
                                 ABTI_task *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
-    if (p_task->request & ABTI_TASK_REQ_CANCEL) {
+    if (ABTD_atomic_acquire_load_uint32(&p_task->request) & ABTI_TASK_REQ_CANCEL) {
         ABTI_xstream_terminate_task(p_local, p_task);
         return;
     }
@@ -1605,7 +1607,7 @@ void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
     p_local->p_thread = NULL;
 
     /* Change the task state */
-    p_task->state = ABT_TASK_STATE_RUNNING;
+    ABTD_atomic_release_store_int(&p_task->state, ABT_TASK_STATE_RUNNING);
 
     /* Set the associated ES */
     p_task->p_xstream = p_xstream;
@@ -1853,7 +1855,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
             type = "UNKNOWN";
             break;
     }
-    switch (p_xstream->state) {
+    switch (ABTD_atomic_acquire_load_int(&p_xstream->state)) {
         case ABT_XSTREAM_STATE_CREATED:
             state = "CREATED";
             break;
@@ -1893,7 +1895,7 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
             "%sscheds    : %s\n"
             "%smain_sched: %p\n",
             prefix, (void *)p_xstream, prefix, p_xstream->rank, prefix, type,
-            prefix, state, prefix, p_xstream->request, prefix,
+            prefix, state, prefix, ABTD_atomic_acquire_load_uint32(&p_xstream->request), prefix,
             p_xstream->max_scheds, prefix, p_xstream->num_scheds, prefix,
             scheds_str, prefix, (void *)p_xstream->p_main_sched);
     ABTU_free(scheds_str);

--- a/src/task.c
+++ b/src/task.c
@@ -226,7 +226,7 @@ int ABT_task_free(ABT_task *task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* Wait until the task terminates */
-    while (ABTD_atomic_load_int((int *)&p_task->state) !=
+    while (ABTD_atomic_acquire_load_int((int *)&p_task->state) !=
            ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
@@ -272,7 +272,7 @@ int ABT_task_join(ABT_task task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* TODO: better implementation */
-    while (ABTD_atomic_load_int((int *)&p_task->state) !=
+    while (ABTD_atomic_acquire_load_int((int *)&p_task->state) !=
            ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {

--- a/src/task.c
+++ b/src/task.c
@@ -933,7 +933,7 @@ void ABTI_task_release(ABTI_task *p_task)
     }
 }
 
-static uint64_t g_task_id = 0;
+static ABTD_atomic_uint64 g_task_id = 0;
 void ABTI_task_reset_id(void)
 {
     g_task_id = 0;

--- a/src/task.c
+++ b/src/task.c
@@ -226,7 +226,7 @@ int ABT_task_free(ABT_task *task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* Wait until the task terminates */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state) !=
+    while (ABTD_atomic_load_int((int *)&p_task->state) !=
            ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {
@@ -272,7 +272,7 @@ int ABT_task_join(ABT_task task)
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     /* TODO: better implementation */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_task->state) !=
+    while (ABTD_atomic_load_int((int *)&p_task->state) !=
            ABT_TASK_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (ABTI_self_get_type(p_local) != ABT_UNIT_TYPE_THREAD) {

--- a/src/task.c
+++ b/src/task.c
@@ -801,7 +801,8 @@ static int ABTI_task_revive(ABTI_local *p_local, ABTI_pool *p_pool,
 {
     int abt_errno = ABT_SUCCESS;
 
-    ABTI_CHECK_TRUE(ABTD_atomic_relaxed_load_int(&p_task->state) == ABT_TASK_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_relaxed_load_int(&p_task->state) ==
+                        ABT_TASK_STATE_TERMINATED,
                     ABT_ERR_INV_TASK);
 
     p_task->p_xstream = NULL;
@@ -909,7 +910,8 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
             prefix, (p_task->migratable == ABT_TRUE) ? "TRUE" : "FALSE",
 #endif
-            prefix, p_task->refcount, prefix, ABTD_atomic_acquire_load_uint32(&p_task->request), prefix,
+            prefix, p_task->refcount, prefix,
+            ABTD_atomic_acquire_load_uint32(&p_task->request), prefix,
             p_task->p_arg, prefix, (void *)p_task->p_keytable);
 
 fn_exit:
@@ -926,8 +928,9 @@ void ABTI_task_release(ABTI_task *p_task)
 {
     uint32_t refcount;
     while ((refcount = p_task->refcount) > 0) {
-        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_task->refcount, refcount,
-                                             refcount - 1)) {
+        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_task
+                                                 ->refcount,
+                                             refcount, refcount - 1)) {
             break;
         }
     }

--- a/src/thread.c
+++ b/src/thread.c
@@ -2158,7 +2158,7 @@ void ABTI_thread_release(ABTI_thread *p_thread)
     }
 }
 
-static uint64_t g_thread_id = 0;
+static ABTD_atomic_uint64 g_thread_id = 0;
 void ABTI_thread_reset_id(void)
 {
     g_thread_id = 0;

--- a/src/thread.c
+++ b/src/thread.c
@@ -313,7 +313,8 @@ int ABT_thread_free(ABT_thread *thread)
                         "The main thread cannot be freed explicitly.");
 
     /* Wait until the thread terminates */
-    if (ABTD_atomic_acquire_load_int(&p_thread->state) != ABT_THREAD_STATE_TERMINATED) {
+    if (ABTD_atomic_acquire_load_int(&p_thread->state) !=
+        ABT_THREAD_STATE_TERMINATED) {
         ABTI_thread_join(&p_local, p_thread);
     }
 
@@ -750,7 +751,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     ABTI_CHECK_TRUE_MSG(p_cur_thread != p_tar_thread, ABT_ERR_INV_THREAD,
                         "The caller and target ULTs are the same.");
 
-    ABTI_CHECK_TRUE_MSG(ABTD_atomic_relaxed_load_int(&p_tar_thread->state) != ABT_THREAD_STATE_TERMINATED,
+    ABTI_CHECK_TRUE_MSG(ABTD_atomic_relaxed_load_int(&p_tar_thread->state) !=
+                            ABT_THREAD_STATE_TERMINATED,
                         ABT_ERR_INV_THREAD,
                         "Cannot yield to the terminated thread");
 
@@ -796,7 +798,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     p_tar_thread->p_last_xstream = p_xstream;
 
     /* Switch the context */
-    ABTD_atomic_release_store_int(&p_tar_thread->state, ABT_THREAD_STATE_RUNNING);
+    ABTD_atomic_release_store_int(&p_tar_thread->state,
+                                  ABT_THREAD_STATE_RUNNING);
     ABTI_thread_context_switch_thread_to_thread(&p_local, p_cur_thread,
                                                 p_tar_thread);
 
@@ -961,7 +964,8 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
                         p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) != ABT_THREAD_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                        ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
 
     /* Find a pool */
@@ -1069,7 +1073,8 @@ int ABT_thread_migrate(ABT_thread thread)
 
         p_xstream = p_xstreams[rand() % gp_ABTI_global->num_xstreams];
         if (p_xstream && p_xstream != p_thread->p_last_xstream) {
-            if (ABTD_atomic_acquire_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING) {
+            if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
+                ABT_XSTREAM_STATE_RUNNING) {
                 abt_errno = ABTI_thread_migrate_to_xstream(&p_local, p_thread,
                                                            p_xstream);
                 if (abt_errno != ABT_ERR_INV_XSTREAM &&
@@ -1602,7 +1607,8 @@ int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
                         p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) != ABT_THREAD_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                        ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
 
     /* checking for migration to the same pool */
@@ -1690,7 +1696,8 @@ int ABTI_thread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
         ABTI_CHECK_ERROR(abt_errno);
         /* When the main scheduler is terminated, the control will jump to the
          * primary ULT. */
-        ABTD_atomic_relaxed_store_thread_context_ptr(&p_newthread->ctx.p_link, &p_main_thread->ctx);
+        ABTD_atomic_relaxed_store_thread_context_ptr(&p_newthread->ctx.p_link,
+                                                     &p_main_thread->ctx);
     } else {
         /* For secondary ESs, the stack of OS thread is used for the main
          * scheduler's ULT. */
@@ -1867,7 +1874,8 @@ int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
     int abt_errno = ABT_SUCCESS;
 
     /* The ULT should be in BLOCKED state. */
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) == ABT_THREAD_STATE_BLOCKED,
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) ==
+                        ABT_THREAD_STATE_BLOCKED,
                     ABT_ERR_THREAD);
 
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
@@ -1908,7 +1916,8 @@ static inline ABT_bool ABTI_thread_is_ready(ABTI_thread *p_thread)
      * is inside a pool and the its state. */
     ABTI_pool *p_pool = p_thread->p_pool;
     if (p_pool->u_is_in_pool(p_thread->unit) == ABT_TRUE &&
-        ABTD_atomic_acquire_load_int(&p_thread->state) == ABT_THREAD_STATE_READY) {
+        ABTD_atomic_acquire_load_int(&p_thread->state) ==
+            ABT_THREAD_STATE_READY) {
         return ABT_TRUE;
     }
 
@@ -2151,14 +2160,16 @@ void ABTI_thread_release(ABTI_thread *p_thread)
 {
     uint32_t refcount;
     while ((refcount = p_thread->refcount) > 0) {
-        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_thread->refcount, refcount,
-                                             refcount - 1)) {
+        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_thread
+                                                 ->refcount,
+                                             refcount, refcount - 1)) {
             break;
         }
     }
 }
 
-static ABTD_atomic_uint64 g_thread_id = ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);
+static ABTD_atomic_uint64 g_thread_id =
+    ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);
 void ABTI_thread_reset_id(void)
 {
     ABTD_atomic_release_store_uint64(&g_thread_id, 0);
@@ -2214,7 +2225,8 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     int abt_errno = ABT_SUCCESS;
     size_t stacksize;
 
-    ABTI_CHECK_TRUE(ABTD_atomic_relaxed_load_int(&p_thread->state) == ABT_THREAD_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
+                        ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
 
     /* Create a ULT context */
@@ -2277,7 +2289,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
 
-    if (ABTD_atomic_acquire_load_int(&p_thread->state) == ABT_THREAD_STATE_TERMINATED)
+    if (ABTD_atomic_acquire_load_int(&p_thread->state) ==
+        ABT_THREAD_STATE_TERMINATED)
         return abt_errno;
 
     ABTI_CHECK_TRUE_MSG(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
@@ -2300,7 +2313,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
     if ((p_self->p_pool == p_thread->p_pool) &&
         (access == ABT_POOL_ACCESS_PRIV || access == ABT_POOL_ACCESS_MPSC ||
          access == ABT_POOL_ACCESS_SPSC) &&
-        (ABTD_atomic_acquire_load_int(&p_thread->state) == ABT_THREAD_STATE_READY)) {
+        (ABTD_atomic_acquire_load_int(&p_thread->state) ==
+         ABT_THREAD_STATE_READY)) {
 
         ABTI_xstream *p_xstream = p_self->p_last_xstream;
 
@@ -2322,10 +2336,12 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
 
         /* Set the link in the context for the target ULT.  Since p_link will be
          * referenced by p_self, this update does not require release store. */
-        ABTD_atomic_relaxed_store_thread_context_ptr(&p_thread->ctx.p_link, &p_self->ctx);
+        ABTD_atomic_relaxed_store_thread_context_ptr(&p_thread->ctx.p_link,
+                                                     &p_self->ctx);
         /* Set the last ES */
         p_thread->p_last_xstream = p_xstream;
-        ABTD_atomic_release_store_int(&p_thread->state, ABT_THREAD_STATE_RUNNING);
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABT_THREAD_STATE_RUNNING);
 
         /* Make the current ULT BLOCKED */
         ABTD_atomic_release_store_int(&p_self->state, ABT_THREAD_STATE_BLOCKED);
@@ -2365,7 +2381,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
         /* Set the link in the context of the target ULT. This p_link might be
          * read by p_thread running on another ES in parallel, so release-store
          * is needed here. */
-        ABTD_atomic_release_store_thread_context_ptr(&p_thread->ctx.p_link, &p_self->ctx);
+        ABTD_atomic_release_store_thread_context_ptr(&p_thread->ctx.p_link,
+                                                     &p_self->ctx);
 
         /* Suspend the current ULT */
         ABTI_thread_suspend(pp_local, p_self);
@@ -2378,7 +2395,8 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
      * Otherwise, the target ULT had been migrated to a different ES, p_self
      * has been resumed by p_self's scheduler.  In the latter case, we don't
      * need to change p_self's state. */
-    if (ABTD_atomic_relaxed_load_int(&p_self->state) == ABT_THREAD_STATE_BLOCKED) {
+    if (ABTD_atomic_relaxed_load_int(&p_self->state) ==
+        ABT_THREAD_STATE_BLOCKED) {
         ABTD_atomic_release_store_int(&p_self->state, ABT_THREAD_STATE_RUNNING);
         ABTI_pool_dec_num_blocked(p_self->p_pool);
         LOG_EVENT("[U%" PRIu64 ":E%d] resume after join\n",
@@ -2418,12 +2436,14 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
     int abt_errno = ABT_SUCCESS;
 
     /* checking for cases when migration is not allowed */
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_xstream->state) != ABT_XSTREAM_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+                        ABT_XSTREAM_STATE_TERMINATED,
                     ABT_ERR_INV_XSTREAM);
     ABTI_CHECK_TRUE(p_thread->type != ABTI_THREAD_TYPE_MAIN &&
                         p_thread->type != ABTI_THREAD_TYPE_MAIN_SCHED,
                     ABT_ERR_INV_THREAD);
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) != ABT_THREAD_STATE_TERMINATED,
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                        ABT_THREAD_STATE_TERMINATED,
                     ABT_ERR_INV_THREAD);
 
     /* We need to find the target scheduler */
@@ -2433,12 +2453,14 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
         ABTI_spinlock_acquire(&p_xstream->sched_lock);
 
         /* We check the state of the ES */
-        if (ABTD_atomic_acquire_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_TERMINATED) {
+        if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
+            ABT_XSTREAM_STATE_TERMINATED) {
             abt_errno = ABT_ERR_INV_XSTREAM;
             ABTI_spinlock_release(&p_xstream->sched_lock);
             goto fn_fail;
 
-        } else if (ABTD_atomic_acquire_load_int(&p_xstream->state) == ABT_XSTREAM_STATE_RUNNING) {
+        } else if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
+                   ABT_XSTREAM_STATE_RUNNING) {
             p_sched = ABTI_xstream_get_top_sched(p_xstream);
 
         } else {

--- a/src/thread.c
+++ b/src/thread.c
@@ -1873,7 +1873,7 @@ int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
      * request. Otherwise, the ULT can be pushed to a pool here and be
      * scheduled by another scheduler if it is pushed to a shared pool. */
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->request) &
+    while (ABTD_atomic_acquire_load_uint32((uint32_t *)&p_thread->request) &
            ABTI_THREAD_REQ_BLOCK)
         ;
 
@@ -2385,7 +2385,7 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
     }
 
 yield_based:
-    while (ABTD_atomic_load_int((int *)&p_thread->state) !=
+    while (ABTD_atomic_acquire_load_int((int *)&p_thread->state) !=
            ABT_THREAD_STATE_TERMINATED) {
         ABTI_thread_yield(pp_local, p_local->p_thread);
         p_local = *pp_local;
@@ -2395,7 +2395,7 @@ yield_based:
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
 busywait_based:
 #endif
-    while (ABTD_atomic_load_int((int *)&p_thread->state) !=
+    while (ABTD_atomic_acquire_load_int((int *)&p_thread->state) !=
            ABT_THREAD_STATE_TERMINATED) {
         ABTD_atomic_pause();
     }

--- a/src/thread.c
+++ b/src/thread.c
@@ -2385,7 +2385,7 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
     }
 
 yield_based:
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state) !=
+    while (ABTD_atomic_load_int((int *)&p_thread->state) !=
            ABT_THREAD_STATE_TERMINATED) {
         ABTI_thread_yield(pp_local, p_local->p_thread);
         p_local = *pp_local;
@@ -2395,7 +2395,7 @@ yield_based:
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
 busywait_based:
 #endif
-    while (ABTD_atomic_load_uint32((uint32_t *)&p_thread->state) !=
+    while (ABTD_atomic_load_int((int *)&p_thread->state) !=
            ABT_THREAD_STATE_TERMINATED) {
         ABTD_atomic_pause();
     }

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -234,7 +234,8 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_local **pp_local,
         p_target = p_queue->low_head;
 
         /* Push p_thread to the queue */
-        ABTD_atomic_release_store_int(&p_thread->state, ABT_THREAD_STATE_BLOCKED);
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABT_THREAD_STATE_BLOCKED);
         if (p_queue->low_head == p_queue->low_tail) {
             p_queue->low_head = p_thread;
             p_queue->low_tail = p_thread;
@@ -251,7 +252,8 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_local **pp_local,
         LOG_EVENT("switch -> U%" PRIu64 "\n", ABTI_thread_get_id(p_target));
 
         /* Context-switch to p_target */
-        ABTD_atomic_release_store_int(&p_target->state, ABT_THREAD_STATE_RUNNING);
+        ABTD_atomic_release_store_int(&p_target->state,
+                                      ABT_THREAD_STATE_RUNNING);
         ABTI_thread_context_switch_thread_to_thread(pp_local, p_thread,
                                                     p_target);
         return ABT_TRUE;


### PR DESCRIPTION
#### Problem

The current Argobots has a wrapper for atomic operations but not atomic variables. This makes it vague whether a specific variable should be atomically accessed or not.

```c
struct ABTI_thread {
  ...
  uint32_t request;  // Should this variable be accessed atomically?
  uint32_t refcount; // How about this variable?
  ...
};
void ABTDI_thread_terminate(...) {
  [...];
  ABTD_atomic_store_uint32(&p_thread->request, ABTI_THREAD_REQ_TERMINATE);
  [...];
}
int ABTI_thread_revive(...)
  [...];
  p_thread->request = 0;  // Can we update it without an atomic operation?
  p_thread->refcount = 1; // How about this?
  [...];
}
```

#### Solution

To ease the programming, this PR makes atomic operations only work for *atomic-type variables*. Developers need to be aware of atomicity when accessing such an atomic-type variable.

```c
struct ABTI_thread {
  ...
  ABTD_atomic_uint32 request; // This atomic-type variable should be accessed atomically.
  uint32_t refcount; // This should not be accessed with atomic operations.
  ...
};
void ABTDI_thread_terminate(...) {
  [...];
  // Explicitly write this as release store.
  ABTD_atomic_release_store_uint32(&p_thread->request, ABTI_THREAD_REQ_TERMINATE);
  [...];
}
int ABTI_thread_revive(...)
  [...];
  // Explicitly write this as relaxed store (if the developer knows it is okay).
  ABTD_atomic_relaxed_store_uint32(&p_thread->request, 0);
  p_thread->refcount = 1; // This should be a normal store.
  // The following causes a compile-time error.
  // ABTD_atomic_relaxed_store_uint32(&p_thread->refcount, 1);
  [...];
}
```

It will not hurt performance because the resulted code should be the same after compilation. Note that MPICH has a similar atomic wrapper.
