### PR TITLE
enrich affinity interface

### DIFF
--- a/src/arch/Makefile.mk
+++ b/src/arch/Makefile.mk
@@ -5,6 +5,7 @@
 
 abt_sources += \
 	arch/abtd_affinity.c \
+	arch/abtd_affinity_parser.c \
 	arch/abtd_env.c \
 	arch/abtd_stream.c \
 	arch/abtd_thread.c \

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -3,6 +3,165 @@
  * See COPYRIGHT in top-level directory.
  */
 
+/*
+ * The Argobots affinity module parses the following grammar while it ignores
+ * all white spaces between tokens.  Double-quoted symbols in the following are
+ * part of the syntax.
+ *
+ * <list>         = <interval>
+ *                | <list> "," <interval>
+ * <interval>     = <es-id-list> ":" <num> ":" <stride>
+ *                | <es-id-list> ":" <num>
+ *                | <es-id-list>
+ * <es-id-list>   = <id>
+ *                | "{" <id-list> "}"
+ * <id-list>      = <id-interval>
+ *                | <id-list> "," <id-interval>
+ * <id-interval>  = <id> ":" <num> ":" <stride>
+ *                | <id> ":" <num>
+ *                | <id>
+ * <id>           = <integer>
+ * <stride>       = <integer>
+ * <num>          = <positive integer>
+ *
+ * An execution stream with rank n refers to the (n % N)th CPU ID list
+ * (<es-id-list>) of the whole list (<list>) that has N items.  The execution
+ * stream will be scheduled on a core that has a CPU ID in its CPU ID list
+ * (<es-id-list>).  If a CPU ID is smaller than zero or larger than the number
+ * of cores recognized by the system, a modulo of the number of cores is used.
+ *
+ * This grammar supports a pattern-based syntax.  <id-interval> can represent
+ * multiple CPU IDs by specifying a base CPU ID (<id>), the number of CPU IDs
+ * (<num>), and a stride (<stride>) as follows:
+ *   <id>, <id> + <stride>, ..., <id> + <stride> * (<num> - 1)
+ * <interval> also accepts a pattern-based syntax as follows:
+ *   <es-id-list>,
+ *   {<es-id-list>[0] + <stride>, <es-id-list>[1] + <stride>, ...}, ...
+ *   {<es-id-list>[0] + <stride> * (<num> - 1),
+ *    <es-id-list>[1] + <stride> * (<num> - 1), ...}
+ * Note that <num> and <stride> are set to 1 if they are omitted.
+ *
+ * Let us assume a 12-core machine (NOTE: "12-core" does not mean 12 physical
+ * cores but indicates 12 hardware threads on modern CPUs).  Examples are as
+ * follows:
+ *
+ * Example 1: bind ES with rank n to a core that has CPU ID = n % 12
+ *
+ * | ES0 | ES1 | ES2 | ES3 | ES4 | ES5 | ES6 | ES7 | ES8 | ES9 | ES10| ES11|
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (1.1) ABT_SET_AFFINITY="{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}"
+ *      This explicitly sets all the CPU IDs.
+ * (1.2) ABT_SET_AFFINITY="0,1,2,3,4,5,6,7,8,9,10,11"
+ *      It is similar to (1.1), but it omits "{}" since "{id}" = "id".
+ * (1.3) ABT_SET_AFFINITY="{0}:12:1"
+ *      This creates 12 CPU ID lists starting from {0}.  The stride is specified
+ *      as 1, so the created lists are {0}, {1}, {2}, ... {11}.
+ * (1.4) ABT_SET_AFFINITY="{0}:12"
+ *      The default stride is 1, so it is the same as (1.3)
+ * (1.5) ABT_SET_AFFINITY="0:12"
+ *      It omits "{}" in (1.4) since "{id}" = "id".
+ *
+ * Example 2: bind ES with rank n to a core that has CPU ID = (n + 6) % 12
+ *
+ * | ES6 | ES7 | ES8 | ES9 | ES10| ES11| ES0 | ES1 | ES2 | ES3 | ES4 | ES5 |
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (2.1) ABT_SET_AFFINITY="{6},{7},{8},{9},{10},{11},{0},{1},{2},{3},{4},{5}"
+ *      This explicitly sets all the CPU IDs.
+ * (2.2) ABT_SET_AFFINITY="6,7,8,9,10,11,0,1,2,3,4,5"
+ *      It is similar to (2.1), but it omits "{}" since "{id}" = "id".
+ * (2.3) ABT_SET_AFFINITY="{6}:6:1,{0}:6:1"
+ *      This first creates 6 CPU ID lists starting from {6} and then 6 lists
+ *      starting from {0}.  The stride is "1", so the created lists are
+ *      {6}, ... {11}, {0} ... {5}.
+ * (2.4) ABT_SET_AFFINITY="{6}:6,{0}:6"
+ *      The default stride is 1, so it is the same as (2.3)
+ * (2.5) ABT_SET_AFFINITY="6:6,0:6"
+ *      It omits "{}" in (2.4) since "{id}" = "id".
+ * (2.6) ABT_SET_AFFINITY="6:12"
+ *      Affinity setting wraps around with respect to the number of cores, so
+ *      this works the same as (2.5) on a 12-core machine.
+ *
+ * Example 3: bind ES with rank n to core that has CPU ID = (n * 4) % 12
+ *
+ * | ES0 |     |     |     | ES1 |     |     |     | ES2 |     |     |     |
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (3.1) ABT_SET_AFFINITY="{0},{4},{8}"
+ *      This explicitly sets all the CPU IDs.
+ * (3.2) ABT_SET_AFFINITY="0,4,8"
+ *      It is similar to (3.1), but it omits "{}" since "{id}" = "id".
+ * (3.3) ABT_SET_AFFINITY="{0}:3:4"
+ *      This creates 3 CPU ID lists starting from {0}. The stride is "4", so
+ *      creates lists are {0}, {4}, {8}.
+ * (3.4) ABT_SET_AFFINITY="0:3:4"
+ *      It omits "{}" in (3.3) since "{id}" = "id".
+ *
+ * Example 4: bind ES with rank n to core that has
+ *            CPU ID = (n * 4 + (n % 12) / 3) % 12
+ *
+ * | ES0 | ES3 | ES6 | ES9 | ES1 | ES4 | ES7 | ES10| ES2 | ES5 | ES9 | ES11|
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (4.1) ABT_SET_AFFINITY="{0},{4},{8},{1},{5},{9},{2},{6},{10},{3},{7},{11}"
+ *      This explicitly sets all the CPU IDs.
+ * (4.2) ABT_SET_AFFINITY="0,4,8,1,5,9,2,6,10,3,7,11"
+ *      It is similar to (4.1), but it omits "{}" since "{id}" = "id".
+ * (4.3) ABT_SET_AFFINITY="{0}:3:4,{1}:3:4,{2}:3:4,{3}:3:4"
+ *      This creates 3 CPU ID lists ({0}, {4}, {8}), then ({1}, {5}, {9}),
+ *      ({2}, {6}, {10}), and ({3}, {7}, {11}).
+ * (4.4) ABT_SET_AFFINITY="0:3:4,1:3:4,2:3:4,3:3:4"
+ *      It omits "{}" in (4.3) since "{id}" = "id".
+ *
+ * Example 5: bind ES with rank n to cores that have
+ *            (n * 4) % 12 <= CPU ID < (n * 4) % 12 + 4
+ *
+ * |          ES0          |          ES1          |          ES2          |
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (5.1) ABT_SET_AFFINITY="{0,1,2,3},{4,5,6,7},{8,9,10,11}"
+ *      This explicitly sets all the CPU IDs.
+ * (5.2) ABT_SET_AFFINITY="{0,1,2,3}:3:4"
+ *      This creates 3 CPU ID lists starting from {0,1,2,3}. The stride is "4",
+ *      so the created lists are "{0,1,2,3}, {4,5,6,7}, {8,9,10,11}".
+ *      Note that "{0,1,2,3}:3:1" (or "{0,1,2,3}:3") is wrong: they create
+ *      "{0,1,2,3}, {2,3,4,5}, {3,4,5,6}" since the stride is 1.
+ * (5.3) ABT_SET_AFFINITY="{0:4:1}:3:4"
+ *      "{0:4:1}" means a CPU ID list of 4 CPU IDs that starts from 0 with a
+ *      stride 1, so it is the same as "{0,1,2,3}".
+ * (5.4) ABT_SET_AFFINITY="{0:4}:3:4"
+ *      The default stride is 1.
+ *
+ * Example 6: bind ES with rank n to cores that have either of the following:
+ *            CPU ID = (n * 2) % 6
+ *            CPU ID = (n * 2) % 6 + 6
+ *
+ * |    ES0    |    ES1    |    ES2    |    ES3    |    ES4    |    ES5    |
+ * |CPU00|CPU06|CPU01|CPU07|CPU02|CPU08|CPU03|CPU09|CPU04|CPU10|CPU05|CPU11|
+ *
+ * (6.1) ABT_SET_AFFINITY="{0,6},{1,7},{2,8},{3,9},{4,10},{5,11}"
+ *      This explicitly sets all the CPU IDs.
+ * (6.2) ABT_SET_AFFINITY="{0,6}:6:1"
+ *      This creates 6 CPU ID lists starting from {0,6}. The stride is "1", so
+ *      the created lists are "{0,6}, {1,7}, {2,8}, {3,9}, {4,10}, {5,11}".
+ * (6.3) ABT_SET_AFFINITY="{0,6}:6"
+ *      The default stride is 1.
+ *
+ * Example 7: bind ESs to cores except for those that have CPU ID = 0 or 1
+ *
+ * |           |                    ES0, ES1, ES2, ...                     |
+ * |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
+ *
+ * (7.1) ABT_SET_AFFINITY="{2,3,4,5,6,7,8,9,10,11}"
+ *      This explicitly sets all the CPU IDs.
+ * (7.2) ABT_SET_AFFINITY="{2:10:1}"
+ *      "{2:10:1}" means a CPU ID list that has 10 CPU IDs starting from 2 with
+ *      a stride 1, so it is the same as "{2,3,4,5,6,7,8,9,10,11}".
+ * (7.3) ABT_SET_AFFINITY="{2:10}"
+ *      The default stride is 1.
+ */
+
 #include "abti.h"
 #include <unistd.h>
 

