### PR TITLE
add a tool interface for profiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,11 @@ AC_ARG_ENABLE([dynamic-promotion],
                    [use the dynamic promotion threading technique that performs
                     better if a ULT does not yield.]))
 
+# --enable-tool
+AC_ARG_ENABLE([tool],
+    AS_HELP_STRING([--enable-tool],
+                   [enable the tool interface, which is disabled by default.]))
+
 # --disable-simple-mutex
 AC_ARG_ENABLE([simple-mutex],
     AS_HELP_STRING([--disable-simple-mutex], [use an experimental mutex implementation]),,
@@ -620,6 +625,10 @@ AS_IF([test "x$enable_dynamic_promotion" = "xyes" -a "x$enable_fcontext" != "xno
                  [Define to use the dynamic promotion technique for ULT])],
       [AC_DEFINE(ABT_CONFIG_THREAD_TYPE, ABT_THREAD_TYPE_FULLY_FLEDGED)])
 
+# --enable-tool
+AS_IF([test "x$enable_tool" != "xyes"],
+      [AC_DEFINE(ABT_CONFIG_DISABLE_TOOL_INTERFACE, 1,
+                 [Define to use the tool interface])])
 
 # check if __atomic builtins are supported
 AC_TRY_COMPILE(

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ abt_sources = \
 	thread_attr.c \
 	thread_htable.c \
 	timer.c \
+	tool.c \
 	unit.c
 
 include $(top_srcdir)/src/arch/Makefile.mk

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -13,6 +13,9 @@ void ABTD_thread_func_wrapper(void *p_arg)
     ABTD_thread_context *p_ctx = (ABTD_thread_context *)p_arg;
     ABTI_thread *p_thread = ABTI_thread_context_get_thread(p_ctx);
     ABTI_xstream *p_local_xstream = p_thread->unit_def.p_last_xstream;
+    ABTI_tool_event_thread_run(p_local_xstream, p_thread,
+                               p_local_xstream->p_unit,
+                               p_thread->unit_def.p_parent);
     p_local_xstream->p_unit = &p_thread->unit_def;
 
     p_thread->unit_def.f_unit(p_thread->unit_def.p_arg);
@@ -49,6 +52,8 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
                       p_thread->unit_def.p_last_xstream->rank);
 
             /* Note that a parent ULT cannot be a joiner. */
+            ABTI_tool_event_thread_resume(p_local_xstream, p_joiner,
+                                          &p_thread->unit_def);
             ABTI_thread_finish_context_to_sibling(p_local_xstream, p_thread,
                                                   p_joiner);
             return;
@@ -126,6 +131,7 @@ void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
             ABTI_thread_set_ready(p_local_xstream, p_joiner);
         }
     }
+    ABTI_tool_event_thread_cancel(p_local_xstream, p_thread);
 }
 
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -187,7 +187,8 @@ int ABT_barrier_wait(ABT_barrier barrier)
 
         if (type == ABT_UNIT_TYPE_THREAD) {
             /* Suspend the current ULT */
-            ABTI_thread_suspend(&p_local_xstream, p_thread);
+            ABTI_thread_suspend(&p_local_xstream, p_thread,
+                                ABT_SYNC_EVENT_TYPE_BARRIER, (void *)p_barrier);
         } else {
             /* External thread is waiting here polling ext_signal. */
             /* FIXME: need a better implementation */

--- a/src/cond.c
+++ b/src/cond.c
@@ -238,7 +238,8 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
         }
 #endif
         ABTI_thread_yield(&p_local_xstream,
-                          ABTI_unit_get_thread(p_local_xstream->p_unit));
+                          ABTI_unit_get_thread(p_local_xstream->p_unit),
+                          ABT_SYNC_EVENT_TYPE_COND, (void *)p_cond);
     }
     ABTU_free(p_unit);
 

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -143,7 +143,9 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
             ABTI_spinlock_release(&p_eventual->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(&p_local_xstream, p_current);
+            ABTI_thread_suspend(&p_local_xstream, p_current,
+                                ABT_SYNC_EVENT_TYPE_EVENTUAL,
+                                (void *)p_eventual);
 
         } else {
             ABTI_spinlock_release(&p_eventual->lock);

--- a/src/futures.c
+++ b/src/futures.c
@@ -172,7 +172,8 @@ int ABT_future_wait(ABT_future future)
             ABTI_spinlock_release(&p_future->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(&p_local_xstream, p_current);
+            ABTI_thread_suspend(&p_local_xstream, p_current,
+                                ABT_SYNC_EVENT_TYPE_FUTURE, (void *)p_future);
 
         } else {
             ABTI_spinlock_release(&p_future->lock);

--- a/src/global.c
+++ b/src/global.c
@@ -197,7 +197,9 @@ int ABT_finalize(void)
                   p_thread->unit_def.p_last_xstream->rank);
 
         /* Switch to the parent */
-        ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread);
+        ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread,
+                                             ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
+                                             (void *)p_local_xstream);
 
         /* Back to the original thread */
         LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -40,6 +40,7 @@ noinst_HEADERS = \
 	include/abti_thread.h \
 	include/abti_thread_attr.h \
 	include/abti_thread_htable.h \
+	include/abti_tool.h \
 	include/abti_unit.h \
 	include/abti_valgrind.h \
 	include/abtu.h

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -221,6 +221,8 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ,
     /* Default sleep time of a predefined scheduler */
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC,
+    /* Whether the tool interface is enabled or not */
+    ABT_INFO_QUERY_KIND_ENABLED_TOOL,
 };
 
 /* Constants for ABT_bool */

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -90,6 +90,7 @@ extern "C" {
 #define ABT_ERR_INV_BARRIER        26  /* Invalid barrier */
 #define ABT_ERR_INV_TIMER          27  /* Invalid timer */
 #define ABT_ERR_INV_QUERY_KIND     28  /* Invalid query kind */
+#define ABT_ERR_INV_TOOL_CONTEXT   52  /* Invalid tool context */
 #define ABT_ERR_XSTREAM            29  /* ES-related error */
 #define ABT_ERR_XSTREAM_STATE      30  /* ES state error */
 #define ABT_ERR_XSTREAM_BARRIER    31  /* ES barrier-related error */
@@ -225,6 +226,62 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_ENABLED_TOOL,
 };
 
+enum ABT_tool_query_kind {
+    ABT_TOOL_QUERY_KIND_POOL,
+    ABT_TOOL_QUERY_KIND_STACK_DEPTH,
+    ABT_TOOL_QUERY_KIND_CALLER_TYPE,
+    ABT_TOOL_QUERY_KIND_CALLER_HANDLE,
+    ABT_TOOL_QUERY_KIND_SYNC_OBJECT_TYPE,
+    ABT_TOOL_QUERY_KIND_SYNC_OBJECT_HANDLE,
+};
+
+/* Execution entity */
+enum ABT_exec_entity_type {
+    ABT_EXEC_ENTITY_TYPE_EXT, /* External thread */
+    ABT_EXEC_ENTITY_TYPE_THREAD,
+    ABT_EXEC_ENTITY_TYPE_TASK,
+};
+
+/* Synchronization event */
+enum ABT_sync_event_type {
+    ABT_SYNC_EVENT_TYPE_UNKNOWN = 0,
+    ABT_SYNC_EVENT_TYPE_USER,
+    ABT_SYNC_EVENT_TYPE_OTHER,
+    ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
+    ABT_SYNC_EVENT_TYPE_THREAD_JOIN,
+    ABT_SYNC_EVENT_TYPE_TASK_JOIN,
+    ABT_SYNC_EVENT_TYPE_MUTEX,
+    ABT_SYNC_EVENT_TYPE_COND,
+    ABT_SYNC_EVENT_TYPE_RWLOCK,
+    ABT_SYNC_EVENT_TYPE_EVENTUAL,
+    ABT_SYNC_EVENT_TYPE_FUTURE,
+    ABT_SYNC_EVENT_TYPE_BARRIER,
+};
+
+/* Tool event masks */
+#define ABT_TOOL_EVENT_THREAD_NONE    (0)
+#define ABT_TOOL_EVENT_THREAD_CREATE  (1 << 0)
+#define ABT_TOOL_EVENT_THREAD_JOIN    (1 << 1)
+#define ABT_TOOL_EVENT_THREAD_FREE    (1 << 2)
+#define ABT_TOOL_EVENT_THREAD_REVIVE  (1 << 3)
+#define ABT_TOOL_EVENT_THREAD_RUN     (1 << 4)
+#define ABT_TOOL_EVENT_THREAD_FINISH  (1 << 5)
+#define ABT_TOOL_EVENT_THREAD_CANCEL  (1 << 6)
+#define ABT_TOOL_EVENT_THREAD_YIELD   (1 << 7)
+#define ABT_TOOL_EVENT_THREAD_SUSPEND (1 << 8)
+#define ABT_TOOL_EVENT_THREAD_RESUME  (1 << 9)
+#define ABT_TOOL_EVENT_THREAD_ALL     ((uint64_t)(0xFFFFFFFFFFFFFFFF))
+
+#define ABT_TOOL_EVENT_TASK_NONE   (0)
+#define ABT_TOOL_EVENT_TASK_CREATE (1 << 0)
+#define ABT_TOOL_EVENT_TASK_JOIN   (1 << 1)
+#define ABT_TOOL_EVENT_TASK_FREE   (1 << 2)
+#define ABT_TOOL_EVENT_TASK_REVIVE (1 << 3)
+#define ABT_TOOL_EVENT_TASK_RUN    (1 << 4)
+#define ABT_TOOL_EVENT_TASK_FINISH (1 << 5)
+#define ABT_TOOL_EVENT_TASK_CANCEL (1 << 6)
+#define ABT_TOOL_EVENT_TASK_ALL    ((uint64_t)(0xFFFFFFFFFFFFFFFF))
+
 /* Constants for ABT_bool */
 #define ABT_TRUE    1
 #define ABT_FALSE   0
