### PR TITLE
Remove ABTI_unit

### DIFF
--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -12,13 +12,12 @@ void ABTD_thread_func_wrapper(void *p_arg)
 {
     ABTD_thread_context *p_ctx = (ABTD_thread_context *)p_arg;
     ABTI_thread *p_thread = ABTI_thread_context_get_thread(p_ctx);
-    ABTI_xstream *p_local_xstream = p_thread->unit_def.p_last_xstream;
+    ABTI_xstream *p_local_xstream = p_thread->p_last_xstream;
     ABTI_tool_event_thread_run(p_local_xstream, p_thread,
-                               p_local_xstream->p_unit,
-                               p_thread->unit_def.p_parent);
-    p_local_xstream->p_unit = &p_thread->unit_def;
+                               p_local_xstream->p_unit, p_thread->p_parent);
+    p_local_xstream->p_unit = p_thread;
 
-    p_thread->unit_def.f_unit(p_thread->unit_def.p_arg);
+    p_thread->f_unit(p_thread->p_arg);
 
     /* This ABTI_local_get_xstream() is controversial since it is called after
      * the context-switchable function (i.e., thread_func()).  We assume that
@@ -35,25 +34,23 @@ void ABTD_thread_exit(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
                                          ABTI_thread *p_thread)
 {
-    ABTD_thread_context *p_ctx = &p_thread->ctx;
+    ABTD_thread_context *p_ctx = &p_thread->ctx.ctx;
     ABTD_thread_context *p_link =
         ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
     if (p_link) {
         /* If p_link is set, it means that other ULT has called the join. */
         ABTI_thread *p_joiner = ABTI_thread_context_get_thread(p_link);
-        if (p_thread->unit_def.p_last_xstream ==
-            p_joiner->unit_def.p_last_xstream) {
+        if (p_thread->p_last_xstream == p_joiner->p_last_xstream) {
             /* Only when the current ULT is on the same ES as p_joiner's,
              * we can jump to the joiner ULT. */
-            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+            ABTD_atomic_release_store_int(&p_thread->state,
                                           ABTI_UNIT_STATE_TERMINATED);
             LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n",
                       ABTI_thread_get_id(p_thread),
-                      p_thread->unit_def.p_last_xstream->rank);
+                      p_thread->p_last_xstream->rank);
 
             /* Note that a parent ULT cannot be a joiner. */
-            ABTI_tool_event_thread_resume(p_local_xstream, p_joiner,
-                                          &p_thread->unit_def);
+            ABTI_tool_event_thread_resume(p_local_xstream, p_joiner, p_thread);
             ABTI_thread_finish_context_to_sibling(p_local_xstream, p_thread,
                                                   p_joiner);
             return;
@@ -65,11 +62,11 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
 
             /* We don't need to use the atomic OR operation here because the ULT
              * will be terminated regardless of other requests. */
-            ABTD_atomic_release_store_uint32(&p_thread->unit_def.request,
+            ABTD_atomic_release_store_uint32(&p_thread->request,
                                              ABTI_UNIT_REQ_TERMINATE);
         }
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->unit_def.request,
+        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
                                                    ABTI_UNIT_REQ_JOIN |
                                                        ABTI_UNIT_REQ_TERMINATE);
         if (req & ABTI_UNIT_REQ_JOIN) {
@@ -96,7 +93,7 @@ void ABTD_thread_terminate_no_arg()
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
-    ABTI_unit *p_unit = p_local_xstream->p_unit;
+    ABTI_thread *p_unit = p_local_xstream->p_unit;
     ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
     ABTD_thread_terminate(p_local_xstream, ABTI_unit_get_thread(p_unit));
 }
@@ -109,7 +106,7 @@ void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
      * ULT has finished its execution and calls ABTD_thread_terminate/exit,
      * this function is called by the scheduler.  Therefore, we should not
      * context switch to the joiner ULT and need to always wake it up. */
-    ABTD_thread_context *p_ctx = &p_thread->ctx;
+    ABTD_thread_context *p_ctx = &p_thread->ctx.ctx;
 
     if (ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link)) {
         /* If p_link is set, it means that other ULT has called the join. */
@@ -117,7 +114,7 @@ void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
             ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link));
         ABTI_thread_set_ready(p_local_xstream, p_joiner);
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->unit_def.request,
+        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
                                                    ABTI_UNIT_REQ_JOIN |
                                                        ABTI_UNIT_REQ_TERMINATE);
         if (req & ABTI_UNIT_REQ_JOIN) {
@@ -137,7 +134,7 @@ void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
 void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent)
 {
     char *prefix = ABTU_get_indent_str(indent);
-    ABTD_thread_context *p_ctx = &p_thread->ctx;
+    ABTD_thread_context *p_ctx = &p_thread->ctx.ctx;
     fprintf(p_os, "%sp_ctx    : %p\n", prefix, p_ctx->p_ctx);
     fprintf(p_os, "%sp_link   : %p\n", prefix,
             (void *)ABTD_atomic_acquire_load_thread_context_ptr(

--- a/src/arch/abtd_thread.c
+++ b/src/arch/abtd_thread.c
@@ -14,10 +14,10 @@ void ABTD_thread_func_wrapper(void *p_arg)
     ABTI_thread *p_thread = ABTI_thread_context_get_thread(p_ctx);
     ABTI_xstream *p_local_xstream = p_thread->p_last_xstream;
     ABTI_tool_event_thread_run(p_local_xstream, p_thread,
-                               p_local_xstream->p_unit, p_thread->p_parent);
-    p_local_xstream->p_unit = p_thread;
+                               p_local_xstream->p_thread, p_thread->p_parent);
+    p_local_xstream->p_thread = p_thread;
 
-    p_thread->f_unit(p_thread->p_arg);
+    p_thread->f_thread(p_thread->p_arg);
 
     /* This ABTI_local_get_xstream() is controversial since it is called after
      * the context-switchable function (i.e., thread_func()).  We assume that
@@ -44,7 +44,7 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
             /* Only when the current ULT is on the same ES as p_joiner's,
              * we can jump to the joiner ULT. */
             ABTD_atomic_release_store_int(&p_thread->state,
-                                          ABTI_UNIT_STATE_TERMINATED);
+                                          ABTI_THREAD_STATE_TERMINATED);
             LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n",
                       ABTI_thread_get_id(p_thread),
                       p_thread->p_last_xstream->rank);
@@ -63,13 +63,14 @@ static inline void ABTD_thread_terminate(ABTI_xstream *p_local_xstream,
             /* We don't need to use the atomic OR operation here because the ULT
              * will be terminated regardless of other requests. */
             ABTD_atomic_release_store_uint32(&p_thread->request,
-                                             ABTI_UNIT_REQ_TERMINATE);
+                                             ABTI_THREAD_REQ_TERMINATE);
         }
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                                                   ABTI_UNIT_REQ_JOIN |
-                                                       ABTI_UNIT_REQ_TERMINATE);
-        if (req & ABTI_UNIT_REQ_JOIN) {
+        uint32_t req =
+            ABTD_atomic_fetch_or_uint32(&p_thread->request,
+                                        ABTI_THREAD_REQ_JOIN |
+                                            ABTI_THREAD_REQ_TERMINATE);
+        if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             do {
@@ -93,9 +94,9 @@ void ABTD_thread_terminate_no_arg()
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
     /* This function is called by `return` in ABTD_thread_context_make_and_call,
      * so it cannot take the argument. We get the thread descriptor from TLS. */
-    ABTI_thread *p_unit = p_local_xstream->p_unit;
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
-    ABTD_thread_terminate(p_local_xstream, ABTI_unit_get_thread(p_unit));
+    ABTI_thread *p_thread = p_local_xstream->p_thread;
+    ABTI_ASSERT(ABTI_thread_type_is_thread(p_thread->type));
+    ABTD_thread_terminate(p_local_xstream, p_thread);
 }
 #endif
 
@@ -114,10 +115,11 @@ void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread)
             ABTD_atomic_relaxed_load_thread_context_ptr(&p_ctx->p_link));
         ABTI_thread_set_ready(p_local_xstream, p_joiner);
     } else {
-        uint32_t req = ABTD_atomic_fetch_or_uint32(&p_thread->request,
-                                                   ABTI_UNIT_REQ_JOIN |
-                                                       ABTI_UNIT_REQ_TERMINATE);
-        if (req & ABTI_UNIT_REQ_JOIN) {
+        uint32_t req =
+            ABTD_atomic_fetch_or_uint32(&p_thread->request,
+                                        ABTI_THREAD_REQ_JOIN |
+                                            ABTI_THREAD_REQ_TERMINATE);
+        if (req & ABTI_THREAD_REQ_JOIN) {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             while (ABTD_atomic_acquire_load_thread_context_ptr(

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -161,7 +161,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local_xstream != NULL) {
-            ABTI_unit *p_self = p_local_xstream->p_unit;
+            ABTI_thread *p_self = p_local_xstream->p_unit;
             ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type),
                             ABT_ERR_BARRIER);
             p_thread = ABTI_unit_get_thread(p_self);

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -161,10 +161,9 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local_xstream != NULL) {
-            ABTI_thread *p_self = p_local_xstream->p_unit;
-            ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type),
+            p_thread = p_local_xstream->p_thread;
+            ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_thread->type),
                             ABT_ERR_BARRIER);
-            p_thread = ABTI_unit_get_thread(p_self);
             type = ABT_UNIT_TYPE_THREAD;
         } else {
             /* external thread */

--- a/src/cond.c
+++ b/src/cond.c
@@ -117,7 +117,7 @@ static inline double convert_timespec_to_sec(const struct timespec *p_ts)
     return secs;
 }
 
-static inline void remove_unit(ABTI_cond *p_cond, ABTI_unit *p_unit)
+static inline void remove_unit(ABTI_cond *p_cond, ABTI_thread *p_unit)
 {
     if (p_unit->p_next == NULL)
         return;
@@ -185,7 +185,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
 
     double tar_time = convert_timespec_to_sec(abstime);
 
-    ABTI_unit *p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+    ABTI_thread *p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
     p_unit->type = ABTI_UNIT_TYPE_EXT;
     ABTD_atomic_relaxed_store_int(&p_unit->state, ABTI_UNIT_STATE_BLOCKED);
 
@@ -283,7 +283,7 @@ int ABT_cond_signal(ABT_cond cond)
     }
 
     /* Wake up the first waiting ULT */
-    ABTI_unit *p_unit = p_cond->p_head;
+    ABTI_thread *p_unit = p_cond->p_head;
 
     p_cond->num_waiters--;
     if (p_cond->num_waiters == 0) {

--- a/src/cond.c
+++ b/src/cond.c
@@ -117,38 +117,38 @@ static inline double convert_timespec_to_sec(const struct timespec *p_ts)
     return secs;
 }
 
