### PR TITLE
Remove deprecated functions and constants

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -54,7 +54,7 @@ int ABT_error_get_str(int err, char *str, size_t *len)
                                      "ABT_ERR_INV_FUTURE",
                                      "ABT_ERR_INV_BARRIER",
                                      "ABT_ERR_INV_TIMER",
-                                     "ABT_ERR_INV_EVENT",
+                                     "ABT_ERR_INV_QUERY_KIND",
                                      "ABT_ERR_XSTREAM",
                                      "ABT_ERR_XSTREAM_STATE",
                                      "ABT_ERR_XSTREAM_BARRIER",

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -119,8 +119,6 @@ extern "C" {
 
 /* Constants */
 enum ABT_xstream_state {
-    ABT_XSTREAM_STATE_CREATED,  /* Deprecated */
-    ABT_XSTREAM_STATE_READY,    /* Deprecated */
     ABT_XSTREAM_STATE_RUNNING,
     ABT_XSTREAM_STATE_TERMINATED
 };
@@ -451,7 +449,6 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
                              ABT_xstream *newxstream) ABT_API_PUBLIC;
 int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
                                  ABT_xstream *newxstream) ABT_API_PUBLIC;
-int ABT_xstream_start(ABT_xstream xstream) ABT_API_PUBLIC ABT_DEPRECATED;
 int ABT_xstream_free(ABT_xstream *xstream) ABT_API_PUBLIC;
 int ABT_xstream_join(ABT_xstream xstream) ABT_API_PUBLIC;
 int ABT_xstream_revive(ABT_xstream xstream) ABT_API_PUBLIC;
@@ -572,8 +569,6 @@ int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_thread_is_primary(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
                      ABT_API_PUBLIC;
-int ABT_thread_retain(ABT_thread thread) ABT_API_PUBLIC ABT_DEPRECATED;
-int ABT_thread_release(ABT_thread thread) ABT_API_PUBLIC ABT_DEPRECATED;
 int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize) ABT_API_PUBLIC;
 int ABT_thread_get_id(ABT_thread thread, ABT_thread_id *thread_id) ABT_API_PUBLIC;
 int ABT_thread_set_arg(ABT_thread thread, void *arg) ABT_API_PUBLIC;
@@ -612,8 +607,6 @@ int ABT_task_get_last_pool_id(ABT_task task, int *id) ABT_API_PUBLIC;
 int ABT_task_set_migratable(ABT_task task, ABT_bool flag) ABT_API_PUBLIC;
 int ABT_task_is_migratable(ABT_task task, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result) ABT_API_PUBLIC;
