### PR TITLE
thread/task: add functions to check if a work unit is unnamed

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -571,6 +571,7 @@ int ABT_thread_set_callback(ABT_thread thread,
 int ABT_thread_set_migratable(ABT_thread thread, ABT_bool flag) ABT_API_PUBLIC;
 int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_thread_is_primary(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
+int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
                      ABT_API_PUBLIC;
 int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize) ABT_API_PUBLIC;
@@ -612,6 +613,7 @@ int ABT_task_get_last_pool(ABT_task task, ABT_pool *pool) ABT_API_PUBLIC;
 int ABT_task_get_last_pool_id(ABT_task task, int *id) ABT_API_PUBLIC;
 int ABT_task_set_migratable(ABT_task task, ABT_bool flag) ABT_API_PUBLIC;
 int ABT_task_is_migratable(ABT_task task, ABT_bool *flag) ABT_API_PUBLIC;
+int ABT_task_is_unnamed(ABT_task task, ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_task_equal(ABT_task task1, ABT_task task2, ABT_bool *result) ABT_API_PUBLIC;
 int ABT_task_get_id(ABT_task task, ABT_unit_id *task_id) ABT_API_PUBLIC;
 int ABT_task_get_arg(ABT_task task, void **arg) ABT_API_PUBLIC;
@@ -622,6 +624,7 @@ int ABT_task_get_specific(ABT_task task, ABT_key key, void **value) ABT_API_PUBL
 int ABT_self_get_type(ABT_unit_type *type) ABT_API_PUBLIC;
 int ABT_self_is_primary(ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_self_on_primary_xstream(ABT_bool *flag) ABT_API_PUBLIC;
+int ABT_self_is_unnamed(ABT_bool *flag) ABT_API_PUBLIC;
 int ABT_self_get_last_pool_id(int *pool_id) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -80,16 +80,19 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
     if (p_thread->unit_def.refcount == 0) {
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                      ABTI_UNIT_STATE_TERMINATED);
-        ABTI_thread_free(p_local_xstream, p_thread);
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    } else if (p_thread->p_sched) {
-        /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                      ABTI_UNIT_STATE_TERMINATED);
-        ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched);
+        if (p_thread->p_sched) {
+            /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
+            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+                                          ABTI_UNIT_STATE_TERMINATED);
+            ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched);
+        } else
 #endif
+        {
+            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+                                          ABTI_UNIT_STATE_TERMINATED);
+            ABTI_thread_free(p_local_xstream, p_thread);
+        }
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
          * because the ULT can be freed on a different ES.  In other words, we

--- a/src/self.c
+++ b/src/self.c
@@ -318,3 +318,38 @@ int ABT_self_get_arg(void **arg)
 fn_exit:
     return abt_errno;
 }
+
+/**
+ * @ingroup SELF
+ * @brief   Check if the running work unit is unnamed
+ *
+ * \c ABT_self_is_unnamed() returns whether the current work units is unnamed or
+ * not.  If the caller is an external thread, it sets ABT_FALSE and returns
+ * ABT_ERR_INV_XSTREAM.
+ *
+ * @param[out] flag  result (<tt>ABT_TRUE</tt> if unnamed)
+ *
+ * @return Error code
+ * @retval ABT_SUCCESS  on success
+ */
+int ABT_self_is_unnamed(ABT_bool *flag)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
+
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+    /* When an external thread called this routine */
+    if (p_local_xstream == NULL) {
+        abt_errno = ABT_ERR_INV_XSTREAM;
+        *flag = ABT_FALSE;
+        goto fn_exit;
+    }
+#endif
+
+    *flag = (p_local_xstream->p_unit->refcount == 0) ? ABT_TRUE : ABT_FALSE;
+
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+fn_exit:
+#endif
+    return abt_errno;
+}

--- a/src/task.c
+++ b/src/task.c
@@ -571,6 +571,36 @@ fn_fail:
 
 /**
  * @ingroup TASK
+ * @brief   Check if the target task is unnamed
+ *
+ * \c ABT_task_is_unnamed() returns whether the target tasklet, \c task, is
+ * unnamed or not.  Note that a handle of an unnamed tasklet can be obtained by,
+ * for example, running \c ABT_task_self() on an unnamed tasklet.
+ *
+ * @param[in]  task  handle to the target tasklet
+ * @param[out] flag  result (<tt>ABT_TRUE</tt> if unnamed)
+ *
+ * @return Error code
+ * @retval ABT_SUCCESS  on success
+ */
+int ABT_task_is_unnamed(ABT_task task, ABT_bool *flag)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_CHECK_NULL_TASK_PTR(p_task);
+
+    *flag = (p_task->unit_def.refcount == 0) ? ABT_TRUE : ABT_FALSE;
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/**
+ * @ingroup TASK
  * @brief   Compare two tasklet handles for equality.
  *
  * \c ABT_task_equal() compares two tasklet handles for equality. If two handles

--- a/src/thread.c
+++ b/src/thread.c
@@ -1252,6 +1252,36 @@ fn_fail:
 
 /**
  * @ingroup ULT
+ * @brief   Check if the target ULT is unnamed
+ *
+ * \c ABT_thread_is_unnamed() returns whether the target ULT, \c thread, is
+ * unnamed or not.  Note that a handle of an unnamed ULT can be obtained by, for
+ * example, running \c ABT_thread_self() on an unnamed ULT.
+ *
+ * @param[in]  thread  handle to the target ULT
+ * @param[out] flag    result (<tt>ABT_TRUE</tt> if unnamed)
+ *
+ * @return Error code
+ * @retval ABT_SUCCESS  on success
+ */
+int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *flag)
+{
+    int abt_errno = ABT_SUCCESS;
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+
+    *flag = (p_thread->unit_def.refcount == 0) ? ABT_TRUE : ABT_FALSE;
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+}
+
+/**
+ * @ingroup ULT
  * @brief   Compare two ULT handles for equality.
  *
  * \c ABT_thread_equal() compares two ULT handles for equality. If two handles

--- a/src/thread.c
+++ b/src/thread.c
@@ -1821,7 +1821,7 @@ int ABTI_thread_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                                     (void (*)(void *))p_sched->run,
                                     (void *)ABTI_sched_get_handle(p_sched),
                                     &attr, ABTI_UNIT_TYPE_THREAD_USER, p_sched,
-                                    1, NULL, ABT_TRUE, &p_sched->p_thread);
+                                    0, NULL, ABT_TRUE, &p_sched->p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:


### PR DESCRIPTION
This patch adds utility functions that check if a given work unit is unnamed (or anonymous) or not.

```c
int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *flag);
int ABT_task_is_unnamed(ABT_task task, ABT_bool *flag);
int ABT_self_is_unnamed(ABT_bool *flag);
```

They should be useful in general, but they are needed specifically for #199 (precisely speaking, for tool tests) because a state transition pattern of a named work unit is different from that of an unnamed work unit (e.g., no "join"). 