### PR TITLE
Miscellaneous scheduler cleanup

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -20,7 +20,7 @@ void ABTD_thread_func_wrapper_thread(void *p_arg)
     /* NOTE: ctx is located in the beginning of ABTI_thread */
     ABTI_thread *p_thread = (ABTI_thread *)p_ctx;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(p_thread->is_sched == NULL);
+    ABTI_ASSERT(p_thread->p_sched == NULL);
 #endif
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
@@ -37,7 +37,7 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
     /* NOTE: ctx is located in the beginning of ABTI_thread */
     ABTI_thread *p_thread = (ABTI_thread *)p_ctx;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(p_thread->is_sched != NULL);
+    ABTI_ASSERT(p_thread->p_sched != NULL);
 #endif
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
@@ -47,7 +47,7 @@ void ABTD_thread_func_wrapper_sched(void *p_arg)
 void ABTD_thread_exit(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->is_sched) {
+    if (p_thread->p_sched) {
         ABTD_thread_terminate_sched(p_local_xstream, p_thread);
     } else {
 #endif
@@ -83,7 +83,7 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             if (is_sched) {
                 ABTI_thread_finish_context_sched_to_thread(p_local_xstream,
-                                                           p_thread->is_sched,
+                                                           p_thread->p_sched,
                                                            p_joiner);
             } else {
 #endif
@@ -125,10 +125,10 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
      * to the scheduler. */
     ABTI_sched *p_sched;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->is_sched) {
+    if (p_thread->p_sched) {
         /* If p_thread is a scheduler ULT, we have to context switch to
          * the parent scheduler. */
-        p_sched = p_thread->is_sched->p_parent_sched;
+        p_sched = p_thread->p_sched->p_parent_sched;
     } else {
 #endif
         p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
@@ -137,7 +137,7 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
 #endif
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (is_sched) {
-        ABTI_thread_finish_context_sched_to_sched(p_thread->is_sched, p_sched);
+        ABTI_thread_finish_context_sched_to_sched(p_thread->p_sched, p_sched);
     } else {
 #endif
         ABTI_thread_finish_context_thread_to_sched(p_thread, p_sched);

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -128,7 +128,7 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
     if (p_thread->is_sched) {
         /* If p_thread is a scheduler ULT, we have to context switch to
          * the parent scheduler. */
-        p_sched = ABTI_xstream_get_parent_sched(p_thread->p_last_xstream);
+        p_sched = p_thread->is_sched->p_parent_sched;
     } else {
 #endif
         p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -206,13 +206,14 @@ struct ABTI_xstream {
     ABTI_xstream_type type;   /* Type */
     ABTD_atomic_int state;    /* State (ABT_xstream_state) */
     ABTI_sched **scheds;      /* Stack of running schedulers */
-    int max_scheds;           /* Allocation size of the array scheds */
-    int num_scheds;           /* Number of scheds */
     ABTI_spinlock sched_lock; /* Lock for the scheduler management */
+    ABTI_sched *p_main_sched; /* Main scheduler, which is the bottom of the
+                               * linked list of schedulers */
+    ABTI_sched *p_sched_top;  /* The currently running scheduler. This is the
+                               * top of the linked list of schedulers. */
 
     ABTD_atomic_uint32 request; /* Request */
     void *p_req_arg;            /* Request argument */
-    ABTI_sched *p_main_sched;   /* Main scheduler */
 
     ABTD_xstream_context ctx; /* ES context */
 
@@ -241,6 +242,10 @@ struct ABTI_sched {
     ABTI_task *p_task;          /* Associated tasklet */
     ABTD_thread_context *p_ctx; /* Context */
     void *data;                 /* Data for a specific scheduler */
+
+    /* Pointers for a scheduler linked list. */
+    ABTI_sched *p_parent_sched;
+    ABTI_sched *p_child_sched;
 
     /* Scheduler functions */
     ABT_sched_init_fn init;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -323,7 +323,7 @@ struct ABTI_thread {
     ABTD_atomic_uint32 request;   /* Request */
     ABTI_xstream *p_last_xstream; /* Last ES where it ran */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
+    ABTI_sched *p_sched; /* Scheduler */
 #endif
     ABT_unit unit;         /* Unit enclosing this thread */
     ABTI_pool *p_pool;     /* Associated pool */
@@ -364,7 +364,7 @@ struct ABTI_task {
     void (*f_task)(void *);     /* Task function */
     void *p_arg;                /* Task arguments */
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *is_sched; /* If it is a scheduler, its ptr */
+    ABTI_sched *p_sched; /* Scheduler */
 #endif
     ABTI_pool *p_pool;       /* Associated pool */
     ABT_unit unit;           /* Unit enclosing this task */

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -103,11 +103,11 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
                                       ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local_xstream, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    } else if (p_thread->is_sched) {
+    } else if (p_thread->p_sched) {
         /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
         ABTD_atomic_release_store_int(&p_thread->state,
                                       ABT_THREAD_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_local_xstream, p_thread->is_sched);
+        ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched);
 #endif
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
@@ -129,11 +129,11 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
                                       ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    } else if (p_task->is_sched) {
+    } else if (p_task->p_sched) {
         /* NOTE: p_task itself will be freed in ABTI_sched_free. */
         ABTD_atomic_release_store_int(&p_task->state,
                                       ABT_TASK_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_local_xstream, p_task->is_sched);
+        ABTI_sched_discard_and_free(p_local_xstream, p_task->p_sched);
 #endif
     } else {
         /* NOTE: We set the task's state as TERMINATED after checking refcount

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -139,7 +139,7 @@ static inline void ABTI_thread_context_switch_thread_to_thread_internal(
     ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(!p_old->is_sched && !p_new->is_sched);
+    ABTI_ASSERT(!p_old->p_sched && !p_new->p_sched);
 #endif
     p_local_xstream->p_thread = p_new;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -164,7 +164,7 @@ static inline void ABTI_thread_context_switch_thread_to_sched_internal(
     ABTI_thread *p_old, ABTI_sched *p_new, ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(!p_old->is_sched);
+    ABTI_ASSERT(!p_old->p_sched);
 #endif
     ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -187,7 +187,7 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
     ABT_bool is_finish)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(!p_new->is_sched);
+    ABTI_ASSERT(!p_new->p_sched);
 #endif
     ABTI_LOG_SET_SCHED(NULL);
     p_local_xstream->p_thread = p_new;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -349,8 +349,7 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_xstream **pp_local_xstream,
                 stop = ABT_TRUE;
             } else {
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
-                ABTI_sched *p_par_sched;
-                p_par_sched = ABTI_xstream_get_parent_sched(p_local_xstream);
+                ABTI_sched *p_par_sched = p_sched->p_parent_sched;
                 ABTI_thread_context_switch_sched_to_sched(pp_local_xstream,
                                                           p_sched, p_par_sched);
             }
@@ -610,6 +609,8 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     p_sched->p_thread = NULL;
     p_sched->p_task = NULL;
     p_sched->p_ctx = NULL;
+    p_sched->p_parent_sched = NULL;
+    p_sched->p_child_sched = NULL;
 
     p_sched->init = def->init;
     p_sched->run = def->run;

--- a/src/stream.c
+++ b/src/stream.c
@@ -73,11 +73,10 @@ int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream)
     ABTD_atomic_relaxed_store_int(&p_newxstream->state,
                                   ABT_XSTREAM_STATE_RUNNING);
     p_newxstream->scheds = NULL;
-    p_newxstream->num_scheds = 0;
-    p_newxstream->max_scheds = 0;
+    p_newxstream->p_main_sched = NULL;
+    p_newxstream->p_sched_top = NULL;
     ABTD_atomic_relaxed_store_uint32(&p_newxstream->request, 0);
     p_newxstream->p_req_arg = NULL;
-    p_newxstream->p_main_sched = NULL;
     p_newxstream->p_thread = NULL;
     p_newxstream->p_task = NULL;
     ABTI_mem_init_local(p_newxstream);
@@ -220,11 +219,10 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     ABTD_atomic_relaxed_store_int(&p_newxstream->state,
                                   ABT_XSTREAM_STATE_RUNNING);
     p_newxstream->scheds = NULL;
-    p_newxstream->num_scheds = 0;
-    p_newxstream->max_scheds = 0;
+    p_newxstream->p_main_sched = NULL;
+    p_newxstream->p_sched_top = NULL;
     ABTD_atomic_relaxed_store_uint32(&p_newxstream->request, 0);
     p_newxstream->p_req_arg = NULL;
-    p_newxstream->p_main_sched = NULL;
     p_newxstream->p_thread = NULL;
     p_newxstream->p_task = NULL;
     ABTI_mem_init_local(p_newxstream);
@@ -262,8 +260,8 @@ int ABTI_xstream_start(ABTI_xstream *p_local_xstream, ABTI_xstream *p_xstream)
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
                 ABT_XSTREAM_STATE_RUNNING);
 
-    /* Add the main scheduler to the stack of schedulers */
-    ABTI_xstream_push_sched(p_xstream, p_xstream->p_main_sched);
+    /* The main scheduler must be the current scheduler */
+    ABTI_ASSERT(p_xstream->p_main_sched == p_xstream->p_sched_top);
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
         LOG_EVENT("[E%d] start\n", p_xstream->rank);
@@ -336,8 +334,8 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
 {
     int abt_errno = ABT_SUCCESS;
 
-    /* Add the main scheduler to the stack of schedulers */
-    ABTI_xstream_push_sched(p_xstream, p_xstream->p_main_sched);
+    /* The main scheduler should be the current scheduler */
+    ABTI_ASSERT(p_xstream->p_main_sched == p_xstream->p_sched_top);
 
     /* The ES's state must be running here. */
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
@@ -1705,6 +1703,7 @@ int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 
     /* Set the scheduler */
     p_xstream->p_main_sched = p_sched;
+    p_xstream->p_sched_top = p_sched;
 
 fn_exit:
     return abt_errno;
@@ -1772,11 +1771,6 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         ABTI_CHECK_TRUE(p_thread->type == ABTI_THREAD_TYPE_MAIN,
                         ABT_ERR_THREAD);
 
-        /* Free the current main scheduler */
-        abt_errno =
-            ABTI_sched_discard_and_free(*pp_local_xstream, p_main_sched);
-        ABTI_CHECK_ERROR(abt_errno);
-
         /* Since the primary ES does not finish its execution until ABT_finalize
          * is called, its main scheduler needs to be automatically freed when
          * it is freed in ABT_finalize. */
@@ -1785,11 +1779,14 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         ABTI_POOL_PUSH(p_tar_pool, p_thread->unit,
                        ABTI_self_get_native_thread_id(*pp_local_xstream));
 
-        /* Pop the top scheduler */
+        /* Replace the top scheduler with the new scheduler */
         ABTI_xstream_pop_sched(p_xstream);
+        ABTI_xstream_push_sched(p_xstream, p_sched);
 
-        /* Set the scheduler */
-        p_xstream->p_main_sched = p_sched;
+        /* Free the current main scheduler */
+        abt_errno =
+            ABTI_sched_discard_and_free(*pp_local_xstream, p_main_sched);
+        ABTI_CHECK_ERROR(abt_errno);
 
         /* Start the primary ES again because we have to create a sched ULT for
          * the new scheduler */
@@ -1817,7 +1814,8 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         p_xstream->p_main_sched = p_sched;
 
         /* Replace the top scheduler with the new scheduler */
-        ABTI_xstream_replace_top_sched(p_xstream, p_sched);
+        ABTI_xstream_pop_sched(p_xstream);
+        ABTI_xstream_push_sched(p_xstream, p_sched);
 
         /* Switch to the current main scheduler */
         ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_NOPUSH);
@@ -1849,9 +1847,6 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
     }
 
     char *type, *state;
-    char *scheds_str;
-    int i;
-    size_t size, pos;
 
     switch (p_xstream->type) {
         case ABTI_XSTREAM_TYPE_PRIMARY:
@@ -1876,33 +1871,19 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
             break;
     }
 
-    size = sizeof(char) * (p_xstream->num_scheds * 20 + 4);
-    scheds_str = (char *)ABTU_calloc(size, 1);
-    scheds_str[0] = '[';
-    scheds_str[1] = ' ';
-    pos = 2;
-    for (i = 0; i < p_xstream->num_scheds; i++) {
-        sprintf(&scheds_str[pos], "%p ", (void *)p_xstream->scheds[i]);
-        pos = strlen(scheds_str);
-    }
-    scheds_str[pos] = ']';
-
     fprintf(p_os,
             "%s== ES (%p) ==\n"
             "%srank      : %d\n"
             "%stype      : %s\n"
             "%sstate     : %s\n"
             "%srequest   : 0x%x\n"
-            "%smax_scheds: %d\n"
-            "%snum_scheds: %d\n"
-            "%sscheds    : %s\n"
+            "%ssched_top : %p\n"
             "%smain_sched: %p\n",
             prefix, (void *)p_xstream, prefix, p_xstream->rank, prefix, type,
             prefix, state, prefix,
             ABTD_atomic_acquire_load_uint32(&p_xstream->request), prefix,
-            p_xstream->max_scheds, prefix, p_xstream->num_scheds, prefix,
-            scheds_str, prefix, (void *)p_xstream->p_main_sched);
-    ABTU_free(scheds_str);
+            (void *)p_xstream->p_sched_top, prefix,
+            (void *)p_xstream->p_main_sched);
 
     if (print_sub == ABT_TRUE) {
         ABTI_sched_print(p_xstream->p_main_sched, p_os, indent + ABTI_INDENT,

--- a/src/task.c
+++ b/src/task.c
@@ -701,7 +701,7 @@ static int ABTI_task_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newtask->f_task = task_func;
     p_newtask->p_arg = arg;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newtask->is_sched = p_sched;
+    p_newtask->p_sched = p_sched;
 #endif
     p_newtask->p_pool = p_pool;
     p_newtask->refcount = refcount;
@@ -836,7 +836,7 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
             "%sstate     : %s\n"
             "%sES        : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            "%sis_sched  : %p\n"
+            "%sp_sched   : %p\n"
 #endif
             "%spool      : %p\n"
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -849,7 +849,7 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
             prefix, (void *)p_task, prefix, ABTI_task_get_id(p_task), prefix,
             state, prefix, (void *)p_task->p_xstream, xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            prefix, (void *)p_task->is_sched,
+            prefix, (void *)p_task->p_sched,
 #endif
             prefix, (void *)p_task->p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION

--- a/src/thread.c
+++ b/src/thread.c
@@ -792,7 +792,7 @@ int ABT_thread_yield_to(ABT_thread thread)
     /* Add a new scheduler if the ULT is a scheduler */
     if (p_tar_thread->is_sched != NULL) {
         p_tar_thread->is_sched->p_ctx =
-            ABTI_xstream_get_sched_ctx(p_local_xstream);
+            ABTI_xstream_get_top_sched(p_local_xstream)->p_ctx;
         ABTI_xstream_push_sched(p_local_xstream, p_tar_thread->is_sched);
         p_tar_thread->is_sched->state = ABT_SCHED_STATE_RUNNING;
     }

--- a/src/thread.c
+++ b/src/thread.c
@@ -778,9 +778,9 @@ int ABT_thread_yield_to(ABT_thread thread)
 
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Delete the last context if the ULT is a scheduler */
-    if (p_cur_thread->is_sched != NULL) {
+    if (p_cur_thread->p_sched != NULL) {
         ABTI_xstream_pop_sched(p_local_xstream);
-        p_cur_thread->is_sched->state = ABT_SCHED_STATE_STOPPED;
+        p_cur_thread->p_sched->state = ABT_SCHED_STATE_STOPPED;
     }
 #endif
 
@@ -790,11 +790,11 @@ int ABT_thread_yield_to(ABT_thread thread)
 
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Add a new scheduler if the ULT is a scheduler */
-    if (p_tar_thread->is_sched != NULL) {
-        p_tar_thread->is_sched->p_ctx =
+    if (p_tar_thread->p_sched != NULL) {
+        p_tar_thread->p_sched->p_ctx =
             ABTI_xstream_get_top_sched(p_local_xstream)->p_ctx;
-        ABTI_xstream_push_sched(p_local_xstream, p_tar_thread->is_sched);
-        p_tar_thread->is_sched->state = ABT_SCHED_STATE_RUNNING;
+        ABTI_xstream_push_sched(p_local_xstream, p_tar_thread->p_sched);
+        p_tar_thread->p_sched->state = ABT_SCHED_STATE_RUNNING;
     }
 #endif
 
@@ -1466,7 +1466,7 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     ABTD_atomic_release_store_uint32(&p_newthread->request, 0);
     p_newthread->p_last_xstream = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newthread->is_sched = p_sched;
+    p_newthread->p_sched = p_sched;
 #endif
     p_newthread->p_pool = p_pool;
     p_newthread->refcount = refcount;
@@ -1936,7 +1936,7 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             "%sstate   : %s\n"
             "%slast_ES : %p (%d)\n"
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            "%sis_sched: %p\n"
+            "%sp_sched : %p\n"
 #endif
             "%spool    : %p\n"
             "%srefcount: %u\n"
@@ -1950,7 +1950,7 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             prefix, type, prefix, state, prefix, (void *)p_xstream,
             xstream_rank,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            prefix, (void *)p_thread->is_sched,
+            prefix, (void *)p_thread->p_sched,
 #endif
             prefix, (void *)p_thread->p_pool, prefix, p_thread->refcount,
             prefix, ABTD_atomic_acquire_load_uint32(&p_thread->request),
@@ -2173,7 +2173,7 @@ static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     /* Create a ULT context */
     stacksize = p_thread->attr.stacksize;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->is_sched) {
+    if (p_thread->p_sched) {
         abt_errno =
             ABTD_thread_context_create_sched(NULL, thread_func, arg, stacksize,
                                              p_thread->attr.p_stack,


### PR DESCRIPTION
This PR fixes small issues in `ABTI_sched` implementation.
-  Use a linked list instead of an array of `ABTI_sched`. A linked list is simpler and does not require additional memory allocation.
- Rename `is_sched` to `p_sched` since it is actually of `ABTI_sched *` type.

This PR is for cleanup and does not affect the performance. 