### PR TITLE
key: extend get/set_specific interface

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -577,6 +577,8 @@ int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize) ABT_API_PUBLI
 int ABT_thread_get_id(ABT_thread thread, ABT_unit_id *thread_id) ABT_API_PUBLIC;
 int ABT_thread_set_arg(ABT_thread thread, void *arg) ABT_API_PUBLIC;
 int ABT_thread_get_arg(ABT_thread thread, void **arg) ABT_API_PUBLIC;
+int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value) ABT_API_PUBLIC;
+int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value) ABT_API_PUBLIC;
 int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr) ABT_API_PUBLIC;
 
 /* ULT Attributes */
@@ -613,6 +615,8 @@ int ABT_task_is_migratable(ABT_task task, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result) ABT_API_PUBLIC;
 int ABT_task_get_id(ABT_task task, ABT_unit_id *task_id) ABT_API_PUBLIC;
 int ABT_task_get_arg(ABT_task task, void **arg) ABT_API_PUBLIC;
+int ABT_task_set_specific(ABT_task task, ABT_key key, void *value) ABT_API_PUBLIC;
+int ABT_task_get_specific(ABT_task task, ABT_key key, void **value) ABT_API_PUBLIC;
 
 /* Self */
 int ABT_self_get_type(ABT_unit_type *type) ABT_API_PUBLIC;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -567,7 +567,6 @@ void ABTI_task_reset_id(void);
 ABT_unit_id ABTI_task_get_id(ABTI_task *p_task);
 
 /* Key */
-ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream, int size);
 void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable);
 
 /* Mutex */
@@ -598,7 +597,6 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_thread.h"
 #include "abti_thread_attr.h"
 #include "abti_task.h"
-#include "abti_key.h"
 #include "abti_mutex.h"
 #include "abti_mutex_attr.h"
 #include "abti_cond.h"
@@ -608,5 +606,6 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_barrier.h"
 #include "abti_timer.h"
 #include "abti_mem.h"
+#include "abti_key.h"
 
 #endif /* ABTI_H_INCLUDED */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -356,15 +356,16 @@ struct ABTI_ktelem {
     void (*f_destructor)(void *value);
     uint32_t key_id;
     void *value;