--- a/src/arch/abtd_affinity_parser.c
+++ b/src/arch/abtd_affinity_parser.c
@@ -1,0 +1,368 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+static ABTD_affinity_id_list *id_list_create(void)
+{
+    return (ABTD_affinity_id_list *)calloc(1, sizeof(ABTD_affinity_id_list));
+}
+
+static void id_list_free(ABTD_affinity_id_list *p_id_list)
+{
+    if (p_id_list)
+        free(p_id_list->ids);
+    free(p_id_list);
+}
+
+static void id_list_add(ABTD_affinity_id_list *p_id_list, int id, int num,
+                        int stride)
+{
+    /* Needs to add num ids. */
+    int i;
+    p_id_list->ids =
+        (int *)ABTU_realloc(p_id_list->ids, sizeof(int) * p_id_list->num,
+                            sizeof(int) * (p_id_list->num + num));
+    for (i = 0; i < num; i++) {
+        p_id_list->ids[p_id_list->num + i] = id + stride * i;
+    }
+    p_id_list->num += num;
+}
+
+static ABTD_affinity_list *list_create(void)
+{
+    return (ABTD_affinity_list *)calloc(1, sizeof(ABTD_affinity_list));
+}
+
+static void list_free(ABTD_affinity_list *p_list)
+{
+    if (p_list) {
+        int i;
+        for (i = 0; i < p_list->num; i++)
+            id_list_free(p_list->p_id_lists[i]);
+        free(p_list->p_id_lists);
+    }
+    free(p_list);
+}
+
+static void list_add(ABTD_affinity_list *p_list, ABTD_affinity_id_list *p_base,
+                     int num, int stride)
+{
+    /* Needs to add num id-lists. */
+    int i, j;
+    p_list->p_id_lists = (ABTD_affinity_id_list **)
+        ABTU_realloc(p_list->p_id_lists,
+                     sizeof(ABTD_affinity_id_list *) * p_list->num,
+                     sizeof(ABTD_affinity_id_list *) * (p_list->num + num));
+    for (i = 1; i < num; i++) {
+        ABTD_affinity_id_list *p_id_list = id_list_create();
+        p_id_list->num = p_base->num;
+        p_id_list->ids = (int *)malloc(sizeof(int) * p_id_list->num);
+        for (j = 0; j < p_id_list->num; j++)
+            p_id_list->ids[j] = p_base->ids[j] + stride * i;
+        p_list->p_id_lists[p_list->num + i] = p_id_list;
+    }
+    p_list->p_id_lists[p_list->num] = p_base;
+    p_list->num += num;
+}
+
+static inline int is_whitespace(char c)
+{
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+/* Integer. */
+static int consume_int(const char *str, int *p_index, int *p_val)
+{
+    int index = *p_index, val = 0, val_sign = 1;
+    char flag = 'n';
+    while (1) {
+        char c = *(str + index);
+        if (flag != 'v' && c == '-') {
+            /* Negative sign. */
+            flag = 's';
+            val_sign = -val_sign;
+        } else if (flag != 'v' && c == '+') {
+            /* Positive sign. */
+            flag = 's';
+        } else if (flag == 'n' && is_whitespace(c)) {
+            /* Skip a whitespace. */
+        } else if ('0' <= c && c <= '9') {
+            /* Value. */
+            flag = 'v';
+            val = val * 10 + (int)(c - '0');
+        } else {
+            /* Encounters a symbol. */
+            if (flag == 'v') {
+                /* Succeeded. */
+                *p_val = val * val_sign;
+                *p_index = index;
+                return 1;
+            } else {
+                /* Failed. The parser could not consume a value. */
+                return 0;
+            }
+        }
+        index++;
+    }
+}
+
+/* Positive integer */
+static int consume_pint(const char *str, int *p_index, int *p_val)
+{
+    int index = *p_index, val;
+    /* The value must be positive. */
+    if (consume_int(str, &index, &val) && val > 0) {
+        *p_index = index;
+        *p_val = val;
+        return 1;
+    }
+    return 0;
+}
+
+/* Symbol.  If succeeded, it returns a consumed characters. */
+static int consume_symbol(const char *str, int *p_index, char symbol)
+{
+    int index = *p_index;
+    while (1) {
+        char c = *(str + index);
+        if (c == symbol) {
+            *p_index = index + 1;
+            return 1;
+        } else if (is_whitespace(c)) {
+            /* Skip a whitespace. */
+        } else {
+            /* Failed. The parser could not consume a symbol. */
+            return 0;
+        }
+        index++;
+    }
+}
+
+static ABTD_affinity_id_list *parse_es_id_list(const char *affinity_str,
+                                               int *p_index)
+{
+    ABTD_affinity_id_list *p_id_list = id_list_create();
+    int val;
+    /* Expect either <id> or { <id-list> } */
+    if (consume_int(affinity_str, p_index, &val)) {
+        /* If the first token is an integer, it is <id> */
+        id_list_add(p_id_list, val, 1, 1);
+        return p_id_list;
+    } else if (consume_symbol(affinity_str, p_index, '{')) {
+        /* It should be "{" <id-list> "}".  Parse <id-list> and "}" */
+        while (1) {
+            int id, num = 1, stride = 1;
+            /* Parse <id-interval>.  First, expect <id> */
+            if (!consume_int(affinity_str, p_index, &id))
+                goto FAILED;
+            /* Optional: ":" <num> */
+            if (consume_symbol(affinity_str, p_index, ':')) {
+                /* Expect <num> */
+                if (!consume_pint(affinity_str, p_index, &num))
+                    goto FAILED;
+                /* Optional: ":" <stride> */
+                if (consume_symbol(affinity_str, p_index, ':')) {
+                    /* Expect <stride> */
+                    if (!consume_int(affinity_str, p_index, &stride))
+                        goto FAILED;
+                }
+            }
+            /* Add ids based on <id-interval> */
+            id_list_add(p_id_list, id, num, stride);
+            /* After <id-interval>, we expect either "," (in <id-list>) or "}"
+             * (in <es-id-list>) */
+            if (consume_symbol(affinity_str, p_index, ',')) {
+                /* Parse <id-interval> again. */
+                continue;
+            }
+            /* Expect "}" */
+            if (!consume_symbol(affinity_str, p_index, '}'))
+                goto FAILED;
+            /* Succeeded. */
+            return p_id_list;
+        }
+    }
+FAILED:
+    id_list_free(p_id_list);
+    return NULL; /* Failed. */
+}
+
+static ABTD_affinity_list *parse_list(const char *affinity_str)
+{
+    if (!affinity_str)
+        return NULL;
+    int index = 0;
+    ABTD_affinity_list *p_list = list_create();
+    ABTD_affinity_id_list *p_id_list = NULL;
+    while (1) {
+        int num = 1, stride = 1;
+        /* Parse <interval> */
+        /* Expect <es-id-list> */
+        p_id_list = parse_es_id_list(affinity_str, &index);
+        if (!p_id_list)
+            goto FAILED;
+        /* Optional: ":" <num> */
+        if (consume_symbol(affinity_str, &index, ':')) {
+            /* Expect <num> */
+            if (!consume_pint(affinity_str, &index, &num))
+                goto FAILED;
+            /* Optional: ":" <stride> */
+            if (consume_symbol(affinity_str, &index, ':')) {
+                /* Expect <stride> */
+                if (!consume_int(affinity_str, &index, &stride))
+                    goto FAILED;
+            }
+        }
+        /* Add <es-id-list> based on <interval> */
+        list_add(p_list, p_id_list, num, stride);
+        p_id_list = NULL;
+        /* After <interval>, expect either "," (in <list>) or "\0" */
+        if (consume_symbol(affinity_str, &index, ',')) {
+            /* Parse <interval> again. */
+            continue;
+        }
+        /* Expect "\0" */
+        if (!consume_symbol(affinity_str, &index, '\0'))
+            goto FAILED;
+        /* Succeeded. */
+        return p_list;
+    }
+FAILED:
+    list_free(p_list);
+    id_list_free(p_id_list);
+    return NULL; /* Failed. */
+}
+
+ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str)
+{
+    return parse_list(affinity_str);
+}
+
+void ABTD_affinity_list_free(ABTD_affinity_list *p_list)
+{
+    list_free(p_list);
+}
+
+#if 0
+
+static int is_equal(const ABTD_affinity_list *a, const ABTD_affinity_list *b)
+{
+    int i, j;
+    if (a->num != b->num)
+        return 0;
+    for (i = 0; i < a->num; i++) {
+        const ABTD_affinity_id_list *a_id = a->p_id_lists[i];
+        const ABTD_affinity_id_list *b_id = b->p_id_lists[i];
+        if (a_id->num != b_id->num)
+            return 0;
+        for (j = 0; j < a_id->num; j++) {
+            if (a_id->ids[j] != b_id->ids[j])
+                return 0;
+        }
+    }
+    return 1;
+}
+
+static int is_equal_str(const char *a_str, const char *b_str)
+{
+    int ret = 1;
+    ABTD_affinity_list *a = parse_list(a_str);
+    ABTD_affinity_list *b = parse_list(b_str);
+    ret = a && b && is_equal(a, b);
+    list_free(a);
+    list_free(b);
+    return ret;
+}
+
+static int is_err_str(const char *str)
+{
+    ABTD_affinity_list *a = parse_list(str);
+    if (a) {
+        list_free(a);
+        return 0;
+    }
+    return 1;
+}
+
+static void test_parse(void)
+{
+    /* Legal strings */
+    assert(!is_err_str("++1"));
+    assert(!is_err_str("+-1"));
+    assert(!is_err_str("+-+-1"));
+    assert(!is_err_str("+0"));
+    assert(!is_err_str("-0"));
+    assert(!is_err_str("-9:1:-9"));
+    assert(!is_err_str("-9:1:0"));
+    assert(!is_err_str("-9:1:9"));
+    assert(!is_err_str("0:1:-9"));
+    assert(!is_err_str("0:1:0"));
+    assert(!is_err_str("0:1:9"));
+    assert(!is_err_str("9:1:-9"));
+    assert(!is_err_str("9:1:0"));
+    assert(!is_err_str("9:1:9"));
+    assert(!is_err_str("{-9:1:-9}"));
+    assert(!is_err_str("{-9:1:0}"));
+    assert(!is_err_str("{-9:1:9}"));
+    assert(!is_err_str("{0:1:-9}"));
+    assert(!is_err_str("{0:1:0}"));
+    assert(!is_err_str("{0:1:9}"));
+    assert(!is_err_str("{9:1:-9}"));
+    assert(!is_err_str("{9:1:0}"));
+    assert(!is_err_str("{9:1:9}"));
+    assert(!is_err_str("1,2,3"));
+    assert(!is_err_str("1,2,{1,2}"));
+    assert(!is_err_str("1,2,{1:2}"));
+    assert(!is_err_str("1:2,{1:2}"));
+    assert(!is_err_str("1:2:1,2"));
+    assert(!is_err_str(" 1 :  +2 , { -1 : \r 2\n:2}\n"));
+    /* Illegal strings */
+    assert(is_err_str(""));
+    assert(is_err_str("{}"));
+    assert(is_err_str("+ 1"));
+    assert(is_err_str("+ +1"));
+    assert(is_err_str("+ -1"));
+    assert(is_err_str("1:"));
+    assert(is_err_str("1:2:"));
+    assert(is_err_str("1:2,"));
+    assert(is_err_str("1:-2"));
+    assert(is_err_str("1:0"));
+    assert(is_err_str("1:-2:4"));
+    assert(is_err_str("1:0:4"));
+    assert(is_err_str("1:1:1:"));
+    assert(is_err_str("1:1:1:1"));
+    assert(is_err_str("1:1:1:1,1"));
+    assert(is_err_str("{1:2:3},"));
+    assert(is_err_str("{1:2:3}:"));
+    assert(is_err_str("{1:2:3}:2:"));
+    assert(is_err_str("{:2:3}"));
+    assert(is_err_str("{{2:3}}"));
+    assert(is_err_str("{2:3}}"));
+    assert(is_err_str("2:3}"));
+    assert(is_err_str("{1:2:3"));
+    assert(is_err_str("{1,2,}"));
+    assert(is_err_str("{1:-2}"));
+    assert(is_err_str("{1:0}"));
+    assert(is_err_str("{1:-2:4}"));
+    assert(is_err_str("{1:0:4}"));
+    /* Comparison */
+    assert(is_equal_str("{1},{2},{3},{4}", "1,2,3,4"));
+    assert(is_equal_str("{1:4:1}", "{1,2,3,4}"));
+    assert(is_equal_str("{1:4}", "{1,2,3,4}"));
+    assert(is_equal_str("1:2,3:2", "1,2,3,4"));
+    assert(is_equal_str("{1:2},3:2", "{1,2},3,4"));
+    assert(is_equal_str("{1:1:4},{2:1:-4},{3:1:0},{4:1}", "1,2,3,4"));
+    assert(is_equal_str("{3:4:-1}", "{3,2,1,0}"));
+    assert(is_equal_str("3:4:-1,-1", "3,2,1,0,-1"));
+    assert(is_equal_str("{1:2:3}:1", "{1,4}"));
+    assert(is_equal_str("{1:2:3}:3", "{1,4},{2,5},{3,6}"));
+    assert(is_equal_str("{1:2:3}:3:2", "{1,4},{3,6},{5,8}"));
+    assert(is_equal_str("{1:2:3}:3:-2", "{1,4},{-1,2},{-3,0}"));
+    assert(is_equal_str("{1:2:3}:3:-2,1", "{1,4},{-1,2},{-3,0},1"));
+    assert(is_equal_str("{-2:3:-2}:2:-4", "{-2,-4,-6},{-6,-8,-10}"));
+}
+
+#endif

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -34,13 +34,12 @@ void ABTD_env_init(ABTI_global *p_global)
     if (env == NULL)
         env = getenv("ABT_ENV_SET_AFFINITY");
     if (env != NULL) {
-        if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
-            strcasecmp(env, "no") == 0) {
+        if (strcasecmp(env, "n") == 0 || strcasecmp(env, "no") == 0) {
             p_global->set_affinity = ABT_FALSE;
         }
     }
     if (p_global->set_affinity == ABT_TRUE) {
-        ABTD_affinity_init();
+        ABTD_affinity_init(env);
     }
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -32,6 +32,10 @@ typedef pthread_barrier_t ABTD_xstream_barrier;
 #else
 typedef void *ABTD_xstream_barrier;
 #endif
