### PR TITLE
sched: narrow the gap between scheduler and thread

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -5,12 +5,10 @@
 
 #include "abti.h"
 
-static inline void ABTD_thread_terminate_thread(ABTI_xstream *p_local_xstream,
-                                                ABTI_thread *p_thread);
-static inline void ABTD_thread_terminate_sched(ABTI_xstream *p_local_xstream,
-                                               ABTI_thread *p_thread);
+static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
+                                         ABTI_thread *p_thread);
 
-void ABTD_thread_func_wrapper_thread(void *p_arg)
+void ABTD_thread_func_wrapper(void *p_arg)
 {
     ABTD_thread_context *p_ctx = (ABTD_thread_context *)p_arg;
     void (*thread_func)(void *) = p_ctx->f_thread;
@@ -23,57 +21,20 @@ void ABTD_thread_func_wrapper_thread(void *p_arg)
 
     thread_func(p_ctx->p_arg);
 
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(p_thread->p_sched == NULL);
-#endif
-
     /* This ABTI_local_get_xstream() is controversial since it is called after
      * the context-switchable function (i.e., thread_func()).  We assume that
      * the compiler does not load TLS offset etc before thread_func(). */
     p_local_xstream = ABTI_local_get_xstream();
-    ABTD_thread_terminate_thread(p_local_xstream, p_thread);
-}
-
-void ABTD_thread_func_wrapper_sched(void *p_arg)
-{
-    ABTD_thread_context *p_ctx = (ABTD_thread_context *)p_arg;
-    void (*thread_func)(void *) = p_ctx->f_thread;
-
-    /* NOTE: ctx is located in the beginning of ABTI_thread */
-    ABTI_thread *p_thread = (ABTI_thread *)p_ctx;
-    ABTI_xstream *p_local_xstream = p_thread->p_last_xstream;
-    p_local_xstream->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
-    p_local_xstream->p_thread = p_thread;
-
-    thread_func(p_ctx->p_arg);
-
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_ASSERT(p_thread->p_sched != NULL);
-#endif
-
-    /* This ABTI_local_get_xstream() is controversial since it is called after
-     * the context-switchable function (i.e., thread_func()).  We assume that
-     * the compiler does not load TLS offset etc before thread_func(). */
-    p_local_xstream = ABTI_local_get_xstream();
-    ABTD_thread_terminate_sched(p_local_xstream, p_thread);
+    ABTD_thread_terminate(p_local_xstream, p_thread);
 }
 
 void ABTD_thread_exit(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 {
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->p_sched) {
-        ABTD_thread_terminate_sched(p_local_xstream, p_thread);
-    } else {
-#endif
-        ABTD_thread_terminate_thread(p_local_xstream, p_thread);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    }
-#endif
+    ABTD_thread_terminate(p_local_xstream, p_thread);
 }
 
-static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
-                                          ABTI_thread *p_thread,
-                                          ABT_bool is_sched)
+static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
+                                         ABTI_thread *p_thread)
 {
     ABTD_thread_context *p_ctx = &p_thread->ctx;
     ABTD_thread_context *p_link =
@@ -90,13 +51,9 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
                       ABTI_thread_get_id(p_thread),
                       p_thread->p_last_xstream->rank);
 
