### PR TITLE
key: use memory pool for allocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -751,6 +751,20 @@ AS_IF([test "x$have_builtin_expect" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_HAVE___BUILTIN_EXPECT, 1,
                  [Define to 1 if you have the `__builtin_expect' function.])])
 
+# check __alignof__
+AC_TRY_COMPILE([], [int a = __alignof__(double); (void)a;],
+               [have_alignof=gcc],
+               [AC_TRY_COMPILE([], [int a = alignof(double); (void)a;],
+                               [have_alignof=c11],
+                               [have_alignof=no])]
+)
+AS_IF([test "x$have_alignof" = "xgcc"],
+      [AC_DEFINE(ABT_CONFIG_HAVE_ALIGNOF_GCC, 1,
+                 [Define to 1 if you have the `__alignof__' operator.])])
+AS_IF([test "x$have_alignof" = "xc11"],
+      [AC_DEFINE(ABT_CONFIG_HAVE_ALIGNOF_C11, 1,
+                 [Define to 1 if you have the `alignof' operator.])])
+
 # check math library
 AC_CHECK_LIB([m], [log10])
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -360,8 +360,11 @@ struct ABTI_ktelem {
 };
 
 struct ABTI_ktable {
-    int size;              /* size of the table */
-    ABTI_ktelem **p_elems; /* element array */
+    int size; /* size of the table */
+    void *p_used_mem;
+    void *p_extra_mem;
+    size_t extra_mem_size;
+    ABTI_ktelem *p_elems[1]; /* element array */
 };
 
 struct ABTI_cond {
@@ -564,8 +567,8 @@ void ABTI_task_reset_id(void);
 ABT_unit_id ABTI_task_get_id(ABTI_task *p_task);
 
 /* Key */
-ABTI_ktable *ABTI_ktable_alloc(int size);
-void ABTI_ktable_free(ABTI_ktable *p_ktable);
+ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream, int size);
+void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable);
 
 /* Mutex */
 void ABTI_mutex_wait(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -191,13 +191,14 @@ struct ABTI_global {
     int mem_lp_alloc;        /* How to allocate large pages */
 
     ABTI_mem_pool_global_pool mem_pool_stack; /* Pool of stack (default size) */
-    ABTI_mem_pool_global_pool mem_pool_task_desc; /* Pool of task descriptors */
+    ABTI_mem_pool_global_pool mem_pool_desc;  /* Pool of descriptors that can
+                                               * store ABTI_task. */
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* They are used for external threads. */
     ABTI_spinlock mem_pool_stack_lock;
     ABTI_mem_pool_local_pool mem_pool_stack_ext;
-    ABTI_spinlock mem_pool_task_desc_lock;
-    ABTI_mem_pool_local_pool mem_pool_task_desc_ext;
+    ABTI_spinlock mem_pool_desc_lock;
+    ABTI_mem_pool_local_pool mem_pool_desc_ext;
 #endif
 #endif
 
@@ -230,7 +231,7 @@ struct ABTI_xstream {
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
     ABTI_mem_pool_local_pool mem_pool_stack;
-    ABTI_mem_pool_local_pool mem_pool_task_desc;
+    ABTI_mem_pool_local_pool mem_pool_desc;
 #endif
 };
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -242,8 +242,7 @@ static inline ABTI_task *ABTI_mem_alloc_task(ABTI_xstream *p_local_xstream)
 #endif
 
     /* Find the page that has an empty block */
-    p_task =
-        (ABTI_task *)ABTI_mem_pool_alloc(&p_local_xstream->mem_pool_task_desc);
+    p_task = (ABTI_task *)ABTI_mem_pool_alloc(&p_local_xstream->mem_pool_desc);
     /* To distinguish it from a malloc'ed case, assign non-NULL value. */
     *(uint32_t *)(((char *)p_task) + sizeof(ABTI_task)) = 0;
     return p_task;
@@ -263,13 +262,13 @@ static inline void ABTI_mem_free_task(ABTI_xstream *p_local_xstream,
         return;
     } else if (!p_local_xstream) {
         /* Return a stack and a descriptor to their global pools. */
-        ABTI_spinlock_acquire(&gp_ABTI_global->mem_pool_task_desc_lock);
-        ABTI_mem_pool_free(&gp_ABTI_global->mem_pool_task_desc_ext, p_task);
-        ABTI_spinlock_release(&gp_ABTI_global->mem_pool_task_desc_lock);
+        ABTI_spinlock_acquire(&gp_ABTI_global->mem_pool_desc_lock);
+        ABTI_mem_pool_free(&gp_ABTI_global->mem_pool_desc_ext, p_task);
+        ABTI_spinlock_release(&gp_ABTI_global->mem_pool_desc_lock);
         return;
     }
 #endif
-    ABTI_mem_pool_free(&p_local_xstream->mem_pool_task_desc, p_task);
+    ABTI_mem_pool_free(&p_local_xstream->mem_pool_desc, p_task);
 #endif
 }
 

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -20,6 +20,18 @@
 #define ABTU_unlikely(cond) (cond)
 #endif
 
+#ifdef ABT_CONFIG_HAVE_ALIGNOF_GCC
+#define ABTU_alignof(type) (__alignof__(type))
+#elif defined(ABT_CONFIG_HAVE_ALIGNOF_C11)
+#define ABTU_alignof(type) (alignof(type))
+#else
+#define ABTU_alignof(type) 16 /* 16 bytes would be a good guess. */
+#endif
+#define ABTU_MAX_ALIGNMENT                                                     \
+    (ABTU_alignof(long double) > ABTU_alignof(long long)                       \
+         ? ABTU_alignof(long double)                                           \
+         : ABTU_alignof(long long))
+
 /* Utility Functions */
 
 static inline void *ABTU_memalign(size_t alignment, size_t size)

--- a/src/key.c
+++ b/src/key.c
@@ -10,7 +10,15 @@
  * work-unit local storage (TLS).
  */
 
-static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
+typedef struct ABTI_ktable_mem_header {
+    struct ABTI_ktable_mem_header *p_next;
+    ABT_bool is_from_mempool;
+} ABTI_ktable_mem_header;
+#define ABTI_KTABLE_DESC_SIZE                                                  \
+    (ABTI_MEM_POOL_DESC_SIZE - sizeof(ABTI_ktable_mem_header))
+
+static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
+                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
                                    void *value);
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
 
@@ -118,11 +126,11 @@ int ABT_key_set(ABT_key key, void *value)
 
     if (p_self->p_keytable == NULL) {
         int key_table_size = gp_ABTI_global->key_table_size;
-        p_self->p_keytable = ABTI_ktable_alloc(key_table_size);
+        p_self->p_keytable = ABTI_ktable_alloc(p_local_xstream, key_table_size);
     }
 
     /* Save the value in the key-value table */
-    ABTI_ktable_set(p_self->p_keytable, p_key, value);
+    ABTI_ktable_set(p_local_xstream, p_self->p_keytable, p_key, value);
 
 fn_exit:
     return abt_errno;
@@ -177,23 +185,48 @@ fn_fail:
     goto fn_exit;
 }
 
-ABTI_ktable *ABTI_ktable_alloc(int size)
+ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream, int size)
 {
-    ABTI_ktable *p_ktable;
-
-    p_ktable = (ABTI_ktable *)ABTU_malloc(sizeof(ABTI_ktable));
     /* size must be a power of 2. */
     ABTI_ASSERT((size & (size - 1)) == 0);
+    /* max alignment must be a power of 2. */
+    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t ktable_size =
+        (offsetof(ABTI_ktable, p_elems) + sizeof(ABTI_ktelem *) * size +
+         ABTU_MAX_ALIGNMENT - 1) &
+        (~(ABTU_MAX_ALIGNMENT - 1));
+    ABTI_ktable *p_ktable;
+    if (ABTU_likely(ktable_size <= ABTI_KTABLE_DESC_SIZE)) {
+        /* Use memory pool. */
+        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_ktable =
+            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_header->p_next = NULL;
+        p_header->is_from_mempool = ABT_TRUE;
+        p_ktable->p_used_mem = p_mem;
+        p_ktable->p_extra_mem = (void *)(((char *)p_ktable) + ktable_size);
+        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - ktable_size;
+    } else {
+        /* Use malloc() */
+        void *p_mem = ABTU_malloc(ktable_size + sizeof(ABTI_ktable_mem_header));
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_ktable =
+            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_header->p_next = NULL;
+        p_header->is_from_mempool = ABT_FALSE;
+        p_ktable->p_used_mem = p_mem;
+        p_ktable->p_extra_mem = NULL;
+        p_ktable->extra_mem_size = 0;
+    }
     p_ktable->size = size;
-    p_ktable->p_elems =
-        (ABTI_ktelem **)ABTU_calloc(size, sizeof(ABTI_ktelem *));
-
+    memset(p_ktable->p_elems, 0, sizeof(ABTI_ktelem *) * size);
     return p_ktable;
 }
 
-void ABTI_ktable_free(ABTI_ktable *p_ktable)
+void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable)
 {
-    ABTI_ktelem *p_elem, *p_next;
+    ABTI_ktelem *p_elem;
     int i;
 
     for (i = 0; i < p_ktable->size; i++) {
@@ -203,14 +236,54 @@ void ABTI_ktable_free(ABTI_ktable *p_ktable)
             if (p_elem->f_destructor && p_elem->value) {
                 p_elem->f_destructor(p_elem->value);
             }
-            p_next = p_elem->p_next;
-            ABTU_free(p_elem);
-            p_elem = p_next;
+            p_elem = p_elem->p_next;
         }
     }
+    ABTI_ktable_mem_header *p_header =
+        (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
+    while (p_header) {
+        ABTI_ktable_mem_header *p_next = p_header->p_next;
+        if (ABTU_likely(p_header->is_from_mempool)) {
+            ABTI_mem_free_desc(p_local_xstream, (void *)p_header);
+        } else {
+            ABTU_free(p_header);
+        }
+        p_header = p_next;
+    }
+}
 
-    ABTU_free(p_ktable->p_elems);
-    ABTU_free(p_ktable);
+static inline void *ABTI_ktable_alloc_elem(ABTI_xstream *p_local_xstream,
+                                           ABTI_ktable *p_ktable, size_t size)
+{
+    ABTI_ASSERT((size & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t extra_mem_size = p_ktable->extra_mem_size;
+    if (extra_mem_size <= size) {
+        /* Use the extra memory. */
+        void *p_ret = p_ktable->p_extra_mem;
+        p_ktable->p_extra_mem = (void *)(((char *)p_ret) + size);
+        p_ktable->extra_mem_size = extra_mem_size - size;
+        return p_ret;
+    } else if (ABTU_likely(size <= ABTI_KTABLE_DESC_SIZE)) {
+        /* Use memory pool. */
+        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
+        p_header->is_from_mempool = ABT_TRUE;
+        p_ktable->p_used_mem = (void *)p_header;
+        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_ktable->p_extra_mem = (void *)(((char *)p_mem) + size);
+        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - size;
+        return p_mem;
+    } else {
+        /* Use malloc() */
+        void *p_mem = ABTU_malloc(size + sizeof(ABTI_ktable_mem_header));
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
+        p_header->is_from_mempool = ABT_FALSE;
+        p_ktable->p_used_mem = (void *)p_header;
+        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        return p_mem;
+    }
 }
 
 static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
@@ -218,7 +291,8 @@ static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
     return p_key->id & (size - 1);
 }
 
-static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
+static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
+                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
                                    void *value)
 {
     uint32_t idx;
@@ -237,7 +311,11 @@ static inline void ABTI_ktable_set(ABTI_ktable *p_ktable, ABTI_key *p_key,
     }
 
     /* The table does not have the same key */
-    p_elem = (ABTI_ktelem *)ABTU_malloc(sizeof(ABTI_ktelem));
+    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t ktelem_size = (sizeof(ABTI_ktelem) + ABTU_MAX_ALIGNMENT - 1) &
+                         (~(ABTU_MAX_ALIGNMENT - 1));
+    p_elem = (ABTI_ktelem *)ABTI_ktable_alloc_elem(p_local_xstream, p_ktable,
+                                                   ktelem_size);
     p_elem->f_destructor = p_key->f_destructor;
     p_elem->key_id = p_key->id;
     p_elem->value = value;

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -62,17 +62,15 @@ void ABTI_mem_init(ABTI_global *p_global)
                                    p_global->mem_sp_size, requested_types,
                                    num_requested_types,
                                    gp_ABTI_global->mem_page_size);
-    /* Round desc_size up to the cacheline size.  The last four bytes will be
-     * used to determine whether the descriptor is allocated externally (i.e.,
-     * malloc()) or taken from a memory pool. */
-    size_t task_desc_size =
-        (sizeof(ABTI_task) + 4 + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
-        (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+    /* The last four bytes will be used to store a mempool flag */
+    ABTI_STATIC_ASSERT(((ABTI_MEM_POOL_DESC_SIZE + 4) &
+                        (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0);
     ABTI_mem_pool_init_global_pool(&p_global->mem_pool_desc,
                                    p_global->mem_max_descs /
                                        ABT_MEM_POOL_MAX_LOCAL_BUCKETS,
-                                   task_desc_size, 0, p_global->mem_page_size,
-                                   requested_types, num_requested_types,
+                                   ABTI_MEM_POOL_DESC_SIZE + 4, 0,
+                                   p_global->mem_page_size, requested_types,
+                                   num_requested_types,
                                    gp_ABTI_global->mem_page_size);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     ABTI_spinlock_clear(&p_global->mem_pool_stack_lock);

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -68,7 +68,7 @@ void ABTI_mem_init(ABTI_global *p_global)
     size_t task_desc_size =
         (sizeof(ABTI_task) + 4 + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
         (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
-    ABTI_mem_pool_init_global_pool(&p_global->mem_pool_task_desc,
+    ABTI_mem_pool_init_global_pool(&p_global->mem_pool_desc,
                                    p_global->mem_max_descs /
                                        ABT_MEM_POOL_MAX_LOCAL_BUCKETS,
                                    task_desc_size, 0, p_global->mem_page_size,
@@ -78,9 +78,9 @@ void ABTI_mem_init(ABTI_global *p_global)
     ABTI_spinlock_clear(&p_global->mem_pool_stack_lock);
     ABTI_mem_pool_init_local_pool(&p_global->mem_pool_stack_ext,
                                   &p_global->mem_pool_stack);
-    ABTI_spinlock_clear(&p_global->mem_pool_task_desc_lock);
-    ABTI_mem_pool_init_local_pool(&p_global->mem_pool_task_desc_ext,
-                                  &p_global->mem_pool_task_desc);
+    ABTI_spinlock_clear(&p_global->mem_pool_desc_lock);
+    ABTI_mem_pool_init_local_pool(&p_global->mem_pool_desc_ext,
+                                  &p_global->mem_pool_desc);
 #endif
 }
 
@@ -88,24 +88,24 @@ void ABTI_mem_init_local(ABTI_xstream *p_local_xstream)
 {
     ABTI_mem_pool_init_local_pool(&p_local_xstream->mem_pool_stack,
                                   &gp_ABTI_global->mem_pool_stack);
-    ABTI_mem_pool_init_local_pool(&p_local_xstream->mem_pool_task_desc,
-                                  &gp_ABTI_global->mem_pool_task_desc);
+    ABTI_mem_pool_init_local_pool(&p_local_xstream->mem_pool_desc,
+                                  &gp_ABTI_global->mem_pool_desc);
 }
 
 void ABTI_mem_finalize(ABTI_global *p_global)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     ABTI_mem_pool_destroy_local_pool(&p_global->mem_pool_stack_ext);
-    ABTI_mem_pool_destroy_local_pool(&p_global->mem_pool_task_desc_ext);
+    ABTI_mem_pool_destroy_local_pool(&p_global->mem_pool_desc_ext);
 #endif
     ABTI_mem_pool_destroy_global_pool(&p_global->mem_pool_stack);
-    ABTI_mem_pool_destroy_global_pool(&p_global->mem_pool_task_desc);
+    ABTI_mem_pool_destroy_global_pool(&p_global->mem_pool_desc);
 }
 
 void ABTI_mem_finalize_local(ABTI_xstream *p_local_xstream)
 {
     ABTI_mem_pool_destroy_local_pool(&p_local_xstream->mem_pool_stack);
-    ABTI_mem_pool_destroy_local_pool(&p_local_xstream->mem_pool_task_desc);
+    ABTI_mem_pool_destroy_local_pool(&p_local_xstream->mem_pool_desc);
 }
 
 int ABTI_mem_check_lp_alloc(int lp_alloc)

--- a/src/task.c
+++ b/src/task.c
@@ -771,7 +771,7 @@ void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task)
 
     /* Free the key-value table */
     if (p_task->unit_def.p_keytable) {
-        ABTI_ktable_free(p_task->unit_def.p_keytable);
+        ABTI_ktable_free(p_local_xstream, p_task->unit_def.p_keytable);
     }
 
     ABTI_mem_free_task(p_local_xstream, p_task);

--- a/src/thread.c
+++ b/src/thread.c
@@ -23,7 +23,8 @@ static int ABTI_thread_migrate_to_xstream(ABTI_xstream **pp_local_xstream,
                                           ABTI_xstream *p_xstream);
 #endif
 static inline ABT_bool ABTI_thread_is_ready(ABTI_thread *p_thread);
-static inline void ABTI_thread_free_internal(ABTI_thread *p_thread);
+static inline void ABTI_thread_free_internal(ABTI_xstream *p_local_xstream,
+                                             ABTI_thread *p_thread);
 static inline ABT_unit_id ABTI_thread_get_new_id(void);
 
 /** @defgroup ULT User-level Thread (ULT)
@@ -1733,7 +1734,8 @@ fn_fail:
     goto fn_exit;
 }
 
-static inline void ABTI_thread_free_internal(ABTI_thread *p_thread)
+static inline void ABTI_thread_free_internal(ABTI_xstream *p_local_xstream,
+                                             ABTI_thread *p_thread)
 {
     /* Free the unit */
     p_thread->unit_def.p_pool->u_free(&p_thread->unit_def.unit);
@@ -1743,7 +1745,7 @@ static inline void ABTI_thread_free_internal(ABTI_thread *p_thread)
 
     /* Free the key-value table */
     if (p_thread->unit_def.p_keytable) {
-        ABTI_ktable_free(p_thread->unit_def.p_keytable);
+        ABTI_ktable_free(p_local_xstream, p_thread->unit_def.p_keytable);
     }
 }
 
@@ -1752,7 +1754,7 @@ void ABTI_thread_free(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
     LOG_DEBUG("[U%" PRIu64 ":E%d] freed\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
 
-    ABTI_thread_free_internal(p_thread);
+    ABTI_thread_free_internal(p_local_xstream, p_thread);
 
     /* Free ABTI_thread (stack will also be freed) */
     ABTI_mem_free_thread(p_local_xstream, p_thread);
@@ -1766,7 +1768,7 @@ void ABTI_thread_free_main(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 
     /* Free the key-value table */
     if (p_thread->unit_def.p_keytable) {
-        ABTI_ktable_free(p_thread->unit_def.p_keytable);
+        ABTI_ktable_free(p_local_xstream, p_thread->unit_def.p_keytable);
     }
 
     ABTI_mem_free_thread(p_local_xstream, p_thread);
@@ -1784,7 +1786,7 @@ void ABTI_thread_free_main_sched(ABTI_xstream *p_local_xstream,
 
     /* Free the key-value table */
     if (p_thread->unit_def.p_keytable) {
-        ABTI_ktable_free(p_thread->unit_def.p_keytable);
+        ABTI_ktable_free(p_local_xstream, p_thread->unit_def.p_keytable);
     }
 
     ABTI_mem_free_thread(p_local_xstream, p_thread);

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -10,7 +10,7 @@
 
 #define DEFAULT_NUM_XSTREAMS 4
 #define DEFAULT_NUM_TASKS 4
-#define NUM_TLS 4
+#define NUM_TLS 128
 
 static ABT_key tls[NUM_TLS];
 static int num_tasks;

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -10,7 +10,7 @@
 
 #define DEFAULT_NUM_XSTREAMS 4
 #define DEFAULT_NUM_THREADS 4
-#define NUM_TLS 4
+#define NUM_TLS 128
 
 static ABT_key tls[NUM_TLS];
 static int num_threads;


### PR DESCRIPTION
This PR, with #196, fixes #159.

## Problems

Too many `malloc()` in `ABT_key` operations significantly degrade the performance, discouraging users from using the `ABT_key` interface.

## Solutions

`malloc()` is replaced by a generic memory pool introduced by #183. This memory pool is shared with the task descriptor pool, so it does not increase the memory footprint (and does not overly make the current memory pool management).

## Impact

The following shows the overhead [ns] of `ABT_key` operations on 56-core (2-socket Intel Xeon Platinum 8180 Processor). Lower is better. The blue one is before the optimization of #196, the orange bar is the current master (#196), and the gray one is this PR. Basically each ES forks and joins 256 threads (=ULTs) in total, while each ULT accesses the TLS several times. Striped bars mean a large error. It does not show the error bar, but overall the performance on 1ES was stable.

<img width="600" alt="img" src="https://user-images.githubusercontent.com/15073003/84519581-eb8ac200-ac97-11ea-9492-d213f913f5e8.png">

This shows that:
- This PR considerably reduces overheads.
- After this PR, the performance on this Skylake (or a typical enterprise Intel server) will be:
  - A new entry creation (i.e., the first access with a certain key) costs 50~100 ns (about 200 cycles).
  - If the key entry already exists in ULT (i.e., subsequent access with the same key), the access cost is around 20 ns (about 50 cycles).

I have not found any issues except for the complicated memory management code. I think this solution is reasonable for now.
