### PR TITLE
thread: allow ABT_xstream_schedule_unit() on a normal ULT

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -81,21 +81,8 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
 
     /* No other ULT is waiting or blocked for this ULT. Since a context does not
      * switch to another context when it finishes, we need to explicitly switch
-     * to the scheduler. */
-    ABTI_sched *p_sched;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    if (p_thread->p_sched) {
-        /* If p_thread is a scheduler ULT, we have to context switch to
-         * the parent scheduler. */
-        p_sched = p_thread->p_sched->p_parent_sched;
-    } else {
-#endif
-        p_sched = ABTI_xstream_get_top_sched(p_thread->unit_def.p_last_xstream);
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    }
-#endif
-    ABTI_thread_finish_context_to_parent(p_local_xstream, p_thread,
-                                         p_sched->p_thread);
+     * to the parent. */
+    ABTI_thread_finish_context_to_parent(p_local_xstream, p_thread);
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION

--- a/src/global.c
+++ b/src/global.c
@@ -174,11 +174,10 @@ int ABT_finalize(void)
                   ABTI_thread_get_id(p_thread),
                   p_thread->unit_def.p_last_xstream->rank);
 
-        /* Switch to the top scheduler */
+        /* Switch to the parent */
         ABTI_sched *p_sched =
             ABTI_xstream_get_top_sched(p_thread->unit_def.p_last_xstream);
-        ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread,
-                                             p_sched->p_thread);
+        ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread);
 
         /* Back to the original thread */
         LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/global.c
+++ b/src/global.c
@@ -175,8 +175,6 @@ int ABT_finalize(void)
                   p_thread->unit_def.p_last_xstream->rank);
 
         /* Switch to the parent */
-        ABTI_sched *p_sched =
-            ABTI_xstream_get_top_sched(p_thread->unit_def.p_last_xstream);
         ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread);
 
         /* Back to the original thread */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -307,6 +307,7 @@ struct ABTI_unit {
     ABTI_unit_type type;          /* Unit type */
     ABT_unit unit;                /* Unit enclosing this thread */
     ABTI_xstream *p_last_xstream; /* Last ES where it ran */
+    ABTI_unit *p_parent;          /* Parent unit */
     void (*f_unit)(void *);       /* Work unit function */
     void *p_arg;                  /* Work unit function argument */
     ABTD_atomic_int state;        /* State (ABTI_unit_state) */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -221,8 +221,6 @@ struct ABTI_xstream {
     ABTI_sched **scheds;      /* Stack of running schedulers */
     ABTI_sched *p_main_sched; /* Main scheduler, which is the bottom of the
                                * linked list of schedulers */
-    ABTI_sched *p_sched_top;  /* The currently running scheduler. This is the
-                               * top of the linked list of schedulers. */
 
     ABTD_atomic_uint32 request; /* Request */
     void *p_req_arg;            /* Request argument */
@@ -248,10 +246,6 @@ struct ABTI_sched {
     int num_pools;              /* Number of work unit pools */
     ABTI_thread *p_thread;      /* Associated ULT */
     void *data;                 /* Data for a specific scheduler */
-
-    /* Pointers for a scheduler linked list. */
-    ABTI_sched *p_parent_sched;
-    ABTI_sched *p_child_sched;
 
     /* Scheduler functions */
     ABT_sched_init_fn init;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -596,8 +596,6 @@ int ABTI_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
     p_sched->num_pools = num_pools;
     p_sched->type = def->type;
     p_sched->p_thread = NULL;
-    p_sched->p_parent_sched = NULL;
-    p_sched->p_child_sched = NULL;
 
     p_sched->init = def->init;
     p_sched->run = def->run;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -340,10 +340,8 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_xstream **pp_local_xstream,
                 stop = ABT_TRUE;
             } else {
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
-                ABTI_sched *p_par_sched = p_sched->p_parent_sched;
                 ABTI_thread_context_switch_to_parent(pp_local_xstream,
-                                                     p_sched->p_thread,
-                                                     p_par_sched->p_thread);
+                                                     p_sched->p_thread);
             }
         }
     }