-static inline void remove_unit(ABTI_cond *p_cond, ABTI_thread *p_unit)
+static inline void remove_thread(ABTI_cond *p_cond, ABTI_thread *p_thread)
 {
-    if (p_unit->p_next == NULL)
+    if (p_thread->p_next == NULL)
         return;
 
     ABTI_spinlock_acquire(&p_cond->lock);
 
-    if (p_unit->p_next == NULL) {
+    if (p_thread->p_next == NULL) {
         ABTI_spinlock_release(&p_cond->lock);
         return;
     }
 
-    /* If p_unit is still in the queue, we have to remove it. */
+    /* If p_thread is still in the queue, we have to remove it. */
     p_cond->num_waiters--;
     if (p_cond->num_waiters == 0) {
         p_cond->p_waiter_mutex = NULL;
         p_cond->p_head = NULL;
         p_cond->p_tail = NULL;
     } else {
-        p_unit->p_prev->p_next = p_unit->p_next;
-        p_unit->p_next->p_prev = p_unit->p_prev;
-        if (p_unit == p_cond->p_head) {
-            p_cond->p_head = p_unit->p_next;
-        } else if (p_unit == p_cond->p_tail) {
-            p_cond->p_tail = p_unit->p_prev;
+        p_thread->p_prev->p_next = p_thread->p_next;
+        p_thread->p_next->p_prev = p_thread->p_prev;
+        if (p_thread == p_cond->p_head) {
+            p_cond->p_head = p_thread->p_next;
+        } else if (p_thread == p_cond->p_tail) {
+            p_cond->p_tail = p_thread->p_prev;
         }
     }
 
     ABTI_spinlock_release(&p_cond->lock);
 
-    p_unit->p_prev = NULL;
-    p_unit->p_next = NULL;
+    p_thread->p_prev = NULL;
+    p_thread->p_next = NULL;
 }
 
 /**
@@ -185,9 +185,9 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
 
     double tar_time = convert_timespec_to_sec(abstime);
 
-    ABTI_thread *p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
-    p_unit->type = ABTI_UNIT_TYPE_EXT;
-    ABTD_atomic_relaxed_store_int(&p_unit->state, ABTI_UNIT_STATE_BLOCKED);
+    ABTI_thread *p_thread = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
+    p_thread->type = ABTI_THREAD_TYPE_EXT;
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_THREAD_STATE_BLOCKED);
 
     ABTI_spinlock_acquire(&p_cond->lock);
 
@@ -198,22 +198,22 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
         if (result == ABT_FALSE) {
             ABTI_spinlock_release(&p_cond->lock);
             abt_errno = ABT_ERR_INV_MUTEX;
-            ABTU_free(p_unit);
+            ABTU_free(p_thread);
             goto fn_fail;
         }
     }
 
     if (p_cond->num_waiters == 0) {
-        p_unit->p_prev = p_unit;
-        p_unit->p_next = p_unit;
-        p_cond->p_head = p_unit;
-        p_cond->p_tail = p_unit;
+        p_thread->p_prev = p_thread;
+        p_thread->p_next = p_thread;
+        p_cond->p_head = p_thread;
+        p_cond->p_tail = p_thread;
     } else {
-        p_cond->p_tail->p_next = p_unit;
-        p_cond->p_head->p_prev = p_unit;
-        p_unit->p_prev = p_cond->p_tail;
-        p_unit->p_next = p_cond->p_head;
-        p_cond->p_tail = p_unit;
+        p_cond->p_tail->p_next = p_thread;
+        p_cond->p_head->p_prev = p_thread;
+        p_thread->p_prev = p_cond->p_tail;
+        p_thread->p_next = p_cond->p_head;
+        p_cond->p_tail = p_thread;
     }
 
     p_cond->num_waiters++;
@@ -223,25 +223,24 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     /* Unlock the mutex that the calling ULT is holding */
     ABTI_mutex_unlock(p_local_xstream, p_mutex);
 
-    while (ABTD_atomic_acquire_load_int(&p_unit->state) !=
-           ABTI_UNIT_STATE_READY) {
+    while (ABTD_atomic_acquire_load_int(&p_thread->state) !=
+           ABTI_THREAD_STATE_READY) {
         double cur_time = ABTI_get_wtime();
         if (cur_time >= tar_time) {
-            remove_unit(p_cond, p_unit);
+            remove_thread(p_cond, p_thread);
             abt_errno = ABT_ERR_COND_TIMEDOUT;
             break;
         }
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-        if (!ABTI_unit_type_is_thread(ABTI_self_get_type(p_local_xstream))) {
+        if (!ABTI_thread_type_is_thread(ABTI_self_get_type(p_local_xstream))) {
             ABTD_atomic_pause();
             continue;
         }
 #endif
-        ABTI_thread_yield(&p_local_xstream,
-                          ABTI_unit_get_thread(p_local_xstream->p_unit),
+        ABTI_thread_yield(&p_local_xstream, p_local_xstream->p_thread,
                           ABT_SYNC_EVENT_TYPE_COND, (void *)p_cond);
     }
-    ABTU_free(p_unit);
+    ABTU_free(p_thread);
 
     /* Lock the mutex again */
     ABTI_mutex_lock(&p_local_xstream, p_mutex);
@@ -283,7 +282,7 @@ int ABT_cond_signal(ABT_cond cond)
     }
 
     /* Wake up the first waiting ULT */
-    ABTI_thread *p_unit = p_cond->p_head;
+    ABTI_thread *p_thread = p_cond->p_head;
 
     p_cond->num_waiters--;
     if (p_cond->num_waiters == 0) {
@@ -291,19 +290,19 @@ int ABT_cond_signal(ABT_cond cond)
         p_cond->p_head = NULL;
         p_cond->p_tail = NULL;
     } else {
-        p_unit->p_prev->p_next = p_unit->p_next;
-        p_unit->p_next->p_prev = p_unit->p_prev;
-        p_cond->p_head = p_unit->p_next;
+        p_thread->p_prev->p_next = p_thread->p_next;
+        p_thread->p_next->p_prev = p_thread->p_prev;
+        p_cond->p_head = p_thread->p_next;
     }
-    p_unit->p_prev = NULL;
-    p_unit->p_next = NULL;
+    p_thread->p_prev = NULL;
+    p_thread->p_next = NULL;
 
-    if (ABTI_unit_type_is_thread(p_unit->type)) {
-        ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
+    if (ABTI_thread_type_is_thread(p_thread->type)) {
         ABTI_thread_set_ready(p_local_xstream, p_thread);
     } else {
         /* When the head is an external thread */
-        ABTD_atomic_release_store_int(&p_unit->state, ABTI_UNIT_STATE_READY);
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABTI_THREAD_STATE_READY);
     }
 
     ABTI_spinlock_release(&p_cond->lock);

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -111,7 +111,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
         ABTI_thread *p_current;
-        ABTI_unit *p_unit;
+        ABTI_thread *p_unit;
 
         if (p_local_xstream != NULL) {
             p_unit = p_local_xstream->p_unit;
@@ -121,7 +121,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
         } else {
             /* external thread */
             p_current = NULL;
-            p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
             p_unit->type = ABTI_UNIT_TYPE_EXT;
             /* use state for synchronization */
             ABTD_atomic_relaxed_store_int(&p_unit->state,
@@ -247,10 +247,10 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     }
 
     /* Wake up all waiting ULTs */
-    ABTI_unit *p_head = p_eventual->p_head;
-    ABTI_unit *p_unit = p_head;
+    ABTI_thread *p_head = p_eventual->p_head;
+    ABTI_thread *p_unit = p_head;
     while (1) {
-        ABTI_unit *p_next = p_unit->p_next;
+        ABTI_thread *p_next = p_unit->p_next;
         p_unit->p_next = NULL;
 
         if (ABTI_unit_type_is_thread(p_unit->type)) {

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -110,40 +110,37 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
-        ABTI_thread *p_current;
-        ABTI_thread *p_unit;
+        ABTI_thread *p_thread;
 
         if (p_local_xstream != NULL) {
-            p_unit = p_local_xstream->p_unit;
-            ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_unit->type),
+            p_thread = p_local_xstream->p_thread;
+            ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_thread->type),
                             ABT_ERR_EVENTUAL);
-            p_current = ABTI_unit_get_thread(p_unit);
         } else {
             /* external thread */
-            p_current = NULL;
-            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
-            p_unit->type = ABTI_UNIT_TYPE_EXT;
+            p_thread = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
+            p_thread->type = ABTI_THREAD_TYPE_EXT;
             /* use state for synchronization */
-            ABTD_atomic_relaxed_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_BLOCKED);
+            ABTD_atomic_relaxed_store_int(&p_thread->state,
+                                          ABTI_THREAD_STATE_BLOCKED);
         }
 
-        p_unit->p_next = NULL;
+        p_thread->p_next = NULL;
         if (p_eventual->p_head == NULL) {
-            p_eventual->p_head = p_unit;
-            p_eventual->p_tail = p_unit;
+            p_eventual->p_head = p_thread;
+            p_eventual->p_tail = p_thread;
         } else {
-            p_eventual->p_tail->p_next = p_unit;
-            p_eventual->p_tail = p_unit;
+            p_eventual->p_tail->p_next = p_thread;
+            p_eventual->p_tail = p_thread;
         }
 
-        if (p_current) {
-            ABTI_thread_set_blocked(p_current);
+        if (p_local_xstream != NULL) {
+            ABTI_thread_set_blocked(p_thread);
 
             ABTI_spinlock_release(&p_eventual->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(&p_local_xstream, p_current,
+            ABTI_thread_suspend(&p_local_xstream, p_thread,
                                 ABT_SYNC_EVENT_TYPE_EVENTUAL,
                                 (void *)p_eventual);
 
@@ -151,10 +148,10 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
             ABTI_spinlock_release(&p_eventual->lock);
 
             /* External thread is waiting here. */
-            while (ABTD_atomic_acquire_load_int(&p_unit->state) !=
-                   ABTI_UNIT_STATE_READY)
+            while (ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                   ABTI_THREAD_STATE_READY)
                 ;
-            ABTU_free(p_unit);
+            ABTU_free(p_thread);
         }
     } else {
         ABTI_spinlock_release(&p_eventual->lock);
@@ -248,23 +245,22 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 
     /* Wake up all waiting ULTs */
     ABTI_thread *p_head = p_eventual->p_head;
-    ABTI_thread *p_unit = p_head;
+    ABTI_thread *p_cur = p_head;
     while (1) {
-        ABTI_thread *p_next = p_unit->p_next;
-        p_unit->p_next = NULL;
+        ABTI_thread *p_next = p_cur->p_next;
+        p_cur->p_next = NULL;
 
-        if (ABTI_unit_type_is_thread(p_unit->type)) {
-            ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
-            ABTI_thread_set_ready(p_local_xstream, p_thread);
+        if (ABTI_thread_type_is_thread(p_cur->type)) {
+            ABTI_thread_set_ready(p_local_xstream, p_cur);
         } else {
             /* When the head is an external thread */
-            ABTD_atomic_release_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_READY);
+            ABTD_atomic_release_store_int(&p_cur->state,
+                                          ABTI_THREAD_STATE_READY);
         }
 
         /* Next ULT */
         if (p_next != NULL) {
-            p_unit = p_next;
+            p_cur = p_next;
         } else {
             break;
         }

--- a/src/futures.c
+++ b/src/futures.c
@@ -135,7 +135,7 @@ int ABT_future_wait(ABT_future future)
     if (ABTD_atomic_relaxed_load_uint32(&p_future->counter) <
         p_future->compartments) {
         ABTI_thread *p_current;
-        ABTI_unit *p_unit;
+        ABTI_thread *p_unit;
 
         if (p_local_xstream != NULL) {
             p_unit = p_local_xstream->p_unit;
@@ -150,7 +150,7 @@ int ABT_future_wait(ABT_future future)
         } else {
             /* external thread */
             p_current = NULL;
-            p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
             p_unit->type = ABTI_UNIT_TYPE_EXT;
             /* use state for synchronization */
             ABTD_atomic_relaxed_store_int(&p_unit->state,
@@ -273,10 +273,10 @@ int ABT_future_set(ABT_future future, void *value)
         }
 
         /* Wake up all waiting ULTs */
-        ABTI_unit *p_head = p_future->p_head;
-        ABTI_unit *p_unit = p_head;
+        ABTI_thread *p_head = p_future->p_head;
+        ABTI_thread *p_unit = p_head;
         while (1) {
-            ABTI_unit *p_next = p_unit->p_next;
+            ABTI_thread *p_next = p_unit->p_next;
             p_unit->p_next = NULL;
 
             if (ABTI_unit_type_is_thread(p_unit->type)) {

--- a/src/futures.c
+++ b/src/futures.c
@@ -134,55 +134,52 @@ int ABT_future_wait(ABT_future future)
     ABTI_spinlock_acquire(&p_future->lock);
     if (ABTD_atomic_relaxed_load_uint32(&p_future->counter) <
         p_future->compartments) {
-        ABTI_thread *p_current;
-        ABTI_thread *p_unit;
+        ABTI_thread *p_thread;
 
         if (p_local_xstream != NULL) {
-            p_unit = p_local_xstream->p_unit;
+            p_thread = p_local_xstream->p_thread;
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-            if (!ABTI_unit_type_is_thread(p_unit->type)) {
+            if (!ABTI_thread_type_is_thread(p_thread->type)) {
                 abt_errno = ABT_ERR_FUTURE;
                 ABTI_spinlock_release(&p_future->lock);
                 goto fn_fail;
             }
 #endif
-            p_current = ABTI_unit_get_thread(p_unit);
         } else {
             /* external thread */
-            p_current = NULL;
-            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
-            p_unit->type = ABTI_UNIT_TYPE_EXT;
+            p_thread = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
+            p_thread->type = ABTI_THREAD_TYPE_EXT;
             /* use state for synchronization */
-            ABTD_atomic_relaxed_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_BLOCKED);
+            ABTD_atomic_relaxed_store_int(&p_thread->state,
+                                          ABTI_THREAD_STATE_BLOCKED);
         }
 
-        p_unit->p_next = NULL;
+        p_thread->p_next = NULL;
         if (p_future->p_head == NULL) {
-            p_future->p_head = p_unit;
-            p_future->p_tail = p_unit;
+            p_future->p_head = p_thread;
+            p_future->p_tail = p_thread;
         } else {
-            p_future->p_tail->p_next = p_unit;
-            p_future->p_tail = p_unit;
+            p_future->p_tail->p_next = p_thread;
+            p_future->p_tail = p_thread;
         }
 
-        if (p_current) {
-            ABTI_thread_set_blocked(p_current);
+        if (p_local_xstream != NULL) {
+            ABTI_thread_set_blocked(p_thread);
 
             ABTI_spinlock_release(&p_future->lock);
 
             /* Suspend the current ULT */
-            ABTI_thread_suspend(&p_local_xstream, p_current,
+            ABTI_thread_suspend(&p_local_xstream, p_thread,
                                 ABT_SYNC_EVENT_TYPE_FUTURE, (void *)p_future);
 
         } else {
             ABTI_spinlock_release(&p_future->lock);
 
             /* External thread is waiting here. */
-            while (ABTD_atomic_acquire_load_int(&p_unit->state) !=
-                   ABTI_UNIT_STATE_READY)
+            while (ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                   ABTI_THREAD_STATE_READY)
                 ;
-            ABTU_free(p_unit);
+            ABTU_free(p_thread);
         }
     } else {
         ABTI_spinlock_release(&p_future->lock);
@@ -274,23 +271,22 @@ int ABT_future_set(ABT_future future, void *value)
 
         /* Wake up all waiting ULTs */
         ABTI_thread *p_head = p_future->p_head;
-        ABTI_thread *p_unit = p_head;
+        ABTI_thread *p_cur = p_head;
         while (1) {
-            ABTI_thread *p_next = p_unit->p_next;
-            p_unit->p_next = NULL;
+            ABTI_thread *p_next = p_cur->p_next;
+            p_cur->p_next = NULL;
 
-            if (ABTI_unit_type_is_thread(p_unit->type)) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
-                ABTI_thread_set_ready(p_local_xstream, p_thread);
+            if (ABTI_thread_type_is_thread(p_cur->type)) {
+                ABTI_thread_set_ready(p_local_xstream, p_cur);
             } else {
                 /* When the head is an external thread */
-                ABTD_atomic_release_store_int(&p_unit->state,
-                                              ABTI_UNIT_STATE_READY);
+                ABTD_atomic_release_store_int(&p_cur->state,
+                                              ABTI_THREAD_STATE_READY);
             }
 
             /* Next ULT */
             if (p_next != NULL) {
-                p_unit = p_next;
+                p_cur = p_next;
             } else {
                 break;
             }

--- a/src/global.c
+++ b/src/global.c
@@ -102,12 +102,12 @@ int ABT_init(int argc, char **argv)
     abt_errno = ABTI_thread_create_main(p_local_xstream, p_local_xstream,
                                         &p_main_thread);
     /* Set as if p_local_xstream is currently running the main thread. */
-    ABTD_atomic_relaxed_store_int(&p_main_thread->unit_def.state,
+    ABTD_atomic_relaxed_store_int(&p_main_thread->state,
                                   ABTI_UNIT_STATE_RUNNING);
-    p_main_thread->unit_def.p_last_xstream = p_local_xstream;
+    p_main_thread->p_last_xstream = p_local_xstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
-    p_local_xstream->p_unit = &p_main_thread->unit_def;
+    p_local_xstream->p_unit = p_main_thread;
 
     /* Start the primary ES */
     abt_errno = ABTI_xstream_start_primary(&p_local_xstream, p_local_xstream,
@@ -170,7 +170,7 @@ int ABT_finalize(void)
                         ABT_ERR_INV_XSTREAM,
                         "ABT_finalize must be called by the primary ES.");
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     ABTI_CHECK_TRUE_MSG(p_self->type == ABTI_UNIT_TYPE_THREAD_MAIN,
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");
@@ -193,8 +193,7 @@ int ABT_finalize(void)
         ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_ORPHAN);
 
         LOG_DEBUG("[U%" PRIu64 ":E%d] yield to scheduler\n",
-                  ABTI_thread_get_id(p_thread),
-                  p_thread->unit_def.p_last_xstream->rank);
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 
         /* Switch to the parent */
         ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread,
@@ -203,8 +202,7 @@ int ABT_finalize(void)
 
         /* Back to the original thread */
         LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",
-                  ABTI_thread_get_id(p_thread),
-                  p_thread->unit_def.p_last_xstream->rank);
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
     }
 
     /* Remove the primary ULT */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -30,19 +30,19 @@
 #define ABTI_SCHED_REQ_FINISH (1 << 0)
 #define ABTI_SCHED_REQ_EXIT (1 << 1)
 
-#define ABTI_UNIT_REQ_JOIN (1 << 0)
-#define ABTI_UNIT_REQ_EXIT (1 << 1)
-#define ABTI_UNIT_REQ_CANCEL (1 << 2)
-#define ABTI_UNIT_REQ_MIGRATE (1 << 3)
-#define ABTI_UNIT_REQ_TERMINATE (1 << 4)
-#define ABTI_UNIT_REQ_BLOCK (1 << 5)
-#define ABTI_UNIT_REQ_ORPHAN (1 << 6)
-#define ABTI_UNIT_REQ_NOPUSH (1 << 7)
-#define ABTI_UNIT_REQ_STOP (ABTI_UNIT_REQ_EXIT | ABTI_UNIT_REQ_TERMINATE)
-#define ABTI_UNIT_REQ_NON_YIELD                                                \
-    (ABTI_UNIT_REQ_EXIT | ABTI_UNIT_REQ_CANCEL | ABTI_UNIT_REQ_MIGRATE |       \
-     ABTI_UNIT_REQ_TERMINATE | ABTI_UNIT_REQ_BLOCK | ABTI_UNIT_REQ_ORPHAN |    \
-     ABTI_UNIT_REQ_NOPUSH)
+#define ABTI_THREAD_REQ_JOIN (1 << 0)
+#define ABTI_THREAD_REQ_EXIT (1 << 1)
+#define ABTI_THREAD_REQ_CANCEL (1 << 2)
+#define ABTI_THREAD_REQ_MIGRATE (1 << 3)
+#define ABTI_THREAD_REQ_TERMINATE (1 << 4)
+#define ABTI_THREAD_REQ_BLOCK (1 << 5)
+#define ABTI_THREAD_REQ_ORPHAN (1 << 6)
+#define ABTI_THREAD_REQ_NOPUSH (1 << 7)
+#define ABTI_THREAD_REQ_STOP (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_TERMINATE)
+#define ABTI_THREAD_REQ_NON_YIELD                                              \
+    (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_CANCEL | ABTI_THREAD_REQ_MIGRATE | \
+     ABTI_THREAD_REQ_TERMINATE | ABTI_THREAD_REQ_BLOCK |                       \
+     ABTI_THREAD_REQ_ORPHAN | ABTI_THREAD_REQ_NOPUSH)
 
 #define ABTI_THREAD_INIT_ID 0xFFFFFFFFFFFFFFFF
 #define ABTI_TASK_INIT_ID 0xFFFFFFFFFFFFFFFF
@@ -63,19 +63,19 @@ enum ABTI_sched_used {
     ABTI_SCHED_IN_POOL
 };
 
-enum ABTI_unit_type {
-    ABTI_UNIT_TYPE_TASK = 0x0,
-    ABTI_UNIT_TYPE_THREAD_USER = 0x1 + (0x0 << 2),
-    ABTI_UNIT_TYPE_THREAD_MAIN_SCHED = 0x1 + (0x1 << 2),
-    ABTI_UNIT_TYPE_THREAD_MAIN = 0x1 + (0x2 << 2),
-    ABTI_UNIT_TYPE_EXT = 0x2,
+enum ABTI_thread_type {
+    ABTI_THREAD_TYPE_TASK = 0x0,
+    ABTI_THREAD_TYPE_THREAD_USER = 0x1 + (0x0 << 2),
+    ABTI_THREAD_TYPE_THREAD_MAIN_SCHED = 0x1 + (0x1 << 2),
+    ABTI_THREAD_TYPE_THREAD_MAIN = 0x1 + (0x2 << 2),
+    ABTI_THREAD_TYPE_EXT = 0x2,
 };
 
-enum ABTI_unit_state {
-    ABTI_UNIT_STATE_READY,
-    ABTI_UNIT_STATE_RUNNING,
-    ABTI_UNIT_STATE_BLOCKED,
-    ABTI_UNIT_STATE_TERMINATED,
+enum ABTI_thread_state {
+    ABTI_THREAD_STATE_READY,
+    ABTI_THREAD_STATE_RUNNING,
+    ABTI_THREAD_STATE_BLOCKED,
+    ABTI_THREAD_STATE_TERMINATED,
 };
 
 enum ABTI_mutex_attr_val {
@@ -108,8 +108,8 @@ typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_thread_context ABTI_thread_context;
 typedef struct ABTI_thread ABTI_thread;
 typedef enum ABTI_stack_type ABTI_stack_type;
-typedef enum ABTI_unit_type ABTI_unit_type;
-typedef enum ABTI_unit_state ABTI_unit_state;
+typedef enum ABTI_thread_type ABTI_thread_type;
+typedef enum ABTI_thread_state ABTI_thread_state;
 typedef struct ABTI_thread_htable ABTI_thread_htable;
 typedef struct ABTI_thread_queue ABTI_thread_queue;
 typedef struct ABTI_key ABTI_key;
@@ -130,9 +130,9 @@ typedef struct ABTI_tool_context ABTI_tool_context;
  * execution streams and external threads */
 struct ABTI_native_thread_id_opaque;
 typedef struct ABTI_native_thread_id_opaque *ABTI_native_thread_id;
-/* ID associated with work unit (i.e., ULTs, tasklets, and external threads) */
-struct ABTI_unit_id_opaque;
-typedef struct ABTI_unit_id_opaque *ABTI_unit_id;
+/* ID associated with work unit (i.e., ULTs and external threads) */
+struct ABTI_thread_id_opaque;
+typedef struct ABTI_thread_id_opaque *ABTI_thread_id;
 
 /* Architecture-Dependent Definitions */
 #include "abtd.h"
@@ -147,11 +147,11 @@ typedef struct ABTI_spinlock ABTI_spinlock;
 
 /* Definitions */
 struct ABTI_mutex_attr {
-    uint32_t attrs;         /* bit-or'ed attributes */
-    uint32_t nesting_cnt;   /* nesting count */
-    ABTI_unit_id owner_id;  /* owner's ID */
-    uint32_t max_handovers; /* max. # of handovers */
-    uint32_t max_wakeups;   /* max. # of wakeups */
+    uint32_t attrs;          /* bit-or'ed attributes */
+    uint32_t nesting_cnt;    /* nesting count */
+    ABTI_thread_id owner_id; /* owner's ID */
+    uint32_t max_handovers;  /* max. # of handovers */
+    uint32_t max_wakeups;    /* max. # of wakeups */
 };
 
 struct ABTI_mutex {
@@ -241,7 +241,7 @@ struct ABTI_xstream {
     ABTD_xstream_context ctx; /* ES context */
 
     ABTU_align_member_var(ABT_CONFIG_STATIC_CACHELINE_SIZE)
-        ABTI_thread *p_unit; /* Current running ULT/tasklet */
+        ABTI_thread *p_thread; /* Current running thread */
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
     ABTI_mem_pool_local_pool mem_pool_stack;
@@ -255,8 +255,8 @@ struct ABTI_sched {
     ABTI_sched_kind kind;       /* Kind of the scheduler  */
     ABT_sched_type type;        /* Can yield or not (ULT or task) */
     ABTD_atomic_uint32 request; /* Request */
-    ABT_pool *pools;            /* Work unit pools */
-    int num_pools;              /* Number of work unit pools */
+    ABT_pool *pools;            /* Thread pools */
+    int num_pools;              /* Number of thread pools */
     ABTI_thread *p_thread;      /* Associated ULT */
     void *data;                 /* Data for a specific scheduler */
 
@@ -329,14 +329,14 @@ struct ABTI_thread_context {
 struct ABTI_thread {
     ABTI_thread *p_prev;
     ABTI_thread *p_next;
-    ABTD_atomic_int is_in_pool;   /* Whether this unit is in a pool or not. */
-    ABTI_unit_type type;          /* Thread type */
+    ABTD_atomic_int is_in_pool;   /* Whether this thread is in a pool or not. */
+    ABTI_thread_type type;        /* Thread type */
     ABT_unit unit;                /* Pool unit enclosing this thread */
     ABTI_xstream *p_last_xstream; /* Last ES where it ran */
     ABTI_thread *p_parent;        /* Parent thread */
-    void (*f_unit)(void *);       /* Thread function */
+    void (*f_thread)(void *);     /* Thread function */
     void *p_arg;                  /* Thread function argument */
-    ABTD_atomic_int state;        /* State (ABTI_unit_state) */
+    ABTD_atomic_int state;        /* State (ABTI_thread_state) */
     ABTD_atomic_uint32 request;   /* Request */
     ABTI_pool *p_pool;            /* Associated pool */
     ABTD_atomic_ptr p_keytable;   /* Thread-specific data (ABTI_ktable *) */
@@ -432,7 +432,7 @@ struct ABTI_tool_context {
     ABTI_thread *p_caller;
     ABTI_pool *p_pool;
     ABTI_thread
-        *p_parent; /* Parent of the target unit.  Used to get the depth */
+        *p_parent; /* Parent of the target thread.  Used to get the depth */
     ABT_sync_event_type sync_event_type;
     void *p_sync_object; /* ABTI type */
 };
@@ -556,8 +556,8 @@ int ABTI_thread_set_ready(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 int ABTI_thread_print_stack(ABTI_thread *p_thread, FILE *p_os);
 void ABTI_thread_reset_id(void);
-ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
-ABT_unit_id ABTI_thread_self_id(ABTI_xstream *p_local_xstream);
+ABT_thread_id ABTI_thread_get_id(ABTI_thread *p_thread);
+ABT_thread_id ABTI_thread_self_id(ABTI_xstream *p_local_xstream);
 int ABTI_thread_get_xstream_rank(ABTI_thread *p_thread);
 int ABTI_thread_self_xstream_rank(ABTI_xstream *p_local_xstream);
 

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -64,17 +64,17 @@ static inline int ABTI_cond_wait(ABTI_xstream **pp_local_xstream,
 
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_thread *p_thread;
-    ABTI_unit *p_unit;
+    ABTI_thread *p_unit;
 
     if (p_local_xstream != NULL) {
-        ABTI_unit *p_self = p_local_xstream->p_unit;
+        ABTI_thread *p_self = p_local_xstream->p_unit;
         ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type), ABT_ERR_COND);
         p_thread = ABTI_unit_get_thread(p_self);
-        p_unit = &p_thread->unit_def;
+        p_unit = p_thread;
     } else {
         /* external thread */
         p_thread = NULL;
-        p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
+        p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
         p_unit->type = ABTI_UNIT_TYPE_EXT;
         /* use state for synchronization */
         ABTD_atomic_relaxed_store_int(&p_unit->state, ABTI_UNIT_STATE_BLOCKED);
@@ -157,10 +157,10 @@ static inline void ABTI_cond_broadcast(ABTI_xstream *p_local_xstream,
     }
 
     /* Wake up all waiting ULTs */
-    ABTI_unit *p_head = p_cond->p_head;
-    ABTI_unit *p_unit = p_head;
+    ABTI_thread *p_head = p_cond->p_head;
+    ABTI_thread *p_unit = p_head;
     while (1) {
-        ABTI_unit *p_next = p_unit->p_next;
+        ABTI_thread *p_next = p_unit->p_next;
 
         p_unit->p_prev = NULL;
         p_unit->p_next = NULL;

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -124,7 +124,7 @@
 
 #define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_task *)NULL) {           \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
             abt_errno = ABT_ERR_INV_TASK;                                      \
             goto fn_fail;                                                      \
         }                                                                      \

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -115,10 +115,9 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
 
                         /* Push the previous ULT to its pool */
                         ABTI_thread *p_giver = p_mutex->p_giver;
-                        ABTD_atomic_release_store_int(&p_giver->unit_def.state,
+                        ABTD_atomic_release_store_int(&p_giver->state,
                                                       ABTI_UNIT_STATE_READY);
-                        ABTI_POOL_PUSH(p_giver->unit_def.p_pool,
-                                       p_giver->unit_def.unit,
+                        ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local_xstream));
                         break;

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -74,12 +74,11 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
-    if (ABTI_unit_type_is_thread(type)) {
+    ABTI_thread_type type = ABTI_self_get_type(p_local_xstream);
+    if (ABTI_thread_type_is_thread(type)) {
         LOG_DEBUG("%p: lock - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
-            ABTI_thread_yield(pp_local_xstream,
-                              ABTI_unit_get_thread(p_local_xstream->p_unit),
+            ABTI_thread_yield(pp_local_xstream, p_local_xstream->p_thread,
                               ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
             p_local_xstream = *pp_local_xstream;
         }
@@ -89,11 +88,11 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
     }
 #else
     int abt_errno;
-    ABTI_unit_type type = ABTI_self_get_type(*pp_local_xstream);
+    ABTI_thread_type type = ABTI_self_get_type(*pp_local_xstream);
 
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
-    if (ABTI_unit_type_is_thread(type)) {
+    if (ABTI_thread_type_is_thread(type)) {
         LOG_DEBUG("%p: lock - try\n", p_mutex);
         int c;
         if ((c = ABTD_atomic_val_cas_strong_uint32(&p_mutex->val, 0, 1)) != 0) {
@@ -107,8 +106,7 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
                  * other ULT on the same ES, we don't need to change the mutex
                  * state. */
                 if (p_mutex->p_handover) {
-                    ABTI_thread *p_self =
-                        ABTI_unit_get_thread((*pp_local_xstream)->p_unit);
+                    ABTI_thread *p_self = (*pp_local_xstream)->p_thread;
                     if (p_self == p_mutex->p_handover) {
                         p_mutex->p_handover = NULL;
                         ABTD_atomic_release_store_uint32(&p_mutex->val, 2);
@@ -116,7 +114,7 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
                         /* Push the previous ULT to its pool */
                         ABTI_thread *p_giver = p_mutex->p_giver;
                         ABTD_atomic_release_store_int(&p_giver->state,
-                                                      ABTI_UNIT_STATE_READY);
+                                                      ABTI_THREAD_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->p_pool, p_giver->unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local_xstream));

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -77,7 +77,7 @@ static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
 {
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_THREAD_STATE_READY);
 
     /* Add the ULT to the associated pool */
     ABTI_pool_push(p_thread->p_pool, p_thread->unit);
@@ -119,7 +119,7 @@ static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
 
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_THREAD_STATE_READY);
 
     /* Add the ULT to the associated pool */
     abt_errno = ABTI_pool_push(p_thread->p_pool, p_thread->unit, producer_id);

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -77,11 +77,10 @@ static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
 {
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_UNIT_STATE_READY);
 
     /* Add the ULT to the associated pool */
-    ABTI_pool_push(p_thread->unit_def.p_pool, p_thread->unit_def.unit);
+    ABTI_pool_push(p_thread->p_pool, p_thread->unit);
 }
 
 #define ABTI_POOL_PUSH(p_pool, unit, p_producer) ABTI_pool_push(p_pool, unit)
@@ -120,12 +119,10 @@ static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
 
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_UNIT_STATE_READY);
 
     /* Add the ULT to the associated pool */
-    abt_errno = ABTI_pool_push(p_thread->unit_def.p_pool,
-                               p_thread->unit_def.unit, producer_id);
+    abt_errno = ABTI_pool_push(p_thread->p_pool, p_thread->unit, producer_id);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -20,36 +20,37 @@ ABTI_self_get_native_thread_id(ABTI_xstream *p_local_xstream)
     return (ABTI_native_thread_id)p_local_xstream;
 }
 
-static inline ABTI_unit_id ABTI_self_get_unit_id(ABTI_xstream *p_local_xstream)
+static inline ABTI_thread_id
+ABTI_self_get_unit_id(ABTI_xstream *p_local_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (p_local_xstream == NULL) {
         /* A pointer to a thread local variable is unique to an external thread
          * and its value is different from pointers to ULTs and tasks. */
-        return (ABTI_unit_id)ABTI_local_get_local_ptr();
+        return (ABTI_thread_id)ABTI_local_get_local_ptr();
     }
 #endif
-    return (ABTI_unit_id)p_local_xstream->p_unit;
+    return (ABTI_thread_id)p_local_xstream->p_thread;
 }
 
-static inline ABTI_unit_type ABTI_self_get_type(ABTI_xstream *p_local_xstream)
+static inline ABTI_thread_type ABTI_self_get_type(ABTI_xstream *p_local_xstream)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (p_local_xstream == NULL) {
-        return ABTI_UNIT_TYPE_EXT;
+        return ABTI_THREAD_TYPE_EXT;
     }
 #endif
-    if (p_local_xstream->p_unit) {
-        return p_local_xstream->p_unit->type;
+    if (p_local_xstream->p_thread) {
+        return p_local_xstream->p_thread->type;
     } else {
         /* Since p_local_xstream->p_thread can return NULL during executing
          * ABTI_init(), it should always be safe to say that the type of caller
          * is ULT if the control reaches here. */
-        return ABTI_UNIT_TYPE_THREAD_MAIN;
+        return ABTI_THREAD_TYPE_THREAD_MAIN;
     }
 }
 

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -54,7 +54,7 @@ static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
 static inline ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_unit *p_unit = p_xstream->p_unit;
+    ABTI_thread *p_unit = p_xstream->p_unit;
     while (p_unit) {
         if (ABTI_unit_type_is_thread(p_unit->type)) {
             ABTI_sched *p_sched = ABTI_unit_get_thread(p_unit)->p_sched;
@@ -78,19 +78,19 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
                                                  ABTI_thread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
-    if (p_thread->unit_def.refcount == 0) {
+              p_thread->p_last_xstream->rank);
+    if (p_thread->refcount == 0) {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
         if (p_thread->p_sched) {
             /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+            ABTD_atomic_release_store_int(&p_thread->state,
                                           ABTI_UNIT_STATE_TERMINATED);
             ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched,
                                         ABT_FALSE);
         } else
 #endif
         {
-            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+            ABTD_atomic_release_store_int(&p_thread->state,
                                           ABTI_UNIT_STATE_TERMINATED);
             ABTI_thread_free(p_local_xstream, p_thread);
         }
@@ -99,18 +99,18 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+        ABTD_atomic_release_store_int(&p_thread->state,
                                       ABTI_UNIT_STATE_TERMINATED);
     }
 }
 
 static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
-                                               ABTI_task *p_task)
+                                               ABTI_thread *p_task)
 {
     LOG_DEBUG("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
-              p_task->unit_def.p_last_xstream->rank);
-    if (p_task->unit_def.refcount == 0) {
-        ABTD_atomic_release_store_int(&p_task->unit_def.state,
+              p_task->p_last_xstream->rank);
+    if (p_task->refcount == 0) {
+        ABTD_atomic_release_store_int(&p_task->state,
                                       ABTI_UNIT_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
     } else {
@@ -118,7 +118,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int(&p_task->unit_def.state,
+        ABTD_atomic_release_store_int(&p_task->state,
                                       ABTI_UNIT_STATE_TERMINATED);
     }
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -54,14 +54,14 @@ static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
 static inline ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_thread *p_unit = p_xstream->p_unit;
-    while (p_unit) {
-        if (ABTI_unit_type_is_thread(p_unit->type)) {
-            ABTI_sched *p_sched = ABTI_unit_get_thread(p_unit)->p_sched;
+    ABTI_thread *p_thread = p_xstream->p_thread;
+    while (p_thread) {
+        if (ABTI_thread_type_is_thread(p_thread->type)) {
+            ABTI_sched *p_sched = p_thread->p_sched;
             if (p_sched)
                 return p_sched;
         }
-        p_unit = p_unit->p_parent;
+        p_thread = p_thread->p_parent;
     }
 #endif
     return p_xstream->p_main_sched;
@@ -84,14 +84,14 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
         if (p_thread->p_sched) {
             /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
             ABTD_atomic_release_store_int(&p_thread->state,
-                                          ABTI_UNIT_STATE_TERMINATED);
+                                          ABTI_THREAD_STATE_TERMINATED);
             ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched,
                                         ABT_FALSE);
         } else
 #endif
         {
             ABTD_atomic_release_store_int(&p_thread->state,
-                                          ABTI_UNIT_STATE_TERMINATED);
+                                          ABTI_THREAD_STATE_TERMINATED);
             ABTI_thread_free(p_local_xstream, p_thread);
         }
     } else {
@@ -100,7 +100,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
         ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+                                      ABTI_THREAD_STATE_TERMINATED);
     }
 }
 
@@ -111,7 +111,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
               p_task->p_last_xstream->rank);
     if (p_task->refcount == 0) {
         ABTD_atomic_release_store_int(&p_task->state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+                                      ABTI_THREAD_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
     } else {
         /* NOTE: We set the task's state as TERMINATED after checking refcount
@@ -119,7 +119,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
         ABTD_atomic_release_store_int(&p_task->state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+                                      ABTI_THREAD_STATE_TERMINATED);
     }
 }
 

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -8,22 +8,22 @@
 
 /* Inlined functions for Tasklet  */
 
-static inline ABTI_task *ABTI_task_get_ptr(ABT_task task)
+static inline ABTI_thread *ABTI_task_get_ptr(ABT_task task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-    ABTI_task *p_task;
+    ABTI_thread *p_task;
     if (task == ABT_TASK_NULL) {
         p_task = NULL;
     } else {
-        p_task = (ABTI_task *)task;
+        p_task = (ABTI_thread *)task;
     }
     return p_task;
 #else
-    return (ABTI_task *)task;
+    return (ABTI_thread *)task;
 #endif
 }
 
-static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
+static inline ABT_task ABTI_task_get_handle(ABTI_thread *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_task h_task;
@@ -38,14 +38,14 @@ static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 #endif
 }
 
-static inline void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_set_request(ABTI_thread *p_task, uint32_t req)
 {
-    ABTD_atomic_fetch_or_uint32(&p_task->unit_def.request, req);
+    ABTD_atomic_fetch_or_uint32(&p_task->request, req);
 }
 
-static inline void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_unset_request(ABTI_thread *p_task, uint32_t req)
 {
-    ABTD_atomic_fetch_and_uint32(&p_task->unit_def.request, ~req);
+    ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }
 
 #endif /* ABTI_TASK_H_INCLUDED */

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -41,7 +41,8 @@ static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 static inline ABTI_thread *
 ABTI_thread_context_get_thread(ABTD_thread_context *p_ctx)
 {
-    return (ABTI_thread *)(((char *)p_ctx) - offsetof(ABTI_thread, ctx));
+    return (ABTI_thread *)(((char *)p_ctx) - offsetof(ABTI_thread, ctx) -
+                           offsetof(ABTI_thread_context, ctx));
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -126,15 +127,15 @@ static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
      *   Lessons Learned from Analyzing Dynamic Promotion for User-Level
      *   Threading, S. Iwasaki, A. Amer, K. Taura, and P. Balaji (SC '18)
      */
-    return ABTD_thread_context_is_dynamic_promoted(&p_thread->ctx);
+    return ABTD_thread_context_is_dynamic_promoted(&p_thread->ctx.ctx);
 }
 
 static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 "] dynamic-promote ULT\n",
               ABTI_thread_get_id(p_thread));
-    void *p_stack = p_thread->p_stack;
-    size_t stacksize = p_thread->stacksize;
+    void *p_stack = p_thread->ctx.p_stack;
+    size_t stacksize = p_thread->ctx.stacksize;
     void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     ABTD_thread_context_dynamic_promote_thread(p_stacktop);
 }
@@ -151,22 +152,22 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_sibling_internal(
     }
     if (!ABTI_thread_is_dynamic_promoted(p_new)) {
         /* p_new does not have a context, so we first need to make it. */
-        ABTD_thread_context_arm_thread(p_new->stacksize, p_new->p_stack,
-                                       &p_new->ctx);
+        ABTD_thread_context_arm_thread(p_new->ctx.stacksize, p_new->ctx.p_stack,
+                                       &p_new->ctx.ctx);
     }
 #endif
-    p_new->unit_def.p_parent = p_old->unit_def.p_parent;
+    p_new->p_parent = p_old->p_parent;
     if (is_finish) {
         ABTI_tool_event_thread_finish(*pp_local_xstream, p_old,
-                                      p_old->unit_def.p_parent);
-        ABTD_thread_finish_context(&p_old->ctx, &p_new->ctx);
+                                      p_old->p_parent);
+        ABTD_thread_finish_context(&p_old->ctx.ctx, &p_new->ctx.ctx);
         ABTU_unreachable();
     } else {
-        ABTD_thread_context_switch(&p_old->ctx, &p_new->ctx);
+        ABTD_thread_context_switch(&p_old->ctx.ctx, &p_new->ctx.ctx);
         ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
         *pp_local_xstream = p_local_xstream;
-        ABTI_unit *p_prev = p_local_xstream->p_unit;
-        p_local_xstream->p_unit = &p_old->unit_def;
+        ABTI_thread *p_prev = p_local_xstream->p_unit;
+        p_local_xstream->p_unit = p_old;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev->type));
         return ABTI_unit_get_thread(p_prev);
     }
@@ -176,8 +177,8 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
     ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABT_bool is_finish,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_old->unit_def.type));
-    ABTI_thread *p_new = ABTI_unit_get_thread(p_old->unit_def.p_parent);
+    ABTI_ASSERT(ABTI_unit_type_is_thread(p_old->type));
+    ABTI_thread *p_new = ABTI_unit_get_thread(p_old->p_parent);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old will be discarded. */
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old))
@@ -187,22 +188,21 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
 #endif
     if (is_finish) {
         ABTI_tool_event_thread_finish(*pp_local_xstream, p_old,
-                                      p_old->unit_def.p_parent);
-        ABTD_thread_finish_context(&p_old->ctx, &p_new->ctx);
+                                      p_old->p_parent);
+        ABTD_thread_finish_context(&p_old->ctx.ctx, &p_new->ctx.ctx);
         ABTU_unreachable();
     } else {
-        ABTI_tool_event_thread_yield(*pp_local_xstream, p_old,
-                                     p_old->unit_def.p_parent, sync_event_type,
-                                     p_sync);
-        ABTD_thread_context_switch(&p_old->ctx, &p_new->ctx);
+        ABTI_tool_event_thread_yield(*pp_local_xstream, p_old, p_old->p_parent,
+                                     sync_event_type, p_sync);
+        ABTD_thread_context_switch(&p_old->ctx.ctx, &p_new->ctx.ctx);
         ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
         *pp_local_xstream = p_local_xstream;
-        ABTI_unit *p_prev = p_local_xstream->p_unit;
-        p_local_xstream->p_unit = &p_old->unit_def;
+        ABTI_thread *p_prev = p_local_xstream->p_unit;
+        p_local_xstream->p_unit = p_old;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev->type));
         /* Invoke an event of thread run. */
         ABTI_tool_event_thread_run(p_local_xstream, p_old, p_prev,
-                                   p_old->unit_def.p_parent);
+                                   p_old->p_parent);
         return ABTI_unit_get_thread(p_prev);
     }
 }
@@ -211,40 +211,38 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
     ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABTI_thread *p_new)
 {
     ABTI_xstream *p_local_xstream;
-    p_new->unit_def.p_parent = &p_old->unit_def;
+    p_new->p_parent = p_old;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     if (!ABTI_thread_is_dynamic_promoted(p_old)) {
         ABTI_thread_dynamic_promote_thread(p_old);
     }
     if (!ABTI_thread_is_dynamic_promoted(p_new)) {
-        void *p_stacktop = ((char *)p_new->p_stack) + p_new->stacksize;
+        void *p_stacktop = ((char *)p_new->ctx.p_stack) + p_new->ctx.stacksize;
         LOG_DEBUG("[U%" PRIu64 "] run ULT (dynamic promotion)\n",
                   ABTI_thread_get_id(p_new));
         p_local_xstream = *pp_local_xstream;
-        p_local_xstream->p_unit = &p_new->unit_def;
+        p_local_xstream->p_unit = p_new;
         /* Invoke an event of thread run. */
-        ABTI_tool_event_thread_run(p_local_xstream, p_new, &p_old->unit_def,
-                                   &p_old->unit_def);
-        ABTD_thread_context_make_and_call(&p_old->ctx, p_new->unit_def.f_unit,
-                                          p_new->unit_def.p_arg, p_stacktop);
+        ABTI_tool_event_thread_run(p_local_xstream, p_new, p_old, p_old);
+        ABTD_thread_context_make_and_call(&p_old->ctx.ctx, p_new->f_unit,
+                                          p_new->p_arg, p_stacktop);
         /* The scheduler continues from here. If the previous thread has not
          * run dynamic promotion, ABTI_thread_context_make_and_call took the
          * fast path. In this case, the request handling has not been done,
          * so it must be done here. */
         p_local_xstream = ABTI_local_get_xstream_uninlined();
         *pp_local_xstream = p_local_xstream;
-        ABTI_unit *p_prev_unit = p_local_xstream->p_unit;
+        ABTI_thread *p_prev_unit = p_local_xstream->p_unit;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev_unit->type));
         ABTI_thread *p_prev = ABTI_unit_get_thread(p_prev_unit);
-        p_local_xstream->p_unit = &p_old->unit_def;
+        p_local_xstream->p_unit = p_old;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
             /* Invoke a thread-finish event of the previous thread. */
-            ABTI_tool_event_thread_finish(p_local_xstream, p_prev,
-                                          &p_old->unit_def);
+            ABTI_tool_event_thread_finish(p_local_xstream, p_prev, p_old);
             /* See ABTDI_thread_terminate for details.
              * TODO: avoid making a copy of the code. */
-            ABTD_thread_context *p_ctx = &p_prev->ctx;
+            ABTD_thread_context *p_ctx = &p_prev->ctx.ctx;
             ABTD_thread_context *p_link =
                 ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link);
             if (p_link) {
@@ -257,11 +255,11 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
 
                 /* We don't need to use the atomic OR operation here because
                  * the ULT will be terminated regardless of other requests. */
-                ABTD_atomic_release_store_uint32(&p_prev->unit_def.request,
+                ABTD_atomic_release_store_uint32(&p_prev->request,
                                                  ABTI_UNIT_REQ_TERMINATE);
             } else {
                 uint32_t req =
-                    ABTD_atomic_fetch_or_uint32(&p_prev->unit_def.request,
+                    ABTD_atomic_fetch_or_uint32(&p_prev->request,
                                                 ABTI_UNIT_REQ_JOIN |
                                                     ABTI_UNIT_REQ_TERMINATE);
                 if (req & ABTI_UNIT_REQ_JOIN) {
@@ -282,11 +280,11 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
     }
 #endif
     {
-        ABTD_thread_context_switch(&p_old->ctx, &p_new->ctx);
+        ABTD_thread_context_switch(&p_old->ctx.ctx, &p_new->ctx.ctx);
         p_local_xstream = ABTI_local_get_xstream_uninlined();
         *pp_local_xstream = p_local_xstream;
-        ABTI_unit *p_prev = p_local_xstream->p_unit;
-        p_local_xstream->p_unit = &p_old->unit_def;
+        ABTI_thread *p_prev = p_local_xstream->p_unit;
+        p_local_xstream->p_unit = p_old;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev->type));
         /* p_old keeps running as a parent, so no thread-run event incurs. */
         return ABTI_unit_get_thread(p_prev);
@@ -346,25 +344,25 @@ ABTI_thread_finish_context_sched_to_main_thread(ABTI_sched *p_main_sched)
 {
     /* The main thread is stored in p_link. */
     ABTI_thread *p_sched_thread = p_main_sched->p_thread;
-    ABTI_ASSERT(p_sched_thread->unit_def.type ==
-                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED);
-    ABTD_thread_context *p_ctx = &p_sched_thread->ctx;
+    ABTI_ASSERT(p_sched_thread->type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED);
+    ABTD_thread_context *p_ctx = &p_sched_thread->ctx.ctx;
     ABTI_thread *p_main_thread = ABTI_thread_context_get_thread(
         ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link));
     ABTI_ASSERT(p_main_thread &&
-                p_main_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_MAIN);
-    ABTD_thread_finish_context(&p_sched_thread->ctx, &p_main_thread->ctx);
+                p_main_thread->type == ABTI_UNIT_TYPE_THREAD_MAIN);
+    ABTD_thread_finish_context(&p_sched_thread->ctx.ctx,
+                               &p_main_thread->ctx.ctx);
 }
 
 static inline void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
 {
-    ABTD_atomic_fetch_or_uint32(&p_thread->unit_def.request, req);
+    ABTD_atomic_fetch_or_uint32(&p_thread->request, req);
 }
 
 static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
                                              uint32_t req)
 {
-    ABTD_atomic_fetch_and_uint32(&p_thread->unit_def.request, ~req);
+    ABTD_atomic_fetch_and_uint32(&p_thread->request, ~req);
 }
 
 static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
@@ -373,11 +371,10 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
                                      void *p_sync)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              p_thread->p_last_xstream->rank);
 
     /* Change the state of current running thread */
-    ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_READY);
+    ABTD_atomic_release_store_int(&p_thread->state, ABTI_UNIT_STATE_READY);
 
     /* Switch to the top scheduler */
     ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
@@ -385,8 +382,7 @@ static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
 
     /* Back to the original thread */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",
-              ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank);
 }
 
 #endif /* ABTI_THREAD_H_INCLUDED */

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -7,7 +7,7 @@
 #define ABTI_TOOL_H_INCLUDED
 
 static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread);
-static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task);
+static inline ABT_task ABTI_task_get_handle(ABTI_thread *p_task);
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
 static inline ABTI_tool_context *
@@ -128,7 +128,7 @@ ABTI_tool_event_task_update_callback(ABT_tool_task_callback_fn cb_func,
 
 static inline void ABTI_tool_event_thread_impl(
     ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_thread *p_thread,
-    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABTI_thread *p_caller, ABTI_pool *p_pool, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -164,8 +164,8 @@ static inline void ABTI_tool_event_thread_impl(
 }
 
 static inline void ABTI_tool_event_task_impl(
-    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_task *p_task,
-    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_thread *p_task,
+    ABTI_thread *p_caller, ABTI_pool *p_pool, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -202,7 +202,7 @@ static inline void ABTI_tool_event_task_impl(
 
 static inline void
 ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_thread *p_thread, ABTI_thread *p_caller,
                                    ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CREATE,
@@ -212,7 +212,7 @@ ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_thread *p_thread, ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_JOIN,
                                 p_thread, p_caller, NULL, NULL,
@@ -221,7 +221,7 @@ ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_thread *p_thread, ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FREE,
                                 p_thread, p_caller, NULL, NULL,
@@ -230,7 +230,7 @@ ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_thread *p_thread, ABTI_thread *p_caller,
                                    ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_REVIVE,
@@ -240,8 +240,8 @@ ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
-                                ABTI_thread *p_thread, ABTI_unit *p_prev,
-                                ABTI_unit *p_parent)
+                                ABTI_thread *p_thread, ABTI_thread *p_prev,
+                                ABTI_thread *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RUN,
                                 p_thread, p_prev, NULL, p_parent,
@@ -250,7 +250,7 @@ ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_finish_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_parent)
+                                   ABTI_thread *p_thread, ABTI_thread *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FINISH,
                                 p_thread, NULL, NULL, p_parent,
@@ -267,45 +267,45 @@ ABTI_tool_event_thread_cancel_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_thread_yield_impl(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
-    if (ABTD_atomic_relaxed_load_uint32(&p_thread->unit_def.request) &
+    if (ABTD_atomic_relaxed_load_uint32(&p_thread->request) &
         ABTI_UNIT_REQ_BLOCK) {
         ABTI_tool_event_thread_impl(p_local_xstream,
                                     ABT_TOOL_EVENT_THREAD_SUSPEND, p_thread,
-                                    NULL, p_thread->unit_def.p_pool, p_parent,
+                                    NULL, p_thread->p_pool, p_parent,
                                     sync_event_type, p_sync);
 
     } else {
         ABTI_tool_event_thread_impl(p_local_xstream,
                                     ABT_TOOL_EVENT_THREAD_YIELD, p_thread, NULL,
-                                    p_thread->unit_def.p_pool, p_parent,
-                                    sync_event_type, p_sync);
+                                    p_thread->p_pool, p_parent, sync_event_type,
+                                    p_sync);
     }
 }
 
 static inline void ABTI_tool_event_thread_suspend_impl(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_SUSPEND,
-                                p_thread, NULL, p_thread->unit_def.p_pool,
-                                p_parent, sync_event_type, p_sync);
+                                p_thread, NULL, p_thread->p_pool, p_parent,
+                                sync_event_type, p_sync);
 }
 
 static inline void
 ABTI_tool_event_thread_resume_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                   ABTI_thread *p_thread, ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RESUME,
-                                p_thread, p_caller, p_thread->unit_def.p_pool,
-                                NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
+                                p_thread, p_caller, p_thread->p_pool, NULL,
+                                ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
 }
 
 static inline void
 ABTI_tool_event_task_create_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_thread *p_task, ABTI_thread *p_caller,
                                  ABTI_pool *p_pool)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CREATE,
