### PR TITLE
maint: update code-cleanup.sh

### DIFF
--- a/maint/code-cleanup.sh
+++ b/maint/code-cleanup.sh
@@ -4,7 +4,7 @@
 # * clang-format < 3.9 cannot be used since SortIncludes is not supported.
 #   SortIncludes must be disabled since abti.h depends on the order of #include.
 
-indent_list="clang-format-9.0 clang-format-8.0 clang-format-7.0 \
+indent_list="clang-format-10 clang-format-9.0 clang-format-8.0 clang-format-7.0 \
              clang-format-6.0 clang-format clang-format-5.0 clang-format-4.0 \
              clang-format-3.9"
 
@@ -34,7 +34,8 @@ indent_code()
                       AlignAfterOpenBracket: Align, \
                       SortIncludes: false, \
                       AllowShortFunctionsOnASingleLine : None, \
-                      PenaltyBreakBeforeFirstCallParameter: 100000}" \
+                      PenaltyBreakBeforeFirstCallParameter: 100000,
+                      SpacesInContainerLiterals: false}" \
                       -i ${file}
 }
 


### PR DESCRIPTION
code-cleanup.sh with the latest `clang-format` (e.g., `clang-format-10`) breaks the current format rule since it treats named arguments of GCC inline assembly differently (precisely speaking, different from `clang-format-6.0`, which is the coding standard of Argobots at present).
```diff
-                         : [pv0] "+&r"(prev0), [pv1] "+&r"(prev1),
+                         : [ pv0 ] "+&r"(prev0), [ pv1 ] "+&r"(prev1),
```
This PR fixes it by adding a new format option.