-            /* Note that a scheduler-type ULT cannot be a joiner. If a scheduler
-             * type ULT would be a joiner (=suspend), no scheduler is available
-             * when a running ULT needs suspension. Hence, it always jumps to a
-             * non-scheduler-type ULT. */
-            ABTI_ASSERT(!is_sched);
-            ABTI_thread_finish_context_thread_to_thread(p_local_xstream,
-                                                        p_thread, p_joiner);
+            /* Note that a parent ULT cannot be a joiner. */
+            ABTI_thread_finish_context_to_sibling(p_local_xstream, p_thread,
+                                                  p_joiner);
             return;
         } else {
             /* If the current ULT's associated ES is different from p_joiner's,
@@ -140,40 +97,18 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     }
 #endif
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (is_sched) {
-        ABTI_thread_finish_context_sched_to_parent_sched(p_local_xstream,
-                                                         p_thread->p_sched,
-                                                         p_sched);
-    } else {
-#endif
-        ABTI_thread_finish_context_thread_to_sched(p_local_xstream, p_thread,
-                                                   p_sched);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    }
-#endif
-}
-
-static inline void ABTD_thread_terminate_thread(ABTI_xstream *p_local_xstream,
-                                                ABTI_thread *p_thread)
-{
-    ABTDI_thread_terminate(p_local_xstream, p_thread, ABT_FALSE);
-}
-
-static inline void ABTD_thread_terminate_sched(ABTI_xstream *p_local_xstream,
-                                               ABTI_thread *p_thread)
-{
-    ABTDI_thread_terminate(p_local_xstream, p_thread, ABT_TRUE);
+    ABTI_thread_finish_context_to_parent(p_local_xstream, p_thread,
+                                         p_sched->p_thread);
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-void ABTD_thread_terminate_thread_no_arg()
+void ABTD_thread_terminate_no_arg()
 {
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
     ABTI_thread *p_thread = p_local_xstream->p_thread;
-    ABTD_thread_terminate_thread(p_local_xstream, p_thread);
+    ABTD_thread_terminate(p_local_xstream, p_thread);
 }
 #endif
 

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -80,18 +80,9 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
              * type ULT would be a joiner (=suspend), no scheduler is available
              * when a running ULT needs suspension. Hence, it always jumps to a
              * non-scheduler-type ULT. */
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            if (is_sched) {
-                ABTI_thread_finish_context_sched_to_thread(p_local_xstream,
-                                                           p_thread->p_sched,
-                                                           p_joiner);
-            } else {
-#endif
-                ABTI_thread_finish_context_thread_to_thread(p_local_xstream,
-                                                            p_thread, p_joiner);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            }
-#endif
+            ABTI_ASSERT(!is_sched);
+            ABTI_thread_finish_context_thread_to_thread(p_local_xstream,
+                                                        p_thread, p_joiner);
             return;
         } else {
             /* If the current ULT's associated ES is different from p_joiner's,

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -137,7 +137,8 @@ static inline void ABTDI_thread_terminate(ABTI_xstream *p_local_xstream,
 #endif
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (is_sched) {
-        ABTI_thread_finish_context_sched_to_sched(p_thread->p_sched, p_sched);
+        ABTI_thread_finish_context_sched_to_parent_sched(p_thread->p_sched,
+                                                         p_sched);
     } else {
 #endif
         ABTI_thread_finish_context_thread_to_sched(p_thread, p_sched);

--- a/src/global.c
+++ b/src/global.c
@@ -184,8 +184,10 @@ int ABT_finalize(void)
     }
 
     /* Remove the primary ULT */
-    ABTI_thread_free_main(p_local_xstream, p_thread);
+    ABTI_ASSERT(p_local_xstream->p_thread == p_thread);
+    ABTI_ASSERT(p_local_xstream->p_task == NULL);
     p_local_xstream->p_thread = NULL;
+    ABTI_thread_free_main(p_local_xstream, p_thread);
 
     /* Free the primary ES */
     abt_errno = ABTI_xstream_free(p_local_xstream, p_local_xstream);

--- a/src/global.c
+++ b/src/global.c
@@ -175,8 +175,8 @@ int ABT_finalize(void)
         /* Switch to the top scheduler */
         ABTI_sched *p_sched =
             ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-        ABTI_thread_context_switch_thread_to_sched(&p_local_xstream, p_thread,
-                                                   p_sched);
+        ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread,
+                                             p_sched->p_thread);
 
         /* Back to the original thread */
         LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -240,7 +240,6 @@ struct ABTI_sched {
     int num_pools;              /* Number of work unit pools */
     ABTI_thread *p_thread;      /* Associated ULT */
     ABTI_task *p_task;          /* Associated tasklet */
-    ABTD_thread_context *p_ctx; /* Context */
     void *data;                 /* Data for a specific scheduler */
 
     /* Pointers for a scheduler linked list. */

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -9,11 +9,6 @@
 #include "abt_config.h"
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-typedef struct {
-    ABTI_sched *p_sched;
-} ABTI_log;
-
-extern ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log;
 
 void ABTI_log_print(FILE *fh, const char *format, ...);
 void ABTI_log_event(FILE *fh, const char *format, ...);
@@ -24,18 +19,6 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           ABTI_native_thread_id consumer_id);
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
-static inline void ABTI_log_set_sched(ABTI_sched *p_sched)
-{
-    l_ABTI_log.p_sched = p_sched;
-}
-
-static inline ABTI_sched *ABTI_log_get_sched(void)
-{
-    return l_ABTI_log.p_sched;
-}
-
-#define ABTI_LOG_SET_SCHED(s) ABTI_log_set_sched(s)
-#define ABTI_LOG_GET_SCHED(ret) ret = ABTI_log_get_sched()
 #define LOG_EVENT(fmt, ...) ABTI_log_event(stderr, fmt, __VA_ARGS__)
 #define LOG_DEBUG(fmt, ...)                                                    \
     ABTI_log_debug(stderr, __FILE__, __LINE__, fmt, __VA_ARGS__)
