### PR TITLE
Fix ABT_future

### DIFF
--- a/src/futures.c
+++ b/src/futures.c
@@ -249,10 +249,10 @@ int ABT_future_set(ABT_future future, void *value)
 
     ABTI_spinlock_acquire(&p_future->lock);
 
+    ABTI_CHECK_TRUE(p_future->counter < p_future->compartments,
+                    ABT_ERR_FUTURE);
     p_future->array[p_future->counter] = value;
     p_future->counter++;
-    ABTI_CHECK_TRUE(p_future->counter <= p_future->compartments,
-                    ABT_ERR_FUTURE);
 
     if (p_future->counter == p_future->compartments) {
         p_future->ready = ABT_TRUE;

--- a/src/futures.c
+++ b/src/futures.c
@@ -141,8 +141,13 @@ int ABT_future_wait(ABT_future future)
 
         if (p_local != NULL) {
             p_current = p_local->p_thread;
-            ABTI_CHECK_TRUE(p_current != NULL, ABT_ERR_FUTURE);
-
+#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
+            if (p_current == NULL) {
+                abt_errno = ABT_ERR_FUTURE;
+                ABTI_spinlock_release(&p_future->lock);
+                goto fn_fail;
+            }
+#endif
             type = ABT_UNIT_TYPE_THREAD;
             p_unit = &p_current->unit_def;
             p_unit->handle.thread = ABTI_thread_get_handle(p_current);
@@ -249,8 +254,13 @@ int ABT_future_set(ABT_future future, void *value)
 
     ABTI_spinlock_acquire(&p_future->lock);
 
-    ABTI_CHECK_TRUE(p_future->counter < p_future->compartments,
-                    ABT_ERR_FUTURE);
+#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
+    if (p_future->counter >= p_future->compartments) {
+        abt_errno = ABT_ERR_FUTURE;
+        ABTI_spinlock_release(&p_future->lock);
+        goto fn_fail;
+    }
+#endif
     p_future->array[p_future->counter] = value;
     p_future->counter++;
 

--- a/src/futures.c
+++ b/src/futures.c
@@ -61,8 +61,7 @@ int ABT_future_create(uint32_t compartments, void (*cb_func)(void **arg),
 
     p_future = (ABTI_future *)ABTU_malloc(sizeof(ABTI_future));
     ABTI_spinlock_clear(&p_future->lock);
-    p_future->ready = ABT_FALSE;
-    p_future->counter = 0;
+    ABTD_atomic_relaxed_store_uint32(&p_future->counter, 0);
     p_future->compartments = compartments;
     p_future->array = ABTU_malloc(compartments * sizeof(void *));
     p_future->p_callback = cb_func;
@@ -133,7 +132,8 @@ int ABT_future_wait(ABT_future future)
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
     ABTI_spinlock_acquire(&p_future->lock);
-    if (p_future->ready == ABT_FALSE) {
+    if (ABTD_atomic_relaxed_load_uint32(&p_future->counter) <
+        p_future->compartments) {
         ABTI_thread *p_current;
         ABTI_unit *p_unit;
         ABT_unit_type type;
@@ -218,7 +218,8 @@ int ABT_future_test(ABT_future future, ABT_bool *flag)
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
-    *flag = p_future->ready;
+    uint32_t counter = ABTD_atomic_acquire_load_uint32(&p_future->counter);
+    *flag = (counter == p_future->compartments) ? ABT_TRUE : ABT_FALSE;
 
 fn_exit:
     return abt_errno;
@@ -254,18 +255,19 @@ int ABT_future_set(ABT_future future, void *value)
 
     ABTI_spinlock_acquire(&p_future->lock);
 
+    int counter = ABTD_atomic_relaxed_load_uint32(&p_future->counter);
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-    if (p_future->counter >= p_future->compartments) {
+    if (counter >= p_future->compartments) {
         abt_errno = ABT_ERR_FUTURE;
         ABTI_spinlock_release(&p_future->lock);
         goto fn_fail;
     }
 #endif
-    p_future->array[p_future->counter] = value;
-    p_future->counter++;
+    p_future->array[counter] = value;
+    counter++;
+    ABTD_atomic_release_store_uint32(&p_future->counter, counter);
 
-    if (p_future->counter == p_future->compartments) {
-        p_future->ready = ABT_TRUE;
+    if (counter == p_future->compartments) {
         if (p_future->p_callback != NULL)
             (*p_future->p_callback)(p_future->array);
 
@@ -334,7 +336,7 @@ int ABT_future_reset(ABT_future future)
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
     ABTI_spinlock_acquire(&p_future->lock);
-    p_future->ready = ABT_FALSE;
+    ABTD_atomic_release_store_uint32(&p_future->counter, 0);
     ABTI_spinlock_release(&p_future->lock);
 
 fn_exit:

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -420,8 +420,7 @@ struct ABTI_eventual {
 
 struct ABTI_future {
     ABTI_spinlock lock;
-    ABT_bool ready;
-    uint32_t counter;
+    ABTD_atomic_uint32 counter;
     uint32_t compartments;
     void **array;
     void (*p_callback)(void **arg);


### PR DESCRIPTION
This PR fixes an implementation of `ABT_future`. Specifically, this PR fixes 

- deadlock issues when errors are found in `ABT_future_wait()` and `ABT_future_set()` and
- functionality of `ABT_future_reset()`.

`ABT_future_reset()` is added to the test `test/basic/future_create.c`.

This fixes #160.