-    struct ABTI_ktelem *p_next;
+    ABTD_atomic_ptr p_next; /* Next element (ABTI_ktelem *) */
 };
 
 struct ABTI_ktable {
-    int size; /* size of the table */
+    int size;           /* size of the table */
+    ABTI_spinlock lock; /* Protects any new entry creation. */
     void *p_used_mem;
     void *p_extra_mem;
     size_t extra_mem_size;
-    ABTI_ktelem *p_elems[1]; /* element array */
+    ABTD_atomic_ptr p_elems[1]; /* element array (ABTI_ktelem *) */
 };
 
 struct ABTI_cond {

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -306,7 +306,7 @@ struct ABTI_unit {
     ABTD_atomic_int state;        /* State (ABTI_unit_state) */
     ABTD_atomic_uint32 request;   /* Request */
     ABTI_pool *p_pool;            /* Associated pool */
-    ABTI_ktable *p_keytable;      /* Work unit-specific data */
+    ABTD_atomic_ptr p_keytable;   /* Work unit-specific data (ABTI_ktable *) */
     ABT_unit_id id;               /* ID */
     uint32_t refcount;            /* Reference count */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -38,4 +38,143 @@ static inline ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 #endif
 }
 
+typedef struct ABTI_ktable_mem_header {
+    struct ABTI_ktable_mem_header *p_next;
+    ABT_bool is_from_mempool;
+} ABTI_ktable_mem_header;
+
+#define ABTI_KTABLE_DESC_SIZE                                                  \
+    (ABTI_MEM_POOL_DESC_SIZE - sizeof(ABTI_ktable_mem_header))
+
+static inline ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream,
+                                             int size)
+{
+    /* size must be a power of 2. */
+    ABTI_ASSERT((size & (size - 1)) == 0);
+    /* max alignment must be a power of 2. */
+    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t ktable_size =
+        (offsetof(ABTI_ktable, p_elems) + sizeof(ABTD_atomic_ptr) * size +
+         ABTU_MAX_ALIGNMENT - 1) &
+        (~(ABTU_MAX_ALIGNMENT - 1));
+    ABTI_ktable *p_ktable;
+    /* Since only one ES can access the memory pool on creation, this uses an
+     * unsafe memory pool without taking a lock. */
+    if (ABTU_likely(ktable_size <= ABTI_KTABLE_DESC_SIZE)) {
+        /* Use memory pool. */
+        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_ktable =
+            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_header->p_next = NULL;
+        p_header->is_from_mempool = ABT_TRUE;
+        p_ktable->p_used_mem = p_mem;
+        p_ktable->p_extra_mem = (void *)(((char *)p_ktable) + ktable_size);
+        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - ktable_size;
+    } else {
+        /* Use malloc() */
+        void *p_mem = ABTU_malloc(ktable_size + sizeof(ABTI_ktable_mem_header));
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_ktable =
+            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_header->p_next = NULL;
+        p_header->is_from_mempool = ABT_FALSE;
+        p_ktable->p_used_mem = p_mem;
+        p_ktable->p_extra_mem = NULL;
+        p_ktable->extra_mem_size = 0;
+    }
+    p_ktable->size = size;
+    memset(p_ktable->p_elems, 0, sizeof(ABTD_atomic_ptr) * size);
+    return p_ktable;
+}
+
+static inline void *ABTI_ktable_alloc_elem(ABTI_xstream *p_local_xstream,
+                                           ABTI_ktable *p_ktable, size_t size)
+{
+    ABTI_ASSERT((size & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t extra_mem_size = p_ktable->extra_mem_size;
+    if (size <= extra_mem_size) {
+        /* Use the extra memory. */
+        void *p_ret = p_ktable->p_extra_mem;
+        p_ktable->p_extra_mem = (void *)(((char *)p_ret) + size);
+        p_ktable->extra_mem_size = extra_mem_size - size;
+        return p_ret;
+    } else if (ABTU_likely(size <= ABTI_KTABLE_DESC_SIZE)) {
+        /* Use memory pool. */
+        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
+        p_header->is_from_mempool = ABT_TRUE;
+        p_ktable->p_used_mem = (void *)p_header;
+        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        p_ktable->p_extra_mem = (void *)(((char *)p_mem) + size);
+        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - size;
+        return p_mem;
+    } else {
+        /* Use malloc() */
+        void *p_mem = ABTU_malloc(size + sizeof(ABTI_ktable_mem_header));
+        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
+        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
+        p_header->is_from_mempool = ABT_FALSE;
+        p_ktable->p_used_mem = (void *)p_header;
+        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
+        return p_mem;
+    }
+}
+
+static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
+{
+    return p_key->id & (size - 1);
+}
+
+static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
+                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
+                                   void *value)
+{
+    uint32_t idx;
+    ABTI_ktelem *p_elem;
+
+    /* Look for the same key */
+    idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
+    p_elem = p_ktable->p_elems[idx];
+    uint32_t key_id = p_key->id;
+    while (p_elem) {
+        if (p_elem->key_id == key_id) {
+            p_elem->value = value;
+            return;
+        }
+        p_elem = p_elem->p_next;
+    }
+
+    /* The table does not have the same key */
+    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
+    size_t ktelem_size = (sizeof(ABTI_ktelem) + ABTU_MAX_ALIGNMENT - 1) &
+                         (~(ABTU_MAX_ALIGNMENT - 1));
+    p_elem = (ABTI_ktelem *)ABTI_ktable_alloc_elem(p_local_xstream, p_ktable,
+                                                   ktelem_size);
+    p_elem->f_destructor = p_key->f_destructor;
+    p_elem->key_id = p_key->id;
+    p_elem->value = value;
+    p_elem->p_next = p_ktable->p_elems[idx];
+    p_ktable->p_elems[idx] = p_elem;
+}
+
+static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key)
+{
+    uint32_t idx;
+    ABTI_ktelem *p_elem;
+
+    idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
+    p_elem = p_ktable->p_elems[idx];
+    uint32_t key_id = p_key->id;
+    while (p_elem) {
+        if (p_elem->key_id == key_id) {
+            return p_elem->value;
+        }
+        p_elem = p_elem->p_next;
+    }
+
+    return NULL;
+}
+
 #endif /* ABTI_KEY_H_INCLUDED */

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -170,18 +170,20 @@ static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
                                    void *value)
 {
     uint32_t idx;
-    ABTI_ktelem *p_elem;
+    ABTI_ktelem *p_elem, **pp_elem;
 
     /* Look for the same key */
     idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
-    p_elem = p_ktable->p_elems[idx];
+    pp_elem = &p_ktable->p_elems[idx];
+    p_elem = *pp_elem;
     uint32_t key_id = p_key->id;
     while (p_elem) {
         if (p_elem->key_id == key_id) {
             p_elem->value = value;
             return;
         }
-        p_elem = p_elem->p_next;
+        pp_elem = &p_elem->p_next;
+        p_elem = *pp_elem;
     }
 
     /* The table does not have the same key */
@@ -193,8 +195,8 @@ static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
     p_elem->f_destructor = p_key->f_destructor;
     p_elem->key_id = p_key->id;
     p_elem->value = value;
-    p_elem->p_next = p_ktable->p_elems[idx];
-    p_ktable->p_elems[idx] = p_elem;
+    p_elem->p_next = NULL;
+    *pp_elem = p_elem;
 }
 
 static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key)

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -8,6 +8,13 @@
 
 /* Inlined functions for ABTI_unit */
 
