### PR TITLE
log: replace LOG_EVENT() with LOG_DEBUG() 

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -47,7 +47,7 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
              * we can jump to the joiner ULT. */
             ABTD_atomic_release_store_int(&p_thread->state,
                                           ABT_THREAD_STATE_TERMINATED);
-            LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n",
+            LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n",
                       ABTI_thread_get_id(p_thread),
                       p_thread->p_last_xstream->rank);
 

--- a/src/global.c
+++ b/src/global.c
@@ -169,7 +169,7 @@ int ABT_finalize(void)
         /* Set the orphan request for the primary ULT */
         ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
 
-        LOG_EVENT("[U%" PRIu64 ":E%d] yield to scheduler\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] yield to scheduler\n",
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch to the top scheduler */
@@ -179,7 +179,7 @@ int ABT_finalize(void)
                                              p_sched->p_thread);
 
         /* Back to the original thread */
-        LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
     }
 

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -23,20 +23,20 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 #define LOG_DEBUG(fmt, ...)                                                    \
     ABTI_log_debug(stderr, __FILE__, __LINE__, fmt, __VA_ARGS__)
 
-#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)                          \
+#define LOG_DEBUG_POOL_PUSH(p_pool, unit, produer_id)                          \
     ABTI_log_pool_push(p_pool, unit, produer_id)
-#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id)                       \
+#define LOG_DEBUG_POOL_REMOVE(p_pool, unit, consumer_id)                       \
     ABTI_log_pool_remove(p_pool, unit, consumer_id)
-#define LOG_EVENT_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
+#define LOG_DEBUG_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
 
 #else
 
 #define LOG_EVENT(fmt, ...)
 #define LOG_DEBUG(fmt, ...)
 
-#define LOG_EVENT_POOL_PUSH(p_pool, unit, produer_id)
-#define LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id)
-#define LOG_EVENT_POOL_POP(p_pool, unit)
+#define LOG_DEBUG_POOL_PUSH(p_pool, unit, produer_id)
+#define LOG_DEBUG_POOL_REMOVE(p_pool, unit, consumer_id)
+#define LOG_DEBUG_POOL_POP(p_pool, unit)
 
 #endif /* ABT_CONFIG_USE_DEBUG_LOG */
 

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -11,17 +11,14 @@
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 
 void ABTI_log_print(FILE *fh, const char *format, ...);
-void ABTI_log_event(FILE *fh, const char *format, ...);
-void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...);
+void ABTI_log_debug(FILE *fh, const char *format, ...);
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                         ABTI_native_thread_id producer_id);
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
                           ABTI_native_thread_id consumer_id);
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
-#define LOG_EVENT(fmt, ...) ABTI_log_event(stderr, fmt, __VA_ARGS__)
-#define LOG_DEBUG(fmt, ...)                                                    \
-    ABTI_log_debug(stderr, __FILE__, __LINE__, fmt, __VA_ARGS__)
+#define LOG_DEBUG(fmt, ...) ABTI_log_debug(stderr, fmt, __VA_ARGS__)
 
 #define LOG_DEBUG_POOL_PUSH(p_pool, unit, produer_id)                          \
     ABTI_log_pool_push(p_pool, unit, produer_id)
@@ -31,7 +28,6 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
 #else
 
