### PR TITLE
Simplify thread migration logic

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -219,7 +219,6 @@ struct ABTI_xstream {
     ABTI_xstream_type type;   /* Type */
     ABTD_atomic_int state;    /* State (ABT_xstream_state) */
     ABTI_sched **scheds;      /* Stack of running schedulers */
-    ABTI_spinlock sched_lock; /* Lock for the scheduler management */
     ABTI_sched *p_main_sched; /* Main scheduler, which is the bottom of the
                                * linked list of schedulers */
     ABTI_sched *p_sched_top;  /* The currently running scheduler. This is the
@@ -244,7 +243,6 @@ struct ABTI_sched {
     ABT_bool automatic;         /* To know if automatic data free */
     ABTI_sched_kind kind;       /* Kind of the scheduler  */
     ABT_sched_type type;        /* Can yield or not (ULT or task) */
-    ABT_sched_state state;      /* State */
     ABTD_atomic_uint32 request; /* Request */
     ABT_pool *pools;            /* Work unit pools */
     int num_pools;              /* Number of work unit pools */

--- a/src/thread.c
+++ b/src/thread.c
@@ -899,14 +899,19 @@ fn_fail:
  * @ingroup ULT
  * @brief   Migrate a thread to a specific ES.
  *
- * The actual migration occurs asynchronously with this function call.
- * In other words, this function may return immediately without the thread
- * being migrated. The migration request will be posted on the thread, such that
- * next time a scheduler picks it up, migration will happen.
- * The target pool is chosen by the running scheduler of the target ES.
+ * The actual migration occurs asynchronously with this function call.  In other
+ * words, this function may return immediately without the thread being
+ * migrated.  The migration request will be posted on the thread, such that next
+ * time a scheduler picks it up, migration will happen.  The target pool is
+ * chosen by the running scheduler of the target ES.
+ *
+ * Note that users must be responsible for keeping the target execution stream,
+ * its main scheduler, and the associated pools available during this function
+ * and, if this function returns ABT_SUCCESS, until the migration process
+ * completes.
+ *
  * The migration will fail if the running scheduler has no pool available for
  * migration.
- *
  *
  * @param[in] thread   handle to the thread to migrate
  * @param[in] xstream  handle to the ES to migrate the thread to
@@ -942,14 +947,18 @@ fn_fail:
  * @ingroup ULT
  * @brief   Migrate a thread to a specific scheduler.
  *
- * The actual migration occurs asynchronously with this function call.
- * In other words, this function may return immediately without the thread
- * being migrated. The migration request will be posted on the thread, such that
- * next time a scheduler picks it up, migration will happen.
- * The target pool is chosen by the scheduler itself.
+ * The actual migration occurs asynchronously with this function call.  In other
+ * words, this function may return immediately without the thread being
+ * migrated.  The migration request will be posted on the thread, such that next
+ * time a scheduler picks it up, migration will happen.  The target pool is
+ * chosen by the scheduler itself.
+ *
+ * Note that users must be responsible for keeping the target scheduler and its
+ * associated pools available during this function and, if this function returns
+ * ABT_SUCCESS, until the migration process completes.
+ *
  * The migration will fail if the target scheduler has no pool available for
  * migration.
- *
  *
  * @param[in] thread handle to the thread to migrate
  * @param[in] sched  handle to the sched to migrate the thread to
@@ -1007,6 +1016,10 @@ fn_fail:
  * being migrated. The migration request will be posted on the thread, such that
  * next time a scheduler picks it up, migration will happen.
  *
+ * Note that users must be responsible for keeping the target pool available
+ * during this function and, if this function returns ABT_SUCCESS, until the
+ * migration process completes.
+ *
  * @param[in] thread handle to the thread to migrate
  * @param[in] pool   handle to the pool to migrate the thread to
  * @return Error code
@@ -1046,7 +1059,12 @@ fn_fail:
  * ABT_thread_migrate requests migration of the thread but does not specify
  * the target ES. The target ES will be determined among available ESs by the
  * runtime. Other semantics of this routine are the same as those of
- * \c ABT_thread_migrate_to_xstream()
+ * \c ABT_thread_migrate_to_xstream().
+ *
+ * Note that users must be responsible for keeping all the execution streams,
+ * their main schedulers, and the associated pools available (i.e., not freed)
+ * during this function and, if this function returns ABT_SUCCESS, until the
+ * whole migration process completes.
  *
  * NOTE: This function may have some bugs.
  *
@@ -2308,11 +2326,9 @@ static int ABTI_thread_migrate_to_xstream(ABTI_xstream **pp_local_xstream,
             ABTI_spinlock_release(&p_xstream->sched_lock);
             goto fn_fail;
 
-        } else if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
-                   ABT_XSTREAM_STATE_RUNNING) {
-            p_sched = ABTI_xstream_get_top_sched(p_xstream);
-
         } else {
+            /* The migration target should be the main scheduler since it is
+             * hard to guarantee the lifetime of the stackable scheduler. */
             p_sched = p_xstream->p_main_sched;
         }
 


### PR DESCRIPTION
This PR removes the complicated synchronization code behind `ABT_thread_migrate_to_sched()`, `ABT_thread_migrate_to_xstream()`, and `ABT_thread_migrate()`.

## Background

`ABT_thread_migrate_to_sched()`, `ABT_thread_migrate_to_xstream()`, and `ABT_thread_migrate()` basically find a pool of the running scheduler (associated with the given execution stream) and creates a request of migration to the pool. The request is attached to a ULT since that ULT might be being scheduled by a scheduler. A scheduler who finds a request attached to a ULT will migrate this ULT to the target pool.

## Problems

Obviously, all the involving objects must be alive during the process (i.e., the target pool may not be freed while a thread is being migrated). This is actually hard to guarantee from the runtime perspective. The current Argobots employ several mechanisms to (incompletely) prevent objects from being released; for example, `ABTI_sched.state`, `ABTI_pool.num_migrations`, and `ABTI_xstream.sched_lock` are maintained only for this purpose. Unfortunately, this migration mechanism is rarely used, so this protection mechanism is not thoroughly debugged. It has several "holes", which can be classified as user's error but Argobots seems to deal with. This behavior is not well documented, so this complicated and not-so-common mechanism just become a heavy burden for code maintenance and optimizations.

## Solutions

This PR explicitly describes that it is a user's responsibility to keep them alive during the migration process. Thanks to this PR, we can remove several complicated synchronization mechanism maintained only for this migration functionality.

## Impact

Note that this does not really break the API/ABI compatibility (much); although it was not documented, it is dangerous if one finishes a scheduler while another thread tries to migrate a thread to that scheduler, although previously some cases might be internally avoided by the protection mechanism above. This significantly improves the performance of a stackable scheduler.

If this PR (or commits around this PR) breaks your program (especially regarding thread migration), please let us know.