@@ -252,6 +309,7 @@ struct ABT_eventual_opaque;
 struct ABT_future_opaque;
 struct ABT_barrier_opaque;
 struct ABT_timer_opaque;
+struct ABT_tool_context_opaque;
 
 /* Execution Stream */
 typedef struct ABT_xstream_opaque *         ABT_xstream;
@@ -317,6 +375,14 @@ typedef struct ABT_timer_opaque *           ABT_timer;
 typedef int                                 ABT_bool;
 /* Query kind */
 typedef enum ABT_info_query_kind            ABT_info_query_kind;
+/* Tool context */
+typedef struct ABT_tool_context_opaque *    ABT_tool_context;
+/* Tool query kind */
+typedef enum ABT_tool_query_kind            ABT_tool_query_kind;
+/* Type of execution entity */
+typedef enum ABT_exec_entity_type           ABT_exec_entity_type;
+/* Type of synchronization event */
+typedef enum ABT_sync_event_type            ABT_sync_event_type;
 
 
 /* Null Object Handles */
@@ -341,6 +407,7 @@ typedef enum ABT_info_query_kind            ABT_info_query_kind;
 #define ABT_FUTURE_NULL          ((ABT_future)         NULL)
 #define ABT_BARRIER_NULL         ((ABT_barrier)        NULL)
 #define ABT_TIMER_NULL           ((ABT_timer)          NULL)
+#define ABT_TOOL_CONTEXT_NULL    ((ABT_tool_context)   NULL)
 #else
 #define ABT_XSTREAM_NULL         ((ABT_xstream)        (0x01))
 #define ABT_XSTREAM_BARRIER_NULL ((ABT_xstream_barrier)(0x02))
@@ -361,6 +428,7 @@ typedef enum ABT_info_query_kind            ABT_info_query_kind;
 #define ABT_FUTURE_NULL          ((ABT_future)         (0x11))
 #define ABT_BARRIER_NULL         ((ABT_barrier)        (0x12))
 #define ABT_TIMER_NULL           ((ABT_timer)          (0x13))
+#define ABT_TOOL_CONTEXT_NULL    ((ABT_tool_context)   (0x14))
 #endif
 
 /* Scheduler config */
@@ -442,6 +510,11 @@ typedef struct {
     ABT_pool_print_all_fn     p_print_all;
 } ABT_pool_def;
 
+/* Tool callback type. */
+typedef void (*ABT_tool_thread_callback_fn)(ABT_thread, ABT_xstream, uint64_t event,
+                                            ABT_tool_context context, void *user_arg);
+typedef void (*ABT_tool_task_callback_fn)(ABT_task, ABT_xstream, uint64_t event,
+                                          ABT_tool_context context, void *user_arg);
 
 /* Init & Finalize */
 int ABT_init(int argc, char **argv) ABT_API_PUBLIC;
@@ -729,6 +802,18 @@ int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool) ABT_API_PUBLIC
 int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
                                              void (*cb_func)(ABT_bool, void *),
                                              void *arg) ABT_API_PUBLIC;
+
+/* Tool Functions */
+int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
+                                      uint64_t event_mask_thread,
+                                      void *user_arg) ABT_API_PUBLIC;
+int ABT_tool_register_task_callback(ABT_tool_task_callback_fn cb_func,
+                                    uint64_t event_mask_task,
+                                    void *user_arg) ABT_API_PUBLIC;
+int ABT_tool_query_thread(ABT_tool_context context, uint64_t event_thread,
+                          ABT_tool_query_kind query_kind, void *val) ABT_API_PUBLIC;
+int ABT_tool_query_task(ABT_tool_context context, uint64_t event_task,
+                        ABT_tool_query_kind query_kind, void *val) ABT_API_PUBLIC;
 
 #if defined(__cplusplus)
 }

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -124,6 +124,9 @@ typedef struct ABTI_eventual ABTI_eventual;
 typedef struct ABTI_future ABTI_future;
 typedef struct ABTI_barrier ABTI_barrier;
 typedef struct ABTI_timer ABTI_timer;
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+typedef struct ABTI_tool_context ABTI_tool_context;
+#endif
 /* ID associated with native thread (e.g, Pthreads), which can distinguish
  * execution streams and external threads */
 struct ABTI_native_thread_id_opaque;
@@ -203,6 +206,18 @@ struct ABTI_global {
 #endif
 
     ABT_bool print_config; /* Whether to print config on ABT_init */
+
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    ABTI_spinlock tool_writer_lock;
+
+    ABT_tool_thread_callback_fn tool_thread_cb_f;
+    void *tool_thread_user_arg;
+    ABTD_atomic_uint64 tool_thread_event_mask_tagged;
+
+    ABT_tool_task_callback_fn tool_task_cb_f;
+    void *tool_task_user_arg;
+    ABTD_atomic_uint64 tool_task_event_mask_tagged;
+#endif
 };
 
 struct ABTI_local_func {
@@ -415,6 +430,16 @@ struct ABTI_timer {
     ABTD_time end;
 };
 
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+struct ABTI_tool_context {
+    ABTI_unit *p_caller;
+    ABTI_pool *p_pool;
+    ABTI_unit *p_parent; /* Parent of the target unit.  Used to get the depth */
+    ABT_sync_event_type sync_event_type;
+    void *p_sync_object; /* ABTI type */
+};
+#endif
+
 /* Global Data */
 extern ABTI_global *gp_ABTI_global;
 extern ABTI_local_func gp_ABTI_local_func;
@@ -595,6 +620,7 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_unit.h"
 #include "abti_stream.h"
 #include "abti_self.h"
+#include "abti_tool.h"
 #include "abti_thread.h"
 #include "abti_thread_attr.h"
 #include "abti_task.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -550,8 +550,8 @@ void ABTI_thread_free_main(ABTI_xstream *p_local_xstream,
 void ABTI_thread_free_main_sched(ABTI_xstream *p_local_xstream,
                                  ABTI_thread *p_thread);
 int ABTI_thread_set_blocked(ABTI_thread *p_thread);
-void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream,
-                         ABTI_thread *p_thread);
+void ABTI_thread_suspend(ABTI_xstream **pp_local_xstream, ABTI_thread *p_thread,
+                         ABT_sync_event_type sync_event_type, void *p_sync);
 int ABTI_thread_set_ready(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
@@ -584,7 +584,9 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
 ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
                                        ABTI_thread_queue *p_queue,
                                        ABTI_thread *p_thread,
-                                       ABTI_thread_htable *p_htable);
+                                       ABTI_thread_htable *p_htable,
+                                       ABT_sync_event_type sync_event_type,
+                                       void *p_sync);
 
 /* Tasklet */
 void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task);

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -121,7 +121,8 @@ static inline int ABTI_cond_wait(ABTI_xstream **pp_local_xstream,
         ABTI_mutex_unlock(p_local_xstream, p_mutex);
 
         /* Suspend the current ULT */
-        ABTI_thread_suspend(pp_local_xstream, p_thread);
+        ABTI_thread_suspend(pp_local_xstream, p_thread,
+                            ABT_SYNC_EVENT_TYPE_COND, (void *)p_cond);
 
     } else {
         ABTI_spinlock_release(&p_cond->lock);

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -211,6 +211,14 @@
         }                                                                      \
     } while (0)
 
+#define ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p)                                    \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_tool_context *)NULL) {   \
+            abt_errno = ABT_ERR_INV_TOOL_CONTEXT;                              \
+            goto fn_fail;                                                      \
+        }                                                                      \
+    } while (0)
+
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
 #define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 1
 #else

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -79,7 +79,8 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
         LOG_DEBUG("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
             ABTI_thread_yield(pp_local_xstream,
-                              ABTI_unit_get_thread(p_local_xstream->p_unit));
+                              ABTI_unit_get_thread(p_local_xstream->p_unit),
+                              ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
             p_local_xstream = *pp_local_xstream;
         }
         LOG_DEBUG("%p: lock - acquired\n", p_mutex);

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -157,6 +157,8 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_sibling_internal(
 #endif
     p_new->unit_def.p_parent = p_old->unit_def.p_parent;
     if (is_finish) {
+        ABTI_tool_event_thread_finish(*pp_local_xstream, p_old,
+                                      p_old->unit_def.p_parent);
         ABTD_thread_finish_context(&p_old->ctx, &p_new->ctx);
         return NULL; /* Unreachable. */
     } else {
@@ -171,7 +173,8 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_sibling_internal(
 }
 
 static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABT_bool is_finish)
+    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABT_bool is_finish,
+    ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_ASSERT(ABTI_unit_type_is_thread(p_old->unit_def.type));
     ABTI_thread *p_new = ABTI_unit_get_thread(p_old->unit_def.p_parent);
@@ -183,15 +186,23 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
     ABTI_ASSERT(ABTI_thread_is_dynamic_promoted(p_new));
 #endif
     if (is_finish) {
+        ABTI_tool_event_thread_finish(*pp_local_xstream, p_old,
+                                      p_old->unit_def.p_parent);
         ABTD_thread_finish_context(&p_old->ctx, &p_new->ctx);
         return NULL; /* Unreachable. */
     } else {
+        ABTI_tool_event_thread_yield(*pp_local_xstream, p_old,
+                                     p_old->unit_def.p_parent, sync_event_type,
+                                     p_sync);
         ABTD_thread_context_switch(&p_old->ctx, &p_new->ctx);
         ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
         *pp_local_xstream = p_local_xstream;
         ABTI_unit *p_prev = p_local_xstream->p_unit;
         p_local_xstream->p_unit = &p_old->unit_def;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev->type));
+        /* Invoke an event of thread run. */
+        ABTI_tool_event_thread_run(p_local_xstream, p_old, p_prev,
+                                   p_old->unit_def.p_parent);
         return ABTI_unit_get_thread(p_prev);
     }
 }