+static inline ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream,
+                                             int size);
+static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
+                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
+                                   void *value);
+static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
+
 static inline ABT_thread_state
 ABTI_unit_state_get_thread_state(ABTI_unit_state state)
 {
@@ -73,6 +80,29 @@ static inline ABTI_thread *ABTI_unit_get_thread(ABTI_unit *p_unit)
 static inline ABTI_task *ABTI_unit_get_task(ABTI_unit *p_unit)
 {
     return (ABTI_task *)(((char *)p_unit) - offsetof(ABTI_task, unit_def));
+}
+
+static inline void ABTI_unit_set_specific(ABTI_xstream *p_local_xstream,
+                                          ABTI_unit *p_unit, ABTI_key *p_key,
+                                          void *value)
+{
+    if (p_unit->p_keytable == NULL) {
+        int key_table_size = gp_ABTI_global->key_table_size;
+        p_unit->p_keytable = ABTI_ktable_alloc(p_local_xstream, key_table_size);
+    }
+
+    /* Save the value in the key-value table */
+    ABTI_ktable_set(p_local_xstream, p_unit->p_keytable, p_key, value);
+}
+
+static inline void *ABTI_unit_get_specific(ABTI_unit *p_unit, ABTI_key *p_key)
+{
+    ABTI_ktable *p_ktable = p_unit->p_keytable;
+    if (p_ktable) {
+        /* Retrieve the value from the key-value table */
+        return ABTI_ktable_get(p_ktable, p_key);
+    }
+    return NULL;
 }
 
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/key.c
+++ b/src/key.c
@@ -109,17 +109,8 @@ int ABT_key_set(ABT_key key, void *value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer. */
-    ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_ASSERT(p_self);
-
-    if (p_self->p_keytable == NULL) {
-        int key_table_size = gp_ABTI_global->key_table_size;
-        p_self->p_keytable = ABTI_ktable_alloc(p_local_xstream, key_table_size);
-    }
-
-    /* Save the value in the key-value table */
-    ABTI_ktable_set(p_local_xstream, p_self->p_keytable, p_key, value);
-
+    ABTI_unit_set_specific(p_local_xstream, p_local_xstream->p_unit, p_key,
+                           value);
 fn_exit:
     return abt_errno;
 
@@ -147,7 +138,6 @@ int ABT_key_get(ABT_key key, void **value)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
-    void *keyval = NULL;
 
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
@@ -157,13 +147,7 @@ int ABT_key_get(ABT_key key, void **value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer */
-    ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_ktable *p_ktable = p_self->p_keytable;
-    if (p_ktable) {
-        /* Retrieve the value from the key-value table */
-        keyval = ABTI_ktable_get(p_ktable, p_key);
-    }
-    *value = keyval;
+    *value = ABTI_unit_get_specific(p_local_xstream->p_unit, p_key);
 
 fn_exit:
     return abt_errno;

--- a/src/key.c
+++ b/src/key.c
@@ -10,18 +10,6 @@
  * work-unit local storage (TLS).
  */
 
-typedef struct ABTI_ktable_mem_header {
-    struct ABTI_ktable_mem_header *p_next;
-    ABT_bool is_from_mempool;
-} ABTI_ktable_mem_header;
-#define ABTI_KTABLE_DESC_SIZE                                                  \
-    (ABTI_MEM_POOL_DESC_SIZE - sizeof(ABTI_ktable_mem_header))
-
-static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
-                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
-                                   void *value);
-static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
-
 static ABTD_atomic_uint32 g_key_id = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
 
 /**
@@ -185,45 +173,6 @@ fn_fail:
     goto fn_exit;
 }
 
-ABTI_ktable *ABTI_ktable_alloc(ABTI_xstream *p_local_xstream, int size)
-{
-    /* size must be a power of 2. */
-    ABTI_ASSERT((size & (size - 1)) == 0);
-    /* max alignment must be a power of 2. */
-    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
-    size_t ktable_size =
-        (offsetof(ABTI_ktable, p_elems) + sizeof(ABTI_ktelem *) * size +
-         ABTU_MAX_ALIGNMENT - 1) &
-        (~(ABTU_MAX_ALIGNMENT - 1));
-    ABTI_ktable *p_ktable;
-    if (ABTU_likely(ktable_size <= ABTI_KTABLE_DESC_SIZE)) {
-        /* Use memory pool. */
-        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
-        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
-        p_ktable =
-            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
-        p_header->p_next = NULL;
-        p_header->is_from_mempool = ABT_TRUE;
-        p_ktable->p_used_mem = p_mem;
-        p_ktable->p_extra_mem = (void *)(((char *)p_ktable) + ktable_size);
-        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - ktable_size;
-    } else {
-        /* Use malloc() */
-        void *p_mem = ABTU_malloc(ktable_size + sizeof(ABTI_ktable_mem_header));
-        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
-        p_ktable =
-            (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
-        p_header->p_next = NULL;
-        p_header->is_from_mempool = ABT_FALSE;
-        p_ktable->p_used_mem = p_mem;
-        p_ktable->p_extra_mem = NULL;
-        p_ktable->extra_mem_size = 0;
-    }
-    p_ktable->size = size;
-    memset(p_ktable->p_elems, 0, sizeof(ABTI_ktelem *) * size);
-    return p_ktable;
-}
-
 void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable)
 {
     ABTI_ktelem *p_elem;
@@ -250,93 +199,4 @@ void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable)
         }
         p_header = p_next;
     }
