### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,9 +415,14 @@ fi
 
 # --enable-perf-opt: set CFLAGS for the performance optimization
 if test "x$enable_perf_opt" = "xyes"; then
-    CFLAGS="$CFLAGS -O3 -ftls-model=initial-exec"
-    CXXFLAGS="$CXXFLAGS -O3 -ftls-model=initial-exec"
-    CCASFLAGS="$CCASFLAGS -O3 -ftls-model=initial-exec"
+    CFLAGS="$CFLAGS -O3"
+    CXXFLAGS="$CXXFLAGS -O3"
+    CCASFLAGS="$CCASFLAGS -O3"
+    if test "$CC" != "xlc"; then
+        CFLAGS="$CFLAGS -ftls-model=initial-exec"
+        CXXFLAGS="$CXXFLAGS -ftls-model=initial-exec"
+        CCASFLAGS="$CCASFLAGS -ftls-model=initial-exec"
+    fi
     if test "$CC" = "icc"; then
         CFLAGS="$CFLAGS -ipo"
         CXXFLAGS="$CFLAGS -ipo"

--- a/configure.ac
+++ b/configure.ac
@@ -633,7 +633,9 @@ AC_TRY_COMPILE(
 [have_atomic_builtin=yes],
 [have_atomic_builtin=no]
 )
-if test "x$have_atomic_builtin" = "xyes" ; then
+# __atomic is broken in XLC-16.1.1, so use __sync as a fallback
+# See https://github.com/pmodels/argobots/issues/162 for details.
+if test "$CC" != "xlc" -a "x$have_atomic_builtin" = "xyes" ; then
     AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_BUILTIN, 1,
               [Define if __atomic builtins are supported])
 fi

--- a/src/arch/fcontext/jump_ppc64_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_ppc64_sysv_elf_gas.S
@@ -282,7 +282,7 @@ jump_fcontext:
     mtfsf  0xff, %f0  # restore FPSCR
 #ifdef __VSX__
     li    %r10, 144
-    lvx   %v19, %r10, %r1 # load VSCR vector
+    lvx   %v19, %r10, %r1 # load VSCR
     mtvscr %v19           # restore VSCR.  Only the last 32 bits are used
     li    %r14, 160
     lvx  %v20, %r14, %r1  # restore V20

--- a/src/arch/fcontext/take_ppc64_sysv_elf_gas.S
+++ b/src/arch/fcontext/take_ppc64_sysv_elf_gas.S
@@ -187,7 +187,7 @@ take_fcontext:
     mtfsf  0xff, %f0  # restore FPSCR
 #ifdef __VSX__
     li    %r10, 144
-    lvx   %v19, %r10, %r1 # load VSCR vector
+    lvx   %v19, %r10, %r1 # load VSCR
     mtvscr %v19           # restore VSCR.  Only the last 32 bits are used
     li    %r14, 160
     lvx  %v20, %r14, %r1  # restore V20

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -244,6 +244,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                 }
             }
         }
+        ABTI_LOG_SET_SCHED(p_old);
         return;
     }
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -1828,7 +1828,7 @@ int ABTI_thread_set_ready(ABTI_local *p_local, ABTI_thread *p_thread)
      * scheduled by another scheduler if it is pushed to a shared pool. */
     while (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
            ABTI_THREAD_REQ_BLOCK)
-        ;
+        ABTD_atomic_pause();
 
     LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);


### PR DESCRIPTION
This PR fixes several bugs while checking Argobots on several architectures. This PR includes a workaround that addresses #162.

### Test environment

We tried Argobots tests on x86/64 (Intel Skylake), 64-bit ARM, and IBM POWER9 with several compilers.
```
Intel Skylake:
  gnu4.8.5 gnu6.5.0 gnu8.3.0 gnu9.2.0 clang3.9.1 clang7.0.1 clang9.0.0, icc18.1, icc19.4
64-bit ARM:
  gnu4.8.5 gnu6.5.0 gnu8.3.0 gnu9.2.0 clang3.9.1 clang7.0.1 clang9.0.0
IBM POWER9
  gnu4.8.5 gnu6.5.0 gnu8.3.0 gnu9.2.0 clang3.9.1 clang7.0.1 clang9.0.0, xlc16.1.1
```

Checked configuration options include:
```
(default arg),
--enable-perf-opt
--enable-debug=yes
--enable-debug=all
--enable-feature=no / randomly chosen
--enable-checks=no / randomly chosen
--disable-simple-mutex
--enable-affinity
```

All combinations above with all the supported context-switching mechanisms (`fcontext`, `ucontext`, `fcontext` + dynamic promotion) have been tried. The following compilation options (some are ignored if compilers do not support) are added to remove annoying compiler-specific warnings.
```
-Wall -Wextra -pedantic-errors -std=gnu99 -Wshadow -Wno-unused-parameter
-Wno-sign-compare -Wno-maybe-uninitialized -Wno-unknown-warning-option
``` 