@@ -211,6 +222,9 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
                   ABTI_thread_get_id(p_new));
         p_local_xstream = *pp_local_xstream;
         p_local_xstream->p_unit = &p_new->unit_def;
+        /* Invoke an event of thread run. */
+        ABTI_tool_event_thread_run(p_local_xstream, p_new, &p_old->unit_def,
+                                   &p_old->unit_def);
         ABTD_thread_context_make_and_call(&p_old->ctx, p_new->unit_def.f_unit,
                                           p_new->unit_def.p_arg, p_stacktop);
         /* The scheduler continues from here. If the previous thread has not
@@ -225,6 +239,9 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
         p_local_xstream->p_unit = &p_old->unit_def;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
+            /* Invoke a thread-finish event of the previous thread. */
+            ABTI_tool_event_thread_finish(p_local_xstream, p_prev,
+                                          &p_old->unit_def);
             /* See ABTDI_thread_terminate for details.
              * TODO: avoid making a copy of the code. */
             ABTD_thread_context *p_ctx = &p_prev->ctx;
@@ -271,6 +288,7 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
         ABTI_unit *p_prev = p_local_xstream->p_unit;
         p_local_xstream->p_unit = &p_old->unit_def;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev->type));
+        /* p_old keeps running as a parent, so no thread-run event incurs. */
         return ABTI_unit_get_thread(p_prev);
     }
 }
@@ -285,12 +303,14 @@ ABTI_thread_context_switch_to_sibling(ABTI_xstream **pp_local_xstream,
                                                           ABT_FALSE);
 }
 
-static inline ABTI_thread *
-ABTI_thread_context_switch_to_parent(ABTI_xstream **pp_local_xstream,
-                                     ABTI_thread *p_old)
+static inline ABTI_thread *ABTI_thread_context_switch_to_parent(
+    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old,
+    ABT_sync_event_type sync_event_type, void *p_sync)
 {
     return ABTI_thread_context_switch_to_parent_internal(pp_local_xstream,
-                                                         p_old, ABT_FALSE);
+                                                         p_old, ABT_FALSE,
+                                                         sync_event_type,
+                                                         p_sync);
 }
 
 static inline ABTI_thread *
@@ -314,7 +334,9 @@ ABTI_thread_finish_context_to_parent(ABTI_xstream *p_local_xstream,
                                      ABTI_thread *p_old)
 {
     ABTI_thread_context_switch_to_parent_internal(&p_local_xstream, p_old,
-                                                  ABT_TRUE);
+                                                  ABT_TRUE,
+                                                  ABT_SYNC_EVENT_TYPE_UNKNOWN,
+                                                  NULL);
 }
 
 static inline void
@@ -344,7 +366,9 @@ static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
 }
 
 static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
-                                     ABTI_thread *p_thread)
+                                     ABTI_thread *p_thread,
+                                     ABT_sync_event_type sync_event_type,
+                                     void *p_sync)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
@@ -354,7 +378,8 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
                                   ABTI_UNIT_STATE_READY);
 
     /* Switch to the top scheduler */
-    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread);
+    ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
+                                         sync_event_type, p_sync);
 
     /* Back to the original thread */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -1,0 +1,515 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTI_TOOL_H_INCLUDED