+typedef struct ABTD_affinity_cpuset {
+    size_t num_cpuids;
+    int *cpuids;
+} ABTD_affinity_cpuset;
 
 /* ES Storage Qualifier */
 #define ABTD_XSTREAM_LOCAL __thread
@@ -50,11 +54,12 @@ int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
 /* ES Affinity */
 void ABTD_affinity_init(void);
 void ABTD_affinity_finalize(void);
-int ABTD_affinity_set(ABTD_xstream_context *p_ctx, int rank);
-int ABTD_affinity_set_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
-                             int *p_cpuset);
-int ABTD_affinity_get_cpuset(ABTD_xstream_context *p_ctx, int cpuset_size,
-                             int *p_cpuset, int *p_num_cpus);
+int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,
+                              ABTD_affinity_cpuset *p_cpuset);
+int ABTD_affinity_cpuset_apply(ABTD_xstream_context *p_ctx,
+                               const ABTD_affinity_cpuset *p_cpuset);
+int ABTD_affinity_cpuset_apply_default(ABTD_xstream_context *p_ctx, int rank);
+void ABTD_affinity_cpuset_destroy(ABTD_affinity_cpuset *p_cpuset);
 
 #include "abtd_stream.h"
 

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -52,7 +52,7 @@ int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
 int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */
-void ABTD_affinity_init(void);
+void ABTD_affinity_init(const char *affinity_str);
 void ABTD_affinity_finalize(void);
 int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,
                               ABTD_affinity_cpuset *p_cpuset);
@@ -60,6 +60,18 @@ int ABTD_affinity_cpuset_apply(ABTD_xstream_context *p_ctx,
                                const ABTD_affinity_cpuset *p_cpuset);
 int ABTD_affinity_cpuset_apply_default(ABTD_xstream_context *p_ctx, int rank);
 void ABTD_affinity_cpuset_destroy(ABTD_affinity_cpuset *p_cpuset);
+
+/* ES Affinity Parser */
+typedef struct ABTD_affinity_id_list {
+    int num;
+    int *ids; /* id here can be negative. */
+} ABTD_affinity_id_list;
+typedef struct ABTD_affinity_parser_list {
+    int num;
+    ABTD_affinity_id_list **p_id_lists;
+} ABTD_affinity_list;
+ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str);
+void ABTD_affinity_list_free(ABTD_affinity_list *p_list);
 
 #include "abtd_stream.h"
 


### PR DESCRIPTION
## Background

Core binding of execution streams could not be easily set via an environmental variable; the current Argobots allows only either assigning ES-n to CPU-n or no affinity.  `ABT_xstream_set_affinity()` allows complicated affinity settings, but it is tedious.