--- a/src/stream.c
+++ b/src/stream.c
@@ -964,6 +964,9 @@ fn_fail:
  * This function can be called by a scheduler after picking one unit. So a user
  * will use it for his own defined scheduler.
  *
+ * EXPERIMENTAL: this function can be called by a normal ULT, too.  The function
+ * name could be changed in the future.
+ *
  * @param[in] unit handle to the unit to run
  * @param[in] pool pool where unit is from
  * @return Error code

--- a/src/stream.c
+++ b/src/stream.c
@@ -349,12 +349,12 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
         ABTI_thread_create_main_sched(*pp_local_xstream, p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
     p_sched->p_thread->unit_def.p_last_xstream = p_xstream;
+    p_thread->unit_def.p_parent = &p_sched->p_thread->unit_def;
 
     /* Start the scheduler by context switching to it */
     LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
-    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
-                                         p_sched->p_thread);
+    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread);
 
     /* Back to the main ULT */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume\n", ABTI_thread_get_id(p_thread),
@@ -1451,16 +1451,16 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     LOG_DEBUG("[U%" PRIu64 ":E%d] start running\n",
               ABTI_thread_get_id(p_thread), p_local_xstream->rank);
 
-    ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_local_xstream);
-
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     /* Add the new scheduler if the ULT is a scheduler */
     if (p_thread->p_sched != NULL) {
         ABTI_xstream_push_sched(p_local_xstream, p_thread->p_sched);
     }
 #endif
-    p_thread = ABTI_thread_context_switch_to_child(pp_local_xstream,
-                                                   p_sched->p_thread, p_thread);
+
+    ABTI_thread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
+    p_thread =
+        ABTI_thread_context_switch_to_child(pp_local_xstream, p_self, p_thread);
     /* The previous ULT (p_thread) may not be the same as one to which the
      * context has been switched. */
     /* The scheduler continues from here. */
@@ -1564,6 +1564,7 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
 
     ABTI_unit *p_sched_unit = p_local_xstream->p_unit;
     p_local_xstream->p_unit = &p_task->unit_def;
+    p_task->unit_def.p_parent = p_sched_unit;
 
     /* Execute the task function */
     LOG_DEBUG("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
@@ -1772,8 +1773,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
 
         /* Switch to the current main scheduler */
         ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_NOPUSH);
-        ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
-                                             p_main_sched->p_thread);
+        ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread);
 
         /* Now, we free the current main scheduler. p_main_sched->p_thread must
          * be NULL to avoid freeing it in ABTI_sched_discard_and_free(). */

--- a/src/task.c
+++ b/src/task.c
@@ -667,6 +667,7 @@ static int ABTI_task_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newtask = ABTI_mem_alloc_task(p_local_xstream);
 
     p_newtask->unit_def.p_last_xstream = NULL;
+    p_newtask->unit_def.p_parent = NULL;
     ABTD_atomic_relaxed_store_int(&p_newtask->unit_def.state,
                                   ABTI_UNIT_STATE_READY);
     ABTD_atomic_relaxed_store_uint32(&p_newtask->unit_def.request, 0);
@@ -721,6 +722,7 @@ static int ABTI_task_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                     ABT_ERR_INV_TASK);
 
     p_task->unit_def.p_last_xstream = NULL;
+    p_task->unit_def.p_parent = NULL;
     ABTD_atomic_relaxed_store_int(&p_task->unit_def.state,
                                   ABTI_UNIT_STATE_READY);
     ABTD_atomic_relaxed_store_uint32(&p_task->unit_def.request, 0);