+#define ABTI_TOOL_H_INCLUDED
+
+static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread);
+static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task);
+
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+static inline ABTI_tool_context *
+ABTI_tool_context_get_ptr(ABT_tool_context tctx)
+{
+#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
+    ABTI_tool_context *p_tctx;
+    if (tctx == ABT_TOOL_CONTEXT_NULL) {
+        p_tctx = NULL;
+    } else {
+        p_tctx = (ABTI_tool_context *)tctx;
+    }
+    return p_tctx;
+#else
+    return (ABTI_tool_context *)tctx;
+#endif
+}
+
+static inline ABT_tool_context
+ABTI_tool_context_get_handle(ABTI_tool_context *p_tctx)
+{
+#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
+    ABT_tool_context h_tctx;
+    if (p_tctx == NULL) {
+        h_tctx = ABT_TOOL_CONTEXT_NULL;
+    } else {
+        h_tctx = (ABT_tool_context)p_tctx;
+    }
+    return h_tctx;
+#else
+    return (ABT_tool_context)p_tctx;
+#endif
+}
+
+#define ABTI_TOOL_EVENT_TAG_SIZE 20 /* bits */
+#define ABTI_TOOL_EVENT_TAG_MASK                                               \
+    ((((uint64_t)1 << (uint64_t)ABTI_TOOL_EVENT_TAG_SIZE) - 1)                 \
+     << (uint64_t)(64 - 1 - ABTI_TOOL_EVENT_TAG_SIZE))
+#define ABTI_TOOL_EVENT_TAG_INC                                                \
+    ((uint64_t)1 << (uint64_t)(64 - 1 - ABTI_TOOL_EVENT_TAG_SIZE))
+#define ABTI_TOOL_EVENT_TAG_DIRTY_BIT ((uint64_t)1 << (uint64_t)(64 - 1))
+
+static inline void
+ABTI_tool_event_thread_update_callback(ABT_tool_thread_callback_fn cb_func,
+                                       uint64_t event_mask_thread,
+                                       void *user_arg)
+{
+    /* The spinlock is needed to avoid data race between two writers. */
+    ABTI_global *p_global = gp_ABTI_global;
+    ABTI_spinlock_acquire(&p_global->tool_writer_lock);
+
+    /*
+     * This atomic writing process is needed to avoid data race between a reader
+     * and a writer.  We need to atomically update three values (callback, event
+     * mask, and user_arg) in the following cases:
+     *
+     * A. ES-W writes the three values while ES-R is reading the three values
+     * B. ES-W1 writes and then ES-W2 writes the three values while ES-R is
+     *    reading the three values
+     *
+     * The reader will first read the event mask and then load the other two.
+     * The reader then read the event mask again and see if it is 1. the same as
+     * the previous and 2. clean.  If both are satisfied, acquire-release memory
+     * order guarantees that the loaded values are ones updated by the same
+     * ABTI_tool_event_thread_update_callback() call, unless the tag value wraps
+     * around (which does not happen practically).
+     */
+
+    uint64_t current = ABTD_atomic_acquire_load_uint64(
+        &p_global->tool_thread_event_mask_tagged);
+    uint64_t new_tag =
+        (current + ABTI_TOOL_EVENT_TAG_INC) & ABTI_TOOL_EVENT_TAG_MASK;
+    uint64_t new_mask =
+        new_tag | ((event_mask_thread & ~ABTI_TOOL_EVENT_TAG_MASK) &
+                   ~ABTI_TOOL_EVENT_TAG_DIRTY_BIT);
+    uint64_t dirty_mask = ABTI_TOOL_EVENT_TAG_DIRTY_BIT | new_mask;
+
+    ABTD_atomic_release_store_uint64(&p_global->tool_thread_event_mask_tagged,
+                                     dirty_mask);
+    p_global->tool_thread_cb_f = cb_func;
+    p_global->tool_thread_user_arg = user_arg;
+    ABTD_atomic_release_store_uint64(&p_global->tool_thread_event_mask_tagged,
+                                     new_mask);
+
+    ABTI_spinlock_release(&p_global->tool_writer_lock);
+}
+
+static inline void
+ABTI_tool_event_task_update_callback(ABT_tool_task_callback_fn cb_func,
+                                     uint64_t event_mask_task, void *user_arg)
+{
+    ABTI_global *p_global = gp_ABTI_global;
+    /* The spinlock is needed to avoid data race between two writers. */
+    ABTI_spinlock_acquire(&p_global->tool_writer_lock);
+
+    /* This following writing process is needed to avoid data race between a
+     * reader and a writer. */
+    uint64_t current =
+        ABTD_atomic_acquire_load_uint64(&p_global->tool_task_event_mask_tagged);
+    uint64_t new_tag =
+        (current + ABTI_TOOL_EVENT_TAG_INC) & ABTI_TOOL_EVENT_TAG_MASK;
+    uint64_t new_mask =
+        new_tag | ((event_mask_task & ~ABTI_TOOL_EVENT_TAG_MASK) &
+                   ~ABTI_TOOL_EVENT_TAG_DIRTY_BIT);
+    uint64_t dirty_mask = ABTI_TOOL_EVENT_TAG_DIRTY_BIT | new_mask;
+
+    ABTD_atomic_release_store_uint64(&p_global->tool_task_event_mask_tagged,
+                                     dirty_mask);
+    p_global->tool_task_cb_f = cb_func;
+    p_global->tool_task_user_arg = user_arg;
+    ABTD_atomic_release_store_uint64(&p_global->tool_task_event_mask_tagged,
+                                     new_mask);
+
+    ABTI_spinlock_release(&p_global->tool_writer_lock);
+}
+
+#endif /* !ABT_CONFIG_DISABLE_TOOL_INTERFACE */
+
+static inline void ABTI_tool_event_thread_impl(
+    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_thread *p_thread,
+    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABT_sync_event_type sync_event_type, void *p_sync_object)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return;
+#else
+    ABTI_global *p_global = gp_ABTI_global;
+    while (1) {
+        uint64_t current_mask = ABTD_atomic_acquire_load_uint64(
+            &p_global->tool_thread_event_mask_tagged);
+        if (current_mask & event_code) {
+            ABT_tool_thread_callback_fn cb_func = p_global->tool_thread_cb_f;
+            void *user_arg = p_global->tool_thread_user_arg;
+            /* Double check the current event mask. */
+            uint64_t current_mask2 = ABTD_atomic_acquire_load_uint64(
+                &p_global->tool_thread_event_mask_tagged);
+            if (ABTU_unlikely(current_mask != current_mask2 ||
+                              (current_mask & ABTI_TOOL_EVENT_TAG_DIRTY_BIT)))
+                continue;
+            ABTI_tool_context tctx;
+            tctx.p_pool = p_pool;
+            tctx.p_parent = p_parent;
+            tctx.p_caller = p_caller;
+            tctx.sync_event_type = sync_event_type;
+            tctx.p_sync_object = p_sync_object;
+            ABT_thread h_thread = ABTI_thread_get_handle(p_thread);
+            ABT_xstream h_xstream = ABTI_xstream_get_handle(p_local_xstream);
+            ABT_tool_context h_tctx = ABTI_tool_context_get_handle(&tctx);
+            cb_func(h_thread, h_xstream, event_code, h_tctx, user_arg);
+        }
+        return;
+    }
+#endif /* !ABT_CONFIG_DISABLE_TOOL_INTERFACE */
+}
+
+static inline void ABTI_tool_event_task_impl(
+    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_task *p_task,
+    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABT_sync_event_type sync_event_type, void *p_sync_object)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return;
+#else
+    ABTI_global *p_global = gp_ABTI_global;
+    while (1) {
+        uint64_t current_mask = ABTD_atomic_acquire_load_uint64(
+            &p_global->tool_task_event_mask_tagged);
+        if (current_mask & event_code) {
+            ABT_tool_task_callback_fn cb_func = p_global->tool_task_cb_f;
+            void *user_arg = p_global->tool_task_user_arg;
+            /* Double check the current event mask. */
+            uint64_t current_mask2 = ABTD_atomic_acquire_load_uint64(
+                &p_global->tool_task_event_mask_tagged);
+            if (ABTU_unlikely(current_mask != current_mask2 ||
+                              (current_mask & ABTI_TOOL_EVENT_TAG_DIRTY_BIT)))
+                continue;
+            ABTI_tool_context tctx;
+            tctx.p_pool = p_pool;
+            tctx.p_parent = p_parent;
+            tctx.p_caller = p_caller;
+            tctx.sync_event_type = sync_event_type;
+            tctx.p_sync_object = p_sync_object;
+            ABT_task h_task = ABTI_task_get_handle(p_task);
+            ABT_xstream h_xstream = ABTI_xstream_get_handle(p_local_xstream);
+            ABT_tool_context h_tctx = ABTI_tool_context_get_handle(&tctx);
+            cb_func(h_task, h_xstream, event_code, h_tctx, user_arg);
+        }
+        return;
+    }
+#endif /* !ABT_CONFIG_DISABLE_TOOL_INTERFACE */
+}
+
+static inline void
+ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
+                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_pool *p_pool)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CREATE,
+                                p_thread, p_caller, p_pool, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_JOIN,
+                                p_thread, p_caller, NULL, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FREE,
+                                p_thread, p_caller, NULL, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
+                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_pool *p_pool)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_REVIVE,
+                                p_thread, p_caller, p_pool, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
+                                ABTI_thread *p_thread, ABTI_unit *p_prev,
+                                ABTI_unit *p_parent)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RUN,
+                                p_thread, p_prev, NULL, p_parent,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_finish_impl(ABTI_xstream *p_local_xstream,
+                                   ABTI_thread *p_thread, ABTI_unit *p_parent)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FINISH,
+                                p_thread, NULL, NULL, p_parent,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_thread_cancel_impl(ABTI_xstream *p_local_xstream,
+                                   ABTI_thread *p_thread)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CANCEL,
+                                p_thread, NULL, NULL, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void ABTI_tool_event_thread_yield_impl(
+    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    if (ABTD_atomic_relaxed_load_uint32(&p_thread->unit_def.request) &
+        ABTI_UNIT_REQ_BLOCK) {
+        ABTI_tool_event_thread_impl(p_local_xstream,
+                                    ABT_TOOL_EVENT_THREAD_SUSPEND, p_thread,
+                                    NULL, p_thread->unit_def.p_pool, p_parent,
+                                    sync_event_type, p_sync);
+
+    } else {
+        ABTI_tool_event_thread_impl(p_local_xstream,
+                                    ABT_TOOL_EVENT_THREAD_YIELD, p_thread, NULL,
+                                    p_thread->unit_def.p_pool, p_parent,
+                                    sync_event_type, p_sync);
+    }
+}
+
+static inline void ABTI_tool_event_thread_suspend_impl(
+    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_SUSPEND,
+                                p_thread, NULL, p_thread->unit_def.p_pool,
+                                p_parent, sync_event_type, p_sync);
+}
+
+static inline void
+ABTI_tool_event_thread_resume_impl(ABTI_xstream *p_local_xstream,
+                                   ABTI_thread *p_thread, ABTI_unit *p_caller)
+{
+    ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RESUME,
+                                p_thread, p_caller, p_thread->unit_def.p_pool,
+                                NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_task_create_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_pool *p_pool)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CREATE,
+                              p_task, p_caller, p_pool, NULL,
+                              ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void ABTI_tool_event_task_join_impl(ABTI_xstream *p_local_xstream,
+                                                  ABTI_task *p_task,
+                                                  ABTI_unit *p_caller)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_JOIN, p_task,
+                              p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
+                              NULL);
+}
+
+static inline void ABTI_tool_event_task_free_impl(ABTI_xstream *p_local_xstream,
+                                                  ABTI_task *p_task,
+                                                  ABTI_unit *p_caller)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FREE, p_task,
+                              p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
+                              NULL);
+}
+
+static inline void
+ABTI_tool_event_task_revive_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_pool *p_pool)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_REVIVE,
+                              p_task, p_caller, p_pool, NULL,
+                              ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void ABTI_tool_event_task_run_impl(ABTI_xstream *p_local_xstream,
+                                                 ABTI_task *p_task,
+                                                 ABTI_unit *p_parent)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_RUN, p_task,
+                              p_parent, NULL, p_parent,
+                              ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_task_finish_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_task *p_task, ABTI_unit *p_parent)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FINISH,
+                              p_task, NULL, NULL, p_parent,
+                              ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+static inline void
+ABTI_tool_event_task_cancel_impl(ABTI_xstream *p_local_xstream,
+                                 ABTI_task *p_task)
+{
+    ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CANCEL,
+                              p_task, NULL, NULL, NULL,
+                              ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+}
+
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+#define ABTI_USE_TOOL_INTERFACE 1
+#else
+#define ABTI_USE_TOOL_INTERFACE 0
+#endif
+
+#define ABTI_tool_event_thread_create(p_local_xstream, p_thread, p_caller,     \
+                                      p_pool)                                  \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_create_impl(p_local_xstream, p_thread,      \
+                                               p_caller, p_pool);              \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_join(p_local_xstream, p_thread, p_caller)       \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_join_impl(p_local_xstream, p_thread,        \
+                                             p_caller);                        \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_free(p_local_xstream, p_thread, p_caller)       \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_free_impl(p_local_xstream, p_thread,        \
+                                             p_caller);                        \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_revive(p_local_xstream, p_thread, p_caller,     \
+                                      p_pool)                                  \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_revive_impl(p_local_xstream, p_thread,      \
+                                               p_caller, p_pool);              \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_run(p_local_xstream, p_thread, p_prev,          \
+                                   p_parent)                                   \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_run_impl(p_local_xstream, p_thread, p_prev, \
+                                            p_parent);                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_finish(p_local_xstream, p_thread, p_parent)     \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_finish_impl(p_local_xstream, p_thread,      \
+                                               p_parent);                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_cancel(p_local_xstream, p_thread)               \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_cancel_impl(p_local_xstream, p_thread);     \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_yield(p_local_xstream, p_thread, p_parent,      \
+                                     sync_event_type, p_sync)                  \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_yield_impl(p_local_xstream, p_thread,       \
+                                              p_parent, sync_event_type,       \
+                                              p_sync);                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_suspend(p_local_xstream, p_thread, p_parent,    \
+                                       sync_event_type, p_sync)                \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_suspend_impl(p_local_xstream, p_thread,     \
+                                                p_parent, sync_event_type,     \
+                                                p_sync);                       \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_thread_resume(p_local_xstream, p_thread, p_caller)     \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_thread_resume_impl(p_local_xstream, p_thread,      \
+                                               p_caller);                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_create(p_local_xstream, p_task, p_caller, p_pool) \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_create_impl(p_local_xstream, p_task,          \
+                                             p_caller, p_pool);                \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_join(p_local_xstream, p_task, p_caller)           \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_join_impl(p_local_xstream, p_task, p_caller); \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_free(p_local_xstream, p_task, p_caller)           \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_free_impl(p_local_xstream, p_task, p_caller); \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_revive(p_local_xstream, p_task, p_caller, p_pool) \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_revive_impl(p_local_xstream, p_task,          \
+                                             p_caller, p_pool);                \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_run(p_local_xstream, p_task, p_parent)            \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_run_impl(p_local_xstream, p_task, p_parent);  \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_finish(p_local_xstream, p_task, p_parent)         \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_finish_impl(p_local_xstream, p_task,          \
+                                             p_parent);                        \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_tool_event_task_cancel(p_local_xstream, p_task)                   \
+    do {                                                                       \
+        if (ABTI_USE_TOOL_INTERFACE) {                                         \
+            ABTI_tool_event_task_cancel_impl(p_local_xstream, p_task);         \
+        }                                                                      \
+    } while (0)
+
+#endif /* ABTI_TOOL_H_INCLUDED */

--- a/src/info.c
+++ b/src/info.c
@@ -97,6 +97,9 @@
  * - ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC
  *   \c val must be a pointer to a variable of the type uint64_t.  The default
  *   sleep time (nanoseconds) of predefined schedulers is set to \c *val.
+ * - ABT_INFO_QUERY_KIND_ENABLED_TOOL
+ *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
+ *   set to \c *val if the tool is enabled.  Otherwise, ABT_FALSE is set.
  *
  * @param[in]  query_kind  query kind
  * @param[out] val         a pointer to a result