-int ABT_task_retain(ABT_task task) ABT_API_PUBLIC ABT_DEPRECATED;
-int ABT_task_release(ABT_task task) ABT_API_PUBLIC ABT_DEPRECATED;
 int ABT_task_get_id(ABT_task task, uint64_t *task_id) ABT_API_PUBLIC;
 int ABT_task_get_arg(ABT_task task, void **arg) ABT_API_PUBLIC;
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -89,7 +89,6 @@ extern "C" {
 #define ABT_ERR_INV_FUTURE         25  /* Invalid future */
 #define ABT_ERR_INV_BARRIER        26  /* Invalid barrier */
 #define ABT_ERR_INV_TIMER          27  /* Invalid timer */
-#define ABT_ERR_INV_EVENT          28  /* Invalid event */
 #define ABT_ERR_XSTREAM            29  /* ES-related error */
 #define ABT_ERR_XSTREAM_STATE      30  /* ES state error */
 #define ABT_ERR_XSTREAM_BARRIER    31  /* ES barrier-related error */
@@ -109,7 +108,6 @@ extern "C" {
 #define ABT_ERR_FUTURE             45  /* Future-related error */
 #define ABT_ERR_BARRIER            46  /* Barrier-related error */
 #define ABT_ERR_TIMER              47  /* Timer-related error */
-#define ABT_ERR_EVENT              48  /* Event-related error */
 #define ABT_ERR_MIGRATION_TARGET   49  /* Migration target error */
 #define ABT_ERR_MIGRATION_NA       50  /* Migration not available */
 #define ABT_ERR_MISSING_JOIN       51  /* An ES or more did not join */

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -89,6 +89,7 @@ extern "C" {
 #define ABT_ERR_INV_FUTURE         25  /* Invalid future */
 #define ABT_ERR_INV_BARRIER        26  /* Invalid barrier */
 #define ABT_ERR_INV_TIMER          27  /* Invalid timer */
+#define ABT_ERR_INV_QUERY_KIND     28  /* Invalid query kind */
 #define ABT_ERR_XSTREAM            29  /* ES-related error */
 #define ABT_ERR_XSTREAM_STATE      30  /* ES state error */
 #define ABT_ERR_XSTREAM_BARRIER    31  /* ES barrier-related error */
@@ -108,11 +109,10 @@ extern "C" {
 #define ABT_ERR_FUTURE             45  /* Future-related error */
 #define ABT_ERR_BARRIER            46  /* Barrier-related error */
 #define ABT_ERR_TIMER              47  /* Timer-related error */
-#define ABT_ERR_MIGRATION_TARGET   49  /* Migration target error */
-#define ABT_ERR_MIGRATION_NA       50  /* Migration not available */
-#define ABT_ERR_MISSING_JOIN       51  /* An ES or more did not join */
-#define ABT_ERR_FEATURE_NA         52  /* Feature not available */
-#define ABT_ERR_INV_QUERY_KIND     53  /* Invalid query kind */
+#define ABT_ERR_MIGRATION_TARGET   48  /* Migration target error */
+#define ABT_ERR_MIGRATION_NA       49  /* Migration not available */
+#define ABT_ERR_MISSING_JOIN       50  /* An ES or more did not join */
+#define ABT_ERR_FEATURE_NA         51  /* Feature not available */
 
 
 /* Constants */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -560,8 +560,6 @@ int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 void ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
 void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);
 #endif
-void ABTI_thread_retain(ABTI_thread *p_thread);
-void ABTI_thread_release(ABTI_thread *p_thread);
 void ABTI_thread_reset_id(void);
 ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread);
 ABT_thread_id ABTI_thread_self_id(ABTI_local *p_local);
@@ -598,8 +596,6 @@ int ABTI_task_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
                            ABTI_sched *p_sched);
 void ABTI_task_free(ABTI_local *p_local, ABTI_task *p_task);
 void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent);
-void ABTI_task_retain(ABTI_task *p_task);
-void ABTI_task_release(ABTI_task *p_task);
 void ABTI_task_reset_id(void);
 uint64_t ABTI_task_get_id(ABTI_task *p_task);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -250,37 +250,6 @@ fn_fail:
     goto fn_exit;
 }
 
