### PR TITLE
sched: use a ULT for a tasklet-type stackable scheduler

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -16,7 +16,7 @@ void ABTD_thread_func_wrapper(void *p_arg)
     /* NOTE: ctx is located in the beginning of ABTI_thread */
     ABTI_thread *p_thread = (ABTI_thread *)p_ctx;
     ABTI_xstream *p_local_xstream = p_thread->p_last_xstream;
-    p_local_xstream->p_task = NULL; /* A tasklet scheduler can invoke ULT. */
+    ABTI_ASSERT(p_local_xstream->p_task == NULL);
     p_local_xstream->p_thread = p_thread;
 
     thread_func(p_ctx->p_arg);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -239,7 +239,6 @@ struct ABTI_sched {
     ABT_pool *pools;            /* Work unit pools */
     int num_pools;              /* Number of work unit pools */
     ABTI_thread *p_thread;      /* Associated ULT */
-    ABTI_task *p_task;          /* Associated tasklet */
     void *data;                 /* Data for a specific scheduler */
 
     /* Pointers for a scheduler linked list. */
@@ -362,14 +361,11 @@ struct ABTI_task {
     ABTD_atomic_uint32 request; /* Request */
     void (*f_task)(void *);     /* Task function */
     void *p_arg;                /* Task arguments */
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *p_sched; /* Scheduler */
-#endif
-    ABTI_pool *p_pool;       /* Associated pool */
-    ABT_unit unit;           /* Unit enclosing this task */
-    ABTI_unit unit_def;      /* Internal unit definition */
-    uint32_t refcount;       /* Reference count */
-    ABTI_ktable *p_keytable; /* Tasklet-specific data */
+    ABTI_pool *p_pool;          /* Associated pool */
+    ABT_unit unit;              /* Unit enclosing this task */
+    ABTI_unit unit_def;         /* Internal unit definition */
+    uint32_t refcount;          /* Reference count */
+    ABTI_ktable *p_keytable;    /* Tasklet-specific data */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABT_bool migratable; /* Migratability */
 #endif
@@ -593,8 +589,6 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
                                        ABTI_thread_htable *p_htable);
 
 /* Tasklet */
-int ABTI_task_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
-                           ABTI_sched *p_sched);
 void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task);
 void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent);
 void ABTI_task_reset_id(void);

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -128,13 +128,6 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
         ABTD_atomic_release_store_int(&p_task->state,
                                       ABT_TASK_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    } else if (p_task->p_sched) {
-        /* NOTE: p_task itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_release_store_int(&p_task->state,
-                                      ABT_TASK_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_local_xstream, p_task->p_sched);
-#endif
     } else {
         /* NOTE: We set the task's state as TERMINATED after checking refcount
          * because the task can be freed on a different ES.  In other words, we

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -202,8 +202,7 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
         LOG_EVENT("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
                   ABTI_thread_get_id(p_new));
         p_local_xstream = *pp_local_xstream;
-        p_local_xstream->p_task =
-            NULL; /* A tasklet scheduler can invoke ULT. */
+        ABTI_ASSERT(p_local_xstream->p_task == NULL);
         p_local_xstream->p_thread = p_new;
         ABTD_thread_context_make_and_call(&p_old->ctx, p_new->ctx.f_thread,
                                           p_new->ctx.p_arg, p_stacktop);

--- a/src/log.c
+++ b/src/log.c
@@ -72,17 +72,8 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
             case ABT_UNIT_TYPE_TASK:
                 rank = p_local_xstream->rank;
                 p_task = p_local_xstream->p_task;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-                if (p_task->p_sched) {
-                    prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                    tid = p_task->p_sched->id;
-                } else {
-#endif
-                    prefix_fmt = "<T%" PRIu64 ":E%d> %s";
-                    tid = p_task ? ABTI_task_get_id(p_task) : 0;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-                }
-#endif
+                prefix_fmt = "<T%" PRIu64 ":E%d> %s";
+                tid = p_task ? ABTI_task_get_id(p_task) : 0;
                 break;
 
             case ABT_UNIT_TYPE_EXT:

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -492,15 +492,11 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_INV_SCHED);
     p_sched->used = ABTI_SCHED_IN_POOL;
 
-    if (p_sched->type == ABT_SCHED_TYPE_ULT) {
-        abt_errno = ABTI_thread_create_sched(p_local_xstream, p_pool, p_sched);
-        ABTI_CHECK_ERROR(abt_errno);
-    } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
-        abt_errno = ABTI_task_create_sched(p_local_xstream, p_pool, p_sched);
-        ABTI_CHECK_ERROR(abt_errno);
-    } else {
-        ABTI_CHECK_TRUE(0, ABT_ERR_SCHED);
-    }
+    /* In both ABT_SCHED_TYPE_ULT and ABT_SCHED_TYPE_TASK cases, we use ULT-type
+     * scheduler to reduce the code maintenance cost.  ABT_SCHED_TYPE_TASK
+     * should be removed in the future. */
+    abt_errno = ABTI_thread_create_sched(p_local_xstream, p_pool, p_sched);
+    ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:
     return abt_errno;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -608,7 +608,6 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     p_sched->num_pools = num_pools;
     p_sched->type = def->type;
     p_sched->p_thread = NULL;
-    p_sched->p_task = NULL;
     p_sched->p_parent_sched = NULL;
     p_sched->p_child_sched = NULL;
 
@@ -820,11 +819,12 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched)
             }
         }
     } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
-        if (p_sched->p_task) {
+        /* The underlying implementation is ULT. */
+        if (p_sched->p_thread) {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            p_sched->p_task->p_sched = NULL;
+            p_sched->p_thread->p_sched = NULL;
 #endif
-            ABTI_task_free(p_local_xstream, p_sched->p_task);
+            ABTI_thread_free(p_local_xstream, p_sched->p_thread);
         }
     }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1681,7 +1681,6 @@ int ABTI_thread_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                              ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_newthread;
     ABTI_thread_attr attr;
 
     /* If p_sched is reused, ABTI_thread_revive() can be used. */
@@ -1702,7 +1701,7 @@ int ABTI_thread_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                                     (void (*)(void *))p_sched->run,
                                     (void *)ABTI_sched_get_handle(p_sched),
                                     &attr, ABTI_THREAD_TYPE_USER, p_sched, 1,
-                                    NULL, ABT_TRUE, &p_newthread);
+                                    NULL, ABT_TRUE, &p_sched->p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:


### PR DESCRIPTION
The current implementation allows a tasklet-type stackable scheduler, which is very restrictive in terms of functionality though it can reduce only little overheads since basically schedulers are not invoked frequently. 

This PR modifies a tasklet-type stackable scheduler to use a ULT internally, while it keeps the external interface that allows users to specify a tasklet type (i.e., Argobots still accepts `ABT_SCHED_TYPE_TASK`). It can simplify the implementation in Argobots.

Note that this does not break the existing API and its semantics since previously there was no way for users to get an underlying work unit implementation in a scheduler context.