### PR TITLE
Remove inappropriate terms in the code

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1009,7 +1009,7 @@ HHC_LOCATION           =
 
 # If the GENERATE_HTMLHELP tag is set to YES, the GENERATE_CHI flag
 # controls if a separate .chi index file is generated (YES) or that
-# it should be included in the master .chm file (NO).
+# it should be included in the main .chm file (NO).
 
 GENERATE_CHI           = NO
 

--- a/maint/hook/pre-commit
+++ b/maint/hook/pre-commit
@@ -9,7 +9,7 @@
 
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
-    against=$(git merge-base --fork-point master)
+    against=$(git merge-base --fork-point main)
 else
     # Initial commit: diff against an git hash-object -t tree /dev/nullempty tree object
     against=4b825dc642cb6eb9a060e54bf8d69288fbee4904

--- a/src/info.c
+++ b/src/info.c
@@ -712,7 +712,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
     /* Wait for the other execution streams using a barrier mechanism. */
     uint32_t self_value = ABTD_atomic_fetch_add_uint32(&print_stack_barrier, 1);
     if (self_value == 0) {
-        /* This ES becomes a master. */
+        /* This ES becomes the main ES. */
         double start_time = ABTI_get_wtime();
         ABT_bool force_print = ABT_FALSE;
 
@@ -778,7 +778,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
         ABTD_atomic_release_store_uint32(&print_stack_flag,
                                          PRINT_STACK_FLAG_FINALIZE);
     } else {
-        /* Wait for the master's work. */
+        /* Wait for the main ES's work. */
         while (ABTD_atomic_acquire_load_uint32(&print_stack_flag) !=
                PRINT_STACK_FLAG_FINALIZE)
             ABTD_atomic_pause();

--- a/test/basic/eventual_test.c
+++ b/test/basic/eventual_test.c
@@ -210,7 +210,7 @@ void eventual_test(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream *xstreams;
-    ABT_thread *masters;
+    ABT_thread *main_threads;
     int i, ret;
 
     /* Initialize */
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    main_threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create Execution Streams */
     ret = ABT_xstream_self(&xstreams[0]);
@@ -251,18 +251,18 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_get_main_pools");
     }
 
-    /* Create a master ULT for each ES */
+    /* Create a main ULT for each ES */
     for (i = 1; i < num_xstreams; i++) {
         ret = ABT_thread_create(pools[i], eventual_test, (void *)(size_t)i,
-                                ABT_THREAD_ATTR_NULL, &masters[i]);
+                                ABT_THREAD_ATTR_NULL, &main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
     eventual_test((void *)0);
 
-    /* Join master ULTs */
+    /* Join main ULTs */
     for (i = 1; i < num_xstreams; i++) {
-        ret = ABT_thread_free(&masters[i]);
+        ret = ABT_thread_free(&main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_free");
     }
 
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 
     free(xstreams);
     free(pools);
-    free(masters);
+    free(main_threads);
 
     return ret;
 }

--- a/test/basic/info_stackdump2.c
+++ b/test/basic/info_stackdump2.c
@@ -72,7 +72,7 @@ void thread_func(void *arg)
         ATS_printf(1, "[U%d:E%d] Raise SIGUSR1\n", t_arg->id, rank);
         g_stop = 1;
         while (g_counter < t_arg->num_xstreams - 2) {
-            /* ensure that all the non-master execution streams are waiting in
+            /* ensure that all the secondary execution streams are waiting in
              * the following busy loop. */
             __sync_synchronize();
         }

--- a/test/basic/sched_randws.c
+++ b/test/basic/sched_randws.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     ABT_xstream *xstreams;
     ABT_sched *scheds;
     ABT_pool *pools, *my_pools;
-    ABT_thread *masters;
+    ABT_thread *main_threads;
     int i, k, ret;
 
     /* Initialize */
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     scheds = (ABT_sched *)malloc(num_xstreams * sizeof(ABT_sched));
     pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    main_threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
 
     /* Create a mutex */
     ret = ABT_mutex_create(&g_mutex);
@@ -154,16 +154,16 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_xstream_create");
     }
 
-    /* Create master ULTs */
+    /* Create main ULTs */
     for (i = 0; i < num_xstreams; i++) {
         ret = ABT_thread_create(pools[i], create_threads, NULL,
-                                ABT_THREAD_ATTR_NULL, &masters[i]);
+                                ABT_THREAD_ATTR_NULL, &main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
-    /* Join and free master ULTs */
+    /* Join and free main ULTs */
     for (i = 0; i < num_xstreams; i++) {
-        ret = ABT_thread_free(&masters[i]);
+        ret = ABT_thread_free(&main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_free");
     }
 
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
     free(xstreams);
     free(scheds);
     free(pools);
-    free(masters);
+    free(main_threads);
 
     return ret;
 }

--- a/test/basic/thread_self_suspend_resume.c
+++ b/test/basic/thread_self_suspend_resume.c
@@ -94,7 +94,7 @@ void thread_test_resume(void *arg)
 int main(int argc, char *argv[])
 {
     ABT_xstream *xstreams;
-    ABT_thread *masters;
+    ABT_thread *main_threads;
     int i, k;
     int ret;
 
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 
     xstreams = (ABT_xstream *)malloc(num_xstreams * sizeof(ABT_xstream));
     pools = (ABT_pool *)malloc(num_xstreams * sizeof(ABT_pool));
-    masters = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
+    main_threads = (ABT_thread *)malloc(num_xstreams * sizeof(ABT_thread));
     threads = (ABT_thread **)malloc(num_xstreams * sizeof(ABT_thread *));
     values = (int **)malloc(num_xstreams * sizeof(int *));
     for (i = 0; i < num_xstreams; i++) {
@@ -144,18 +144,18 @@ int main(int argc, char *argv[])
     }
 
     /* Create one ULT for each ES */
-    ret = ABT_thread_self(&masters[0]);
+    ret = ABT_thread_self(&main_threads[0]);
     ATS_ERROR(ret, "ABT_thread_self");
     for (i = 1; i < num_xstreams; i++) {
         ret = ABT_thread_create(pools[i], thread_test_resume, (void *)(size_t)i,
-                                ABT_THREAD_ATTR_NULL, &masters[i]);
+                                ABT_THREAD_ATTR_NULL, &main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }
 
     thread_test_resume((void *)0);
 
     for (i = 1; i < num_xstreams; i++) {
-        ret = ABT_thread_free(&masters[i]);
+        ret = ABT_thread_free(&main_threads[i]);
         ATS_ERROR(ret, "ABT_thread_free");
     }
 
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
     }
     free(threads);
     free(values);
-    free(masters);
+    free(main_threads);
     free(pools);
     free(xstreams);
 

--- a/test/benchmark/task_fork_join.c
+++ b/test/benchmark/task_fork_join.c
@@ -67,7 +67,7 @@ static void task_func(void *arg)
     ATS_UNUSED(arg);
 }
 
-static void master_thread_func(void *arg)
+static void main_thread_func(void *arg)
 {
     int my_es = (int)(size_t)arg;
     int t, ntasks;
@@ -180,11 +180,11 @@ int main(int argc, char *argv[])
     }
 
     for (i = 1; i < ness; i++) {
-        ABT_thread_create(pools[i], master_thread_func, (void *)(size_t)i,
+        ABT_thread_create(pools[i], main_thread_func, (void *)(size_t)i,
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
-    master_thread_func((void *)(size_t)0);
+    main_thread_func((void *)(size_t)0);
 #else
     /* Create pools */
     for (i = 0; i < ness; i++) {
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
     }
 
     for (i = 1; i < ness; i++) {
-        ABT_thread_create(pools[i], master_thread_func, (void *)(size_t)i,
+        ABT_thread_create(pools[i], main_thread_func, (void *)(size_t)i,
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
     }
 
-    master_thread_func((void *)(size_t)0);
+    main_thread_func((void *)(size_t)0);
 #endif
 
     for (i = 1; i < ness; i++) {

--- a/test/benchmark/thread_fork_join.c
+++ b/test/benchmark/thread_fork_join.c
@@ -81,7 +81,7 @@ static void thread_func(void *arg)
     ATS_UNUSED(arg);
 }
 
-static void master_thread_func(void *arg)
+static void main_thread_func(void *arg)
 {
     int my_es = (int)(size_t)arg;
     int t, nults;
@@ -217,11 +217,11 @@ int main(int argc, char *argv[])
     }
 
     for (i = 1; i < ness; i++) {
-        ABT_thread_create(pools[i], master_thread_func, (void *)(size_t)i,
+        ABT_thread_create(pools[i], main_thread_func, (void *)(size_t)i,
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
-    master_thread_func((void *)(size_t)0);
+    main_thread_func((void *)(size_t)0);
 #else
     /* Create pools */
     for (i = 0; i < ness; i++) {
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
     }
 
     for (i = 1; i < ness; i++) {
-        ABT_thread_create(pools[i], master_thread_func, (void *)(size_t)i,
+        ABT_thread_create(pools[i], main_thread_func, (void *)(size_t)i,
                           ABT_THREAD_ATTR_NULL, NULL);
     }
 
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
                                  ABT_SCHED_CONFIG_NULL, &xstreams[i]);
     }
 
-    master_thread_func((void *)(size_t)0);
+    main_thread_func((void *)(size_t)0);
 #endif
 
     for (i = 1; i < ness; i++) {


### PR DESCRIPTION
This PR updates some terms in the Argobots code.

We also change the default branch of Argobots to `main`; we will keep `master` updated for a week or so but plan to remove the branch after that.