### PR TITLE
mem: fix memory allocation code when the memory pool is disabled

### DIFF
--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -157,4 +157,22 @@ int ABTI_mem_check_lp_alloc(int lp_alloc)
     }
 }
 
-#endif /* ABT_CONFIG_USE_MEM_POOL */
+#else /* !ABT_CONFIG_USE_MEM_POOL */
+
+void ABTI_mem_init(ABTI_global *p_global)
+{
+}
+
+void ABTI_mem_init_local(ABTI_xstream *p_local_xstream)
+{
+}
+
+void ABTI_mem_finalize(ABTI_global *p_global)
+{
+}
+
+void ABTI_mem_finalize_local(ABTI_xstream *p_local_xstream)
+{
+}
+
+#endif /* !ABT_CONFIG_USE_MEM_POOL */


### PR DESCRIPTION
`--disable-mem-pool` disables the memory pool optimizations in Argobots, but the current Argobots cannot be compiled with this option since it has been overlooked for a while. This PR fixes this issue.

 `--disable-mem-pool` is added to Jenkins tests (as one of the random configurations), so this option will be tested regularly.

Note that this option is useful if one uses an external scalable memory allocator (e.g., tcmalloc and jemalloc).