-#define LOG_EVENT(fmt, ...)
 #define LOG_DEBUG(fmt, ...)
 
 #define LOG_DEBUG_POOL_PUSH(p_pool, unit, produer_id)

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -10,7 +10,6 @@
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 
-void ABTI_log_print(FILE *fh, const char *format, ...);
 void ABTI_log_debug(FILE *fh, const char *format, ...);
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
                         ABTI_native_thread_id producer_id);

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -65,7 +65,7 @@ static inline void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
 static inline void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 {
-    LOG_EVENT_POOL_PUSH(p_pool, unit,
+    LOG_DEBUG_POOL_PUSH(p_pool, unit,
                         ABTI_self_get_native_thread_id(
                             ABTI_local_get_xstream()));
 
@@ -95,7 +95,7 @@ static inline int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 {
     int abt_errno = ABT_SUCCESS;
 
-    LOG_EVENT_POOL_PUSH(p_pool, unit, producer_id);
+    LOG_DEBUG_POOL_PUSH(p_pool, unit, producer_id);
 
     /* Save the producer ES information in the pool */
     abt_errno = ABTI_pool_set_producer(p_pool, producer_id);
@@ -152,7 +152,7 @@ static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 {
     int abt_errno = ABT_SUCCESS;
 
-    LOG_EVENT_POOL_REMOVE(p_pool, unit,
+    LOG_DEBUG_POOL_REMOVE(p_pool, unit,
                           ABTI_self_get_native_thread_id(
                               ABTI_local_get_xstream()));
 
@@ -178,7 +178,7 @@ static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
 {
     int abt_errno = ABT_SUCCESS;
 
-    LOG_EVENT_POOL_REMOVE(p_pool, unit, consumer_id);
+    LOG_DEBUG_POOL_REMOVE(p_pool, unit, consumer_id);
 
     abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);
     ABTI_CHECK_ERROR(abt_errno);
@@ -210,7 +210,7 @@ static inline ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool,
     ABT_unit unit;
 
     unit = p_pool->p_pop_timedwait(ABTI_pool_get_handle(p_pool), abstime_secs);
-    LOG_EVENT_POOL_POP(p_pool, unit);
+    LOG_DEBUG_POOL_POP(p_pool, unit);
 
     return unit;
 }
@@ -220,7 +220,7 @@ static inline ABT_unit ABTI_pool_pop(ABTI_pool *p_pool)
     ABT_unit unit;
 
     unit = p_pool->p_pop(ABTI_pool_get_handle(p_pool));
-    LOG_EVENT_POOL_POP(p_pool, unit);
+    LOG_DEBUG_POOL_POP(p_pool, unit);
 
     return unit;
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -96,7 +96,7 @@ static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
                                                  ABTI_thread *p_thread)
 {
-    LOG_EVENT("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
     if (p_thread->refcount == 0) {
         ABTD_atomic_release_store_int(&p_thread->state,
@@ -122,7 +122,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
 static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
                                                ABTI_task *p_task)
 {
-    LOG_EVENT("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
+    LOG_DEBUG("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->p_xstream->rank);
     if (p_task->refcount == 0) {
         ABTD_atomic_release_store_int(&p_task->state,

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -125,7 +125,7 @@ static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
 
 static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 {
-    LOG_EVENT("[U%" PRIu64 "] dynamic-promote ULT\n",
+    LOG_DEBUG("[U%" PRIu64 "] dynamic-promote ULT\n",
               ABTI_thread_get_id(p_thread));
     void *p_stack = p_thread->attr.p_stack;
     size_t stacksize = p_thread->attr.stacksize;
@@ -199,7 +199,7 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
     if (!ABTI_thread_is_dynamic_promoted(p_new)) {
         void *p_stacktop =
             ((char *)p_new->attr.p_stack) + p_new->attr.stacksize;
-        LOG_EVENT("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
+        LOG_DEBUG("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
                   ABTI_thread_get_id(p_new));
         p_local_xstream = *pp_local_xstream;
         ABTI_ASSERT(p_local_xstream->p_task == NULL);
@@ -339,7 +339,7 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
 {
     ABTI_sched *p_sched;
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
 
     /* Change the state of current running thread */
@@ -351,7 +351,7 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
                                          p_sched->p_thread);
 
     /* Back to the original thread */
-    LOG_EVENT("[U%" PRIu64 ":E%d] resume after yield\n",
+    LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -9,18 +9,6 @@
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 
-void ABTI_log_print(FILE *fh, const char *format, ...)
-{
-    if (gp_ABTI_global->use_logging == ABT_FALSE)
-        return;
-
-    va_list list;
-    va_start(list, format);
-    vfprintf(fh, format, list);
-    va_end(list);
-    fflush(fh);
-}
-
 void ABTI_log_debug(FILE *fh, const char *format, ...)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)

--- a/src/log.c
+++ b/src/log.c
@@ -144,13 +144,13 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
             if (p_thread->p_last_xstream) {
-                LOG_EVENT("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
+                LOG_DEBUG("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
-                LOG_EVENT("[U%" PRIu64 "] pushed to P%" PRIu64 " "
+                LOG_DEBUG("[U%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread), p_pool->id,
                           (void *)producer_id);
@@ -160,12 +160,12 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
             if (p_task->p_xstream) {
-                LOG_EVENT("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
+                LOG_DEBUG("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task), p_task->p_xstream->rank,
                           p_pool->id, (void *)producer_id);
             } else {
-                LOG_EVENT("[T%" PRIu64 "] pushed to P%" PRIu64 " "
+                LOG_DEBUG("[T%" PRIu64 "] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task), p_pool->id,
                           (void *)producer_id);
@@ -190,13 +190,13 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
             if (p_thread->p_last_xstream) {
-                LOG_EVENT("[U%" PRIu64 ":E%d] removed from "
+                LOG_DEBUG("[U%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
-                LOG_EVENT("[U%" PRIu64 "] removed from P%" PRIu64 " "
+                LOG_DEBUG("[U%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread), p_pool->id,
                           (void *)consumer_id);
@@ -206,12 +206,12 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
             if (p_task->p_xstream) {
-                LOG_EVENT("[T%" PRIu64 ":E%d] removed from "
+                LOG_DEBUG("[T%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_task_get_id(p_task), p_task->p_xstream->rank,
                           p_pool->id, (void *)consumer_id);
             } else {
-                LOG_EVENT("[T%" PRIu64 "] removed from P%" PRIu64 " "
+                LOG_DEBUG("[T%" PRIu64 "] removed from P%" PRIu64 " "
                           "(consumer: NT %p)\n",
                           ABTI_task_get_id(p_task), p_pool->id,
                           (void *)consumer_id);
@@ -237,12 +237,12 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
             if (p_thread->p_last_xstream) {
-                LOG_EVENT("[U%" PRIu64 ":E%d] popped from "
+                LOG_DEBUG("[U%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread),
                           p_thread->p_last_xstream->rank, p_pool->id);
             } else {
-                LOG_EVENT("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
+                LOG_DEBUG("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread), p_pool->id);
             }
             break;
@@ -250,12 +250,12 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
             if (p_task->p_xstream) {
-                LOG_EVENT("[T%" PRIu64 ":E%d] popped from "
+                LOG_DEBUG("[T%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task), p_task->p_xstream->rank,
                           p_pool->id);
             } else {
-                LOG_EVENT("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
+                LOG_DEBUG("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task), p_pool->id);
             }
             break;

--- a/src/log.c
+++ b/src/log.c
@@ -21,7 +21,7 @@ void ABTI_log_print(FILE *fh, const char *format, ...)
     fflush(fh);
 }
 
-void ABTI_log_event(FILE *fh, const char *format, ...)
+void ABTI_log_debug(FILE *fh, const char *format, ...)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
@@ -99,29 +99,6 @@ void ABTI_log_event(FILE *fh, const char *format, ...)
         newfmt = (char *)ABTU_malloc(newfmt_len + 1);
         sprintf(newfmt, prefix_fmt, prefix, format);
     }
-
-    va_list list;
-    va_start(list, format);
-    vfprintf(fh, newfmt, list);
-    va_end(list);
-    fflush(fh);
-
-    ABTU_free(newfmt);
-}
-
-void ABTI_log_debug(FILE *fh, char *path, int line, const char *format, ...)
-{
-    if (gp_ABTI_global->use_debug == ABT_FALSE)
-        return;
-
-    int line_len;
-    size_t newfmt_len;
-    char *newfmt;
-
-    line_len = ABTU_get_int_len(line);
-    newfmt_len = strlen(path) + line_len + 4 + strlen(format);
-    newfmt = (char *)ABTU_malloc(newfmt_len + 1);
-    sprintf(newfmt, "[%s:%d] %s", path, line, format);
 
     va_list list;
     va_start(list, format);

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -576,7 +576,7 @@ int ABTI_pool_create(ABT_pool_def *def, ABT_pool_config config,
     p_pool->p_free = def->p_free;
     p_pool->p_print_all = def->p_print_all;
     p_pool->id = ABTI_pool_get_new_id();
-    LOG_EVENT("[P%" PRIu64 "] created\n", p_pool->id);
+    LOG_DEBUG("[P%" PRIu64 "] created\n", p_pool->id);
 
     /* Configure the pool */
     if (p_pool->p_init) {
@@ -629,7 +629,7 @@ fn_fail:
 
 void ABTI_pool_free(ABTI_pool *p_pool)
 {
-    LOG_EVENT("[P%" PRIu64 "] freed\n", p_pool->id);
+    LOG_DEBUG("[P%" PRIu64 "] freed\n", p_pool->id);
     ABT_pool h_pool = ABTI_pool_get_handle(p_pool);
     p_pool->p_free(h_pool);
     ABTU_free(p_pool);

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -97,7 +97,7 @@ static void sched_run(ABT_sched sched)
             pool = p_pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
             unit = ABTI_pool_pop(p_pool);
-            LOG_EVENT_POOL_POP(p_pool, unit);
+            LOG_DEBUG_POOL_POP(p_pool, unit);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_unit_set_associated_pool(unit, p_pool);
                 ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -619,7 +619,7 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     p_sched->id = ABTI_sched_get_new_id();
 #endif
-    LOG_EVENT("[S%" PRIu64 "] created\n", p_sched->id);
+    LOG_DEBUG("[S%" PRIu64 "] created\n", p_sched->id);
 
     /* Return value */
     ABT_sched newsched = ABTI_sched_get_handle(p_sched);
@@ -828,7 +828,7 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched)
         }
     }
 
-    LOG_EVENT("[S%" PRIu64 "] freed\n", p_sched->id);
+    LOG_DEBUG("[S%" PRIu64 "] freed\n", p_sched->id);
 
     p_sched->free(ABTI_sched_get_handle(p_sched));
     p_sched->data = NULL;

--- a/src/task.c
+++ b/src/task.c
@@ -681,7 +681,7 @@ static int ABTI_task_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     h_newtask = ABTI_task_get_handle(p_newtask);
     p_newtask->unit = p_pool->u_create_from_task(h_newtask);
 
-    LOG_EVENT("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
+    LOG_DEBUG("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
 
     /* Add this task to the scheduler's pool */
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
@@ -736,7 +736,7 @@ static int ABTI_task_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         p_task->unit = p_pool->u_create_from_task(task);
     }
 
-    LOG_EVENT("[T%" PRIu64 "] revived\n", ABTI_task_get_id(p_task));
+    LOG_DEBUG("[T%" PRIu64 "] revived\n", ABTI_task_get_id(p_task));
 
     /* Add this task to the scheduler's pool */
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
@@ -757,7 +757,7 @@ fn_fail:
 
 void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task)
 {
-    LOG_EVENT("[T%" PRIu64 "] freed\n", ABTI_task_get_id(p_task));
+    LOG_DEBUG("[T%" PRIu64 "] freed\n", ABTI_task_get_id(p_task));
 
     /* Free the unit */
     p_task->p_pool->u_free(&p_task->unit);

--- a/src/thread.c
+++ b/src/thread.c
@@ -745,7 +745,7 @@ int ABT_thread_yield_to(ABT_thread thread)
 
     ABTI_thread *p_tar_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_tar_thread);
-    LOG_EVENT("[U%" PRIu64 ":E%d] yield_to -> U%" PRIu64 "\n",
+    LOG_DEBUG("[U%" PRIu64 ":E%d] yield_to -> U%" PRIu64 "\n",
               ABTI_thread_get_id(p_cur_thread),
               p_cur_thread->p_last_xstream->rank,
               ABTI_thread_get_id(p_tar_thread));
@@ -1483,13 +1483,13 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     ABT_thread_id thread_id = ABTI_thread_get_id(p_newthread);
     if (thread_type == ABTI_THREAD_TYPE_MAIN) {
-        LOG_EVENT("[U%" PRIu64 ":E%d] main ULT created\n", thread_id,
+        LOG_DEBUG("[U%" PRIu64 ":E%d] main ULT created\n", thread_id,
                   p_parent_xstream ? p_parent_xstream->rank : 0);
     } else if (thread_type == ABTI_THREAD_TYPE_MAIN_SCHED) {
-        LOG_EVENT("[U%" PRIu64 ":E%d] main sched ULT created\n", thread_id,
+        LOG_DEBUG("[U%" PRIu64 ":E%d] main sched ULT created\n", thread_id,
                   p_parent_xstream ? p_parent_xstream->rank : 0);
     } else {
-        LOG_EVENT("[U%" PRIu64 "] created\n", thread_id);
+        LOG_DEBUG("[U%" PRIu64 "] created\n", thread_id);
     }
 #endif
 
@@ -1735,7 +1735,7 @@ void ABTI_thread_free(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
     ABTI_spinlock_acquire(&p_thread->lock);
 #endif
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] freed\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] freed\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
 
     ABTI_thread_free_internal(p_thread);
@@ -1746,7 +1746,7 @@ void ABTI_thread_free(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 
 void ABTI_thread_free_main(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 {
-    LOG_EVENT("[U%" PRIu64 ":E%d] main ULT freed\n",
+    LOG_DEBUG("[U%" PRIu64 ":E%d] main ULT freed\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
     /* Free the key-value table */
@@ -1760,7 +1760,7 @@ void ABTI_thread_free_main(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 void ABTI_thread_free_main_sched(ABTI_xstream *p_local_xstream,
                                  ABTI_thread *p_thread)
 {
-    LOG_EVENT("[U%" PRIu64 ":E%d] main sched ULT freed\n",
+    LOG_DEBUG("[U%" PRIu64 ":E%d] main sched ULT freed\n",
               ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
     /* Free the context */
@@ -1792,7 +1792,7 @@ int ABTI_thread_set_blocked(ABTI_thread *p_thread)
     ABTI_pool *p_pool = p_thread->p_pool;
     ABTI_pool_inc_num_blocked(p_pool);
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] blocked\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] blocked\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
 
 fn_exit:
@@ -1812,13 +1812,13 @@ void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream, ABTI_thread *p_thread)
 
     /* Switch to the scheduler, i.e., suspend p_thread  */
     ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_local_xstream);
-    LOG_EVENT("[U%" PRIu64 ":E%d] suspended\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] suspended\n", ABTI_thread_get_id(p_thread),
               p_local_xstream->rank);
     ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
                                          p_sched->p_thread);
 
     /* The suspended ULT resumes its execution from here. */
-    LOG_EVENT("[U%" PRIu64 ":E%d] resumed\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] resumed\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
 }
 
@@ -1838,7 +1838,7 @@ int ABTI_thread_set_ready(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
            ABTI_THREAD_REQ_BLOCK)
         ABTD_atomic_pause();
 
-    LOG_EVENT("[U%" PRIu64 ":E%d] set ready\n", ABTI_thread_get_id(p_thread),
+    LOG_DEBUG("[U%" PRIu64 ":E%d] set ready\n", ABTI_thread_get_id(p_thread),
               p_thread->p_last_xstream->rank);
 
     /* p_thread->p_pool is loaded before ABTI_POOL_ADD_THREAD to keep
@@ -2191,7 +2191,7 @@ static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         p_thread->unit = p_pool->u_create_from_thread(h_thread);
     }
 
-    LOG_EVENT("[U%" PRIu64 "] revived\n", ABTI_thread_get_id(p_thread));
+    LOG_DEBUG("[U%" PRIu64 "] revived\n", ABTI_thread_get_id(p_thread));
 
     /* Add this thread to the pool */
 #ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
@@ -2273,10 +2273,10 @@ static inline int ABTI_thread_join(ABTI_xstream **pp_local_xstream,
         /* Make the current ULT BLOCKED */
         ABTD_atomic_release_store_int(&p_self->state, ABT_THREAD_STATE_BLOCKED);
 
-        LOG_EVENT("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
                   ABTI_thread_get_id(p_self), p_self->p_last_xstream->rank,
                   ABTI_thread_get_id(p_thread));
-        LOG_EVENT("[U%" PRIu64 ":E%d] start running\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] start running\n",
                   ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch the context */
@@ -2302,7 +2302,7 @@ static inline int ABTI_thread_join(ABTI_xstream **pp_local_xstream,
             goto yield_based;
 
         ABTI_thread_set_blocked(p_self);
-        LOG_EVENT("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] blocked to join U%" PRIu64 "\n",
                   ABTI_thread_get_id(p_self), p_self->p_last_xstream->rank,
                   ABTI_thread_get_id(p_thread));
 
@@ -2327,7 +2327,7 @@ static inline int ABTI_thread_join(ABTI_xstream **pp_local_xstream,
         ABT_THREAD_STATE_BLOCKED) {
         ABTD_atomic_release_store_int(&p_self->state, ABT_THREAD_STATE_RUNNING);
         ABTI_pool_dec_num_blocked(p_self->p_pool);
-        LOG_EVENT("[U%" PRIu64 ":E%d] resume after join\n",
+        LOG_DEBUG("[U%" PRIu64 ":E%d] resume after join\n",
                   ABTI_thread_get_id(p_self), p_self->p_last_xstream->rank);
         return abt_errno;
     }

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -249,7 +249,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
     ABTI_thread_queue_release_low_mutex(p_queue);
 
     if (p_target) {
-        LOG_EVENT("switch -> U%" PRIu64 "\n", ABTI_thread_get_id(p_target));
+        LOG_DEBUG("switch -> U%" PRIu64 "\n", ABTI_thread_get_id(p_target));
 
         /* Context-switch to p_target */
         ABTD_atomic_release_store_int(&p_target->state,


### PR DESCRIPTION
## Problem

Argobots has two logging interface: `LOG_EVENT()` and `LOG_DEBUG()`.

- `LOG_EVENT()` prints an event message. It prints the information of the underlying execution stream and ULT/tasklet in addition to the event message.
- `LOG_DEBUG()` prints a debug message. It prints the information of `__FILE__` and `__LINE__` in addition to the event message.

Those two are very similar and both are used primarily for debugging (since these logging interface is quite heavy). However, they are controlled by different environmental variables (`ABT_USE_LOG` and `ABT_USE_DEBUG`), which is confusing.

## Solution

This PR removes `LOG_EVENT()` and uses `LOG_DEBUG()` instead. The implementation of `LOG_DEBUG()` is actually replaced by that of `LOG_EVENT()`, however, since `LOG_EVENT()` prints more useful information. The log mode can be switched by `ABT_USE_LOG=0|1`.

## Impact

With the default setting, no impact. When logging is enabled (`./configure --enable-debug=XXX`, which is turned off by default), the printed messages might get slightly different, but it will not affect the most messages.

Note that this PR neither degrades nor improves the contents of debug messages.

### Note

This PR contains some minor cleanup.