### PR TITLE
Memory code cleanup

### DIFF
--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -31,7 +31,7 @@ struct ABTI_sp_header {
     ABTD_atomic_uint32 num_empty_stacks; /* Number of empty stacks */
     size_t stacksize;                    /* Stack size */
     uint64_t id;                         /* ID */
-    ABT_bool is_mmapped;                 /* ABT_TRUE if it is mmapped */
+    ABTU_MEM_LARGEPAGE_TYPE lp_type;     /* Large page type */
     void *p_sp;             /* Pointer to the allocated stack page */
     ABTI_sp_header *p_next; /* Next stack page header */
 };
@@ -52,7 +52,7 @@ struct ABTI_page_header {
     ABTI_native_thread_id owner_id;     /* Owner's ID */
     ABTI_page_header *p_prev;           /* Prev page header */
     ABTI_page_header *p_next;           /* Next page header */
-    ABT_bool is_mmapped;                /* ABT_TRUE if it is mmapped */
+    ABTU_MEM_LARGEPAGE_TYPE lp_type;    /* Large page type */
 };
 
 struct ABTI_blk_header {

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -81,6 +81,22 @@ static inline void *ABTU_realloc(void *ptr, size_t old_size, size_t new_size)
 
 #endif /* !ABT_CONFIG_USE_ALIGNED_ALLOC */
 
+typedef enum ABTU_MEM_LARGEPAGE_TYPE {
+    ABTU_MEM_LARGEPAGE_MALLOC,   /* ABTU_malloc(). */
+    ABTU_MEM_LARGEPAGE_MEMALIGN, /* memalign() */
+    ABTU_MEM_LARGEPAGE_MMAP,     /* normal private memory obtained by mmap() */
+    ABTU_MEM_LARGEPAGE_MMAP_HUGEPAGE, /* hugepage obtained by mmap() */
+} ABTU_MEM_LARGEPAGE_TYPE;
+
+/* Returns 1 if a given large page type is supported. */
+int ABTU_is_supported_largepage_type(size_t size, size_t alignment_hint,
+                                     ABTU_MEM_LARGEPAGE_TYPE requested);
+void *ABTU_alloc_largepage(size_t size, size_t alignment_hint,
+                           const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
+                           int num_requested_types,
+                           ABTU_MEM_LARGEPAGE_TYPE *p_actual);
+void ABTU_free_largepage(void *ptr, size_t size, ABTU_MEM_LARGEPAGE_TYPE type);
+
 #define ABTU_strcpy(d, s) strcpy(d, s)
 #define ABTU_strncpy(d, s, n) strncpy(d, s, n)
 

--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -4,5 +4,5 @@
 #
 
 abt_sources += \
-	util/util.c
-
+	util/util.c \
+	util/largepage.c

--- a/src/util/largepage.c
+++ b/src/util/largepage.c
@@ -1,0 +1,134 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abtu.h"
+#include <sys/types.h>
+#include <sys/mman.h>
+
+#define ABTU_LP_PROTS (PROT_READ | PROT_WRITE)
+
+#if defined(HAVE_MAP_ANONYMOUS)
+#define ABTU_LP_FLAGS_RP (MAP_PRIVATE | MAP_ANONYMOUS)
+#define ABTU_LP_USE_MMAP 1
+#elif defined(HAVE_MAP_ANON)
+#define ABTU_LP_FLAGS_RP (MAP_PRIVATE | MAP_ANON)
+#define ABTU_LP_USE_MMAP 1
+#else
+#define ABTU_LP_USE_MMAP 0
+#endif
+
+#if ABTU_LP_USE_MMAP && defined(HAVE_MAP_HUGETLB)
+#define ABTU_LP_FLAGS_HP (ABTU_LP_FLAGS_RP | MAP_HUGETLB)
+#define ABTU_LP_USE_MMAP_HUGEPAGE 1
+#else
+/* NOTE: On Mac OS, we tried VM_FLAGS_SUPERPAGE_SIZE_ANY that is defined in
+ * <mach/vm_statistics.h>, but mmap() failed with it and its execution was too
+ * slow.  By that reason, we do not support it for now. */
+#define ABTU_LP_USE_HUGEPAGE 0
+#endif
+
+static void *ABTU_mmap_regular(size_t size)
+{
+#if ABTU_LP_USE_MMAP
+    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_RP, 0, 0);
+    return p_page != MAP_FAILED ? p_page : NULL;
+#else
+    return NULL;
+#endif
+}
+
+static void *ABTU_mmap_hugepage(size_t size)
+{
+#if ABTU_LP_USE_MMAP && ABTU_LP_USE_MMAP_HUGEPAGE
+    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_HP, 0, 0);
+    return p_page != MAP_FAILED ? p_page : NULL;
+#else
+    return NULL;
+#endif
+}
+
+static void ABTU_munmap(void *p_page, size_t size)
+{
+    munmap(p_page, size);
+}
+
+/* Returns if a given large page type is supported. */
+int ABTU_is_supported_largepage_type(size_t size, size_t alignment_hint,
+                                     ABTU_MEM_LARGEPAGE_TYPE requested)
+{
+    if (requested == ABTU_MEM_LARGEPAGE_MALLOC) {
+        /* It always succeeds. */
+        return 1;
+    } else if (requested == ABTU_MEM_LARGEPAGE_MEMALIGN) {
+        void *p_page = ABTU_memalign(alignment_hint, size);
+        if (p_page) {
+            ABTU_free(p_page);
+            return 1;
+        }
+    } else if (requested == ABTU_MEM_LARGEPAGE_MMAP) {
+        void *p_page = ABTU_mmap_regular(size);
+        if (p_page) {
+            ABTU_munmap(p_page, size);
+            return 1;
+        }
+    } else if (requested == ABTU_MEM_LARGEPAGE_MMAP_HUGEPAGE) {
+        void *p_page = ABTU_mmap_hugepage(size);
+        if (p_page) {
+            ABTU_munmap(p_page, size);
+            return 1;
+        }
+    }
+    /* Not supported. */
+    return 0;
+}
+
+void *ABTU_alloc_largepage(size_t size, size_t alignment_hint,
+                           const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
+                           int num_requested_types,
+                           ABTU_MEM_LARGEPAGE_TYPE *p_actual)
+{
+    int i;
+    for (i = 0; i < num_requested_types; i++) {
+        ABTU_MEM_LARGEPAGE_TYPE requested = requested_types[i];
+        if (requested == ABTU_MEM_LARGEPAGE_MALLOC) {
+            *p_actual = ABTU_MEM_LARGEPAGE_MALLOC;
+            return ABTU_malloc(size);
+        } else if (requested == ABTU_MEM_LARGEPAGE_MEMALIGN) {
+            void *p_page = ABTU_memalign(alignment_hint, size);
+            if (p_page) {
+                *p_actual = ABTU_MEM_LARGEPAGE_MEMALIGN;
+                return p_page;
+            }
+        } else if (requested == ABTU_MEM_LARGEPAGE_MMAP) {
+            void *p_page = ABTU_mmap_regular(size);
+            if (p_page) {
+                *p_actual = ABTU_MEM_LARGEPAGE_MMAP;
+                return p_page;
+            }
+        } else if (requested == ABTU_MEM_LARGEPAGE_MMAP_HUGEPAGE) {
+            void *p_page = ABTU_mmap_hugepage(size);
+            if (p_page) {
+                *p_actual = ABTU_MEM_LARGEPAGE_MMAP_HUGEPAGE;
+                return p_page;
+            }
+        }
+    }
+    return NULL;
+}
+
+void ABTU_free_largepage(void *ptr, size_t size, ABTU_MEM_LARGEPAGE_TYPE type)
+{
+    if (!ptr)
+        return;
+    if (type == ABTU_MEM_LARGEPAGE_MALLOC) {
+        ABTU_free(ptr);
+    } else if (type == ABTU_MEM_LARGEPAGE_MEMALIGN) {
+        ABTU_free(ptr);
+    } else if (type == ABTU_MEM_LARGEPAGE_MMAP) {
+        ABTU_munmap(ptr, size);
+    } else if (type == ABTU_MEM_LARGEPAGE_MMAP_HUGEPAGE) {
+        ABTU_munmap(ptr, size);
+    }
+}


### PR DESCRIPTION
This PR applies code refactoring to `malloc.c` and `abti_mem.h`.

1. Create `ABTU_xxx_largepage()` functions and use them in `malloc.c`.
    - `malloc.c` does not need to handle detailed `mmap` options, which are now handled in `util/largepage.c`.
2. Clean up control flow in `ABTI_mem_alloc_thread()`
    - The current code is too complicated to understand which path is finally taken with a certain situation (e.g., default vs explicit MEMPOOL under external threads). This PR fixes it, though it makes the code a bit longer.

The logic will not be changed by this PR.



