### PR TITLE
mutex: use strong compare-and-swap for mutex lock operations

### DIFF
--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -77,7 +77,7 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
     ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
     if (ABTI_unit_type_is_thread(type)) {
         LOG_DEBUG("%p: lock - try\n", p_mutex);
-        while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
+        while (!ABTD_atomic_bool_cas_strong_uint32(&p_mutex->val, 0, 1)) {
             ABTI_thread_yield(pp_local_xstream,
                               ABTI_unit_get_thread(p_local_xstream->p_unit),
                               ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -181,7 +181,7 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
     ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
     if (ABTI_unit_type_is_thread(type)) {
         LOG_DEBUG("%p: lock_low - try\n", p_mutex);
-        while (!ABTD_atomic_bool_cas_weak_uint32(&p_mutex->val, 0, 1)) {
+        while (!ABTD_atomic_bool_cas_strong_uint32(&p_mutex->val, 0, 1)) {
             ABTI_thread_yield(pp_local_xstream,
                               ABTI_unit_get_thread(p_local_xstream->p_unit),
                               ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);


### PR DESCRIPTION
With a weak compare-and-swap operation, mutex lock can spuriously fail, which causes counterintuitive phenomena.  Specifically, `ABT_mutex_lock()` internally yields although no thread is hold a lock.

For example, `test/basic/cond_signal_in_main.c` failed because of this bug:
https://github.com/pmodels/argobots/blob/c01b4b0d2c2f8e9f1bd9900d23485ba971fc1a21/test/basic/cond_signal_in_main.c#L18
In this test code, only one execution stream is used, so the schedule is deterministic (at least that is what users expect), but `ABT_mutex_lock()` sometimes fails on some architectures (we found this bug on POWER9 with GCC10) because internal `ABTD_atomic_bool_cas_weak_uint32()` spuriously fails. This extremely rare scheduling change causes a deadlock on POWER9.

This patch fixes this issue by using strong compare-and-swap for `ABT_mutex_lock()`. This can increase the compare-and-swap cost of `ABT_mutex_lock()`, but I believe this fix is necessary to remove extremely error-prone behavior.

Note that neither POWER9 nor GCC is wrong; this is an implementation issue in Argobots.