--- a/src/thread.c
+++ b/src/thread.c
@@ -784,23 +784,9 @@ int ABT_thread_yield_to(ABT_thread thread)
     ABTI_POOL_PUSH(p_cur_thread->unit_def.p_pool, p_cur_thread->unit_def.unit,
                    ABTI_self_get_native_thread_id(p_local_xstream));
 
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    /* Delete the last context if the ULT is a scheduler */
-    if (p_cur_thread->p_sched != NULL) {
-        ABTI_xstream_pop_sched(p_local_xstream);
-    }
-#endif
-
     /* Remove the target ULT from the pool */
     ABTI_POOL_REMOVE(p_tar_thread->unit_def.p_pool, p_tar_thread->unit_def.unit,
                      ABTI_self_get_native_thread_id(p_local_xstream));
-
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    /* Add a new scheduler if the ULT is a scheduler */
-    if (p_tar_thread->p_sched != NULL) {
-        ABTI_xstream_push_sched(p_local_xstream, p_tar_thread->p_sched);
-    }
-#endif
 
     /* We set the last ES */
     p_tar_thread->unit_def.p_last_xstream = p_local_xstream;

--- a/src/thread.c
+++ b/src/thread.c
@@ -1493,6 +1493,7 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                                   ABTI_UNIT_STATE_READY);
     ABTD_atomic_release_store_uint32(&p_newthread->unit_def.request, 0);
     p_newthread->unit_def.p_last_xstream = NULL;
+    p_newthread->unit_def.p_parent = NULL;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     p_newthread->p_sched = p_sched;
 #endif
@@ -1841,11 +1842,9 @@ void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream, ABTI_thread *p_thread)
     ABTI_ASSERT(p_thread->unit_def.p_last_xstream == p_local_xstream);
 
     /* Switch to the scheduler, i.e., suspend p_thread  */
-    ABTI_sched *p_sched = ABTI_xstream_get_top_sched(p_local_xstream);
     LOG_DEBUG("[U%" PRIu64 ":E%d] suspended\n", ABTI_thread_get_id(p_thread),
               p_local_xstream->rank);
-    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
-                                         p_sched->p_thread);
+    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread);
 
     /* The suspended ULT resumes its execution from here. */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resumed\n", ABTI_thread_get_id(p_thread),
@@ -2103,6 +2102,7 @@ static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                                   ABTI_UNIT_STATE_READY);
     ABTD_atomic_relaxed_store_uint32(&p_thread->unit_def.request, 0);
     p_thread->unit_def.p_last_xstream = NULL;
+    p_thread->unit_def.p_parent = NULL;
     p_thread->unit_def.refcount = 1;
     p_thread->unit_def.type = ABTI_UNIT_TYPE_THREAD_USER;
 

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -25,6 +25,7 @@ basic/thread_task_arg
 basic/thread_task_num
 basic/sched_basic
 basic/sched_basic_wait
+basic/sched_on_thread
 basic/sched_prio
 basic/sched_randws
 basic/sched_set_main

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -30,6 +30,7 @@ TESTS = \
 	thread_task_num \
 	sched_basic \
 	sched_basic_wait \
+	sched_on_thread \
 	sched_prio \
 	sched_randws \
 	sched_set_main \
@@ -100,6 +101,7 @@ thread_task_arg_SOURCES = thread_task_arg.c
 thread_task_num_SOURCES = thread_task_num.c
 sched_basic_SOURCES = sched_basic.c
 sched_basic_wait_SOURCES = sched_basic_wait.c
+sched_on_thread_SOURCES = sched_on_thread.c
 sched_prio_SOURCES = sched_prio.c
 sched_randws_SOURCES = sched_randws.c
 sched_set_main_SOURCES = sched_set_main.c
@@ -158,6 +160,7 @@ testing:
 	./thread_task_num
 	./sched_basic
 	./sched_basic_wait
+	./sched_on_thread
 	./sched_prio
 	./sched_randws
 	./sched_set_main