@@ -47,9 +30,6 @@ static inline ABTI_sched *ABTI_log_get_sched(void)
 #define LOG_EVENT_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
 
 #else
-
-#define ABTI_LOG_SET_SCHED(s)
-#define ABTI_LOG_GET_SCHED(ret)
 
 #define LOG_EVENT(fmt, ...)
 #define LOG_DEBUG(fmt, ...)

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -268,66 +268,46 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
 }
 
 /* Return the previous thread. */
-static inline ABTI_thread *ABTI_thread_context_switch_thread_to_thread(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABTI_thread *p_new)
+static inline ABTI_thread *
+ABTI_thread_context_switch_to_sibling(ABTI_xstream **pp_local_xstream,
+                                      ABTI_thread *p_old, ABTI_thread *p_new)
 {
     return ABTI_thread_context_switch_to_sibling_internal(pp_local_xstream,
                                                           p_old, p_new,
                                                           ABT_FALSE);
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_thread_to_sched(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABTI_sched *p_new)
+static inline ABTI_thread *
+ABTI_thread_context_switch_to_parent(ABTI_xstream **pp_local_xstream,
+                                     ABTI_thread *p_old, ABTI_thread *p_new)
 {
     return ABTI_thread_context_switch_to_parent_internal(pp_local_xstream,
-                                                         p_old, p_new->p_thread,
+                                                         p_old, p_new,
                                                          ABT_FALSE);
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_sched_to_thread(
-    ABTI_xstream **pp_local_xstream, ABTI_sched *p_old, ABTI_thread *p_new)
+static inline ABTI_thread *
+ABTI_thread_context_switch_to_child(ABTI_xstream **pp_local_xstream,
+                                    ABTI_thread *p_old, ABTI_thread *p_new)
 {
-    return ABTI_thread_context_switch_to_child_internal(pp_local_xstream,
-                                                        p_old->p_thread, p_new);
+    return ABTI_thread_context_switch_to_child_internal(pp_local_xstream, p_old,
+                                                        p_new);
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_sched_to_parent_sched(
-    ABTI_xstream **pp_local_xstream, ABTI_sched *p_old, ABTI_sched *p_new)
-{
-    return ABTI_thread_context_switch_to_parent_internal(pp_local_xstream,
-                                                         p_old->p_thread,
-                                                         p_new->p_thread,
-                                                         ABT_FALSE);
-}
-
-static inline ABTI_thread *ABTI_thread_context_switch_sched_to_child_sched(
-    ABTI_xstream **pp_local_xstream, ABTI_sched *p_old, ABTI_sched *p_new)
-{
-    return ABTI_thread_context_switch_to_child_internal(pp_local_xstream,
-                                                        p_old->p_thread,
-                                                        p_new->p_thread);
-}
-
-static inline void ABTI_thread_finish_context_thread_to_thread(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_old, ABTI_thread *p_new)
+static inline void
+ABTI_thread_finish_context_to_sibling(ABTI_xstream *p_local_xstream,
+                                      ABTI_thread *p_old, ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_to_sibling_internal(&p_local_xstream, p_old,
                                                    p_new, ABT_TRUE);
 }
 
-static inline void ABTI_thread_finish_context_thread_to_sched(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_old, ABTI_sched *p_new)
+static inline void
+ABTI_thread_finish_context_to_parent(ABTI_xstream *p_local_xstream,
+                                     ABTI_thread *p_old, ABTI_thread *p_new)
 {
     ABTI_thread_context_switch_to_parent_internal(&p_local_xstream, p_old,
-                                                  p_new->p_thread, ABT_TRUE);
-}
-
-static inline void ABTI_thread_finish_context_sched_to_parent_sched(
-    ABTI_xstream *p_local_xstream, ABTI_sched *p_old, ABTI_sched *p_new)
-{
-    ABTI_thread_context_switch_to_parent_internal(&p_local_xstream,
-                                                  p_old->p_thread,
-                                                  p_new->p_thread, ABT_TRUE);
+                                                  p_new, ABT_TRUE);
 }
 
 static inline void
@@ -368,8 +348,8 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
 
     /* Switch to the top scheduler */
     p_sched = ABTI_xstream_get_top_sched(p_thread->p_last_xstream);
-    ABTI_thread_context_switch_thread_to_sched(pp_local_xstream, p_thread,
-                                               p_sched);
+    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
+                                         p_sched->p_thread);
 
     /* Back to the original thread */
     LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -166,7 +166,6 @@ static inline void ABTI_thread_context_switch_thread_to_sched_internal(
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_old->p_sched);
 #endif
-    ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old is discarded. */
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old))
@@ -189,7 +188,6 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     ABTI_ASSERT(!p_new->p_sched);
 #endif