## This PR

This PR extends `ABT_SET_AFFINITY`.  `ABT_SET_AFFINITY=XXX` allows detailed affinity description including multiple cores per ES and a strided pattern.  Note that this PR does not change the existing behavior.

The grammar is similar to that of Open MP (`OMP_PLACES`), but slightly different.  The specific grammar is as follows (or please see `src/arch/abtd_affinity.c`).

## Grammar

 The Argobots affinity module parses the following grammar while it ignores all white spaces between tokens.  Double-quoted symbols in the following are part of the syntax.

```
 <list>         = <interval>
                | <list> "," <interval>
 <interval>     = <es-id-list> ":" <num> ":" <stride>
                | <es-id-list> ":" <num>
                | <es-id-list>
 <es-id-list>   = <id>
                | "{" <id-list> "}"
 <id-list>      = <id-interval>
                | <id-list> "," <id-interval>
 <id-interval>  = <id> ":" <num> ":" <stride>
                | <id> ":" <num>
                | <id>
 <id>           = <integer>
 <stride>       = <integer>
 <num>          = <positive integer>
```

 An execution stream with rank n refers to the `(n % N)` th CPU ID list (`<es-id-list>`) of the whole list (`<list>`) that has `N` items.  The execution stream will be scheduled on a core that has a CPU ID in its CPU ID list (`<es-id-list>`).  If a CPU ID is smaller than zero or larger than the number of cores recognized by the system, a modulo of the number of cores is used.

 This grammar supports a pattern-based syntax.  `<id-interval>` can represent multiple CPU IDs by specifying a base CPU ID (`<id>`), the number of CPU IDs (`<num>`), and a stride (`<stride>`) as follows:
```
   <id>, <id> + <stride>, ..., <id> + <stride> * (<num> - 1)
```

 `<interval>` also accepts a pattern-based syntax as follows:

```
   <es-id-list>,
   {<es-id-list>[0] + <stride>, <es-id-list>[1] + <stride>, ...}, ...
   {<es-id-list>[0] + <stride> * (<num> - 1),
    <es-id-list>[1] + <stride> * (<num> - 1), ...}
```

Note that `<num>` and `<stride>` are set to `1` if they are omitted.


## Examples

Assume a 12-core machine (NOTE: "12-core" does not mean 12 physical cores but indicates 12 hardware threads on modern CPUs).  Examples are as follows:

### Example 1: bind ES with rank `n` to a core that has CPU ID = `n % 12`

```
 | ES0 | ES1 | ES2 | ES3 | ES4 | ES5 | ES6 | ES7 | ES8 | ES9 | ES10| ES11|
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (1.1) `ABT_SET_AFFINITY="{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10},{11}"`

This explicitly sets all the CPU IDs.

 (1.2) `ABT_SET_AFFINITY="0,1,2,3,4,5,6,7,8,9,10,11"`

It is similar to (1.1), but it omits "{}" since "{id}" = "id".

 (1.3) `ABT_SET_AFFINITY="{0}:12:1"`

This creates 12 CPU ID lists starting from `{0}`.  The stride is specified as `1`, so the created lists are `{0}, {1}, {2}, ... {11}`.

 (1.4) `ABT_SET_AFFINITY="{0}:12"`

The default stride is `1`, so it is the same as (1.3).

 (1.5) `ABT_SET_AFFINITY="0:12"`

It omits "{}" in (1.4) since "{id}" = "id".

### Example 2: bind ES with rank `n` to a core that has CPU ID = `(n + 6) % 12`

```
 | ES6 | ES7 | ES8 | ES9 | ES10| ES11| ES0 | ES1 | ES2 | ES3 | ES4 | ES5 |
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (2.1) `ABT_SET_AFFINITY="{6},{7},{8},{9},{10},{11},{0},{1},{2},{3},{4},{5}"`