-}
-
-static inline void *ABTI_ktable_alloc_elem(ABTI_xstream *p_local_xstream,
-                                           ABTI_ktable *p_ktable, size_t size)
-{
-    ABTI_ASSERT((size & (ABTU_MAX_ALIGNMENT - 1)) == 0);
-    size_t extra_mem_size = p_ktable->extra_mem_size;
-    if (size <= extra_mem_size) {
-        /* Use the extra memory. */
-        void *p_ret = p_ktable->p_extra_mem;
-        p_ktable->p_extra_mem = (void *)(((char *)p_ret) + size);
-        p_ktable->extra_mem_size = extra_mem_size - size;
-        return p_ret;
-    } else if (ABTU_likely(size <= ABTI_KTABLE_DESC_SIZE)) {
-        /* Use memory pool. */
-        void *p_mem = ABTI_mem_alloc_desc(p_local_xstream);
-        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
-        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
-        p_header->is_from_mempool = ABT_TRUE;
-        p_ktable->p_used_mem = (void *)p_header;
-        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
-        p_ktable->p_extra_mem = (void *)(((char *)p_mem) + size);
-        p_ktable->extra_mem_size = ABTI_KTABLE_DESC_SIZE - size;
-        return p_mem;
-    } else {
-        /* Use malloc() */
-        void *p_mem = ABTU_malloc(size + sizeof(ABTI_ktable_mem_header));
-        ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
-        p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
-        p_header->is_from_mempool = ABT_FALSE;
-        p_ktable->p_used_mem = (void *)p_header;
-        p_mem = (void *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
-        return p_mem;
-    }
-}
-
-static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
-{
-    return p_key->id & (size - 1);
-}
-
-static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
-                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
-                                   void *value)
-{
-    uint32_t idx;
-    ABTI_ktelem *p_elem;
-
-    /* Look for the same key */
-    idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
-    p_elem = p_ktable->p_elems[idx];
-    uint32_t key_id = p_key->id;
-    while (p_elem) {
-        if (p_elem->key_id == key_id) {
-            p_elem->value = value;
-            return;
-        }
-        p_elem = p_elem->p_next;
-    }
-
-    /* The table does not have the same key */
-    ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
-    size_t ktelem_size = (sizeof(ABTI_ktelem) + ABTU_MAX_ALIGNMENT - 1) &
-                         (~(ABTU_MAX_ALIGNMENT - 1));
-    p_elem = (ABTI_ktelem *)ABTI_ktable_alloc_elem(p_local_xstream, p_ktable,
-                                                   ktelem_size);
-    p_elem->f_destructor = p_key->f_destructor;
-    p_elem->key_id = p_key->id;
-    p_elem->value = value;
-    p_elem->p_next = p_ktable->p_elems[idx];
-    p_ktable->p_elems[idx] = p_elem;
-}
-
-static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key)
-{
-    uint32_t idx;
-    ABTI_ktelem *p_elem;
-
-    idx = ABTI_ktable_get_idx(p_key, p_ktable->size);
-    p_elem = p_ktable->p_elems[idx];
-    uint32_t key_id = p_key->id;
-    while (p_elem) {
-        if (p_elem->key_id == key_id) {
-            return p_elem->value;
-        }
-        p_elem = p_elem->p_next;
-    }
-
-    return NULL;
 }