-    ABTI_LOG_SET_SCHED(NULL);
     p_local_xstream->p_thread = p_new;
     p_local_xstream->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -245,7 +243,6 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
                 }
             }
         }
-        ABTI_LOG_SET_SCHED(p_old);
         return;
     }
 #endif
@@ -259,7 +256,6 @@ static inline void ABTI_thread_context_switch_sched_to_thread_internal(
 static inline void ABTI_thread_context_switch_sched_to_sched_internal(
     ABTI_sched *p_old, ABTI_sched *p_new, ABT_bool is_finish)
 {
-    ABTI_LOG_SET_SCHED(p_new);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Schedulers' contexts must be initialized eagerly. */
     ABTI_ASSERT(!p_old->p_thread ||

--- a/src/log.c
+++ b/src/log.c
@@ -8,7 +8,6 @@
 #include "abti.h"
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
-ABTD_XSTREAM_LOCAL ABTI_log l_ABTI_log = { NULL };
 
 void ABTI_log_print(FILE *fh, const char *format, ...)
 {
@@ -56,26 +55,16 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
                     }
                 } else {
                     rank = p_local_xstream->rank;
-                    if (l_ABTI_log.p_sched) {
-                        prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                        tid = l_ABTI_log.p_sched->id;
-                    } else {
-                        prefix_fmt = "<U%" PRIu64 ":E%d> %s";
-                        tid = ABTI_thread_get_id(p_thread);
-                    }
+                    prefix_fmt = "<U%" PRIu64 ":E%d> %s";
+                    tid = ABTI_thread_get_id(p_thread);
                 }
                 break;
 
             case ABT_UNIT_TYPE_TASK:
                 rank = p_local_xstream->rank;
                 p_task = p_local_xstream->p_task;
-                if (l_ABTI_log.p_sched) {
-                    prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                    tid = l_ABTI_log.p_sched->id;
-                } else {
-                    prefix_fmt = "<T%" PRIu64 ":E%d> %s";
-                    tid = ABTI_task_get_id(p_task);
-                }
+                prefix_fmt = "<T%" PRIu64 ":E%d> %s";
+                tid = p_task ? ABTI_task_get_id(p_task) : 0;
                 break;
 
             case ABT_UNIT_TYPE_EXT:

--- a/src/log.c
+++ b/src/log.c
@@ -55,16 +55,34 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
                     }
                 } else {
                     rank = p_local_xstream->rank;
-                    prefix_fmt = "<U%" PRIu64 ":E%d> %s";
-                    tid = ABTI_thread_get_id(p_thread);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+                    if (p_thread->p_sched) {
+                        prefix_fmt = "<S%" PRIu64 ":E%d> %s";
+                        tid = p_thread->p_sched->id;
+                    } else {
+#endif
+                        prefix_fmt = "<U%" PRIu64 ":E%d> %s";
+                        tid = ABTI_thread_get_id(p_thread);
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+                    }
+#endif
                 }
                 break;
 
             case ABT_UNIT_TYPE_TASK:
                 rank = p_local_xstream->rank;
                 p_task = p_local_xstream->p_task;
