### PR TITLE
Add ABTI_xstream_init_main_sched()

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -81,7 +81,7 @@ int ABT_init(int argc, char **argv)
 
     /* Create the primary ES */
     ABTI_xstream *p_newxstream;
-    abt_errno = ABTI_xstream_create_primary(&p_local, &p_newxstream);
+    abt_errno = ABTI_xstream_create_primary(&p_newxstream);
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_create_primary");
     p_local->p_xstream = p_newxstream;
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -473,8 +473,10 @@ int ABTI_xstream_schedule_thread(ABTI_local **pp_local, ABTI_xstream *p_xstream,
 void ABTI_xstream_schedule_task(ABTI_local *p_local, ABTI_xstream *p_xstream,
                                 ABTI_task *p_task);
 int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread);
-int ABTI_xstream_set_main_sched(ABTI_local **pp_local, ABTI_xstream *p_xstream,
-                                ABTI_sched *p_sched);
+int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
+int ABTI_xstream_update_main_sched(ABTI_local **pp_local,
+                                   ABTI_xstream *p_xstream,
+                                   ABTI_sched *p_sched);
 int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched);
 void *ABTI_xstream_launch_main_sched(void *p_arg);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -456,10 +456,8 @@ int ABTI_local_init(ABTI_local **pp_local);
 int ABTI_local_finalize(ABTI_local **pp_local);
 
 /* Execution Stream (ES) */
-int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
-                        ABTI_xstream **pp_xstream);
-int ABTI_xstream_create_primary(ABTI_local **pp_local,
-                                ABTI_xstream **pp_xstream);
+int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream);
+int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
 int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream);
 int ABTI_xstream_start_primary(ABTI_local **pp_local, ABTI_xstream *p_xstream,
                                ABTI_thread *p_thread);

--- a/src/stream.c
+++ b/src/stream.c
@@ -41,7 +41,7 @@ int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
                         ABT_ERR_INV_SCHED);
     }
 
-    abt_errno = ABTI_xstream_create(&p_local, p_sched, &p_newxstream);
+    abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Start this ES */
@@ -60,8 +60,7 @@ fn_fail:
     goto fn_exit;
 }
 
-int ABTI_xstream_create(ABTI_local **pp_local, ABTI_sched *p_sched,
-                        ABTI_xstream **pp_xstream)
+int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_newxstream;
@@ -100,8 +99,7 @@ fn_fail:
     goto fn_exit;
 }
 
-int ABTI_xstream_create_primary(ABTI_local **pp_local,
-                                ABTI_xstream **pp_xstream)
+int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_newxstream;
@@ -112,7 +110,7 @@ int ABTI_xstream_create_primary(ABTI_local **pp_local,
                                         ABT_SCHED_CONFIG_NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABTI_xstream_create(pp_local, p_sched, &p_newxstream);
+    abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
     ABTI_CHECK_ERROR(abt_errno);
 
     p_newxstream->type = ABTI_XSTREAM_TYPE_PRIMARY;
@@ -156,7 +154,7 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
         ABTI_sched_create_basic(predef, num_pools, pools, config, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = ABTI_xstream_create(&p_local, p_sched, &p_newxstream);
+    abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Start this ES */


### PR DESCRIPTION
This PR implements `ABTI_xstream_init_main_sched()`, an initialization-only version of `ABTI_xstream_set_main_sched()`. Since this does not take `ABTI_local **`, this change enables `ABTI_xstream_create()` and `ABTI_xstream_create_primary()` to remove an argument of `ABTI_local **`. The new function types of `ABTI_xstream_create_XXX()` are very natural since these functions never context switch.

This is just an internal cleanup and incurs no visible performance difference.