--- a/src/key.c
+++ b/src/key.c
@@ -163,13 +163,15 @@ void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable)
     int i;
 
     for (i = 0; i < p_ktable->size; i++) {
-        p_elem = p_ktable->p_elems[i];
+        p_elem =
+            (ABTI_ktelem *)ABTD_atomic_relaxed_load_ptr(&p_ktable->p_elems[i]);
         while (p_elem) {
             /* Call the destructor if it exists and the value is not null. */
             if (p_elem->f_destructor && p_elem->value) {
                 p_elem->f_destructor(p_elem->value);
             }
-            p_elem = p_elem->p_next;
+            p_elem =
+                (ABTI_ktelem *)ABTD_atomic_relaxed_load_ptr(&p_elem->p_next);
         }
     }
     ABTI_ktable_mem_header *p_header =

--- a/src/task.c
+++ b/src/task.c
@@ -649,6 +649,75 @@ fn_fail:
     goto fn_exit;
 }
 
+/**
+ * @ingroup TASK
+ * @brief  Set the tasklet-specific value associated with the key
+ *
+ * \c ABT_task_set_specific() associates a value, \c value, with a work
+ * unit-specific data key, \c key.  The target work unit is \c task.
+ *
+ * @param[in] task   handle to the target tasklet
+ * @param[in] key    handle to the target key
+ * @param[in] value  value for the key
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_task_set_specific(ABT_task task, ABT_key key, void *value)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
+
+    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
+
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    /* Set the value. */
+    ABTI_unit_set_specific(p_local_xstream, &p_task->unit_def, p_key, value);
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/**
+ * @ingroup TASK
+ * @brief   Get the tasklet-specific value associated with the key
+ *
+ * \c ABT_task_get_specific() returns the value associated with a target work
+ * unit-specific data key, \c key, through \c value.  The target work unit is
+ * \c task.  If \c task has never set a value for the key, this routine returns
+ * \c NULL to \c value.
+ *
+ * @param[in]  task   handle to the target tasklet
+ * @param[in]  key    handle to the target key
+ * @param[out] value  value for the key
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_task_get_specific(ABT_task task, ABT_key key, void **value)
+{
+    int abt_errno = ABT_SUCCESS;
+
+    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
+
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    /* Get the value. */
+    *value = ABTI_unit_get_specific(&p_task->unit_def, p_key);
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/

