### PR TITLE
Cleanup thread migration code

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -345,8 +345,8 @@ struct ABTI_thread {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     void (*f_migration_cb)(ABT_thread, void *); /* Callback function */
     void *p_migration_cb_arg;                   /* Callback function argument */
-    ABTI_pool *p_migration_pool;                /* Destination of migration */
-    ABTI_spinlock lock;                         /* Spinlock */
+    ABTD_atomic_ptr
+        p_migration_pool; /* Destination of migration (ABTI_pool *) */
 #endif
 };
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -110,7 +110,6 @@ typedef struct ABTI_thread ABTI_thread;
 typedef enum ABTI_stack_type ABTI_stack_type;
 typedef enum ABTI_unit_type ABTI_unit_type;
 typedef enum ABTI_unit_state ABTI_unit_state;
-typedef struct ABTI_thread_req_arg ABTI_thread_req_arg;
 typedef struct ABTI_thread_list ABTI_thread_list;
 typedef struct ABTI_thread_entry ABTI_thread_entry;
 typedef struct ABTI_thread_htable ABTI_thread_htable;
@@ -346,18 +345,10 @@ struct ABTI_thread {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     void (*f_migration_cb)(ABT_thread, void *); /* Callback function */
     void *p_migration_cb_arg;                   /* Callback function argument */
-    ABTI_thread_req_arg *p_req_arg;             /* Request argument */
+    ABTI_pool *p_migration_pool;                /* Destination of migration */
     ABTI_spinlock lock;                         /* Spinlock */
 #endif
 };
-
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-struct ABTI_thread_req_arg {
-    uint32_t request;
-    void *p_arg;
-    ABTI_thread_req_arg *next;
-};
-#endif
 
 struct ABTI_thread_list {
     ABTI_thread_entry *head;
@@ -555,10 +546,6 @@ void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream,
 int ABTI_thread_set_ready(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-void ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg);
-void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req);
-#endif
 void ABTI_thread_reset_id(void);
 ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
 ABT_unit_id ABTI_thread_self_id(ABTI_xstream *p_local_xstream);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1612,9 +1612,7 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
     ABTI_spinlock_acquire(&p_thread->lock); // TODO: mutex useful?
     {
         /* extracting argument in migration request */
-        p_pool =
-            (ABTI_pool *)ABTI_thread_extract_req_arg(p_thread,
-                                                     ABTI_UNIT_REQ_MIGRATE);
+        p_pool = p_thread->p_migration_pool;
         ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
         LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",

--- a/src/stream.c
+++ b/src/stream.c
@@ -1609,25 +1609,25 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
         p_thread->f_migration_cb(thread, p_thread->p_migration_cb_arg);
     }
 
-    ABTI_spinlock_acquire(&p_thread->lock); // TODO: mutex useful?
-    {
-        /* extracting argument in migration request */
-        p_pool = p_thread->p_migration_pool;
-        ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
+    /* If request is set, p_migration_pool has a valid pool pointer. */
+    ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
+                ABTI_UNIT_REQ_MIGRATE);
 
-        LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",
-                  ABTI_thread_get_id(p_thread),
-                  p_thread->unit_def.p_last_xstream->rank,
-                  (void *)p_pool->consumer_id);
+    /* Extracting argument in migration request. */
+    p_pool = ABTD_atomic_relaxed_load_ptr(&p_thread->p_migration_pool);
+    ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
-        /* Change the associated pool */
-        p_thread->unit_def.p_pool = p_pool;
+    LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",
+              ABTI_thread_get_id(p_thread),
+              p_thread->unit_def.p_last_xstream->rank,
+              (void *)p_pool->consumer_id);
 
-        /* Add the unit to the scheduler's pool */
-        ABTI_POOL_PUSH(p_pool, p_thread->unit_def.unit,
-                       ABTI_self_get_native_thread_id(p_local_xstream));
-    }
-    ABTI_spinlock_release(&p_thread->lock);
+    /* Change the associated pool */
+    p_thread->unit_def.p_pool = p_pool;
+
+    /* Add the unit to the scheduler's pool */
+    ABTI_POOL_PUSH(p_pool, p_thread->unit_def.unit,
+                   ABTI_self_get_native_thread_id(p_local_xstream));
 
     ABTI_pool_dec_num_migrations(p_pool);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1486,7 +1486,7 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newthread->unit_def.refcount = refcount;
     p_newthread->unit_def.type = unit_type;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_newthread->p_req_arg = NULL;