-                prefix_fmt = "<T%" PRIu64 ":E%d> %s";
-                tid = p_task ? ABTI_task_get_id(p_task) : 0;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+                if (p_task->p_sched) {
+                    prefix_fmt = "<S%" PRIu64 ":E%d> %s";
+                    tid = p_task->p_sched->id;
+                } else {
+#endif
+                    prefix_fmt = "<T%" PRIu64 ":E%d> %s";
+                    tid = p_task ? ABTI_task_get_id(p_task) : 0;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+                }
+#endif
                 break;
 
             case ABT_UNIT_TYPE_EXT:

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -573,8 +573,7 @@ handover:
         ;
     ABTI_pool_dec_num_blocked(p_next->p_pool);
     ABTD_atomic_release_store_int(&p_next->state, ABT_THREAD_STATE_RUNNING);
-    ABTI_thread_context_switch_thread_to_thread(pp_local_xstream, p_thread,
-                                                p_next);
+    ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread, p_next);
 #endif
 
     return abt_errno;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -350,8 +350,8 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_xstream **pp_local_xstream,
             } else {
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
                 ABTI_sched *p_par_sched = p_sched->p_parent_sched;
-                ABTI_thread_context_switch_sched_to_sched(pp_local_xstream,
-                                                          p_sched, p_par_sched);
+                ABTI_thread_context_switch_sched_to_parent_sched(
+                    pp_local_xstream, p_sched, p_par_sched);
             }
         }
     }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -350,8 +350,9 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_xstream **pp_local_xstream,
             } else {
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
                 ABTI_sched *p_par_sched = p_sched->p_parent_sched;
-                ABTI_thread_context_switch_sched_to_parent_sched(
-                    pp_local_xstream, p_sched, p_par_sched);
+                ABTI_thread_context_switch_to_parent(pp_local_xstream,
+                                                     p_sched->p_thread,
+                                                     p_par_sched->p_thread);
             }
         }
     }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -810,6 +810,9 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched)
     /* Free the associated work unit */
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         if (p_sched->p_thread) {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+            p_sched->p_thread->p_sched = NULL;
+#endif
             if (p_sched->p_thread->type == ABTI_THREAD_TYPE_MAIN_SCHED) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
             } else {
@@ -818,6 +821,9 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched)
         }
     } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
         if (p_sched->p_task) {
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+            p_sched->p_task->p_sched = NULL;
+#endif
             ABTI_task_free(p_local_xstream, p_sched->p_task);
         }
     }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -608,7 +608,6 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     p_sched->type = def->type;
     p_sched->p_thread = NULL;
     p_sched->p_task = NULL;
-    p_sched->p_ctx = NULL;
     p_sched->p_parent_sched = NULL;
     p_sched->p_child_sched = NULL;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1445,7 +1445,6 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Add the new scheduler if the ULT is a scheduler */
     if (p_thread->p_sched != NULL) {
-        p_thread->p_sched->p_ctx = &p_thread->ctx;
         ABTI_xstream_push_sched(p_local_xstream, p_thread->p_sched);
         p_thread->p_sched->state = ABT_SCHED_STATE_RUNNING;
     }
@@ -1592,7 +1591,6 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
         ABTI_sched *current_sched = ABTI_xstream_get_top_sched(p_local_xstream);
         ABTI_thread *p_last_thread = current_sched->p_thread;
 
-        p_task->p_sched->p_ctx = current_sched->p_ctx;
         ABTI_xstream_push_sched(p_local_xstream, p_task->p_sched);
         p_task->p_sched->state = ABT_SCHED_STATE_RUNNING;
         p_task->p_sched->p_thread = p_last_thread;
@@ -1798,7 +1796,6 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         /* If the ES is secondary, we should take the associated ULT of the
          * current main scheduler and keep it in the new scheduler. */
         p_sched->p_thread = p_main_sched->p_thread;
-        p_sched->p_ctx = p_main_sched->p_ctx;
 
         /* The current ULT is pushed to the new scheduler's pool so that when
          * the new scheduler starts (see below), it can be scheduled by the new

--- a/src/stream.c
+++ b/src/stream.c
@@ -1801,7 +1801,6 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         /* If the ES is secondary, we should take the associated ULT of the
          * current main scheduler and keep it in the new scheduler. */
         p_sched->p_thread = p_main_sched->p_thread;
