### PR TITLE
Robust logging

### DIFF
--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -15,8 +15,6 @@ typedef struct {
 
 extern ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log;
 
-void ABTI_log_init(void);
-void ABTI_log_finalize(void);
 void ABTI_log_print(FILE *fh, const char *format, ...);
 void ABTI_log_event(FILE *fh, const char *format, ...);
 void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...);
@@ -36,8 +34,6 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
     return l_ABTI_log.p_sched;
 }
 
-#define ABTI_LOG_INIT() ABTI_log_init()
-#define ABTI_LOG_FINALIZE() ABTI_log_finalize()
 #define ABTI_LOG_SET_SCHED(s) ABTI_log_set_sched(s)
 #define ABTI_LOG_GET_SCHED(ret) ret = ABTI_log_get_sched()
 #define LOG_EVENT(fmt, ...) ABTI_log_event(stderr, fmt, __VA_ARGS__)
@@ -52,8 +48,6 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
 
 #else
 
-#define ABTI_LOG_INIT()
-#define ABTI_LOG_FINALIZE()
 #define ABTI_LOG_SET_SCHED(s)
 #define ABTI_LOG_GET_SCHED(ret)
 

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -13,7 +13,7 @@ typedef struct {
     ABTI_sched *p_sched;
 } ABTI_log;
 
-extern ABTD_XSTREAM_LOCAL ABTI_log *lp_ABTI_log;
+extern ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log;
 
 void ABTI_log_init(void);
 void ABTI_log_finalize(void);
@@ -28,12 +28,12 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
 static inline void ABTI_log_set_sched(ABTI_sched *p_sched)
 {
-    lp_ABTI_log->p_sched = p_sched;
+    l_ABTI_log.p_sched = p_sched;
 }
 
 static inline ABTI_sched *ABTI_log_get_sched(void)
 {
-    return lp_ABTI_log->p_sched;
+    return l_ABTI_log.p_sched;
 }
 
 #define ABTI_LOG_INIT() ABTI_log_init()

--- a/src/local.c
+++ b/src/local.c
@@ -45,7 +45,7 @@ int ABTI_local_init(ABTI_local **pp_local)
 
     ABTI_mem_init_local(p_local);
 
-    ABTI_LOG_INIT();
+    ABTI_LOG_SET_SCHED(NULL);
     *pp_local = p_local;
 
 fn_exit:
@@ -66,8 +66,6 @@ int ABTI_local_finalize(ABTI_local **pp_local)
     lp_ABTI_local = NULL;
     *pp_local = NULL;
     ABTI_local_set_local(NULL);
-
-    ABTI_LOG_FINALIZE();
 
 fn_exit:
     return abt_errno;

--- a/src/local.c
+++ b/src/local.c
@@ -45,7 +45,6 @@ int ABTI_local_init(ABTI_local **pp_local)
 
     ABTI_mem_init_local(p_local);
 
-    ABTI_LOG_SET_SCHED(NULL);
     *pp_local = p_local;
 
 fn_exit:

--- a/src/log.c
+++ b/src/log.c
@@ -8,18 +8,15 @@
 #include "abti.h"
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-ABTD_XSTREAM_LOCAL ABTI_log *lp_ABTI_log = NULL;
+ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log = { NULL };
 
 void ABTI_log_init(void)
 {
-    lp_ABTI_log = (ABTI_log *)ABTU_malloc(sizeof(ABTI_log));
-    lp_ABTI_log->p_sched = NULL;
+    l_ABTI_log.p_sched = NULL;
 }
 
 void ABTI_log_finalize(void)
 {
-    ABTU_free(lp_ABTI_log);
-    lp_ABTI_log = NULL;
 }
 
 void ABTI_log_print(FILE *fh, const char *format, ...)
@@ -66,9 +63,9 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
                 }
             } else {
                 rank = p_xstream->rank;
-                if (lp_ABTI_log->p_sched) {
+                if (l_ABTI_log.p_sched) {
                     prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                    tid = lp_ABTI_log->p_sched->id;
+                    tid = l_ABTI_log.p_sched->id;
                 } else {
                     prefix_fmt = "<U%" PRIu64 ":E%d> %s";
                     tid = ABTI_thread_get_id(p_thread);
@@ -80,9 +77,9 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
             p_xstream = p_local->p_xstream;
             rank = p_xstream->rank;
             p_task = p_local->p_task;
-            if (lp_ABTI_log->p_sched) {
+            if (l_ABTI_log.p_sched) {
                 prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                tid = lp_ABTI_log->p_sched->id;
+                tid = l_ABTI_log.p_sched->id;
             } else {
                 prefix_fmt = "<T%" PRIu64 ":E%d> %s";
                 tid = ABTI_task_get_id(p_task);

--- a/src/log.c
+++ b/src/log.c
@@ -10,15 +10,6 @@
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log = { NULL };
 
-void ABTI_log_init(void)
-{
-    l_ABTI_log.p_sched = NULL;
-}
-
-void ABTI_log_finalize(void)
-{
-}
-
 void ABTI_log_print(FILE *fh, const char *format, ...)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)

--- a/src/stream.c
+++ b/src/stream.c
@@ -1391,6 +1391,9 @@ void ABTI_xstream_schedule(void *p_arg)
         p_sched->run(ABTI_sched_get_handle(p_sched));
         LOG_EVENT("[S%" PRIu64 "] end\n", p_sched->id);
         p_sched->state = ABT_SCHED_STATE_TERMINATED;
+        p_local->p_task = NULL;
+        p_local->p_thread = NULL;
+        ABTI_LOG_SET_SCHED(NULL);
 
         ABTI_spinlock_release(&p_xstream->sched_lock);
 


### PR DESCRIPTION
Although `ABTI_log` functions are for debugging, they do not work because of SEGV when  `lp_local == NULL` and `lp_ABTI_log == NULL`. The log interface should be robust so that it can be used everywhere. This PR fixes it.

Note that there is no performance impact if a user does not explicitly set `--enable-debug=log` or stronger; even with this option, there should not be performance difference.