This explicitly sets all the CPU IDs.

 (2.2) `ABT_SET_AFFINITY="6,7,8,9,10,11,0,1,2,3,4,5"`

It is similar to (2.1), but it omits "{}" since "{id}" = "id".

 (2.3) `ABT_SET_AFFINITY="{6}:6:1,{0}:6:1"`

This first creates `6` CPU ID lists starting from `{6}` and then 6 lists starting from `{0}`.  The stride is `1`, so the created lists are `{6}, ... {11}, {0} ... {5}`.

 (2.4) `ABT_SET_AFFINITY="{6}:6,{0}:6"`

The default stride is `1`, so it is the same as (2.3)

 (2.5) `ABT_SET_AFFINITY="6:6,0:6"`

It omits "{}" in (2.4) since "{id}" = "id".

 (2.6) `ABT_SET_AFFINITY="6:12"`

Affinity setting wraps around with respect to the number of cores, so this works the same as (2.5) on a 12-core machine.

### Example 3: bind ES with rank `n` to core that has CPU ID = `(n * 4) % 12`

```
 | ES0 |     |     |     | ES1 |     |     |     | ES2 |     |     |     |
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (3.1) `ABT_SET_AFFINITY="{0},{4},{8}"`

This explicitly sets all the CPU IDs.

 (3.2) `ABT_SET_AFFINITY="0,4,8"`

It is similar to (3.1), but it omits "{}" since "{id}" = "id".

 (3.3) `ABT_SET_AFFINITY="{0}:3:4"`

This creates 3 CPU ID lists starting from `{0}`. The stride is `4`, so creates lists are `{0}, {4}, {8}`.

 (3.4) `ABT_SET_AFFINITY="0:3:4"`

It omits "{}" in (3.3) since "{id}" = "id".

### Example 4: bind ES with rank `n` to core that has CPU ID = `(n * 4 + (n % 12) / 3) % 12`

```
 | ES0 | ES3 | ES6 | ES9 | ES1 | ES4 | ES7 | ES10| ES2 | ES5 | ES9 | ES11|
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (4.1) `ABT_SET_AFFINITY="{0},{4},{8},{1},{5},{9},{2},{6},{10},{3},{7},{11}"`