--- a/src/thread.c
+++ b/src/thread.c
@@ -1390,6 +1390,75 @@ fn_fail:
 
 /**
  * @ingroup ULT
+ * @brief  Set the ULT-specific value associated with the key
+ *
+ * \c ABT_thread_set_specific() associates a value, \c value, with a work
+ * unit-specific data key, \c key.  The target work unit is \c thread.
+ *
+ * @param[in] thread  handle to the target ULT
+ * @param[in] key     handle to the target key
+ * @param[in] value   value for the key
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
+
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    /* Set the value. */
+    ABTI_unit_set_specific(p_local_xstream, &p_thread->unit_def, p_key, value);
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/**
+ * @ingroup ULT
+ * @brief   Get the ULT-specific value associated with the key
+ *
+ * \c ABT_thread_get_specific() returns the value associated with a target work
+ * unit-specific data key, \c key, through \c value.  The target work unit is
+ * \c thread.  If \c thread has never set a value for the key, this routine
+ * returns \c NULL to \c value.
+ *
+ * @param[in]  thread  handle to the target ULT
+ * @param[in]  key     handle to the target key
+ * @param[out] value   value for the key
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value)
+{
+    int abt_errno = ABT_SUCCESS;
+
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    /* Get the value. */
+    *value = ABTI_unit_get_specific(&p_thread->unit_def, p_key);
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/**
+ * @ingroup ULT
  * @brief   Get attributes of the target ULT
  *
  * \c ABT_thread_get_attr() returns the attributes of the ULT \c thread to

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -15,11 +15,13 @@ basic/thread_yield_to
 basic/thread_self_suspend_resume
 basic/thread_migrate
 basic/thread_data
+basic/thread_data2
 basic/thread_id
 basic/task_create
 basic/task_create_on_xstream
 basic/task_revive
 basic/task_data
+basic/task_data2
 basic/thread_task
 basic/thread_task_arg
 basic/thread_task_num

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -20,11 +20,13 @@ TESTS = \
 	thread_self_suspend_resume \
 	thread_migrate \
 	thread_data \
+	thread_data2 \
 	thread_id \
 	task_create \
 	task_create_on_xstream \
 	task_revive \
 	task_data \
+	task_data2 \
 	thread_task \
 	thread_task_arg \
 	thread_task_num \
@@ -91,11 +93,13 @@ thread_yield_to_SOURCES = thread_yield_to.c
 thread_self_suspend_resume_SOURCES = thread_self_suspend_resume.c
 thread_migrate_SOURCES = thread_migrate.c
 thread_data_SOURCES = thread_data.c
+thread_data2_SOURCES = thread_data2.c
 thread_id_SOURCES = thread_id.c
 task_create_SOURCES = task_create.c
 task_create_on_xstream_SOURCES = task_create_on_xstream.c
 task_revive_SOURCES = task_revive.c
 task_data_SOURCES = task_data.c
+task_data2_SOURCES = task_data2.c
 thread_task_SOURCES = thread_task.c
 thread_task_arg_SOURCES = thread_task_arg.c
 thread_task_num_SOURCES = thread_task_num.c
@@ -150,11 +154,13 @@ testing:
 	./thread_self_suspend_resume
 	./thread_migrate
 	./thread_data
+	./thread_data2
 	./thread_id
 	./task_create
 	./task_create_on_xstream
 	./task_revive
 	./task_data
+	./task_data2
 	./thread_task
 	./thread_task_arg
 	./thread_task_num

--- a/test/basic/task_data2.c
+++ b/test/basic/task_data2.c
@@ -1,0 +1,136 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_TASKS 8
+#define NUM_TLS 8
+#define NUM_STEPS 128
+
+static ABT_key tls[NUM_TLS];
+static int num_tasks;
+
+static void task_f(void *arg)
+{
+    int i, ret;
+    /* Check if there is no data race. */
+    for (i = 0; i < NUM_TLS; i++) {
+        void *check;
+        ret = ABT_key_get(tls[i], &check);
+        ATS_ERROR(ret, "ABT_key_get");
+        assert(check == NULL || check == (void *)(intptr_t)i);
+        ret = ABT_key_set(tls[i], (void *)(intptr_t)(i * 2));
+        ATS_ERROR(ret, "ABT_key_set");
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int num_xstreams;
+    ABT_xstream *xstreams;
+    ABT_task *tasks;
+    ABT_pool *pools;
+    int i, j, step, ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    if (argc < 2) {
+        num_xstreams = DEFAULT_NUM_XSTREAMS;
+        num_tasks = DEFAULT_NUM_TASKS;
+    } else {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_tasks = ATS_get_arg_val(ATS_ARG_N_ULT);
+    }
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs/ES: %d\n", num_tasks);
+    for (i = 0; i < NUM_TLS; i++) {
+        tls[i] = ABT_KEY_NULL;
+    }
+
+    xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    tasks = (ABT_task *)malloc(num_tasks * sizeof(ABT_task));
+
+    /* Create ULT-specific data keys */
+    assert(NUM_TLS >= 4);
+    for (i = 0; i < NUM_TLS; i++) {
+        ret = ABT_key_create(NULL, &tls[i]);
+        ATS_ERROR(ret, "ABT_key_create");
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to each ES */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (step = 0; step < NUM_STEPS; step++) {
+        /* Create one ULT for each ES */
+        for (i = 1; i < num_tasks; i++) {
+            ret = ABT_task_create(pools[i % num_xstreams], task_f, NULL,
+                                  &tasks[i]);
+            ATS_ERROR(ret, "ABT_task_create");
+        }
+        for (i = 1; i < num_tasks; i++) {
+            for (j = 0; j < NUM_TLS; j++) {
+                if (j % 2 == 0) {
+                    ret = ABT_task_set_specific(tasks[i], tls[j],
+                                                (void *)(intptr_t)j);
+                    ATS_ERROR(ret, "ABT_task_set_specific");
+                } else {
+                    void *check;
+                    ret = ABT_task_get_specific(tasks[i], tls[j], &check);
+                    ATS_ERROR(ret, "ABT_task_get_specific");
+                    assert(check == NULL || check == (void *)(intptr_t)(j * 2));
+                }
+            }
+        }
+        /* Join ULTs */
+        for (i = 1; i < num_tasks; i++) {
+            ret = ABT_task_free(&tasks[i]);
+            ATS_ERROR(ret, "ABT_task_free");
+            assert(tasks[i] == ABT_TASK_NULL);
+        }
+    }
+
+    /* Join and free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+        assert(xstreams[i] == ABT_XSTREAM_NULL);
+    }
+
+    /* Delete keys */
+    for (i = 0; i < NUM_TLS; i++) {
+        ret = ABT_key_free(&tls[i]);
+        ATS_ERROR(ret, "ABT_key_free");
+        assert(tls[i] == ABT_KEY_NULL);
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(pools);
+    free(tasks);
+
+    return ret;
+}

--- a/test/basic/thread_data2.c
+++ b/test/basic/thread_data2.c
@@ -1,0 +1,177 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 8
+#define NUM_TLS 8
+#define NUM_STEPS 128
+
+static ABT_barrier g_barrier;
+static ABT_key tls[NUM_TLS];
+static int num_threads;
+
+static void thread_f(void *arg)
+{
+    int i, ret;
+
+    ret = ABT_barrier_wait(g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_wait");
+    /* Check the value. */
+    for (i = 0; i < 3; i++) {
+        void *check;
+        ret = ABT_key_get(tls[i], &check);
+        ATS_ERROR(ret, "ABT_key_get");
+        assert(check == (void *)(intptr_t)i);
+        ret = ABT_key_set(tls[i], (void *)(intptr_t)(i * 2));
+        ATS_ERROR(ret, "ABT_key_set");
+    }
+    ret = ABT_barrier_wait(g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_wait");
+    ret = ABT_barrier_wait(g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_wait");
+    /* Check if there is no data race. */
+    for (i = 3; i < NUM_TLS; i++) {
+        void *check;
+        ret = ABT_key_get(tls[i], &check);
+        ATS_ERROR(ret, "ABT_key_get");
+        assert(check == NULL || check == (void *)(intptr_t)i);
+        ret = ABT_key_set(tls[i], (void *)(intptr_t)(i * 2));
+        ATS_ERROR(ret, "ABT_key_set");
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int num_xstreams;
+    ABT_xstream *xstreams;
+    ABT_thread *threads;
+    ABT_pool *pools;
+    int i, j, step, ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    if (argc < 2) {
+        num_xstreams = DEFAULT_NUM_XSTREAMS;
+        num_threads = DEFAULT_NUM_THREADS;
+    } else {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+    }
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(1, "# of ESs    : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs/ES: %d\n", num_threads);
+    for (i = 0; i < NUM_TLS; i++) {
+        tls[i] = ABT_KEY_NULL;
+    }
+
+    xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
+    pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
+    threads = (ABT_thread *)malloc(num_threads * sizeof(ABT_thread));
+
+    /* Create ULT-specific data keys */
+    assert(NUM_TLS >= 4);
+    for (i = 0; i < NUM_TLS; i++) {
+        ret = ABT_key_create(NULL, &tls[i]);
+        ATS_ERROR(ret, "ABT_key_create");
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to each ES */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    ret = ABT_barrier_create(num_threads, &g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+    for (step = 0; step < NUM_STEPS; step++) {
+        /* Create one ULT for each ES */
+        for (i = 1; i < num_threads; i++) {
+            ret = ABT_thread_create(pools[i % num_xstreams], thread_f, NULL,
+                                    ABT_THREAD_ATTR_NULL, &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+            /* Access that TLS. */
+            for (j = 0; j < 3; j++) {
+                ret = ABT_thread_set_specific(threads[i], tls[j],
+                                              (void *)(intptr_t)j);
+                ATS_ERROR(ret, "ABT_thread_set_specific");
+            }
+        }
+        ret = ABT_barrier_wait(g_barrier);
+        ATS_ERROR(ret, "ABT_barrier_wait");
+        ret = ABT_barrier_wait(g_barrier);
+        ATS_ERROR(ret, "ABT_barrier_wait");
+        for (i = 1; i < num_threads; i++) {
+            for (j = 0; j < 3; j++) {
+                void *check;
+                ret = ABT_thread_get_specific(threads[i], tls[j], &check);
+                ATS_ERROR(ret, "ABT_thread_get_specific");
+                assert(check == (void *)(intptr_t)(j * 2));
+            }
+        }
+        ret = ABT_barrier_wait(g_barrier);
+        ATS_ERROR(ret, "ABT_barrier_wait");
+        for (i = 1; i < num_threads; i++) {
+            for (j = 3; j < NUM_TLS; j++) {
+                if (j % 2 == 0) {
+                    ret = ABT_thread_set_specific(threads[i], tls[j],
+                                                  (void *)(intptr_t)j);
+                    ATS_ERROR(ret, "ABT_thread_set_specific");
+                } else {
+                    void *check;
+                    ret = ABT_thread_get_specific(threads[i], tls[j], &check);
+                    ATS_ERROR(ret, "ABT_thread_get_specific");
+                    assert(check == NULL || check == (void *)(intptr_t)(j * 2));
+                }
+            }
+        }
+        /* Join ULTs */
+        for (i = 1; i < num_threads; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+            assert(threads[i] == ABT_THREAD_NULL);
+        }
+    }
+    ret = ABT_barrier_free(&g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Join and free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+        assert(xstreams[i] == ABT_XSTREAM_NULL);
+    }
+
+    /* Delete keys */
+    for (i = 0; i < NUM_TLS; i++) {
+        ret = ABT_key_free(&tls[i]);
+        ATS_ERROR(ret, "ABT_key_free");
+        assert(tls[i] == ABT_KEY_NULL);
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(pools);
+    free(threads);
+
+    return ret;
+}


### PR DESCRIPTION
## Problems

This addresses #198; it would be nice to have TLS functions that can be accessed by not only the owner (=self) but also other parallel units as well.

## Solutions

This PR implements the following functions:
```c
int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value);
int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value);
int ABT_task_set_specific(ABT_task task, ABT_key key, void *value);
int ABT_task_get_specific(ABT_task task, ABT_key key, void **value);
```
These functions take a work unit handle, so these functions can access other's TLS.

## Performance impact

It degrades the performance of `ABT_key` access since atomic operations are newly added in some paths. In Argobots, a key table and its element of a key table are lazily created, so synchronization is necessary if two parallel units try to allocate a key table or insert a new element (i.e., two parallel `ABT_xxx_set_specific()`).

The following is the overheads (nanoseconds) of `ABT_key` operations on some CPUs: 56-core Skylake (2-socket Intel Xeon Platinum 8180 Processor), 64-core Intel Knights Landing 7210, and Summit-like POWER 9. I also measured the performance on a nice ARM CPU. Lower is better.

The blue one is before the optimization of #196, the orange bar is #196, the gray one is #197, and the yellow one shows this PR. Basically each ES forks and joins many ULTs (256 for 1ES and 4096 for more ESs) in total, while each ULT accesses **its own TLS** several times (so no contention). It shows the average of five time measurement.

<img width="728" alt="img2" src="https://user-images.githubusercontent.com/15073003/84725417-2d459200-af50-11ea-9237-3b525321109f.png">

The result shows that, yes, this new synchronization adds certain overheads (10% - 80%)), but I believe this cost is acceptable enough considering the original performance of `ABT_key` operations. Specifically, this feature is useful for #199 but also contributes to #198. The performance on 64-bit ARM was almost similar to the other three CPUs.

Note that basically the performance is degraded only on the first entry creation; subsequent TLS access with the same `ABT_key` does not get costlier.