-
         /* The current ULT is pushed to the new scheduler's pool so that when
          * the new scheduler starts (see below), it can be scheduled by the new
          * scheduler. When the current ULT resumes its execution, it will free
@@ -1824,6 +1823,9 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         /* Now, we free the current main scheduler. p_main_sched->p_thread must
          * be NULL to avoid freeing it in ABTI_sched_discard_and_free(). */
         p_main_sched->p_thread = NULL;
+#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
+        p_sched->p_thread->p_sched = p_sched;
+#endif
         abt_errno =
             ABTI_sched_discard_and_free(*pp_local_xstream, p_main_sched);
         ABTI_CHECK_ERROR(abt_errno);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1408,6 +1408,12 @@ void ABTI_xstream_schedule(void *p_arg)
     ABTD_atomic_release_store_int(&p_xstream->state,
                                   ABT_XSTREAM_STATE_TERMINATED);
     LOG_EVENT("[E%d] terminated\n", p_xstream->rank);
+
+    if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
+        /* Let us jump back to the main thread. */
+        ABTI_thread_finish_context_sched_to_main_thread(
+            p_xstream->p_main_sched);
+    }
 }
 
 int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,

--- a/src/stream.c
+++ b/src/stream.c
@@ -1799,7 +1799,6 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * current main scheduler and keep it in the new scheduler. */
         p_sched->p_thread = p_main_sched->p_thread;
         p_sched->p_ctx = p_main_sched->p_ctx;
-        p_main_sched->p_thread = NULL;
 
         /* The current ULT is pushed to the new scheduler's pool so that when
          * the new scheduler starts (see below), it can be scheduled by the new
@@ -1820,7 +1819,9 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         ABTI_thread_context_switch_thread_to_sched(pp_local_xstream, p_thread,
                                                    p_main_sched);
 
-        /* Now, we free the current main scheduler */
+        /* Now, we free the current main scheduler. p_main_sched->p_thread must
+         * be NULL to avoid freeing it in ABTI_sched_discard_and_free(). */
+        p_main_sched->p_thread = NULL;
         abt_errno =
             ABTI_sched_discard_and_free(*pp_local_xstream, p_main_sched);
         ABTI_CHECK_ERROR(abt_errno);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1457,8 +1457,9 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_local_xstream);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_thread->p_sched != NULL) {
-        ABTI_thread_context_switch_sched_to_sched(pp_local_xstream, p_sched,
-                                                  p_thread->p_sched);
+        ABTI_thread_context_switch_sched_to_child_sched(pp_local_xstream,
+                                                        p_sched,
+                                                        p_thread->p_sched);
         /* The scheduler continues from here. */
         p_local_xstream = *pp_local_xstream;
         /* Because of the stackable scheduler concept, the previous ULT must

--- a/src/thread.c
+++ b/src/thread.c
@@ -791,8 +791,6 @@ int ABT_thread_yield_to(ABT_thread thread)
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Add a new scheduler if the ULT is a scheduler */
     if (p_tar_thread->p_sched != NULL) {
-        p_tar_thread->p_sched->p_ctx =
-            ABTI_xstream_get_top_sched(p_local_xstream)->p_ctx;
         ABTI_xstream_push_sched(p_local_xstream, p_tar_thread->p_sched);
         p_tar_thread->p_sched->state = ABT_SCHED_STATE_RUNNING;
     }
@@ -1669,7 +1667,6 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_local_xstream,
 
     /* Return value */
     p_sched->p_thread = p_newthread;
-    p_sched->p_ctx = &p_newthread->ctx;
 
 fn_exit:
     return abt_errno;

--- a/src/thread.c
+++ b/src/thread.c
@@ -802,8 +802,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     /* Switch the context */
     ABTD_atomic_release_store_int(&p_tar_thread->state,
                                   ABT_THREAD_STATE_RUNNING);
-    ABTI_thread_context_switch_thread_to_thread(&p_local_xstream, p_cur_thread,
-                                                p_tar_thread);
+    ABTI_thread_context_switch_to_sibling(&p_local_xstream, p_cur_thread,
+                                          p_tar_thread);
 
 fn_exit:
     return abt_errno;
@@ -1443,9 +1443,9 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 #if ABT_CONFIG_THREAD_TYPE != ABT_THREAD_TYPE_DYNAMIC_PROMOTION
         size_t stack_size = p_newthread->attr.stacksize;
         void *p_stack = p_newthread->attr.p_stack;
-        abt_errno = ABTD_thread_context_create_thread(NULL, thread_func, arg,
-                                                      stack_size, p_stack,
-                                                      &p_newthread->ctx);
+        abt_errno =
+            ABTD_thread_context_create(NULL, thread_func, arg, stack_size,
+                                       p_stack, &p_newthread->ctx);
 #else
         /* The context is not fully created now. */
         abt_errno =
@@ -1455,8 +1455,8 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         size_t stack_size = p_newthread->attr.stacksize;
         void *p_stack = p_newthread->attr.p_stack;
         abt_errno =
-            ABTD_thread_context_create_sched(NULL, thread_func, arg, stack_size,
-                                             p_stack, &p_newthread->ctx);
+            ABTD_thread_context_create(NULL, thread_func, arg, stack_size,
+                                       p_stack, &p_newthread->ctx);
     }
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -1815,8 +1815,8 @@ void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream, ABTI_thread *p_thread)
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_local_xstream);
     LOG_EVENT("[U%" PRIu64 ":E%d] suspended\n", ABTI_thread_get_id(p_thread),
               p_local_xstream->rank);
