### PR TITLE
abt.h: remove unnecessary const

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -454,7 +454,7 @@ int ABT_xstream_exit(void) ABT_API_PUBLIC;
 int ABT_xstream_cancel(ABT_xstream xstream) ABT_API_PUBLIC;
 int ABT_xstream_self(ABT_xstream *xstream) ABT_API_PUBLIC;
 int ABT_xstream_self_rank(int *rank) ABT_API_PUBLIC;
-int ABT_xstream_set_rank(ABT_xstream xstream, const int rank) ABT_API_PUBLIC;
+int ABT_xstream_set_rank(ABT_xstream xstream, int rank) ABT_API_PUBLIC;
 int ABT_xstream_get_rank(ABT_xstream xstream, int *rank) ABT_API_PUBLIC;
 int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched) ABT_API_PUBLIC;
 int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,

--- a/src/stream.c
+++ b/src/stream.c
@@ -637,7 +637,7 @@ fn_fail:
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_xstream_set_rank(ABT_xstream xstream, const int rank)
+int ABT_xstream_set_rank(ABT_xstream xstream, int rank)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);


### PR DESCRIPTION
`ABT_xstream_set_rank()` was declared as follows, but the const qualifier to a scalar-type argument is meaningless.
```c
int ABT_xstream_set_rank(ABT_xstream xstream, const int rank);
```
This change keeps the same function type, so it won't break the compatibility; for example, the following is allowed (without any compiler warning) as far as I checked.
```c
int ABT_xstream_set_rank(ABT_xstream xstream, int rank); // no const
void func() {
  typedef void (*old_fn_type)(ABT_xstream, const int); // const here
  old_fn_type fn_type = ABT_xstream_set_rank; // no warning
}
```