+    p_newthread->p_migration_pool = NULL;
 #endif
     p_newthread->unit_def.p_keytable = NULL;
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
@@ -1586,7 +1586,7 @@ int ABTI_thread_migrate_to_pool(ABTI_xstream **pp_local_xstream,
 
     /* adding request to the thread */
     ABTI_spinlock_acquire(&p_thread->lock);
-    ABTI_thread_add_req_arg(p_thread, ABTI_UNIT_REQ_MIGRATE, p_pool);
+    p_thread->p_migration_pool = p_pool;
     ABTI_spinlock_release(&p_thread->lock);
     ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
@@ -1961,9 +1961,6 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             "%spool    : %p\n"
             "%srefcount: %u\n"
             "%srequest : 0x%x\n"
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-            "%sreq_arg : %p\n"
-#endif
             "%skeytable: %p\n",
             prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
             prefix, type, prefix, state, prefix, (void *)p_xstream,
@@ -1975,9 +1972,6 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             (void *)p_thread->unit_def.p_pool, prefix,
             p_thread->unit_def.refcount, prefix,
             ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request),
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-            prefix, (void *)p_thread->p_req_arg,
-#endif
             prefix, (void *)p_thread->unit_def.p_keytable);
 
 fn_exit:
@@ -2034,101 +2028,6 @@ int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os)
     }
     return ABT_SUCCESS;
 }
-
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-void ABTI_thread_add_req_arg(ABTI_thread *p_thread, uint32_t req, void *arg)
-{
-    ABTI_thread_req_arg *new;
-    ABTI_thread_req_arg *p_head = p_thread->p_req_arg;
-
-    /* Overwrite the previous same request if exists */
-    while (p_head != NULL) {
-        if (p_head->request == req) {
-            p_head->p_arg = arg;
-            return;
-        }
-    }
-
-    new = (ABTI_thread_req_arg *)ABTU_malloc(sizeof(ABTI_thread_req_arg));
-
-    /* filling the new argument data structure */
-    new->request = req;
-    new->p_arg = arg;
-    new->next = NULL;
-
-    if (p_head == NULL) {
-        p_thread->p_req_arg = new;
-    } else {
-        while (p_head->next != NULL)
-            p_head = p_head->next;
-        p_head->next = new;
-    }
-}
-
-void *ABTI_thread_extract_req_arg(ABTI_thread *p_thread, uint32_t req)
-{
-    void *result = NULL;
-    ABTI_thread_req_arg *p_last = NULL, *p_head = p_thread->p_req_arg;
-
-    while (p_head != NULL) {
-        if (p_head->request == req) {
-            result = p_head->p_arg;
-            if (p_last == NULL)
-                p_thread->p_req_arg = p_head->next;
-            else
-                p_last->next = p_head->next;
-            ABTU_free(p_head);
-            break;
-        }
-        p_last = p_head;
-        p_head = p_head->next;
-    }
-
-    return result;
-}
-
-void ABTI_thread_put_req_arg(ABTI_thread *p_thread,
-                             ABTI_thread_req_arg *p_req_arg)
-{
-    ABTI_spinlock_acquire(&p_thread->lock);
-    ABTI_thread_req_arg *p_head = p_thread->p_req_arg;
-
-    if (p_head == NULL) {
-        p_thread->p_req_arg = p_req_arg;
-    } else {
-        while (p_head->next != NULL) {
-            p_head = p_head->next;
-        }
-        p_head->next = p_req_arg;
-    }
-    ABTI_spinlock_release(&p_thread->lock);
-}
-
-ABTI_thread_req_arg *ABTI_thread_get_req_arg(ABTI_thread *p_thread,
-                                             uint32_t req)
-{
-    ABTI_thread_req_arg *p_result = NULL;
-    ABTI_thread_req_arg *p_last = NULL;
-
-    ABTI_spinlock_acquire(&p_thread->lock);
-    ABTI_thread_req_arg *p_head = p_thread->p_req_arg;
-    while (p_head != NULL) {
-        if (p_head->request == req) {
-            p_result = p_head;
-            if (p_last == NULL)
-                p_thread->p_req_arg = p_head->next;
-            else
-                p_last->next = p_head->next;
-            break;
-        }
-        p_last = p_head;
-        p_head = p_head->next;
-    }
-    ABTI_spinlock_release(&p_thread->lock);
-
-    return p_result;
-}
-#endif /* ABT_CONFIG_DISABLE_MIGRATION */
 
 static ABTD_atomic_uint64 g_thread_id =
     ABTD_ATOMIC_UINT64_STATIC_INITIALIZER(0);


### PR DESCRIPTION
This PR simplifies the current thread migration code, which is complicated and costly.

This PR does not change the current API/ABI. This change should improve the performance if the migration feature is used; otherwise there should be no visible performance difference.