-    ABTI_thread_context_switch_thread_to_sched(pp_local_xstream, p_thread,
-                                               p_sched);
+    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
+                                         p_sched->p_thread);
 
     /* The suspended ULT resumes its execution from here. */
     LOG_EVENT("[U%" PRIu64 ":E%d] resumed\n", ABTI_thread_get_id(p_thread),
@@ -2169,21 +2169,9 @@ static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 
     /* Create a ULT context */
     stacksize = p_thread->attr.stacksize;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->p_sched) {
-        abt_errno =
-            ABTD_thread_context_create_sched(NULL, thread_func, arg, stacksize,
-                                             p_thread->attr.p_stack,
-                                             &p_thread->ctx);
-    } else {
-#endif
-        abt_errno =
-            ABTD_thread_context_create_thread(NULL, thread_func, arg, stacksize,
-                                              p_thread->attr.p_stack,
-                                              &p_thread->ctx);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    }
-#endif
+    abt_errno =
+        ABTD_thread_context_create(NULL, thread_func, arg, stacksize,
+                                   p_thread->attr.p_stack, &p_thread->ctx);
     ABTI_CHECK_ERROR(abt_errno);
 
     ABTD_atomic_relaxed_store_int(&p_thread->state, ABT_THREAD_STATE_READY);
@@ -2293,8 +2281,8 @@ static inline int ABTI_thread_join(ABTI_xstream **pp_local_xstream,
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch the context */
-        ABTI_thread_context_switch_thread_to_thread(pp_local_xstream, p_self,
-                                                    p_thread);
+        ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_self,
+                                              p_thread);
         p_local_xstream = *pp_local_xstream;
 
     } else if ((p_self->p_pool != p_thread->p_pool) &&

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -254,8 +254,8 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         /* Context-switch to p_target */
         ABTD_atomic_release_store_int(&p_target->state,
                                       ABT_THREAD_STATE_RUNNING);
-        ABTI_thread_context_switch_thread_to_thread(pp_local_xstream, p_thread,
-                                                    p_target);
+        ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
+                                              p_target);
         return ABT_TRUE;
     } else {
         return ABT_FALSE;


### PR DESCRIPTION
## Problem

In Argobots, a scheduler (`ABTI_sched`) is treated like a first-class schedulable work unit though its underlying implementation is either a ULT or a tasklet. This work unit type creates a weird context called *a scheduler context*, which is visible to users in a user-defined scheduler. As mentioned in #170, this scheduler context is restricted by the underlying implementation (i.e., ULT or tasklet), but also has its own semantics (e.g., `ABT_self_xxx()` is disallowed). In the Argobots runtime, this scheduler handling is a mess (e.g., `ABTI_LOG_SET_SCHED()`).  Since essentially a scheduler is (and should be) a ULT in terms of threading capabilities, we should narrow this gap as much as possible.

## Solution

This PR does not fix all the issues, but it removes most part of special handling for scheduler contexts in Argobots.  Now a stackable scheduler can be simply invoked as a thread.

## Known impact

This PR adds a small overhead on context switching since it adds flag updates that are not performed in scheduler contexts. This flag management is unavoidable to unify the contexts (especially in order to treat a scheduler like a normal ULT).

This does not break the current API.