This explicitly sets all the CPU IDs.

 (4.2) `ABT_SET_AFFINITY="0,4,8,1,5,9,2,6,10,3,7,11"`

It is similar to (4.1), but it omits "{}" since "{id}" = "id".

 (4.3) `ABT_SET_AFFINITY="{0}:3:4,{1}:3:4,{2}:3:4,{3}:3:4"`

This creates 3 CPU ID lists `({0}, {4}, {8})`, then `({1}, {5}, {9})`, `({2}, {6}, {10})`, and `({3}, {7}, {11})`.

 (4.4) `ABT_SET_AFFINITY="0:3:4,1:3:4,2:3:4,3:3:4"`

It omits "{}" in (4.3) since "{id}" = "id".

### Example 5: bind ES with rank `n` to cores that have `(n * 4) % 12 <= CPU ID < (n * 4) % 12 + 4`

```
 |          ES0          |          ES1          |          ES2          |
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (5.1) `ABT_SET_AFFINITY="{0,1,2,3},{4,5,6,7},{8,9,10,11}"`

This explicitly sets all the CPU IDs.

 (5.2) `ABT_SET_AFFINITY="{0,1,2,3}:3:4"`

This creates 3 CPU ID lists starting from `{0,1,2,3}`. The stride is `4`, so the created lists are `"{0,1,2,3}, {4,5,6,7}, {8,9,10,11}"`. Note that `"{0,1,2,3}:3:1"` (or `"{0,1,2,3}:3"`) is *wrong*: they create `"{0,1,2,3}, {2,3,4,5}, {3,4,5,6}"` since the stride is `1`.

 (5.3) `ABT_SET_AFFINITY="{0:4:1}:3:4"`

`"{0:4:1}"` means a CPU ID list of 4 CPU IDs that starts from `0` with a stride `1`, so it is the same as `"{0,1,2,3}"`.

 (5.4) `ABT_SET_AFFINITY="{0:4}:3:4"`

The default stride is `1`.

### Example 6: bind ES with rank `n` to cores that have either CPU ID = `(n * 2) % 6` or CPU ID = `(n * 2) % 6 + 6`

```
 |    ES0    |    ES1    |    ES2    |    ES3    |    ES4    |    ES5    |
 |CPU00|CPU06|CPU01|CPU07|CPU02|CPU08|CPU03|CPU09|CPU04|CPU10|CPU05|CPU11|
```

 (6.1) `ABT_SET_AFFINITY="{0,6},{1,7},{2,8},{3,9},{4,10},{5,11}"`

This explicitly sets all the CPU IDs.

 (6.2) `ABT_SET_AFFINITY="{0,6}:6:1"`

This creates 6 CPU ID lists starting from `{0,6}`. The stride is `1`, so the created lists are `"{0,6}, {1,7}, {2,8}, {3,9}, {4,10}, {5,11}"`.

 (6.3) `ABT_SET_AFFINITY="{0,6}:6"`

The default stride is `1`.

### Example 7: bind ESs to cores except for those that have CPU ID = `0` or `1`

```
 |           |                    ES0, ES1, ES2, ...                     |
 |CPU00|CPU01|CPU02|CPU03|CPU04|CPU05|CPU06|CPU07|CPU08|CPU09|CPU10|CPU11|
```

 (7.1) `ABT_SET_AFFINITY="{2,3,4,5,6,7,8,9,10,11}"`

This explicitly sets all the CPU IDs.

 (7.2) `ABT_SET_AFFINITY="{2:10:1}"`

`"{2:10:1}"` means a CPU ID list that has `10` CPU IDs starting from `2` with a stride `1`, so it is the same as `"{2,3,4,5,6,7,8,9,10,11}"`.

 (7.3) `ABT_SET_AFFINITY="{2:10}"`

The default stride is `1`.