@@ -221,6 +224,13 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC:
             *((uint64_t *)val) = gp_ABTI_global->sched_sleep_nsec;
+            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_TOOL:
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+            *((ABT_bool *)val) = ABT_TRUE;
+#else
+            *((ABT_bool *)val) = ABT_FALSE;
+#endif
             break;
         default:
             abt_errno = ABT_ERR_INV_QUERY_KIND;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -341,7 +341,9 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_xstream **pp_local_xstream,
             } else {
                 ABTI_ASSERT(p_sched->type == ABT_SCHED_TYPE_ULT);
                 ABTI_thread_context_switch_to_parent(pp_local_xstream,
-                                                     p_sched->p_thread);
+                                                     p_sched->p_thread,
+                                                     ABT_SYNC_EVENT_TYPE_OTHER,
+                                                     NULL);
             }
         }
     }

--- a/src/self.c
+++ b/src/self.c
@@ -232,7 +232,8 @@ int ABT_self_suspend(void)
     abt_errno = ABTI_thread_set_blocked(ABTI_unit_get_thread(p_self));
     ABTI_CHECK_ERROR(abt_errno);
 
-    ABTI_thread_suspend(&p_local_xstream, ABTI_unit_get_thread(p_self));
+    ABTI_thread_suspend(&p_local_xstream, ABTI_unit_get_thread(p_self),
+                        ABT_SYNC_EVENT_TYPE_USER, NULL);
 
 fn_exit:
     return abt_errno;

--- a/src/task.c
+++ b/src/task.c
@@ -205,9 +205,11 @@ int ABT_task_free(ABT_task *task)
         }
 #endif
         ABTI_thread_yield(&p_local_xstream,
-                          ABTI_unit_get_thread(p_local_xstream->p_unit));
+                          ABTI_unit_get_thread(p_local_xstream->p_unit),
+                          ABT_SYNC_EVENT_TYPE_TASK_JOIN, (void *)p_task);
     }
-
+    ABTI_tool_event_task_join(p_local_xstream, p_task,
+                              p_local_xstream ? p_local_xstream->p_unit : NULL);
     /* Free the ABTI_task structure */
     ABTI_task_free(p_local_xstream, p_task);
 
@@ -252,8 +254,11 @@ int ABT_task_join(ABT_task task)
         }
 #endif
         ABTI_thread_yield(&p_local_xstream,
-                          ABTI_unit_get_thread(p_local_xstream->p_unit));
+                          ABTI_unit_get_thread(p_local_xstream->p_unit),
+                          ABT_SYNC_EVENT_TYPE_TASK_JOIN, (void *)p_task);
     }
+    ABTI_tool_event_task_join(p_local_xstream, p_task,
+                              p_local_xstream ? p_local_xstream->p_unit : NULL);
 
 fn_exit:
     return abt_errno;
@@ -785,6 +790,10 @@ static int ABTI_task_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newtask->unit_def.type = ABTI_UNIT_TYPE_TASK;
     p_newtask->unit_def.unit = p_pool->u_create_from_task(h_newtask);
 
+    ABTI_tool_event_task_create(p_local_xstream, p_newtask,
+                                p_local_xstream ? p_local_xstream->p_unit
+                                                : NULL,
+                                p_pool);
     LOG_DEBUG("[T%" PRIu64 "] created\n", ABTI_task_get_id(p_newtask));
 
     /* Add this task to the scheduler's pool */
@@ -842,6 +851,10 @@ static int ABTI_task_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         p_task->unit_def.unit = p_pool->u_create_from_task(task);
     }
 
+    ABTI_tool_event_task_revive(p_local_xstream, p_task,
+                                p_local_xstream ? p_local_xstream->p_unit
+                                                : NULL,
+                                p_pool);
     LOG_DEBUG("[T%" PRIu64 "] revived\n", ABTI_task_get_id(p_task));
 
     /* Add this task to the scheduler's pool */
