### PR TITLE
test/basic: fix memory leaks

### DIFF
--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -18,7 +18,7 @@ void fn1(void *args)
 {
     ATS_UNUSED(args);
     int i = 0;
-    void *data = malloc(EVENTUAL_SIZE);
+    void *data;
     ATS_printf(1, "Thread 1 iteration %d waiting for eventual\n", i);
     ABT_eventual_wait(myeventual, &data);
     ATS_printf(1,
@@ -31,7 +31,7 @@ void fn2(void *args)
 {
     ATS_UNUSED(args);
     int i = 0, is_ready = 0;
-    void *data = malloc(EVENTUAL_SIZE);
+    void *data;
     ATS_printf(1, "Thread 2 iteration %d waiting from eventual\n", i);
     ABT_eventual_test(myeventual, &data, &is_ready);
     while (!is_ready) {
@@ -52,6 +52,7 @@ void fn3(void *args)
     ATS_printf(1, "Thread 3 iteration %d signal eventual \n", i);
     char *data = (char *)malloc(EVENTUAL_SIZE);
     ABT_eventual_set(myeventual, data, EVENTUAL_SIZE);
+    free(data);
     ATS_printf(1, "Thread 3 continue iteration %d \n", i);
 }
 
@@ -101,6 +102,9 @@ int main(int argc, char *argv[])
     ATS_ERROR(ret, "ABT_thread_free");
 
     ATS_printf(1, "END\n");
+
+    ret = ABT_eventual_free(&myeventual);
+    ATS_ERROR(ret, "ABT_eventual_free");
 
     ret = ATS_finalize(0);
 

--- a/test/basic/init_finalize.c
+++ b/test/basic/init_finalize.c
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
         ret = pthread_join(threads[i], NULL);
         assert(ret == 0);
     }
+    free(threads);
 
     /* Finalize */
     ret = ATS_finalize(0);

--- a/test/basic/rwlock_reader_incl.c
+++ b/test/basic/rwlock_reader_incl.c
@@ -160,6 +160,10 @@ int main(int argc, char *argv[])
     ret = ABT_rwlock_free(&targ.rwlock);
     ATS_ERROR(ret, "ABT_rwlock_free");
 
+    /* Free the barrier */
+    ret = ABT_barrier_free(&targ.barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
     /* Free Execution Streams */
     for (i = 1; i < targ.num_xstreams; i++) {
         ret = ABT_xstream_free(&xstreams[i]);

--- a/test/basic/sched_on_thread.c
+++ b/test/basic/sched_on_thread.c
@@ -113,6 +113,7 @@ int main(int argc, char *argv[])
         ret = ABT_thread_free(&threads[i]);
         ATS_ERROR(ret, "ABT_thread_free");
     }
+    free(threads);
 
     /* Join Execution Streams */
     for (i = 1; i < num_xstreams; i++) {

--- a/test/basic/task_data.c
+++ b/test/basic/task_data.c
@@ -101,6 +101,7 @@ static void task_create(void *arg)
         ret = ABT_task_free(&tasks[i]);
         ATS_ERROR(ret, "ABT_task_free");
     }
+    free(tasks);
 }
 
 int main(int argc, char *argv[])

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -108,6 +108,7 @@ static void thread_create(void *arg)
         ret = ABT_thread_free(&threads[i]);
         ATS_ERROR(ret, "ABT_thread_free");
     }
+    free(threads);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR fixes memory leaks in `test/basic`. Note that this bugs are not in the Argobots library but in the test programs.