@@ -314,8 +314,8 @@ ABTI_tool_event_task_create_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_join_impl(ABTI_xstream *p_local_xstream,
-                                                  ABTI_task *p_task,
-                                                  ABTI_unit *p_caller)
+                                                  ABTI_thread *p_task,
+                                                  ABTI_thread *p_caller)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_JOIN, p_task,
                               p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
@@ -323,8 +323,8 @@ static inline void ABTI_tool_event_task_join_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_free_impl(ABTI_xstream *p_local_xstream,
-                                                  ABTI_task *p_task,
-                                                  ABTI_unit *p_caller)
+                                                  ABTI_thread *p_task,
+                                                  ABTI_thread *p_caller)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FREE, p_task,
                               p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
@@ -333,7 +333,7 @@ static inline void ABTI_tool_event_task_free_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_revive_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_thread *p_task, ABTI_thread *p_caller,
                                  ABTI_pool *p_pool)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_REVIVE,
@@ -342,8 +342,8 @@ ABTI_tool_event_task_revive_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_run_impl(ABTI_xstream *p_local_xstream,
-                                                 ABTI_task *p_task,
-                                                 ABTI_unit *p_parent)
+                                                 ABTI_thread *p_task,
+                                                 ABTI_thread *p_parent)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_RUN, p_task,
                               p_parent, NULL, p_parent,