@@ -863,6 +876,8 @@ fn_fail:
 
 void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task)
 {
+    ABTI_tool_event_task_free(p_local_xstream, p_task,
+                              p_local_xstream ? p_local_xstream->p_unit : NULL);
     LOG_DEBUG("[T%" PRIu64 "] freed\n", ABTI_task_get_id(p_task));
 
     /* Free the unit */

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -223,9 +223,12 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
 ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
                                        ABTI_thread_queue *p_queue,
                                        ABTI_thread *p_thread,
-                                       ABTI_thread_htable *p_htable)
+                                       ABTI_thread_htable *p_htable,
+                                       ABT_sync_event_type sync_event_type,
+                                       void *p_sync)
 {
     ABTI_thread *p_target = NULL;
+    ABTI_xstream *p_local_xstream = *pp_local_xstream;
 
     ABTI_thread_queue_acquire_low_mutex(p_queue);
     if (p_queue->low_head) {
@@ -234,6 +237,9 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         /* Push p_thread to the queue */
         ABTD_atomic_release_store_int(&p_thread->unit_def.state,
                                       ABTI_UNIT_STATE_BLOCKED);
+        ABTI_tool_event_thread_suspend(p_local_xstream, p_thread,
+                                       p_thread->unit_def.p_parent,
+                                       sync_event_type, p_sync);
         if (p_queue->low_head == p_queue->low_tail) {
             p_queue->low_head = p_thread;
             p_queue->low_tail = p_thread;
@@ -251,8 +257,15 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         /* Context-switch to p_target */
         ABTD_atomic_release_store_int(&p_target->unit_def.state,
                                       ABTI_UNIT_STATE_RUNNING);
-        ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
-                                              p_target);
+        ABTI_tool_event_thread_resume(p_local_xstream, p_target,
+                                      p_local_xstream ? p_local_xstream->p_unit
+                                                      : NULL);
+        ABTI_thread *p_prev =
+            ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
+                                                  p_target);
+        ABTI_tool_event_thread_run(*pp_local_xstream, p_thread,
+                                   &p_prev->unit_def,
+                                   p_thread->unit_def.p_parent);
         return ABT_TRUE;
     } else {
         return ABT_FALSE;

--- a/src/tool.c
+++ b/src/tool.c
@@ -1,0 +1,346 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
+                                  ABT_tool_query_kind query_kind, void *val);
+#endif
+
+/** @defgroup Tool interface
+ * This group is for the tool interface.
+ */
+
+/**
+ * @ingroup TOOL
+ * @brief   Register a callback function for ULT events
+ *
+ * \c ABT_tool_register_thread_callback() sets a callback function \c cb_func
+ * for ULT events.  Events that are not in \c event_mask are excluded.  Users
+ * can stop the event callback by setting \c cb_func to zero.
+ *
+ * \c cb_func is called with a target thread (the first argument), an underlying
+ * execution stream (the second argument), an event code (the third argument,
+ * see ABT_TOOL_EVENT_THREAD), and the tool context that can be used for
+ * ABT_tool_query().  If the event occurs on an external thread,
+ * ABT_XSTREAM_NULL is passed.  The returned tool context is only valid in the
+ * callback function.
+ *
+ * An object to which a returned handle points to may be in an intermediate
+ * state, so users are discouraged not to read any internal state of such an
+ * object (e.g., by ABT_thread_get_state()).
+ *
+ * @param[in]  cb_func     callback function pointer
+ * @param[in]  event_mask  event code mask
+ * @param[in]  user_arg    user argument passed to \c cb_func
+ * @return Error code
+ * @retval ABT_SUCCESS         on success
+ * @retval ABT_ERR_FEATURE_NA  tool feature is not supported
+ */
+int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
+                                      uint64_t event_mask_thread,
+                                      void *user_arg)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return ABT_ERR_FEATURE_NA;
+#else
+    if (cb_func == NULL)
+        event_mask_thread = ABT_TOOL_EVENT_THREAD_NONE;
+    ABTI_tool_event_thread_update_callback(cb_func,
+                                           event_mask_thread &
+                                               ABT_TOOL_EVENT_THREAD_ALL,
+                                           user_arg);
+    return ABT_SUCCESS;
+#endif
+}
+
+/**
+ * @ingroup TOOL
+ * @brief   Register a callback function for tasklet events
+ *
+ * \c ABT_tool_register_task_callback() sets a callback function \c cb_func for
+ * tasklet events.  Events that are not in \c event_mask are excluded.  Users
+ * can stop the event callback by setting \c cb_func to zero.
+ *
+ * \c cb_func is called with a target tasklet (the first argument), an
+ * underlying execution stream (the second argument), an event code (the third
+ * argument, see ABT_TOOL_EVENT_TASK), and the tool context that can be used
+ * for ABT_tool_query().  If the event occurs on an external thread,
+ * ABT_XSTREAM_NULL is passed.  The returned tool context is only valid in the
+ * callback function.
+ *
+ * An object to which a returned handle points to may be in an intermediate
+ * state, so users are discouraged not to read any internal state of such an
+ * object (e.g., by ABT_thread_get_state()).
+ *
+ * @param[in]  cb_func     callback function pointer
+ * @param[in]  event_mask  event code mask
+ * @param[in]  user_arg    user argument passed to \c cb_func
+ * @return Error code
+ * @retval ABT_SUCCESS         on success
+ * @retval ABT_ERR_FEATURE_NA  tool feature is not supported
+ */
+int ABT_tool_register_task_callback(ABT_tool_task_callback_fn cb_func,
+                                    uint64_t event_mask_task, void *user_arg)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return ABT_ERR_FEATURE_NA;
+#else
+    if (cb_func == NULL)
+        event_mask_task = ABT_TOOL_EVENT_TASK_NONE;
+    ABTI_tool_event_task_update_callback(cb_func,
+                                         event_mask_task &
+                                             ABT_TOOL_EVENT_TASK_ALL,
+                                         user_arg);
+    return ABT_SUCCESS;
+#endif
+}
+
+/**
+ * @ingroup TOOL
+ * @brief   Query information associated with a ULT event.
+ *
+ * \c ABT_tool_query() returns information associated with the tool context
+ * \c context through \c val.  Since \c context is valid only in the callback
+ * handler, this function must be called in the callback handler.
+ *
+ * When \c query_kind is ABT_TOOL_QUERY_KIND_POOL, it sets \c *val to
+ * \c ABT_pool of a pool to which a work unit is or will be pushed.  The query
+ * is valid when \c event is THREAD_CREATE, THREAD_REVIVE, THREAD_YIELD,
+ * THREAD_RESUME, TASK_CREATE, or TASK_REVIVE.  Otherwise, \c *val is set to
+ * ABT_POOL_NULL.
+ *
+ * When \c query_kind is ABT_TOOL_QUERY_KIND_STACK_DEPTH, it sets \c *val to the
+ * current depth of stackable work units as an \c int value while the level of
+ * the main scheduler is zero.  For example, if the current thread is directly
+ * running on the main scheduler, the depth is 1.  The query is valid when
+ * \c event is THREAD_RUN and TASK_RUN (the depth after the work unit runs),
+ * THREAD_FINISH and TASK_FINISH (the depth before the work unit finishes),
+ * THREAD_YIELD (the depth before the work unit yields), and THREAD_SUSPEND
+ * (the depth before the work unit suspends).  Otherwise, \c *val is set to
+ * zero.
+ *
+ * When \c query_kind is ABT_TOOL_QUERY_KIND_CALLER_TYPE, \c *val is set to
+ * ABT_exec_entity_type of an entity which incurs this event.  The query is
+ * valid for all events.
+ *
+ * When \c query_kind is ABT_TOOL_QUERY_KIND_CALLER_HANDLE, \c *val is set to a
+ * handle of an entity which incurs this event.  Specifically, \c *val is set
+ * to a ULT handle (ABT_thread) if the caller type is
+ * ABT_EXEC_ENTITY_TYPE_THREAD.  \c *val is set to a tasklet handle (ABT_task)
+ * if the caller type is ABT_EXEC_ENTITY_TYPE_TASK.  If the caller is an
+ * external thread, \c *val is set to NULL.  The query is valid for all events
+ * except for THREAD_CANCEL and TASK_CANCEL.  Note that the caller is a
+ * previous work unit when \c event is THRAED_RUN or TASK_RUN.
+ *
+ * When \c query_kind is ABT_TOOL_QUERY_KIND_SYNC_OBJECT_TYPE, \c *val is set to
+ * ABT_sync_event_type of an synchronization object which incurs this event.
+ * The synchronization object is returned when \c query_kind is
+ * ABT_TOOL_QUERY_KIND_SYNC_OBJECT_HANDLE.  Synchronization events, and
+ * ABT_sync_event_type, and synchronization objects are mapped as follows:
+ *  - ABT_SYNC_EVENT_TYPE_USER:
+ *      User's explicit call (e.g., ABT_thread_yield())
+ *      The synchronization object is not set ((void *)NULL).
+ *  - ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN:
+ *      Waiting for completion of execution streams (e.g., ABT_xstream_join())
+ *      The synchronization object is an execution stream (ABT_xstream).
+ *  - ABT_SYNC_EVENT_TYPE_THREAD_JOIN:
+ *      Waiting for completion of ULTs (e.g., ABT_thread_join())
+ *      The synchronization object is a ULT (ABT_thread).
+ *  - ABT_SYNC_EVENT_TYPE_TASK_JOIN:
+ *      Waiting for completion of tasklets (e.g., ABT_task_join())
+ *      The synchronization object is a tasklet (ABT_task).
+ *  - ABT_SYNC_EVENT_TYPE_MUTEX:
+ *      Synchronization regarding a mutex (e.g., ABT_mutex_lock())
+ *      The synchronization object is a mutex (ABT_mutex).
+ *  - ABT_SYNC_EVENT_TYPE_COND:
+ *      Synchronization regarding a condition variable(e.g., ABT_cond_wait())
+ *      The synchronization object is a condition variable (ABT_cond).
+ *  - ABT_SYNC_EVENT_TYPE_RWLOCK:
+ *      Synchronization regarding a rwlock (e.g., ABT_rwlock_rdlock())
+ *      The synchronization object is a rwlock (ABT_rwlock).
+ *  - ABT_SYNC_EVENT_TYPE_EVENTUAL:
+ *      Synchronization regarding an eventual (e.g., ABT_eventual_wait())
+ *      The synchronization object is an eventual (ABT_eventual).
+ *  - ABT_SYNC_EVENT_TYPE_FUTURE:
+ *      Synchronization regarding a future (e.g., ABT_future_wait())
+ *      The synchronization object is a future (ABT_future).
+ *  - ABT_SYNC_EVENT_TYPE_BARRIER:
+ *      Synchronization regarding a barrier (e.g., ABT_barrier_wait())
+ *      The synchronization object is a barrier (ABT_barrier).
+ *  - ABT_SYNC_EVENT_TYPE_OTHER:
+ *      Unclassified synchronization (e.g., ABT_xstream_exit())
+ *      The synchronization object is not set ((void *)NULL).
+ *  - ABT_SYNC_EVENT_TYPE_UNKNOWN
+ *      \c event is neither THREAD_YIELD nor THREAD_SUSPEND.
+ *      The synchronization object is not set ((void *)NULL).
+ * This query is valid for THREAD_YIELD and THREAD_SUSPEND.
+ *
+ * An object to which a returned handle points to may be in an intermediate
+ * state, so users are discouraged not to read any internal state of such an
+ * object (e.g., by ABT_thread_get_state() or ABT_pool_get_size()).
+ *
+ * @param[in]  context    handle to the tool context
+ * @param[in]  event      event code passed to the callback function
+ * @param[in]  query_kind query kind
+ * @param[out] val        pointer to storage where a returned value is saved
+ * @return Error code
+ * @retval ABT_SUCCESS        on success
+ * @retval ABT_ERR_FEATURE_NA the tool feature is not supported
+ */
+int ABT_tool_query_thread(ABT_tool_context context, uint64_t event_thread,
+                          ABT_tool_query_kind query_kind, void *val)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return ABT_ERR_FEATURE_NA;
+#else
+    int abt_errno = ABT_SUCCESS;
+
+    ABTI_tool_context *p_tctx = ABTI_tool_context_get_ptr(context);
+    ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p_tctx);
+    abt_errno = ABTI_tool_query(p_tctx, query_kind, val);
+    ABTI_CHECK_ERROR(abt_errno);
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+#endif
+}
+
+/**
+ * @ingroup TOOL
+ * @brief   Query information associated with a tasklet event.
+ *
+ * \c ABT_tool_query_task() returns information associated with the tasklet
+ * event via \c context.  See \c ABT_tool_query_thread() for details.
+ *
+ * @param[in]  context     handle to the tool context
+ * @param[in]  event_task  tasklet event code passed to the callback function
+ * @param[in]  query_kind  query kind
+ * @param[out] val         pointer to storage where a returned value is saved
+ * @return Error code
+ * @retval ABT_SUCCESS        on success
+ * @retval ABT_ERR_FEATURE_NA the tool feature is not supported
+ */
+int ABT_tool_query_task(ABT_tool_context context, uint64_t event_task,
+                        ABT_tool_query_kind query_kind, void *val)
+{
+#ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+    return ABT_ERR_FEATURE_NA;
+#else
+    int abt_errno = ABT_SUCCESS;
+
+    ABTI_tool_context *p_tctx = ABTI_tool_context_get_ptr(context);
+    ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p_tctx);
+    abt_errno = ABTI_tool_query(p_tctx, query_kind, val);
+    ABTI_CHECK_ERROR(abt_errno);
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+#endif
+}
+
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
+                                  ABT_tool_query_kind query_kind, void *val)
+{
+    int abt_errno = ABT_SUCCESS;
+
+    switch (query_kind) {
+        case ABT_TOOL_QUERY_KIND_POOL:
+            *(ABT_pool *)val = ABTI_pool_get_handle(p_tctx->p_pool);
+            break;
+        case ABT_TOOL_QUERY_KIND_STACK_DEPTH:
+            if (!p_tctx->p_parent) {
+                *(int *)val = 0;
+            } else {
+                int depth = 0;
+                ABTI_unit *p_cur = p_tctx->p_parent;
+                while (p_cur) {
+                    depth++;
+                    p_cur = p_cur->p_parent;
+                }
+                *(int *)val = depth;
+            }
+            break;
+        case ABT_TOOL_QUERY_KIND_CALLER_TYPE:
+            if (!p_tctx->p_caller) {
+                *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_EXT;
+            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
+                *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_THREAD;
+            } else {
+                *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_TASK;
+            }
+            break;
+        case ABT_TOOL_QUERY_KIND_CALLER_HANDLE:
+            if (!p_tctx->p_caller) {
+                *(void **)val = NULL;
+            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
+                *(ABT_thread *)val = ABTI_thread_get_handle(
+                    ABTI_unit_get_thread(p_tctx->p_caller));
+            } else {
+                *(ABT_task *)val =
+                    ABTI_task_get_handle(ABTI_unit_get_task(p_tctx->p_caller));
+            }
+            break;
+        case ABT_TOOL_QUERY_KIND_SYNC_OBJECT_TYPE:
+            *(ABT_sync_event_type *)val = p_tctx->sync_event_type;
+            break;
+        case ABT_TOOL_QUERY_KIND_SYNC_OBJECT_HANDLE:
+            switch (p_tctx->sync_event_type) {
+                case ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN:
+                    *(ABT_xstream *)val = ABTI_xstream_get_handle(
+                        (ABTI_xstream *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_THREAD_JOIN:
+                    *(ABT_thread *)val = ABTI_thread_get_handle(
+                        (ABTI_thread *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_TASK_JOIN:
+                    *(ABT_task *)val = ABTI_task_get_handle(
+                        (ABTI_task *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_MUTEX:
+                    *(ABT_mutex *)val = ABTI_mutex_get_handle(
+                        (ABTI_mutex *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_COND:
+                    *(ABT_cond *)val = ABTI_cond_get_handle(
+                        (ABTI_cond *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_RWLOCK:
+                    *(ABT_rwlock *)val = ABTI_rwlock_get_handle(
+                        (ABTI_rwlock *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_EVENTUAL:
+                    *(ABT_eventual *)val = ABTI_eventual_get_handle(
+                        (ABTI_eventual *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_FUTURE:
+                    *(ABT_future *)val = ABTI_future_get_handle(
+                        (ABTI_future *)p_tctx->p_sync_object);
+                    break;
+                case ABT_SYNC_EVENT_TYPE_BARRIER:
+                    *(ABT_barrier *)val = ABTI_barrier_get_handle(
+                        (ABTI_barrier *)p_tctx->p_sync_object);
+                    break;
+                default:
+                    *(void **)val = NULL;
+            }
+            break;
+        default:
+            abt_errno = ABT_ERR_OTHER;
+    }
+    return abt_errno;
+}
+#endif

--- a/test/util/abttest.c
+++ b/test/util/abttest.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <unistd.h>
+#include <pthread.h>
 #include "abt.h"
 #include "abttest.h"
 
@@ -17,6 +18,10 @@ static int g_num_errs = 0;
  * ATS_arg in abttest.h. */
 #define NUM_ARG_KINDS 4
 static int g_arg_val[NUM_ARG_KINDS];
+
+static void ATS_tool_init();
+static void ATS_tool_finialize();
+static ABT_bool g_tool_enabled;
 
 void ATS_init(int argc, char **argv, int num_xstreams)
 {
@@ -50,11 +55,29 @@ void ATS_init(int argc, char **argv, int num_xstreams)
             fflush(stderr);
         }
     }
+
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_TOOL,
+                                &g_tool_enabled);
+    ATS_ERROR(ret, "ABT_info_query_config");
+    envval = getenv("ATS_ENABLE_TOOL");
+    if (envval && atoi(envval) == 0) {
+        g_tool_enabled = 0;
+    }
+
+    if (g_tool_enabled) {
+        /* Let's debug the tool interface as well. */
+        ATS_tool_init();
+    }
 }
 
 int ATS_finalize(int err)
 {
     int ret;
+
+    if (g_tool_enabled) {
+        /* Finalize the tool interface. */
+        ATS_tool_finialize();
+    }
 
     /* Finalize Argobots */
     ret = ABT_finalize();
@@ -110,6 +133,17 @@ void ATS_error(int err, const char *msg, const char *file, int line)
     fprintf(stderr, "%s (%d): %s (%s:%d)\n", err_str, err, msg, file, line);
 
     free(err_str);
+
+    g_num_errs++;
+
+    exit(EXIT_FAILURE);
+}
+
+void ATS_error_if(int cond, const char *msg, const char *file, int line)
+{
+    if (!cond)
+        return;
+    fprintf(stderr, "%s (%s:%d)\n", msg, file, line);
 
     g_num_errs++;
 
@@ -183,4 +217,293 @@ void ATS_print_line(FILE *fp, char c, int len)
     }
     fprintf(fp, "\n");
     fflush(fp);
+}
+
+typedef enum {
+    ATS_TOOL_UNIT_STATE_UNINIT = 0,
+    ATS_TOOL_UNIT_STATE_READY,
+    ATS_TOOL_UNIT_STATE_RUNNING,
+    ATS_TOOL_UNIT_STATE_BLOCKED,
+    ATS_TOOL_UNIT_STATE_FINISHED,
+    ATS_TOOL_UNIT_STATE_JOINED,
+} ATS_tool_unit_state;
+
+typedef struct ATS_tool_unit_entry {
+    const void *unit;
+    ATS_tool_unit_state state;
+    ABT_xstream last_xstream;
+    struct ATS_tool_unit_entry *p_next;
+} ATS_tool_unit_entry;
+
+/* ABT_tool_unit_entry_table_index() assumes the following constant is 256. */
+#define ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES 256
+typedef struct {
+    /* The simplest hast table with a spinlock.  Since we cannot use Argobots
+     * locks in a callback handler, the following uses pthread_spinlock. */
+    pthread_spinlock_t lock;
+    ATS_tool_unit_entry *entries[ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES];
+} ATS_tool_unit_entry_table;
+static ATS_tool_unit_entry_table g_tool_unit_entry_table;
+
+static inline size_t ABT_tool_unit_entry_table_index(const void *unit)
+{
+    /* Xor the pointer value. */
+    if (sizeof(void *) == 4) {
+        uint32_t val = (uint32_t)(uintptr_t)unit;
+        uint32_t val2 = val ^ (val >> 16);
+        return (val2 ^ (val2 >> 8)) &
+               (ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES - 1);
+    } else if (sizeof(void *) == 8) {
+        uint64_t val = (uint64_t)(uintptr_t)unit;
+        uint64_t val2 = val ^ (val >> 32);
+        uint64_t val3 = val2 ^ (val2 >> 16);
+        return (val3 ^ (val3 >> 8)) &
+               (ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES - 1);
+    }
+    return 0;
+}
+
+static ATS_tool_unit_entry *ATS_tool_get_unit_entry(const void *unit)
+{
+    ATS_tool_unit_entry_table *p_table = &g_tool_unit_entry_table;
+    ATS_tool_unit_entry *p_ret = NULL;
+    pthread_spin_lock(&p_table->lock);
+    size_t index = ABT_tool_unit_entry_table_index(unit);
+    ATS_tool_unit_entry *p_cur = p_table->entries[index];
+    if (!p_cur) {
+        p_ret = (ATS_tool_unit_entry *)calloc(1, sizeof(ATS_tool_unit_entry));
+        p_ret->unit = unit;
+        p_table->entries[index] = p_ret;
+    } else {
+        do {
+            if (p_cur->unit == unit) {
+                /* Already created. */
+                p_ret = p_cur;
+                break;
+            } else if (!p_cur->p_next) {
+                p_ret =
+                    (ATS_tool_unit_entry *)calloc(1,
+                                                  sizeof(ATS_tool_unit_entry));
+                p_ret->unit = unit;
+                p_cur->p_next = p_ret;
+                break;
+            }
+            p_cur = p_cur->p_next;
+        } while (1);
+    }
+    pthread_spin_unlock(&p_table->lock);
+    return p_ret;
+}
+
+static void ATS_tool_remove_unit_entry(const void *unit)
+{
+    ATS_tool_unit_entry_table *p_table = &g_tool_unit_entry_table;
+    pthread_spin_lock(&g_tool_unit_entry_table.lock);
+    size_t index = ABT_tool_unit_entry_table_index(unit);
+    ATS_tool_unit_entry *p_cur = p_table->entries[index];
+    if (p_cur == NULL) {
+        /* Not registered / double free */
+        ATS_ERROR(ABT_ERR_OTHER, "ATS_tool_remove_unit_entry");
+    } else if (p_cur->unit == unit) {
+        p_table->entries[index] = p_cur->p_next;
+        free(p_cur);
+    } else {
+        while (1) {
+            ATS_tool_unit_entry *p_next = p_cur->p_next;
+            if (!p_next) {
+                /* Not registered / double free */
+                ATS_ERROR(ABT_ERR_OTHER, "ATS_tool_remove_unit_entry");
+            }
+            if (p_next->unit == unit) {
+                p_cur->p_next = p_next->p_next;
+                free(p_next);
+                break;
+            }
+            p_cur = p_next;
+        }
+    }
+    pthread_spin_unlock(&g_tool_unit_entry_table.lock);
+}
+
+static void ATS_tool_thread_callback(ABT_thread thread, ABT_xstream xstream,
+                                     uint64_t event, ABT_tool_context context,
+                                     void *user_arg)
+{
+    ATS_tool_unit_entry *p_entry = ATS_tool_get_unit_entry((void *)thread);
+
+    ABT_bool is_unnamed = ABT_FALSE;
+    int ret = ABT_thread_is_unnamed(thread, &is_unnamed);
+    ATS_ERROR(ret, "ABT_thread_is_unnamed");
+
+    switch (event) {
+        case ABT_TOOL_EVENT_THREAD_CREATE:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_UNINIT);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        case ABT_TOOL_EVENT_THREAD_JOIN:
+            ATS_ERROR_IF(is_unnamed ||
+                         (p_entry->state != ATS_TOOL_UNIT_STATE_FINISHED &&
+                          p_entry->state != ATS_TOOL_UNIT_STATE_JOINED));
+            p_entry->state = ATS_TOOL_UNIT_STATE_JOINED;
+            break;
+        case ABT_TOOL_EVENT_THREAD_FREE:
+            /* The main scheduler has been already running, but the state is
+             * UNINIT since there is no chance to update it.  The state can be
+             * ready if the created work unit cannot be pushed to the pool. */
+            if (is_unnamed) {
+                ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_UNINIT &&
+                             p_entry->state != ATS_TOOL_UNIT_STATE_READY &&
+                             p_entry->state != ATS_TOOL_UNIT_STATE_FINISHED);
+            } else {
+                ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_UNINIT &&
+                             p_entry->state != ATS_TOOL_UNIT_STATE_JOINED);
+            }
+            ATS_tool_remove_unit_entry((void *)thread);
+            break;
+        case ABT_TOOL_EVENT_THREAD_REVIVE:
+            ATS_ERROR_IF(is_unnamed ||
+                         p_entry->state != ATS_TOOL_UNIT_STATE_JOINED);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        case ABT_TOOL_EVENT_THREAD_RUN:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY);
+            p_entry->state = ATS_TOOL_UNIT_STATE_RUNNING;
+            p_entry->last_xstream = xstream;
+            break;
+        case ABT_TOOL_EVENT_THREAD_FINISH:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_RUNNING ||
+                         p_entry->last_xstream != xstream);
+            p_entry->state = ATS_TOOL_UNIT_STATE_FINISHED;
+            break;
+        case ABT_TOOL_EVENT_THREAD_CANCEL:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY);
+            p_entry->state = ATS_TOOL_UNIT_STATE_FINISHED;
+            break;
+        case ABT_TOOL_EVENT_THREAD_YIELD:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_RUNNING);
+            ATS_ERROR_IF(p_entry->last_xstream != xstream);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        case ABT_TOOL_EVENT_THREAD_SUSPEND:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_RUNNING);
+            ATS_ERROR_IF(p_entry->state == ATS_TOOL_UNIT_STATE_RUNNING &&
+                         p_entry->last_xstream != xstream);
+            p_entry->state = ATS_TOOL_UNIT_STATE_BLOCKED;
+            break;
+        case ABT_TOOL_EVENT_THREAD_RESUME:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_BLOCKED);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        default:
+            /* Unknown event. */
+            ATS_ERROR(ABT_ERR_OTHER, "ATS_tool_thread_callback");
+    }
+}
+
+static void ATS_tool_task_callback(ABT_task task, ABT_xstream xstream,
+                                   uint64_t event, ABT_tool_context context,
+                                   void *user_arg)
+{
+    ATS_tool_unit_entry *p_entry = ATS_tool_get_unit_entry((void *)task);
+
+    ABT_bool is_unnamed = ABT_FALSE;
+    int ret = ABT_task_is_unnamed(task, &is_unnamed);
+    ATS_ERROR(ret, "ABT_task_is_unnamed");
+
+    switch (event) {
+        case ABT_TOOL_EVENT_TASK_CREATE:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_UNINIT);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        case ABT_TOOL_EVENT_TASK_JOIN:
+            ATS_ERROR_IF(is_unnamed ||
+                         (p_entry->state != ATS_TOOL_UNIT_STATE_FINISHED &&
+                          p_entry->state != ATS_TOOL_UNIT_STATE_JOINED));
+            p_entry->state = ATS_TOOL_UNIT_STATE_JOINED;
+            break;
+        case ABT_TOOL_EVENT_TASK_FREE:
+            /* The state can be ready if the created work unit cannot be pushed
+             * to the pool. */
+            if (is_unnamed) {
+                ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY &&
+                             p_entry->state != ATS_TOOL_UNIT_STATE_FINISHED);
+            } else {
+                ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY &&
+                             p_entry->state != ATS_TOOL_UNIT_STATE_JOINED);
+            }
+            ATS_tool_remove_unit_entry((void *)task);
+            break;
+        case ABT_TOOL_EVENT_TASK_REVIVE:
+            ATS_ERROR_IF(is_unnamed ||
+                         p_entry->state != ATS_TOOL_UNIT_STATE_JOINED);
+            p_entry->state = ATS_TOOL_UNIT_STATE_READY;
+            break;
+        case ABT_TOOL_EVENT_TASK_RUN:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY);
+            p_entry->state = ATS_TOOL_UNIT_STATE_RUNNING;
+            p_entry->last_xstream = xstream;
+            break;
+        case ABT_TOOL_EVENT_TASK_FINISH:
+            ATS_ERROR_IF(p_entry->state == ATS_TOOL_UNIT_STATE_RUNNING &&
+                         p_entry->last_xstream != xstream);
+            p_entry->state = ATS_TOOL_UNIT_STATE_FINISHED;
+            break;
+        case ABT_TOOL_EVENT_TASK_CANCEL:
+            ATS_ERROR_IF(p_entry->state != ATS_TOOL_UNIT_STATE_READY);
+            p_entry->state = ATS_TOOL_UNIT_STATE_FINISHED;
+            break;
+        default:
+            /* Unknown event. */
+            ATS_ERROR(ABT_ERR_OTHER, "ATS_tool_task_callback");
+    }
+}
+
+static void ATS_tool_init()
+{
+    /* Initialize the hash table. */
+    int ret, i;
+    ATS_tool_unit_entry_table *p_table = &g_tool_unit_entry_table;
+    pthread_spin_init(&p_table->lock, 0);
+    for (i = 0; i < ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES; i++) {
+        p_table->entries[i] = NULL;
+    }
+    /* Add this main thread. */
+    ABT_thread self_thread;
+    ABT_xstream self_xstream;
+    ret = ABT_thread_self(&self_thread);
+    ATS_ERROR(ret, "ABT_thread_self");
+    ret = ABT_xstream_self(&self_xstream);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    ATS_tool_unit_entry *p_entry = ATS_tool_get_unit_entry((void *)self_thread);
+    p_entry->state = ATS_TOOL_UNIT_STATE_RUNNING;
+    p_entry->last_xstream = self_xstream;
+
+    ret = ABT_tool_register_thread_callback(ATS_tool_thread_callback,
+                                            ABT_TOOL_EVENT_THREAD_ALL, NULL);
+    ATS_ERROR(ret, "ABT_tool_register_thread_callback");
+    ret = ABT_tool_register_task_callback(ATS_tool_task_callback,
+                                          ABT_TOOL_EVENT_TASK_ALL, NULL);
+    ATS_ERROR(ret, "ABT_tool_register_task_callback");
+}
+
+static void ATS_tool_finialize()
+{
+    int ret, i;
+    ATS_tool_unit_entry_table *p_table = &g_tool_unit_entry_table;
+    for (i = 0; i < ATS_TOOL_UNIT_ENTRY_TABLE_NUM_ENTIRES; i++) {
+        ATS_tool_unit_entry *p_cur = p_table->entries[i];
+        while (p_cur) {
+            ATS_tool_unit_entry *p_next = p_cur->p_next;
+            free(p_cur);
+            p_cur = p_next;
+        }
+        p_table->entries[i] = NULL;
+    }
+    pthread_spin_destroy(&p_table->lock);
+
+    ret = ABT_tool_register_thread_callback(NULL, ABT_TOOL_EVENT_THREAD_NONE,
+                                            NULL);
+    ATS_ERROR(ret, "ABT_tool_register_thread_callback");
+    ret = ABT_tool_register_task_callback(NULL, ABT_TOOL_EVENT_TASK_NONE, NULL);
+    ATS_ERROR(ret, "ABT_tool_register_task_callback");
 }

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -126,6 +126,7 @@ int ATS_get_arg_val(ATS_arg arg);
  */
 void ATS_print_line(FILE *fp, char c, int len);
 