-/**
- * @ingroup ES
- * @brief   Start the target ES.
- *
- * \c ABT_xstream_start() starts the target ES \c xstream if it has not been
- * started.  That is, this routine is effective only when the state of the
- * target ES is CREATED or READY, and once this routine returns, the ES's state
- * becomes RUNNING.
- *
- * @param[in] xstream  handle to the target ES
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_xstream_start(ABT_xstream xstream)
-{
-    int abt_errno = ABT_SUCCESS;
-    ABTI_local *p_local = ABTI_local_get_local();
-    ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
-    ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
-
-    abt_errno = ABTI_xstream_start(p_local, p_xstream);
-    ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
 int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
 {
     int abt_errno = ABT_SUCCESS;
@@ -1865,12 +1834,6 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
             break;
     }
     switch (ABTD_atomic_acquire_load_int(&p_xstream->state)) {
-        case ABT_XSTREAM_STATE_CREATED:
-            state = "CREATED";
-            break;
-        case ABT_XSTREAM_STATE_READY:
-            state = "READY";
-            break;
         case ABT_XSTREAM_STATE_RUNNING:
             state = "RUNNING";
             break;

--- a/src/task.c
+++ b/src/task.c
@@ -622,62 +622,6 @@ int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result)
 
 /**
  * @ingroup TASK
- * @brief   Increment the tasklet's reference count.
- *
- * \c ABT_task_retain() increments the tasklet's reference count by one.
- * If the user obtains a tasklet handle through \c ABT_task_create(),
- * the creation routine performs an implicit retain.
- *
- * @param[in] task  handle to the tasklet
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_task_retain(ABT_task task)
-{
-    int abt_errno = ABT_SUCCESS;
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
-    ABTI_CHECK_NULL_TASK_PTR(p_task);
-
-    ABTI_task_retain(p_task);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-/**
- * @ingroup TASK
- * @brief   Decrement the tasklet's reference count.
- *
- * \c ABT_task_release() decrements the tasklet's reference count by one.
- * After the tasklet's reference count becomes zero, the tasklet object will
- * be freed.
- *
- * @param[in] task  handle to the tasklet
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_task_release(ABT_task task)
-{
-    int abt_errno = ABT_SUCCESS;
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
-    ABTI_CHECK_NULL_TASK_PTR(p_task);
-
-    ABTI_task_release(p_task);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-/**
- * @ingroup TASK
  * @brief   Get the tasklet's id
  *
  * \c ABT_task_get_id() returns the id of \c task.
@@ -917,23 +861,6 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
 fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
-}
-
-void ABTI_task_retain(ABTI_task *p_task)
-{
-    ABTD_atomic_fetch_add_uint32((ABTD_atomic_uint32 *)&p_task->refcount, 1);
-}
-
-void ABTI_task_release(ABTI_task *p_task)
-{
-    uint32_t refcount;
-    while ((refcount = p_task->refcount) > 0) {
-        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_task
-                                                 ->refcount,
-                                             refcount, refcount - 1)) {
-            break;
-        }
-    }
 }
 
 static ABTD_atomic_uint64 g_task_id = ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);

--- a/src/thread.c
+++ b/src/thread.c
@@ -1263,61 +1263,6 @@ int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
 
 /**
  * @ingroup ULT
- * @brief   Increment the ULT's reference count.
- *
- * \c ABT_thread_retain() increments the ULT's reference count by one. If the
- * user obtains a ULT handle through \c ABT_thread_create(), the creation
- * routine performs an implicit retain.
- *
- * @param[in] thread  handle to the ULT
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_thread_retain(ABT_thread thread)
-{
-    int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
-
-    ABTI_thread_retain(p_thread);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-/**
- * @ingroup ULT
- * @brief   Decrement the ULT's reference count.
- *
- * \c ABT_thread_release() decrements the ULT's reference count by one.
- * After the ULT's reference count becomes zero, the ULT object will be freed.
- *
- * @param[in] thread  handle to the ULT
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_thread_release(ABT_thread thread)
-{
-    int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
-
-    ABTI_thread_release(p_thread);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-/**
- * @ingroup ULT
  * @brief   Get the ULT's stack size.
  *
  * \c ABT_thread_get_stacksize() returns the stack size of \c thread in bytes.
@@ -2150,23 +2095,6 @@ ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
     return p_result;
 }
 #endif /* ABT_CONFIG_DISABLE_MIGRATION */
-
-void ABTI_thread_retain(ABTI_thread *p_thread)
-{
-    ABTD_atomic_fetch_add_uint32((ABTD_atomic_uint32 *)&p_thread->refcount, 1);
-}
-
-void ABTI_thread_release(ABTI_thread *p_thread)
-{
-    uint32_t refcount;
-    while ((refcount = p_thread->refcount) > 0) {
-        if (ABTD_atomic_bool_cas_weak_uint32((ABTD_atomic_uint32 *)&p_thread
-                                                 ->refcount,
-                                             refcount, refcount - 1)) {
-            break;
-        }
-    }
-}
 
 static ABTD_atomic_uint64 g_thread_id =
     ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);


### PR DESCRIPTION
This patch removes deprecated functions, enum constants, and macros.

- Remove deprecated functions
  - `ABT_thread_retain()`, `ABT_thread_release()`, `ABT_task_retain()`, `ABT_task_release()`.
    - See #138.
  - `ABT_xstream_start()`
    - See #147
- Remove deprecated constants
  - `ABT_XSTREAM_STATE_CREATED` and `ABT_XSTREAM_STATE_READY`
    - See #147
  - `ABT_ERR_INV_EVENT` and `ABT_ERR_EVENT`
    - See #144 

This PR is part of #156