--- a/test/basic/sched_on_thread.c
+++ b/test/basic/sched_on_thread.c
@@ -1,0 +1,135 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+/*
+ * In this test, normal ULTs will schedule other ULTs.  This can mimic a
+ * stackable scheduler without creating a scheduler.  Termination condition and
+ * event handling must be taken care of by a user.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+int num_xstreams;
+int num_threads;
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 4
+#define NUM_LEAF_THREADS 8
+ABT_pool *pools;
+int atomic_val = 0;
+#define ATOMIC_VAL_SUM (num_threads * num_xstreams * NUM_LEAF_THREADS)
+
+void leaf_func(void *arg)
+{
+    /* Meaningless yield to check the robustness. */
+    int ret = ABT_thread_yield();
+    ATS_ERROR(ret, "ABT_thread_yield");
+    __atomic_fetch_add(&atomic_val, 1, __ATOMIC_ACQ_REL);
+}
+
+void root_func(void *arg)
+{
+    /* root_func creates threads and schedule them. */
+    int ret, i;
+    for (i = 0; i < NUM_LEAF_THREADS; i++) {
+        ret = ABT_thread_create(pools[i % num_xstreams], leaf_func,
+                                (void *)(size_t)i, ABT_THREAD_ATTR_NULL, NULL);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+    while (__atomic_load_n(&atomic_val, __ATOMIC_ACQUIRE) != ATOMIC_VAL_SUM) {
+        int rank = 0;
+        ret = ABT_xstream_self_rank(&rank);
+        ATS_ERROR(ret, "ABT_xstream_self_rank");
+
+        /* Get a unit and schedule it. */
+        ABT_unit unit;
+        ret = ABT_pool_pop(pools[rank], &unit);
+        ATS_ERROR(ret, "ABT_pool_pop");
+
+        if (unit != ABT_UNIT_NULL) {
+            ret = ABT_xstream_run_unit(unit, pools[rank]);
+            ATS_ERROR(ret, "ABT_xstream_run_unit");
+        } else {
+            ret = ABT_thread_yield();
+            ATS_ERROR(ret, "ABT_thread_yield");
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j;
+    int ret;
+    num_xstreams = DEFAULT_NUM_XSTREAMS;
+    num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
+    assert(num_xstreams >= 0);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    ABT_xstream *xstreams;
+    xstreams = (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create threads */
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_xstreams * num_threads);
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            size_t tid = i * num_threads + j + 1;
+            ret = ABT_thread_create(pools[i], root_func, (void *)tid,
+                                    ABT_THREAD_ATTR_NULL,
+                                    &threads[i * num_threads + j]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+    }
+
+    for (i = 0; i < num_xstreams * num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(pools);
+    free(xstreams);
+
+    return ret;
+}


### PR DESCRIPTION
This patch enables `ABT_xstream_schedule_unit()` on a non-scheduler ULT. This is a large change because this PR essentially provides a way to implement a scheduler without `ABT_sched`.

Specifically, this allows a normal ULT to "directly" schedule ULTs and tasklets by combining `ABT_pool_xxx()` and `ABT_xstream_schedule_unit()` while, for example, waiting for something. From another viewpoint, one can make a scheduler that can also work as a normal ULT (e.g., calling a barrier etc).

This feature should be useful to implement a complicated scheduler, for example, a parallel work unit that does both scheduling and computation. For example, OpenMP thread is a scheduler of OpenMP tasks (belonging to that parallel region) but can perform computation (e.g., `#pragma omp for`).

Internally, this changes the concept of "stackable schedulers" in Argobots. Now it becomes "stackable threads"; any thread can create a "child" thread by `ABT_xstream_schedule_unit()` and return to the "parent" thread by `ABT_thread_yield()` or `ABT_thread_exit()`.  `test/basic/sched_on_thread.c` demonstrates how this feature can be used.

Note that this PR keeps the current API/ABI, so the existing code (including ones that use stackable schedulers) should work.