+#define ATS_ERROR_IF(cond) ATS_error_if(cond, #cond, __FILE__, __LINE__)
 #define ATS_ERROR(e, m) ATS_error(e, m, __FILE__, __LINE__)
 #define ATS_UNUSED(a) (void)(a)
 


### PR DESCRIPTION
## Backgrounds

Now Argobots does not provide any interface to check the internal state, so it is hard to profile or debug Argobots without modifying the Argobots runtime. As done by MPI and OpenMP (e.g., PMPI and OMPT), Argobots should expose a similar interface. A profiling interface (or, actually a profiling tool) has been demanded by several users (recently from @roblatham00), it would be nice to implement such now.

## Solutions

Argobots provides an interface ("tool interface") to register callback functions, which are called on several threads and tasklets events (e.g., creation, run, join, yield, ... ). The interface is work-unit centric, so with this feature, users can know  avg/max/min execution time of threads (i.e., thread granularity), number of yields and suspensions, delay of scheduling (i.e., time of the first run - time of the creation) and so on with this interface.

## Current issues

The obvious problem is that there exists no such a profiling tool, so I am not sure whether the current set of events is satisfactory or not.

~In any case, working examples should be bundled with Argobots, but the thread-specific storage issue (#198) is the biggest bottleneck for a scalable and reasonably practical profiler; specifically, a profiler needs to save timestamps somewhere per work unit, but getting such a memory location in a scalable manner (`ABT_thread` -> storage: for example, highly scalable TLS with an extended API or highly scalable parallel hash-table / parallel search tree) is not easy with the current Argobots implementation.~ [EDIT] This specific issue was solved.

This PR should be merged after confirming a few profilers work well.

### Note

This feature definitely adds an overhead, so this is disabled by default (`--enable-tool` is needed). CI has been already set up, so we will test this feature regularly. The current code is messy, so it should require refactoring in the future. 

Any suggestions or comments are welcome.

### [EDIT] Performance Impact

The following shows the overhead of ULT fork-join, which is one of the representative performance-critical operations in Argobots. The benchmark repeats fork-join N ULTs (N = X axis) on multiple execution streams. The error bar was not measured.

The blue bars show the performance of the current master. The orange bars show the performance of this PR (without the tool feature, which is the default behavior). The gray shows the overheads when the tool feature is enabled (which must be specified by a user). I wanted to show the following
1. Blue = Orange: with the default configurations, this PR does not change the performance significantly.
2. Gray > Orange and Blue: the tool feature can slightly increase the overheads. 

In reality, however, I can hardly say that there is a performance difference from the results without error bars. In any case, the performance difference is similar and acceptable.
#### Intel Xeon Platinum 8180
![Intel Xeon Platinum 8180](https://user-images.githubusercontent.com/15073003/86263437-d8785d00-bb86-11ea-899a-b092487057c6.png)
#### Intel Xeon Phi 7210 (KNL)
![Intel Xeon Phi 7210 (KNL)](https://user-images.githubusercontent.com/15073003/86263780-4755b600-bb87-11ea-9955-be9f8bb9cf9f.png)

#### Summit-like POWER 9
![Summit-like POWER 9](https://user-images.githubusercontent.com/15073003/86263327-b383ea00-bb86-11ea-992a-dd6c1155a0be.png)
