### PR TITLE
Miscellaneous thread allocation fixes

### DIFF
--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -173,7 +173,7 @@ static inline ABTI_thread *ABTI_mem_alloc_thread(ABTI_xstream *p_local_xstream,
         }
 
         stacksize = p_attr->stacksize;
-        if (stacksize != def_stacksize || stacktype == ABTI_STACK_TYPE_MALLOC) {
+        if (stacktype == ABTI_STACK_TYPE_MALLOC) {
             /* Since the stack size requested is not the same as default one,
              * we use ABTU_malloc. */
             return ABTI_mem_alloc_thread_with_stacksize(stacksize, p_attr);

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -178,6 +178,12 @@ static inline ABTI_thread *ABTI_mem_alloc_thread(ABTI_xstream *p_local_xstream,
              * we use ABTU_malloc. */
             return ABTI_mem_alloc_thread_with_stacksize(stacksize, p_attr);
         }
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+        /* If an external thread allocates a stack, we use ABTU_malloc. */
+        if (p_local_xstream == NULL) {
+            return ABTI_mem_alloc_thread_with_stacksize(stacksize, p_attr);
+        }
+#endif
     }
 
     /* Use the stack pool */

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -109,7 +109,11 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
         }
         p_attr->stacktype = ABTI_STACK_TYPE_USER;
     } else {
-        p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;
+        if (stacksize == ABTI_global_get_thread_stacksize()) {
+            p_attr->stacktype = ABTI_STACK_TYPE_MEMPOOL;
+        } else {
+            p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;
+        }
     }
     p_attr->stacksize = stacksize;
 
@@ -175,6 +179,11 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
 
     /* Set the value */
     p_attr->stacksize = stacksize;
+    if (stacksize == ABTI_global_get_thread_stacksize()) {
+        p_attr->stacktype = ABTI_STACK_TYPE_MEMPOOL;
+    } else {
+        p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;
+    }
 
 fn_exit:
     return abt_errno;

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -101,12 +101,12 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
+    p_attr->p_stack = stackaddr;
     if (stackaddr != NULL) {
         if (((uintptr_t)stackaddr & 0x7) != 0) {
             abt_errno = ABT_ERR_OTHER;
             goto fn_fail;
         }
-        p_attr->p_stack = stackaddr;
         p_attr->stacktype = ABTI_STACK_TYPE_USER;
     } else {
         p_attr->stacktype = ABTI_STACK_TYPE_MALLOC;


### PR DESCRIPTION
This PR fixes small issues and cleans up `ABTI_mem_alloc_thread()`.

#### 1. A (potential) bug when `ABT_thread_attr_set_stack()` is called twice

The following code does not reset a "stack" variable in `ABTI_thread_attr`. This PR fixes it.
```c
ABT_thread_attr_set_stack(attr, stack, stacksize1);
ABT_thread_attr_set_stack(attr, NULL, stacksize2);
// Since NULL is set here, p_stack should be internally updated
```

#### 2. SEGV when `ABT_thread_create_XXX` is called with the default thread attribute on an external thread.

The following code tries to access a local memory pool, which causes SEGV. This PR fixes it.
```c
external_thread():
  ABT_thread_attr attr;
  ABT_thread_attr_create(&attr); // attr is initialized.
  ABT_thread_create(..., attr, ...);
```

#### 3. Remove a comparison

This slightly simplifies the complicated branch in `ABTI_mem_alloc_thread()`. This also compensates the additional branch added by 2.

They are not performance critical, so the performance difference is not visible.