### PR TITLE
unit: use is_in_pool instead of pool in ABTI_unit

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -189,9 +189,9 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
     p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-    /* Check size if ext_signal can be stored in p_unit->pool. */
-    ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
-    p_unit->pool = (ABT_pool)&ext_signal;
+    /* Check size if ext_signal can be stored in p_unit->handle.thread. */
+    ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->handle.thread));
+    p_unit->handle.thread = (ABT_thread)&ext_signal;
     p_unit->type = ABT_UNIT_TYPE_EXT;
 
     ABTI_spinlock_acquire(&p_cond->lock);
@@ -305,7 +305,8 @@ int ABT_cond_signal(ABT_cond cond)
         ABTI_thread_set_ready(p_local, p_thread);
     } else {
         /* When the head is an external thread */
-        ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
+        ABTD_atomic_int32 *p_ext_signal =
+            (ABTD_atomic_int32 *)p_unit->handle.thread;
         ABTD_atomic_release_store_int32(p_ext_signal, 1);
     }
 

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -127,9 +127,11 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
             /* external thread */
             type = ABT_UNIT_TYPE_EXT;
             p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-            /* Check size if ext_signal can be stored in p_unit->pool. */
-            ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
-            p_unit->pool = (ABT_pool)&ext_signal;
+            /* Check size if ext_signal can be stored in p_unit->handle.thread.
+             */
+            ABTI_STATIC_ASSERT(sizeof(ext_signal) <=
+                               sizeof(p_unit->handle.thread));
+            p_unit->handle.thread = (ABT_thread)&ext_signal;
             p_unit->type = type;
         }
 
@@ -263,7 +265,8 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
             ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
-            ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
+            ABTD_atomic_int32 *p_ext_signal =
+                (ABTD_atomic_int32 *)p_unit->handle.thread;
             ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -151,9 +151,11 @@ int ABT_future_wait(ABT_future future)
             /* external thread */
             type = ABT_UNIT_TYPE_EXT;
             p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-            /* Check size if ext_signal can be stored in p_unit->pool. */
-            ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
-            p_unit->pool = (ABT_pool)&ext_signal;
+            /* Check size if ext_signal can be stored in p_unit->handle.thread.
+             */
+            ABTI_STATIC_ASSERT(sizeof(ext_signal) <=
+                               sizeof(p_unit->handle.thread));
+            p_unit->handle.thread = (ABT_thread)&ext_signal;
             p_unit->type = type;
         }
 
@@ -280,7 +282,7 @@ int ABT_future_set(ABT_future future, void *value)
             } else {
                 /* When the head is an external thread */
                 ABTD_atomic_int32 *p_ext_signal =
-                    (ABTD_atomic_int32 *)p_unit->pool;
+                    (ABTD_atomic_int32 *)p_unit->handle.thread;
                 ABTD_atomic_release_store_int32(p_ext_signal, 1);
             }
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -295,11 +295,11 @@ struct ABTI_pool {
 struct ABTI_unit {
     ABTI_unit *p_prev;
     ABTI_unit *p_next;
-    ABT_pool pool;
     union {
         ABT_thread thread;
         ABT_task task;
     } handle;
+    ABTD_atomic_int is_in_pool;
     ABT_unit_type type;
 };
 

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -80,9 +80,9 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
         /* external thread */
         type = ABT_UNIT_TYPE_EXT;
         p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-        /* Check size if ext_signal can be stored in p_unit->pool. */
-        ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->pool));
-        p_unit->pool = (ABT_pool)&ext_signal;
+        /* Check size if ext_signal can be stored in p_unit->handle.thread. */
+        ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_unit->handle.thread));
+        p_unit->handle.thread = (ABT_thread)&ext_signal;
         p_unit->type = type;
     }
 
@@ -174,7 +174,8 @@ static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
             ABTI_thread_set_ready(p_local, p_thread);
         } else {
             /* When the head is an external thread */
-            ABTD_atomic_int32 *p_ext_signal = (ABTD_atomic_int32 *)p_unit->pool;
+            ABTD_atomic_int32 *p_ext_signal =
+                (ABTD_atomic_int32 *)p_unit->handle.thread;
             ABTD_atomic_release_store_int32(p_ext_signal, 1);
         }
 

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -319,7 +319,6 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
 
     ABTI_CHECK_TRUE_RET(p_data->num_units != 0, ABT_ERR_POOL);
     ABTI_CHECK_TRUE_RET(p_unit->pool != ABT_POOL_NULL, ABT_ERR_POOL);
