### PR TITLE
support PGI compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -652,7 +652,9 @@ AC_TRY_COMPILE(
 )
 # __atomic is broken in XLC-16.1.1, so use __sync as a fallback
 # See https://github.com/pmodels/argobots/issues/162 for details.
-if test "$CC" != "xlc" -a "x$have_atomic_builtin" = "xyes" ; then
+# __atomic is broken in PGI-20.1-0, so use __sunc as a fallback
+# See https://github.com/pmodels/argobots/issues/211 for details
+if test "$CC" != "xlc" -a "$CC" != "pgcc" -a "x$have_atomic_builtin" = "xyes" ; then
     AC_DEFINE(ABT_CONFIG_HAVE_ATOMIC_BUILTIN, 1,
               [Define if __atomic builtins are supported])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -830,6 +830,13 @@ int main() {
 
 AM_CONDITIONAL([ABT_USE_INT128_ATOMIC], [test "x$ABT_CONFIG_HAVE_ATOMIC_INT128" != "x"])
 
+# set compiler-specific flags
+if test x"$CC" = x"pgcc" ; then
+  # Suppress PGI warning
+  # #546-D: transfer of control bypasses initialization
+  PAC_APPEND_FLAG([--diag_suppress=546], [CFLAGS])
+fi
+
 dnl ----------------------------------------------------------------------------
 
 AM_INIT_AUTOMAKE([-Wall -Wno-portability-recursive -Werror foreign 1.12.3 subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -423,7 +423,7 @@ if test "x$enable_perf_opt" = "xyes"; then
     CFLAGS="$CFLAGS -O3"
     CXXFLAGS="$CXXFLAGS -O3"
     CCASFLAGS="$CCASFLAGS -O3"
-    if test "$CC" != "xlc" -a "$CC" != "suncc"; then
+    if test "$CC" != "xlc" -a "$CC" != "suncc" -a "$CC" != "pgcc" ; then
         CFLAGS="$CFLAGS -ftls-model=initial-exec"
         CXXFLAGS="$CXXFLAGS -ftls-model=initial-exec"
         CCASFLAGS="$CCASFLAGS -ftls-model=initial-exec"

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -6,7 +6,7 @@
 #ifndef ABTD_H_INCLUDED
 #define ABTD_H_INCLUDED
 
-#define __USE_GNU
+#define __USE_GNU 1
 #include <pthread.h>
 #include "abtd_atomic.h"
 #include "abtd_context.h"

--- a/test/basic/info_stackdump.c
+++ b/test/basic/info_stackdump.c
@@ -18,8 +18,7 @@ void callback_f(ABT_bool timeout, void *arg)
 {
     assert(timeout == ABT_FALSE);
     assert((intptr_t)arg == (intptr_t)1);
-    g_go = 1;
-    __sync_synchronize();
+    ATS_atomic_store(&g_go, 1);
 }
 
 void signal_handler(int sig)
@@ -70,8 +69,7 @@ void thread_func(void *arg)
         raise(SIGUSR1);
     }
 
-    while (g_go == 0) {
-        __sync_synchronize();
+    while (ATS_atomic_load(&g_go) == 0) {
         ABT_thread_yield();
     }
 }

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -153,4 +153,42 @@ static inline uint64_t ATS_get_cycles()
 }
 #endif
 
+#if defined(__PGIC__) || defined(__ibmxl__)
+
+/* Those two compilers have implementation issues in __atomic built-ins. */
+static inline int ATS_atomic_load(volatile int *p_val)
+{
+    __sync_synchronize();
+    int val = *p_val;
+    __sync_synchronize();
+    return val;
+}
+static inline void ATS_atomic_store(volatile int *p_val, int val)
+{
+    __sync_synchronize();
+    *p_val = val;
+    __sync_synchronize();
+}
+static inline int ATS_atomic_fetch_add(volatile int *p_val, int val)
+{
+    return __sync_fetch_and_add(p_val, val);
+}
+
+#else
+
+static inline int ATS_atomic_load(volatile int *p_val)
+{
+    return __atomic_load_n(p_val, __ATOMIC_ACQUIRE);
+}
+static inline void ATS_atomic_store(volatile int *p_val, int val)
+{
+    __atomic_store_n(p_val, val, __ATOMIC_RELEASE);
+}
+static inline int ATS_atomic_fetch_add(volatile int *p_val, int val)
+{
+    return __atomic_fetch_add(p_val, val, __ATOMIC_ACQ_REL);
+}
+
+#endif
+
 #endif /* ABTTEST_H_INCLUDED */


### PR DESCRIPTION
PGI 20.x is sufficiently modernized so now it can compile Argobots. This PR fixes minor issues to enable PGI to compile Argobots. Argobots + PGI compiler will be tested regularly.    

Note that Argobots does not work with older PGI compiler (-19). If your program needs an old PGI compiler, please link your program to the Argobots library already compiled by another compiler (e.g., GCC).