### PR TITLE
key: optimize ABT_key operations

### DIFF
--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -95,6 +95,15 @@ void ABTD_env_init(ABTI_global *p_global)
     } else {
         p_global->key_table_size = ABTD_KEY_TABLE_DEFAULT_SIZE;
     }
+    /* key_table_size must be a power of 2. */
+    {
+        int i;
+        for (i = 0; i < sizeof(int) * 8; i++) {
+            if ((p_global->key_table_size - 1) >> i == 0)
+                break;
+        }
+        p_global->key_table_size = 1 << i;
+    }
 
     /* Default stack size for ULT */
     env = getenv("ABT_THREAD_STACKSIZE");

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -360,7 +360,6 @@ struct ABTI_ktelem {
 
 struct ABTI_ktable {
     int size;              /* size of the table */
-    int num;               /* number of elements stored */
     ABTI_ktelem **p_elems; /* element array */
 };
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -354,6 +354,9 @@ struct ABTI_key {
 
 struct ABTI_ktelem {
     ABTI_key *p_key;
+    /* information of ABTI_key */
+    void (*f_destructor)(void *value);
+    uint32_t key_id;
     void *value;
     struct ABTI_ktelem *p_next;
 };

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -348,12 +348,9 @@ struct ABTI_task {
 struct ABTI_key {
     void (*f_destructor)(void *value);
     uint32_t id;
-    ABTD_atomic_uint32 refcount; /* Reference count */
-    ABT_bool freed;              /* TRUE: freed, FALSE: not */
 };
 
 struct ABTI_ktelem {
-    ABTI_key *p_key;
     /* information of ABTI_key */
     void (*f_destructor)(void *value);
     uint32_t key_id;

--- a/src/key.c
+++ b/src/key.c
@@ -13,7 +13,6 @@
 static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
                                    void *value);
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
-void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key);
 
 static ABTD_atomic_uint32 g_key_id = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
@@ -279,30 +278,4 @@ static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key)
     }
 
     return NULL;
-}
-
-void ABTI_ktable_delete(ABTI_ktable *p_ktable, ABTI_key *p_key)
-{
-    uint32_t idx;
-    ABTI_ktelem *p_prev = NULL;
-    ABTI_ktelem *p_elem;
-
-    idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
-    p_elem = p_ktable->p_elems[idx];
-    while (p_elem) {
-        if (p_elem->p_key == p_key) {
-            if (p_prev) {
-                p_prev->p_next = p_elem->p_next;
-            } else {
-                p_ktable->p_elems[idx] = p_elem->p_next;
-            }
-            p_ktable->num--;
-
-            ABTU_free(p_elem);
-            return;
-        }
-
-        p_prev = p_elem;
-        p_elem = p_elem->p_next;
-    }
 }

--- a/src/key.c
+++ b/src/key.c
@@ -192,6 +192,8 @@ ABTI_ktable *ABTI_ktable_alloc(int size)
     ABTI_ktable *p_ktable;
 
     p_ktable = (ABTI_ktable *)ABTU_malloc(sizeof(ABTI_ktable));
+    /* size must be a power of 2. */
+    ABTI_ASSERT((size & (size - 1)) == 0);
     p_ktable->size = size;
     p_ktable->num = 0;
     p_ktable->p_elems =
@@ -232,7 +234,7 @@ void ABTI_ktable_free(ABTI_ktable *p_ktable)
 
 static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
 {
-    return p_key->id % size;
+    return p_key->id & (size - 1);
 }
 
 static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,

--- a/src/key.c
+++ b/src/key.c
@@ -185,7 +185,6 @@ ABTI_ktable *ABTI_ktable_alloc(int size)
     /* size must be a power of 2. */
     ABTI_ASSERT((size & (size - 1)) == 0);
     p_ktable->size = size;
-    p_ktable->num = 0;
     p_ktable->p_elems =
         (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
 
@@ -244,8 +243,6 @@ static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
     p_elem->value = value;
     p_elem->p_next = p_ktable->p_elems[idx];
     p_ktable->p_elems[idx] = p_elem;
-
-    p_ktable->num++;
 }
 
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key)


### PR DESCRIPTION
It is related to #159.

This PR optimizes the current `ABT_key` mechanism. Specifically, this PR removes the following:
- Modulo (`%`)
- A reference counter (`refcount`) that is atomically incremented/decremented.

This PR also cleans up `src/key.c`.