@@ -352,7 +352,7 @@ static inline void ABTI_tool_event_task_run_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_finish_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_parent)
+                                 ABTI_thread *p_task, ABTI_thread *p_parent)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FINISH,
                               p_task, NULL, NULL, p_parent,
@@ -361,7 +361,7 @@ ABTI_tool_event_task_finish_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_cancel_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task)
+                                 ABTI_thread *p_task)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CANCEL,
                               p_task, NULL, NULL, NULL,

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -271,7 +271,7 @@ static inline void ABTI_tool_event_thread_yield_impl(
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     if (ABTD_atomic_relaxed_load_uint32(&p_thread->request) &
-        ABTI_UNIT_REQ_BLOCK) {
+        ABTI_THREAD_REQ_BLOCK) {
         ABTI_tool_event_thread_impl(p_local_xstream,
                                     ABT_TOOL_EVENT_THREAD_SUSPEND, p_thread,
                                     NULL, p_thread->p_pool, p_parent,

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -6,7 +6,7 @@
 #ifndef ABTI_UNIT_H_INCLUDED
 #define ABTI_UNIT_H_INCLUDED
 
-/* Inlined functions for ABTI_unit */
+/* Inlined functions for ABTI_thread */
 
 static inline ABTI_ktable *
 ABTI_ktable_ensure_allocation(ABTI_xstream *p_local_xstream,
@@ -74,18 +74,18 @@ static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)
     }
 }
 
-static inline ABTI_thread *ABTI_unit_get_thread(ABTI_unit *p_unit)
+static inline ABTI_thread *ABTI_unit_get_thread(ABTI_thread *p_unit)
 {
-    return (ABTI_thread *)(((char *)p_unit) - offsetof(ABTI_thread, unit_def));
+    return p_unit;
 }
 
-static inline ABTI_task *ABTI_unit_get_task(ABTI_unit *p_unit)
+static inline ABTI_thread *ABTI_unit_get_task(ABTI_thread *p_unit)
 {
-    return (ABTI_task *)(((char *)p_unit) - offsetof(ABTI_task, unit_def));
+    return p_unit;
 }
 
 static inline void ABTI_unit_set_specific(ABTI_xstream *p_local_xstream,
-                                          ABTI_unit *p_unit, ABTI_key *p_key,
+                                          ABTI_thread *p_unit, ABTI_key *p_key,
                                           void *value)
 {
     ABTI_ktable *p_ktable =
@@ -94,7 +94,7 @@ static inline void ABTI_unit_set_specific(ABTI_xstream *p_local_xstream,
     ABTI_ktable_set(p_local_xstream, p_ktable, p_key, value);
 }
 
-static inline void *ABTI_unit_get_specific(ABTI_unit *p_unit, ABTI_key *p_key)
+static inline void *ABTI_unit_get_specific(ABTI_thread *p_unit, ABTI_key *p_key)
 {
     ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(&p_unit->p_keytable);
     if (ABTI_ktable_is_valid(p_ktable)) {

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -18,16 +18,16 @@ static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
 static inline int ABTI_ktable_is_valid(ABTI_ktable *p_ktable);
 
 static inline ABT_thread_state
-ABTI_unit_state_get_thread_state(ABTI_unit_state state)
+ABTI_thread_state_get_thread_state(ABTI_thread_state state)
 {
     switch (state) {
-        case ABTI_UNIT_STATE_READY:
+        case ABTI_THREAD_STATE_READY:
             return ABT_THREAD_STATE_READY;
-        case ABTI_UNIT_STATE_RUNNING:
+        case ABTI_THREAD_STATE_RUNNING:
             return ABT_THREAD_STATE_RUNNING;
-        case ABTI_UNIT_STATE_BLOCKED:
+        case ABTI_THREAD_STATE_BLOCKED:
             return ABT_THREAD_STATE_BLOCKED;
-        case ABTI_UNIT_STATE_TERMINATED:
+        case ABTI_THREAD_STATE_TERMINATED:
             return ABT_THREAD_STATE_TERMINATED;
         default:
             ABTI_ASSERT(0);
@@ -36,67 +36,58 @@ ABTI_unit_state_get_thread_state(ABTI_unit_state state)
 }
 
 static inline ABT_task_state
-ABTI_unit_state_get_task_state(ABTI_unit_state state)
+ABTI_thread_state_get_task_state(ABTI_thread_state state)
 {
     switch (state) {
-        case ABTI_UNIT_STATE_READY:
+        case ABTI_THREAD_STATE_READY:
             return ABT_TASK_STATE_READY;
-        case ABTI_UNIT_STATE_RUNNING:
+        case ABTI_THREAD_STATE_RUNNING:
             return ABT_TASK_STATE_RUNNING;
-        case ABTI_UNIT_STATE_TERMINATED:
+        case ABTI_THREAD_STATE_TERMINATED:
             return ABT_TASK_STATE_TERMINATED;
-        case ABTI_UNIT_STATE_BLOCKED:
+        case ABTI_THREAD_STATE_BLOCKED:
         default:
             ABTI_ASSERT(0);
             ABTU_unreachable();
     }
 }
 
-static inline ABT_bool ABTI_unit_type_is_thread(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_thread(ABTI_thread_type type)
 {
-    ABTI_STATIC_ASSERT(!(ABTI_UNIT_TYPE_TASK & 0x1));
-    ABTI_STATIC_ASSERT(!(ABTI_UNIT_TYPE_EXT & 0x1));
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_MAIN_SCHED & 0x1);
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_USER & 0x1);
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_MAIN & 0x1);
+    ABTI_STATIC_ASSERT(!(ABTI_THREAD_TYPE_TASK & 0x1));
+    ABTI_STATIC_ASSERT(!(ABTI_THREAD_TYPE_EXT & 0x1));
+    ABTI_STATIC_ASSERT(ABTI_THREAD_TYPE_THREAD_MAIN_SCHED & 0x1);
+    ABTI_STATIC_ASSERT(ABTI_THREAD_TYPE_THREAD_USER & 0x1);
+    ABTI_STATIC_ASSERT(ABTI_THREAD_TYPE_THREAD_MAIN & 0x1);
     return (type & 0x1) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)
+static inline ABT_unit_type ABTI_thread_type_get_type(ABTI_thread_type type)
 {
-    if (ABTI_unit_type_is_thread(type)) {
+    if (ABTI_thread_type_is_thread(type)) {
         return ABT_UNIT_TYPE_THREAD;
-    } else if (type == ABTI_UNIT_TYPE_TASK) {
+    } else if (type == ABTI_THREAD_TYPE_TASK) {
         return ABT_UNIT_TYPE_TASK;
     } else {
-        ABTI_ASSERT(type == ABTI_UNIT_TYPE_EXT);
+        ABTI_ASSERT(type == ABTI_THREAD_TYPE_EXT);
         return ABT_UNIT_TYPE_EXT;
     }
 }
 
-static inline ABTI_thread *ABTI_unit_get_thread(ABTI_thread *p_unit)
-{
-    return p_unit;
-}
-
-static inline ABTI_thread *ABTI_unit_get_task(ABTI_thread *p_unit)
-{
-    return p_unit;
-}
-
-static inline void ABTI_unit_set_specific(ABTI_xstream *p_local_xstream,
-                                          ABTI_thread *p_unit, ABTI_key *p_key,
-                                          void *value)
+static inline void ABTI_thread_set_specific(ABTI_xstream *p_local_xstream,
+                                            ABTI_thread *p_thread,
+                                            ABTI_key *p_key, void *value)
 {
     ABTI_ktable *p_ktable =
-        ABTI_ktable_ensure_allocation(p_local_xstream, &p_unit->p_keytable);
+        ABTI_ktable_ensure_allocation(p_local_xstream, &p_thread->p_keytable);
     /* Save the value in the key-value table */
     ABTI_ktable_set(p_local_xstream, p_ktable, p_key, value);
 }
 
-static inline void *ABTI_unit_get_specific(ABTI_thread *p_unit, ABTI_key *p_key)
+static inline void *ABTI_thread_get_specific(ABTI_thread *p_thread,
+                                             ABTI_key *p_key)
 {
-    ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(&p_unit->p_keytable);
+    ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(&p_thread->p_keytable);
     if (ABTI_ktable_is_valid(p_ktable)) {
         /* Retrieve the value from the key-value table */
         return ABTI_ktable_get(p_ktable, p_key);

--- a/src/info.c
+++ b/src/info.c
@@ -461,7 +461,7 @@ fn_fail:
 int ABT_info_print_task(FILE *fp, ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     ABTI_task_print(p_task, fp, 0);
@@ -531,7 +531,7 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
         fprintf(fp,
                 "stack     : %p\n"
                 "stacksize : %" PRIu64 "\n",
-                p_thread->p_stack, (uint64_t)p_thread->stacksize);
+                p_thread->ctx.p_stack, (uint64_t)p_thread->ctx.stacksize);
         int abt_errno = ABTI_thread_print_stack(p_thread, fp);
         if (abt_errno != ABT_SUCCESS)
             fprintf(fp, "Failed to print stack.\n");

--- a/src/key.c
+++ b/src/key.c
@@ -109,8 +109,8 @@ int ABT_key_set(ABT_key key, void *value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer. */
-    ABTI_unit_set_specific(p_local_xstream, p_local_xstream->p_unit, p_key,
-                           value);
+    ABTI_thread_set_specific(p_local_xstream, p_local_xstream->p_thread, p_key,
+                             value);
 fn_exit:
     return abt_errno;
 
@@ -147,7 +147,7 @@ int ABT_key_get(ABT_key key, void **value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer */
-    *value = ABTI_unit_get_specific(p_local_xstream->p_unit, p_key);
+    *value = ABTI_thread_get_specific(p_local_xstream->p_thread, p_key);
 
 fn_exit:
     return abt_errno;

--- a/src/log.c
+++ b/src/log.c
@@ -16,7 +16,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
 
     ABTI_thread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     char *prefix_fmt = NULL, *prefix = NULL;
     char *newfmt;
     uint64_t tid;
@@ -98,15 +98,15 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
         return;
 
     ABTI_thread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] pushed to P%" PRIu64 " "
@@ -118,11 +118,11 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_task->p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] pushed to P%" PRIu64 " "
@@ -145,15 +145,15 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
         return;
 
     ABTI_thread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_thread->p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] removed from P%" PRIu64 " "
@@ -165,11 +165,11 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_task->p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] removed from P%" PRIu64 " "
@@ -193,15 +193,15 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
         return;
 
     ABTI_thread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id);
+                          p_thread->p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread), p_pool->id);
@@ -210,11 +210,11 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id);
+                          p_task->p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task), p_pool->id);