-    ABTI_CHECK_TRUE_MSG_RET(p_unit->pool == pool, ABT_ERR_POOL, "Not my pool");
 
     ABTI_spinlock_acquire(&p_data->mutex);
     if (p_data->num_units == 1) {
@@ -353,7 +352,6 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
 
     ABTI_CHECK_TRUE_RET(p_data->num_units != 0, ABT_ERR_POOL);
     ABTI_CHECK_TRUE_RET(p_unit->pool != ABT_POOL_NULL, ABT_ERR_POOL);
-    ABTI_CHECK_TRUE_MSG_RET(p_unit->pool == pool, ABT_ERR_POOL, "Not my pool");
 
     if (p_data->num_units == 1) {
         p_data->p_head = NULL;

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -127,7 +127,7 @@ static void pool_push(ABT_pool pool, ABT_unit unit)
     }
     p_data->num_units++;
 
-    p_unit->pool = pool;
+    ABTD_atomic_release_store_int(&p_unit->is_in_pool, 1);
     pthread_cond_signal(&p_data->cond);
     pthread_mutex_unlock(&p_data->mutex);
 }
@@ -168,7 +168,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
 
         p_unit->p_prev = NULL;
         p_unit->p_next = NULL;
-        p_unit->pool = ABT_POOL_NULL;
+        ABTD_atomic_release_store_int(&p_unit->is_in_pool, 0);
 
         h_unit = (ABT_unit)p_unit;
     }
@@ -199,7 +199,7 @@ static ABT_unit pool_pop(ABT_pool pool)
 
         p_unit->p_prev = NULL;
         p_unit->p_next = NULL;
-        p_unit->pool = ABT_POOL_NULL;
+        ABTD_atomic_release_store_int(&p_unit->is_in_pool, 0);
 
         h_unit = (ABT_unit)p_unit;
     }
@@ -215,7 +215,8 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
     unit_t *p_unit = (unit_t *)unit;
 
     ABTI_CHECK_TRUE_RET(p_data->num_units != 0, ABT_ERR_POOL);
-    ABTI_CHECK_TRUE_RET(p_unit->pool != ABT_POOL_NULL, ABT_ERR_POOL);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_unit->is_in_pool) == 1,
+                        ABT_ERR_POOL);
 
     pthread_mutex_lock(&p_data->mutex);
     if (p_data->num_units == 1) {
@@ -232,7 +233,7 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
     }
     p_data->num_units--;
 
-    p_unit->pool = ABT_POOL_NULL;
+    ABTD_atomic_release_store_int(&p_unit->is_in_pool, 0);
     pthread_mutex_unlock(&p_data->mutex);
 
     p_unit->p_prev = NULL;
@@ -298,7 +299,8 @@ static ABT_task unit_get_task(ABT_unit unit)
 static ABT_bool unit_is_in_pool(ABT_unit unit)
 {
     unit_t *p_unit = (unit_t *)unit;
-    return (p_unit->pool != ABT_POOL_NULL) ? ABT_TRUE : ABT_FALSE;
+    return ABTD_atomic_acquire_load_int(&p_unit->is_in_pool) ? ABT_TRUE
+                                                             : ABT_FALSE;
 }
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
@@ -307,7 +309,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool = ABT_POOL_NULL;
+    ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
     p_unit->handle.thread = thread;
     p_unit->type = ABT_UNIT_TYPE_THREAD;
 
@@ -320,7 +322,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     unit_t *p_unit = &p_task->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
-    p_unit->pool = ABT_POOL_NULL;
+    ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
     p_unit->handle.task = task;
     p_unit->type = ABT_UNIT_TYPE_TASK;
 

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -216,7 +216,6 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
 
     ABTI_CHECK_TRUE_RET(p_data->num_units != 0, ABT_ERR_POOL);
     ABTI_CHECK_TRUE_RET(p_unit->pool != ABT_POOL_NULL, ABT_ERR_POOL);
-    ABTI_CHECK_TRUE_MSG_RET(p_unit->pool == pool, ABT_ERR_POOL, "Not my pool");
 
     pthread_mutex_lock(&p_data->mutex);
     if (p_data->num_units == 1) {


### PR DESCRIPTION
### Problem

Information whether a unit is in a pool or not can be accessed by multiple threads.

https://github.com/pmodels/argobots/blob/master/src/thread.c#L1918
https://github.com/pmodels/argobots/blob/master/src/thread.c#L2321-L2327 

An `ABT_pool`-type variable, `pool`, is used to get this information, but this `pool` is accessed and updated with non-atomic operations, so it can potentially  cause a bug if multithreaded.

### Solution and benefits

This PR simplifies the overall `is_in_pool` mechanism by introducing an `ABT_atomic_int`-type variable, `is_in_pool`. Good things are as follows:
- Atomic acquire/release operations can guarantee completion of pool operations.
- This change reduces the size of `ABTI_unit` by 8 bytes.
  - This is demanded to add a new `void *` member variable to implement `ABT_{thread/task}_{get/set}_arg()`.

#### Note

Note that a parent-pool check is removed from `pool_remove` operations, but this is user's responsibility and thus not required.

 