### PR TITLE
doxygen: remove doxygen comments for private functions

### DIFF
--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -8,17 +8,6 @@
 
 /* Inlined functions for ULT Attributes */
 
-/**
- * @ingroup ULT_ATTR_PRIVATE
- * @brief   Get \c ABTI_thread_attr pointer from \c ABT_thread_attr handle.
- *
- * \c ABTI_thread_attr_get_ptr() returns \c ABTI_thread_attr pointer
- * corresponding to \c ABT_thread_attr handle \c attr. If \c attr is
- * \c ABT_THREAD_NULL, \c NULL is returned.
- *
- * @param[in] attr  handle to the ULT attribute
- * @return ABTI_thread_attr pointer
- */
 static inline ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
@@ -34,17 +23,6 @@ static inline ABTI_thread_attr *ABTI_thread_attr_get_ptr(ABT_thread_attr attr)
 #endif
 }
 
-/**
- * @ingroup ULT_ATTR_PRIVATE
- * @brief   Get \c ABT_thread_attr handle from \c ABTI_thread_attr pointer.
- *
- * \c ABTI_thread_attr_get_handle() returns \c ABT_thread_attr handle
- * corresponding to \c ABTI_thread_attr pointer \c attr. If \c attr is
- * \c NULL, \c ABT_THREAD_NULL is returned.
- *
- * @param[in] p_attr  pointer to ABTI_thread_attr
- * @return ABT_thread_attr handle
- */
 static inline ABT_thread_attr
 ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 {

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -300,23 +300,6 @@ fn_fail:
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-/** @defgroup ULT_ATTR_PRIVATE ULT Attributes (Private)
- * This group combines private APIs for ULT attributes.
- */
-
-/**
- * @ingroup ULT_ATTR_PRIVATE
- * @brief   Print field values of ABTI_thread_attr.
- *
- * \c ABTI_thread_attr_print() prints out values of all fields in
- * \c ABTI_thread_attr struct.
- *
- * @param[in] p_attr  pointer to ABTI_thread_attr
- * @param[in] p_os    pointer to a FILE object (output stream)
- * @param[in] indent  amount of space to indent
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
 void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent)
 {
     char *prefix = ABTU_get_indent_str(indent);


### PR DESCRIPTION
We do not maintain doxygen comments for private functions (e.g.,`ABTI_*`).  To be consistent, a few existing comments for `ABTI_` functions should be removed.