--- a/src/log.c
+++ b/src/log.c
@@ -24,13 +24,13 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     int tid_len = 0, rank_len = 0;
     size_t newfmt_len;
 
-    if (!p_local_xstream || !p_local_xstream->p_unit) {
+    if (!p_local_xstream || !p_local_xstream->p_thread) {
         prefix = "<UNKNOWN> ";
         prefix_fmt = "%s%s";
     } else {
-        ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
-        if (ABTI_unit_type_is_thread(type)) {
-            p_thread = ABTI_unit_get_thread(p_local_xstream->p_unit);
+        ABTI_thread_type type = ABTI_self_get_type(p_local_xstream);
+        if (ABTI_thread_type_is_thread(type)) {
+            p_thread = p_local_xstream->p_thread;
             if (p_thread == NULL) {
                 if (p_local_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY) {
                     prefix_fmt = "<U%" PRIu64 ":E%d> %s";
@@ -53,9 +53,9 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
                     tid = ABTI_thread_get_id(p_thread);
                 }
             }
-        } else if (type == ABTI_UNIT_TYPE_TASK) {
+        } else if (type == ABTI_THREAD_TYPE_TASK) {
             rank = p_local_xstream->rank;
-            p_task = ABTI_unit_get_task(p_local_xstream->p_unit);
+            p_task = p_local_xstream->p_thread;
             prefix_fmt = "<T%" PRIu64 ":E%d> %s";
             tid = ABTI_task_get_id(p_task);
         } else {

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -22,7 +22,7 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-typedef ABTI_unit unit_t;
+typedef ABTI_thread unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_task unit_get_task(ABT_unit unit);
@@ -477,7 +477,7 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    unit_t *p_unit = &p_thread->unit_def;
+    unit_t *p_unit = p_thread;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
@@ -488,8 +488,8 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 
 static ABT_unit unit_create_from_task(ABT_task task)
 {
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
-    unit_t *p_unit = &p_task->unit_def;
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
+    unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -440,15 +440,15 @@ static int pool_print_all(ABT_pool pool, void *arg,
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
     unit_t *p_unit = (unit_t *)unit;
-    return ABTI_unit_type_get_type(p_unit->type);
+    return ABTI_thread_type_get_type(p_unit->type);
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_thread(p_unit->type)) {
-        h_thread = ABTI_thread_get_handle(ABTI_unit_get_thread(p_unit));
+    if (ABTI_thread_type_is_thread(p_unit->type)) {
+        h_thread = ABTI_thread_get_handle(p_unit);
     } else {
         h_thread = ABT_THREAD_NULL;
     }
@@ -459,8 +459,8 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (p_unit->type == ABTI_UNIT_TYPE_TASK) {
-        h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
+    if (p_unit->type == ABTI_THREAD_TYPE_TASK) {
+        h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -481,7 +481,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_thread(p_unit->type));
 
     return (ABT_unit)p_unit;
 }
@@ -493,7 +493,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(p_unit->type == ABTI_UNIT_TYPE_TASK);
+    ABTI_ASSERT(p_unit->type == ABTI_THREAD_TYPE_TASK);
 
     return (ABT_unit)p_unit;
 }

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -18,7 +18,7 @@ static int pool_remove(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-typedef ABTI_unit unit_t;
+typedef ABTI_thread unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_task unit_get_task(ABT_unit unit);
@@ -367,7 +367,7 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    unit_t *p_unit = &p_thread->unit_def;
+    unit_t *p_unit = p_thread;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
@@ -378,8 +378,8 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 
 static ABT_unit unit_create_from_task(ABT_task task)
 {
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
-    unit_t *p_unit = &p_task->unit_def;
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
+    unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -330,15 +330,15 @@ static int pool_print_all(ABT_pool pool, void *arg,
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
     unit_t *p_unit = (unit_t *)unit;
-    return ABTI_unit_type_get_type(p_unit->type);
+    return ABTI_thread_type_get_type(p_unit->type);
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_thread(p_unit->type)) {
-        h_thread = ABTI_thread_get_handle(ABTI_unit_get_thread(p_unit));
+    if (ABTI_thread_type_is_thread(p_unit->type)) {
+        h_thread = ABTI_thread_get_handle(p_unit);
     } else {
         h_thread = ABT_THREAD_NULL;
     }
@@ -349,8 +349,8 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (p_unit->type == ABTI_UNIT_TYPE_TASK) {
-        h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
+    if (p_unit->type == ABTI_THREAD_TYPE_TASK) {
+        h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -371,7 +371,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_thread(p_unit->type));
 
     return (ABT_unit)p_unit;
 }
@@ -383,7 +383,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(p_unit->type == ABTI_UNIT_TYPE_TASK);
+    ABTI_ASSERT(p_unit->type == ABTI_THREAD_TYPE_TASK);
 
     return (ABT_unit)p_unit;
 }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -801,8 +801,7 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             p_sched->p_thread->p_sched = NULL;
 #endif
-            if (p_sched->p_thread->unit_def.type ==
-                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
+            if (p_sched->p_thread->type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
             } else {
                 ABTI_thread_free(p_local_xstream, p_sched->p_thread);

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -801,7 +801,7 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             p_sched->p_thread->p_sched = NULL;
 #endif
-            if (p_sched->p_thread->type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
+            if (p_sched->p_thread->type == ABTI_THREAD_TYPE_THREAD_MAIN_SCHED) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
             } else {
                 ABTI_thread_free(p_local_xstream, p_sched->p_thread);

--- a/src/self.c
+++ b/src/self.c
@@ -94,7 +94,7 @@ int ABT_self_is_primary(ABT_bool *flag)
     }
 #endif
 
-    ABTI_unit *p_unit = p_local_xstream->p_unit;
+    ABTI_thread *p_unit = p_local_xstream->p_unit;
     if (p_unit->type == ABTI_UNIT_TYPE_THREAD_MAIN) {
         *flag = ABT_TRUE;
     } else {
@@ -190,7 +190,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
     }
 #endif
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     ABTI_ASSERT(p_self->p_pool);
     *pool_id = (int)(p_self->p_pool->id);
 
@@ -227,7 +227,7 @@ int ABT_self_suspend(void)
     }
 #endif
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type), ABT_ERR_INV_THREAD);
     abt_errno = ABTI_thread_set_blocked(ABTI_unit_get_thread(p_self));
     ABTI_CHECK_ERROR(abt_errno);

--- a/src/stream.c
+++ b/src/stream.c
@@ -261,7 +261,7 @@ int ABTI_xstream_start(ABTI_xstream *p_local_xstream, ABTI_xstream *p_xstream)
         abt_errno =
             ABTI_thread_create_main_sched(p_local_xstream, p_xstream, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched->p_thread->unit_def.p_last_xstream = p_xstream;
+        p_sched->p_thread->p_last_xstream = p_xstream;
 
     } else {
         /* Start the main scheduler on a different ES */
@@ -340,18 +340,18 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     abt_errno =
         ABTI_thread_create_main_sched(*pp_local_xstream, p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
-    p_sched->p_thread->unit_def.p_last_xstream = p_xstream;
-    p_thread->unit_def.p_parent = &p_sched->p_thread->unit_def;
+    p_sched->p_thread->p_last_xstream = p_xstream;
+    p_thread->p_parent = p_sched->p_thread;
 
     /* Start the scheduler by context switching to it */
     LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              p_thread->p_last_xstream->rank);
     ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
                                          ABT_SYNC_EVENT_TYPE_OTHER, NULL);
 
     /* Back to the main ULT */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              p_thread->p_last_xstream->rank);
 
 fn_exit:
     return abt_errno;
@@ -481,7 +481,7 @@ int ABT_xstream_exit(void)
     ABTI_xstream_set_request(p_local_xstream, ABTI_XSTREAM_REQ_EXIT);
 
     /* Wait until the ES terminates */
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     do {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (!ABTI_unit_type_is_thread(p_self->type)) {
@@ -693,7 +693,7 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type), ABT_ERR_INV_THREAD);
 
     /* For now, if the target ES is running, we allow to change the main
@@ -1007,7 +1007,7 @@ int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
 
     } else if (type == ABT_UNIT_TYPE_TASK) {
         ABT_task task = p_pool->u_get_task(unit);
-        ABTI_task *p_task = ABTI_task_get_ptr(task);
+        ABTI_thread *p_task = ABTI_task_get_ptr(task);
         /* Execute the task */
         ABTI_xstream_schedule_task(*pp_local_xstream, p_task);
 
@@ -1271,14 +1271,14 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
      * the blocked ULT ready. */
     p_local_xstream = *pp_local_xstream;
     if (p_local_xstream) {
-        ABTI_unit *p_self = p_local_xstream->p_unit;
+        ABTI_thread *p_self = p_local_xstream->p_unit;
         if (ABTI_unit_type_is_thread(p_self->type)) {
             p_thread = ABTI_unit_get_thread(p_self);
         }
     }
 
     if (p_thread) {
-        ABT_pool_access access = p_thread->unit_def.p_pool->access;
+        ABT_pool_access access = p_thread->p_pool->access;
         if (access == ABT_POOL_ACCESS_MPSC || access == ABT_POOL_ACCESS_MPMC) {
             is_blockable = ABT_TRUE;
         }
@@ -1299,7 +1299,7 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
 
     /* Wait until the target ES terminates */
     if (is_blockable == ABT_TRUE) {
-        ABTI_POOL_SET_CONSUMER(p_thread->unit_def.p_pool,
+        ABTI_POOL_SET_CONSUMER(p_thread->p_pool,
                                ABTI_self_get_native_thread_id(p_local_xstream));
 
         /* Save the caller ULT to set it ready when the ES is terminated */
@@ -1400,7 +1400,7 @@ void ABTI_xstream_schedule(void *p_arg)
 
         /* Execute the run function of scheduler */
         ABTI_sched *p_sched = p_xstream->p_main_sched;
-        ABTI_ASSERT(p_local_xstream->p_unit == &p_sched->p_thread->unit_def);
+        ABTI_ASSERT(p_local_xstream->p_unit == p_sched->p_thread);
         LOG_DEBUG("[S%" PRIu64 "] start\n", p_sched->id);
         p_sched->run(ABTI_sched_get_handle(p_sched));
         LOG_DEBUG("[S%" PRIu64 "] end\n", p_sched->id);
@@ -1430,8 +1430,7 @@ void ABTI_xstream_schedule(void *p_arg)
         }
     }
 
-    ABTI_ASSERT(p_local_xstream->p_unit ==
-                &p_xstream->p_main_sched->p_thread->unit_def);
+    ABTI_ASSERT(p_local_xstream->p_unit == p_xstream->p_main_sched->p_thread);
 
     /* Set the ES's state as TERMINATED */
     ABTD_atomic_release_store_int(&p_xstream->state,
@@ -1452,7 +1451,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    if (ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
         ABTI_UNIT_REQ_CANCEL) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank);
@@ -1463,7 +1462,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    if (ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
         ABTI_UNIT_REQ_MIGRATE) {
         abt_errno = ABTI_xstream_migrate_thread(p_local_xstream, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
@@ -1472,11 +1471,10 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
 #endif
 
     /* Change the last ES */
-    p_thread->unit_def.p_last_xstream = p_local_xstream;
+    p_thread->p_last_xstream = p_local_xstream;
 
     /* Change the ULT state */
-    ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_RUNNING);
+    ABTD_atomic_release_store_int(&p_thread->state, ABTI_UNIT_STATE_RUNNING);
 
     /* Switch the context */
     LOG_DEBUG("[U%" PRIu64 ":E%d] start running\n",
@@ -1497,8 +1495,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     /* We do not need to acquire-load request since all critical requests
      * (BLOCK, ORPHAN, STOP, and NOPUSH) are written by p_thread. CANCEL might
      * be delayed. */
-    uint32_t request =
-        ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request);
+    uint32_t request = ABTD_atomic_acquire_load_uint32(&p_thread->request);
     if (request & ABTI_UNIT_REQ_STOP) {
         /* The ULT has completed its execution or it called the exit request. */
         LOG_DEBUG("[U%" PRIu64 ":E%d] %s\n", ABTI_thread_get_id(p_thread),
@@ -1537,8 +1534,8 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
         LOG_DEBUG("[U%" PRIu64 ":E%d] orphaned\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank);
         ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_ORPHAN);
-        p_thread->unit_def.p_pool->u_free(&p_thread->unit_def.unit);
-        p_thread->unit_def.p_pool = NULL;
+        p_thread->p_pool->u_free(&p_thread->unit);
+        p_thread->p_pool = NULL;
     } else if (request & ABTI_UNIT_REQ_NOPUSH) {
         /* The ULT is not pushed back to the pool */
         LOG_DEBUG("[U%" PRIu64 ":E%d] not pushed\n",
@@ -1558,10 +1555,10 @@ fn_fail:
 }
 
 void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
-                                ABTI_task *p_task)
+                                ABTI_thread *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
-    if (ABTD_atomic_acquire_load_uint32(&p_task->unit_def.request) &
+    if (ABTD_atomic_acquire_load_uint32(&p_task->request) &
         ABTI_UNIT_REQ_CANCEL) {
         ABTI_tool_event_task_cancel(p_local_xstream, p_task);
         ABTI_xstream_terminate_task(p_local_xstream, p_task);
@@ -1570,25 +1567,24 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
 #endif
 
     /* Change the task state */
-    ABTD_atomic_release_store_int(&p_task->unit_def.state,
-                                  ABTI_UNIT_STATE_RUNNING);
+    ABTD_atomic_release_store_int(&p_task->state, ABTI_UNIT_STATE_RUNNING);
 
     /* Set the associated ES */
-    p_task->unit_def.p_last_xstream = p_local_xstream;
+    p_task->p_last_xstream = p_local_xstream;
 
     /* Execute the task function */
     LOG_DEBUG("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
 
-    ABTI_unit *p_sched_unit = p_local_xstream->p_unit;
-    p_local_xstream->p_unit = &p_task->unit_def;
-    p_task->unit_def.p_parent = p_sched_unit;
+    ABTI_thread *p_sched_unit = p_local_xstream->p_unit;
+    p_local_xstream->p_unit = p_task;
+    p_task->p_parent = p_sched_unit;
 
     /* Execute the task function */
     ABTI_tool_event_task_run(p_local_xstream, p_task, p_sched_unit);
     LOG_DEBUG("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
-    p_task->unit_def.f_unit(p_task->unit_def.p_arg);
+    p_task->f_unit(p_task->p_arg);
     ABTI_tool_event_task_finish(p_local_xstream, p_task, p_sched_unit);
     LOG_DEBUG("[T%" PRIu64 ":E%d] stopped\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
@@ -1616,7 +1612,7 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
     }
 
     /* If request is set, p_migration_pool has a valid pool pointer. */
-    ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
+    ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->request) &
                 ABTI_UNIT_REQ_MIGRATE);
 
     /* Extracting argument in migration request. */
@@ -1624,15 +1620,14 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
     ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
     LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",
-              ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank,
+              ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
               (void *)p_pool->consumer_id);
 
     /* Change the associated pool */
-    p_thread->unit_def.p_pool = p_pool;
+    p_thread->p_pool = p_pool;
 
     /* Add the unit to the scheduler's pool */
-    ABTI_POOL_PUSH(p_pool, p_thread->unit_def.unit,
+    ABTI_POOL_PUSH(p_pool, p_thread->unit,
                    ABTI_self_get_native_thread_id(p_local_xstream));
 
     ABTI_pool_dec_num_migrations(p_pool);
@@ -1731,20 +1726,18 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     /* If the caller ULT is associated with a pool of the current main
      * scheduler, it needs to be associated to a pool of new scheduler. */
     for (p = 0; p < p_main_sched->num_pools; p++) {
-        if (p_thread->unit_def.p_pool ==
-            ABTI_pool_get_ptr(p_main_sched->pools[p])) {
+        if (p_thread->p_pool == ABTI_pool_get_ptr(p_main_sched->pools[p])) {
             /* Associate the work unit to the first pool of new scheduler */
-            p_thread->unit_def.p_pool->u_free(&p_thread->unit_def.unit);
+            p_thread->p_pool->u_free(&p_thread->unit);
             ABT_thread h_thread = ABTI_thread_get_handle(p_thread);
-            p_thread->unit_def.unit =
-                p_tar_pool->u_create_from_thread(h_thread);
-            p_thread->unit_def.p_pool = p_tar_pool;
+            p_thread->unit = p_tar_pool->u_create_from_thread(h_thread);
+            p_thread->p_pool = p_tar_pool;
             break;
         }
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_MAIN,
+        ABTI_CHECK_TRUE(p_thread->type == ABTI_UNIT_TYPE_THREAD_MAIN,
                         ABT_ERR_THREAD);
 
         /* Since the primary ES does not finish its execution until ABT_finalize
@@ -1752,7 +1745,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * it is freed in ABT_finalize. */
         p_sched->automatic = ABT_TRUE;
 
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit_def.unit,
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit,
                        ABTI_self_get_native_thread_id(*pp_local_xstream));
 
         /* Replace the top scheduler with the new scheduler */
@@ -1779,7 +1772,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * the new scheduler starts (see below), it can be scheduled by the new
          * scheduler. When the current ULT resumes its execution, it will free
          * the current main scheduler (see below). */
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit_def.unit,
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit,
                        ABTI_self_get_native_thread_id(*pp_local_xstream));
 
         /* Set the scheduler */
@@ -1880,14 +1873,14 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
         abt_errno = ABTI_thread_create_main_sched(p_local_xstream,
                                                   p_local_xstream, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched->p_thread->unit_def.p_last_xstream = p_local_xstream;
+        p_sched->p_thread->p_last_xstream = p_local_xstream;
     } else {
         ABTI_tool_event_thread_create(p_local_xstream, p_sched->p_thread, NULL,
                                       NULL);
     }
 
     /* Set the sched ULT as the current ULT */
-    p_local_xstream->p_unit = &p_sched->p_thread->unit_def;
+    p_local_xstream->p_unit = p_sched->p_thread;
 
     /* Execute the main scheduler of this ES */
     LOG_DEBUG("[E%d] start\n", p_local_xstream->rank);

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -81,7 +81,7 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
         p_queue->head = p_thread;
         p_queue->tail = p_thread;
     } else {
-        p_queue->tail->unit_def.p_next = &p_thread->unit_def;
+        p_queue->tail->p_next = p_thread;
         p_queue->tail = p_thread;
     }
     p_queue->num_threads++;
@@ -107,7 +107,7 @@ ABT_bool ABTI_thread_htable_add(ABTI_thread_htable *p_htable, int idx,
         /* Change the ULT's state to BLOCKED */
         ABTI_thread_set_blocked(p_thread);
 
-        p_queue->tail->unit_def.p_next = &p_thread->unit_def;
+        p_queue->tail->p_next = p_thread;
         p_queue->tail = p_thread;
     }
     p_queue->num_threads++;
@@ -145,7 +145,7 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
         p_queue->low_head = p_thread;
         p_queue->low_tail = p_thread;
     } else {
-        p_queue->low_tail->unit_def.p_next = &p_thread->unit_def;
+        p_queue->low_tail->p_next = p_thread;
         p_queue->low_tail = p_thread;
     }
     p_queue->low_num_threads++;
@@ -171,7 +171,7 @@ ABT_bool ABTI_thread_htable_add_low(ABTI_thread_htable *p_htable, int idx,
         /* Change the ULT's state to BLOCKED */
         ABTI_thread_set_blocked(p_thread);
 
-        p_queue->low_tail->unit_def.p_next = &p_thread->unit_def;
+        p_queue->low_tail->p_next = p_thread;
         p_queue->low_tail = p_thread;
     }
     p_queue->low_num_threads++;
@@ -193,7 +193,7 @@ ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
             p_queue->head = NULL;
             p_queue->tail = NULL;
         } else {
-            p_queue->head = ABTI_unit_get_thread(p_thread->unit_def.p_next);
+            p_queue->head = ABTI_unit_get_thread(p_thread->p_next);
         }
 
         p_queue->num_threads--;
@@ -216,7 +216,7 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
             p_queue->low_head = NULL;
             p_queue->low_tail = NULL;
         } else {
-            p_queue->low_head = ABTI_unit_get_thread(p_thread->unit_def.p_next);
+            p_queue->low_head = ABTI_unit_get_thread(p_thread->p_next);
         }
 
         p_queue->low_num_threads--;
@@ -241,17 +241,17 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         p_target = p_queue->low_head;
 
         /* Push p_thread to the queue */
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+        ABTD_atomic_release_store_int(&p_thread->state,
                                       ABTI_UNIT_STATE_BLOCKED);
         ABTI_tool_event_thread_suspend(p_local_xstream, p_thread,
-                                       p_thread->unit_def.p_parent,
-                                       sync_event_type, p_sync);
+                                       p_thread->p_parent, sync_event_type,
+                                       p_sync);
         if (p_queue->low_head == p_queue->low_tail) {
             p_queue->low_head = p_thread;
             p_queue->low_tail = p_thread;
         } else {
-            p_queue->low_head = ABTI_unit_get_thread(p_target->unit_def.p_next);
-            p_queue->low_tail->unit_def.p_next = &p_thread->unit_def;
+            p_queue->low_head = ABTI_unit_get_thread(p_target->p_next);
+            p_queue->low_tail->p_next = p_thread;
             p_queue->low_tail = p_thread;
         }
     }
@@ -261,7 +261,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         LOG_DEBUG("switch -> U%" PRIu64 "\n", ABTI_thread_get_id(p_target));
 
         /* Context-switch to p_target */
-        ABTD_atomic_release_store_int(&p_target->unit_def.state,
+        ABTD_atomic_release_store_int(&p_target->state,
                                       ABTI_UNIT_STATE_RUNNING);
         ABTI_tool_event_thread_resume(p_local_xstream, p_target,
                                       p_local_xstream ? p_local_xstream->p_unit
@@ -269,9 +269,8 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         ABTI_thread *p_prev =
             ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
                                                   p_target);
-        ABTI_tool_event_thread_run(*pp_local_xstream, p_thread,
-                                   &p_prev->unit_def,
-                                   p_thread->unit_def.p_parent);
+        ABTI_tool_event_thread_run(*pp_local_xstream, p_thread, p_prev,
+                                   p_thread->p_parent);
         return ABT_TRUE;
     } else {
         return ABT_FALSE;

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -193,7 +193,7 @@ ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
             p_queue->head = NULL;
             p_queue->tail = NULL;
         } else {
-            p_queue->head = ABTI_unit_get_thread(p_thread->p_next);
+            p_queue->head = p_thread->p_next;
         }
 
         p_queue->num_threads--;
@@ -216,7 +216,7 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
             p_queue->low_head = NULL;
             p_queue->low_tail = NULL;
         } else {
-            p_queue->low_head = ABTI_unit_get_thread(p_thread->p_next);
+            p_queue->low_head = p_thread->p_next;
         }
 
         p_queue->low_num_threads--;
@@ -242,7 +242,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
 
         /* Push p_thread to the queue */
         ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABTI_UNIT_STATE_BLOCKED);
+                                      ABTI_THREAD_STATE_BLOCKED);
         ABTI_tool_event_thread_suspend(p_local_xstream, p_thread,
                                        p_thread->p_parent, sync_event_type,
                                        p_sync);
@@ -250,7 +250,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
             p_queue->low_head = p_thread;
             p_queue->low_tail = p_thread;
         } else {
-            p_queue->low_head = ABTI_unit_get_thread(p_target->p_next);
+            p_queue->low_head = p_target->p_next;
             p_queue->low_tail->p_next = p_thread;
             p_queue->low_tail = p_thread;
         }
@@ -262,10 +262,11 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
 
         /* Context-switch to p_target */
         ABTD_atomic_release_store_int(&p_target->state,
-                                      ABTI_UNIT_STATE_RUNNING);
+                                      ABTI_THREAD_STATE_RUNNING);
         ABTI_tool_event_thread_resume(p_local_xstream, p_target,
-                                      p_local_xstream ? p_local_xstream->p_unit
-                                                      : NULL);
+                                      p_local_xstream
+                                          ? p_local_xstream->p_thread
+                                          : NULL);
         ABTI_thread *p_prev =
             ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
                                                   p_target);

--- a/src/tool.c
+++ b/src/tool.c
@@ -265,7 +265,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                 *(int *)val = 0;
             } else {
                 int depth = 0;
-                ABTI_unit *p_cur = p_tctx->p_parent;
+                ABTI_thread *p_cur = p_tctx->p_parent;
                 while (p_cur) {
                     depth++;
                     p_cur = p_cur->p_parent;
@@ -308,7 +308,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                     break;
                 case ABT_SYNC_EVENT_TYPE_TASK_JOIN:
                     *(ABT_task *)val = ABTI_task_get_handle(
-                        (ABTI_task *)p_tctx->p_sync_object);
+                        (ABTI_thread *)p_tctx->p_sync_object);
                     break;
                 case ABT_SYNC_EVENT_TYPE_MUTEX:
                     *(ABT_mutex *)val = ABTI_mutex_get_handle(

--- a/src/tool.c
+++ b/src/tool.c
@@ -276,7 +276,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
         case ABT_TOOL_QUERY_KIND_CALLER_TYPE:
             if (!p_tctx->p_caller) {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_EXT;
-            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
+            } else if (ABTI_thread_type_is_thread(p_tctx->p_caller->type)) {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_THREAD;
             } else {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_TASK;
@@ -285,12 +285,10 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
         case ABT_TOOL_QUERY_KIND_CALLER_HANDLE:
             if (!p_tctx->p_caller) {
                 *(void **)val = NULL;
-            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
-                *(ABT_thread *)val = ABTI_thread_get_handle(
-                    ABTI_unit_get_thread(p_tctx->p_caller));
+            } else if (ABTI_thread_type_is_thread(p_tctx->p_caller->type)) {
+                *(ABT_thread *)val = ABTI_thread_get_handle(p_tctx->p_caller);
             } else {
-                *(ABT_task *)val =
-                    ABTI_task_get_handle(ABTI_unit_get_task(p_tctx->p_caller));
+                *(ABT_task *)val = ABTI_task_get_handle(p_tctx->p_caller);
             }
             break;
         case ABT_TOOL_QUERY_KIND_SYNC_OBJECT_TYPE:

--- a/src/unit.c
+++ b/src/unit.c
@@ -52,12 +52,12 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
     if (type == ABT_UNIT_TYPE_THREAD) {
         ABT_thread thread = p_pool->u_get_thread(unit);
         ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-        p_thread->unit_def.p_pool = p_pool;
+        p_thread->p_pool = p_pool;
 
     } else {
         ABTI_ASSERT(type == ABT_UNIT_TYPE_TASK);
         ABT_task task = p_pool->u_get_task(unit);
-        ABTI_task *p_task = ABTI_task_get_ptr(task);
-        p_task->unit_def.p_pool = p_pool;
+        ABTI_thread *p_task = ABTI_task_get_ptr(task);
+        p_task->p_pool = p_pool;
     }
 }


### PR DESCRIPTION
## Background

The current structures of `ABTI_unit`, `ABTI_thread`, and `ABTI_task` are as follows:
```c
struct ABTI_unit {
    [...]; // Common variables
};
struct ABTI_thread { // ULT descriptor
    ABTI_unit unit_def;
    [...]; // ULT-specific variables
};
struct ABTI_task { // tasklet descriptor
    ABTI_unit unit_def;
};
```
Obviously, there is no tasklet-specific data, so `ABTI_task` is equal to `ABTI_unit`. This composition makes the code lengthy and dirty.

## This PR
This PR changes the structures as follows.
```c
struct ABTI_thread { // descriptor for both ULT and tasklet
    [...]; // Common variables
    ABTI_thread_context ctx;
};
struct ABTI_thread_context {
    [...]; // ULT-specific variables
};
```
`ABTI_thread` is used for both ULTs and tasklets, but `ABTI_thread` for tasklets is smaller; it does not allocate the `ABTI_thread_context` part in `ABTI_thread` so that a tasklet descriptor fit in two 64-byte cache lines. Consequently, this PR renames/removes `unit`-related variables and functions.

### Expected Impact

This PR only changes the internal implementation (for example, this PR keeps `ABT_unit`) while we will integrate tasklets and ULTs more. The performance change should be negligible.
