### PR TITLE
Always enable the stackable scheduler feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,7 +181,6 @@ AC_ARG_ENABLE([feature],
         no-thread-cancel    - disable ULT cancellation
         no-task-cancel      - disable tasklet cancellation
         no-migration        - disable ULT migrationtask
-        no-stackable-sched  - disable stackable scheduler
         no-ext-thread       - disable supporting external threads
         none|no             - disable all features above
 ],,[enable_feature=all])
@@ -572,7 +571,6 @@ for option in $enable_feature ; do
             enable_thread_cancel=yes
             enable_task_cancel=yes
             enable_migration=yes
-            enable_stackable_sched=yes
             enable_ext_thread=yes
         ;;
         no-thread-cancel)
@@ -584,9 +582,6 @@ for option in $enable_feature ; do
         no-migration)
             enable_migration=no
         ;;
-        no-stackable-sched)
-            enable_stackable_sched=no
-        ;;
         no-ext-thread)
             enable_ext_thread=no
         ;;
@@ -594,7 +589,6 @@ for option in $enable_feature ; do
             enable_thread_cancel=no
             enable_task_cancel=no
             enable_migration=no
-            enable_stackable_sched=no
             enable_ext_thread=no
         ;;
         *)
@@ -617,10 +611,6 @@ AS_IF([test "x$enable_task_cancel" = "xno"],
 AS_IF([test "x$enable_migration" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_MIGRATION, 1,
         [Define to disable ULT migration])])
-
-AS_IF([test "x$enable_stackable_sched" = "xno"],
-    [AC_DEFINE(ABT_CONFIG_DISABLE_STACKABLE_SCHED, 1,
-        [Define to disable stackable scheduler])])
 
 AS_IF([test "x$enable_ext_thread" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_EXT_THREAD, 1,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -342,11 +342,8 @@ struct ABTI_thread_attr {
 };
 
 struct ABTI_thread {
-    ABTD_thread_context ctx; /* Context */
-    ABTI_unit unit_def;      /* Internal unit definition */
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_sched *p_sched; /* Scheduler */
-#endif
+    ABTD_thread_context ctx;   /* Context */
+    ABTI_unit unit_def;        /* Internal unit definition */
     void *p_stack;             /* Stack address */
     size_t stacksize;          /* Stack size (in bytes) */
     ABTI_stack_type stacktype; /* Stack type */

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -38,6 +38,15 @@ static inline ABT_key ABTI_key_get_handle(ABTI_key *p_key)
 #endif
 }
 
+/* Static initializer for ABTI_key */
+#define ABTI_KEY_STATIC_INITIALIZER(f_destructor, id)                          \
+    {                                                                          \
+        f_destructor, id                                                       \
+    }
+
+#define ABTI_KEY_ID_STACKABLE_SCHED 0
+#define ABTI_KEY_ID_END_ 1
+
 typedef struct ABTI_ktable_mem_header {
     struct ABTI_ktable_mem_header *p_next;
     ABT_bool is_from_mempool;

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -63,20 +63,9 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
     if (p_thread->unit_def.refcount == 0) {
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        if (p_thread->p_sched) {
-            /* NOTE: p_thread itself will be freed in ABTI_sched_free. */
-            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                          ABTI_UNIT_STATE_TERMINATED);
-            ABTI_sched_discard_and_free(p_local_xstream, p_thread->p_sched,
-                                        ABT_FALSE);
-        } else
-#endif
-        {
-            ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                          ABTI_UNIT_STATE_TERMINATED);
-            ABTI_thread_free(p_local_xstream, p_thread);
-        }
+        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
+                                      ABTI_UNIT_STATE_TERMINATED);
+        ABTI_thread_free(p_local_xstream, p_thread);
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
          * because the ULT can be freed on a different ES.  In other words, we

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -50,23 +50,6 @@ static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
     ABTD_atomic_fetch_and_uint32(&p_xstream->request, ~req);
 }
 
-/* Get the top scheduler from the sched list */
-static inline ABTI_sched *ABTI_xstream_get_top_sched(ABTI_xstream *p_xstream)
-{
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    ABTI_unit *p_unit = p_xstream->p_unit;
-    while (p_unit) {
-        if (ABTI_unit_type_is_thread(p_unit->type)) {
-            ABTI_sched *p_sched = ABTI_unit_get_thread(p_unit)->p_sched;
-            if (p_sched)
-                return p_sched;
-        }
-        p_unit = p_unit->p_parent;
-    }
-#endif
-    return p_xstream->p_main_sched;
-}
-
 /* Get the first pool of the main scheduler. */
 static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 {

--- a/src/info.c
+++ b/src/info.c
@@ -184,11 +184,7 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_STACKABLE_SCHED:
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
             *((ABT_bool *)val) = ABT_TRUE;
-#else
-            *((ABT_bool *)val) = ABT_FALSE;
-#endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD:
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD

--- a/src/key.c
+++ b/src/key.c
@@ -10,7 +10,8 @@
  * work-unit local storage (TLS).
  */
 
-static ABTD_atomic_uint32 g_key_id = ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
+static ABTD_atomic_uint32 g_key_id =
+    ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(ABTI_KEY_ID_END_);
 
 /**
  * @ingroup KEY

--- a/src/log.c
+++ b/src/log.c
@@ -42,16 +42,8 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
                 }
             } else {
                 rank = p_local_xstream->rank;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-                if (p_thread->p_sched) {
-                    prefix_fmt = "<S%" PRIu64 ":E%d> %s";
-                    tid = p_thread->p_sched->id;
-                } else
-#endif
-                {
-                    prefix_fmt = "<U%" PRIu64 ":E%d> %s";
-                    tid = ABTI_thread_get_id(p_thread);
-                }
+                prefix_fmt = "<U%" PRIu64 ":E%d> %s";
+                tid = ABTI_thread_get_id(p_thread);
             }
         } else if (type == ABTI_UNIT_TYPE_TASK) {
             rank = p_local_xstream->rank;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -475,9 +475,6 @@ fn_fail:
  */
 int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 {
-#ifdef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    return ABT_ERR_FEATURE_NA;
-#else
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
 
@@ -547,7 +544,6 @@ fn_exit:
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
-#endif
 }
 
 /**

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -798,9 +798,6 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
     /* Free the associated work unit */
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         if (p_sched->p_thread) {
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            p_sched->p_thread->p_sched = NULL;
-#endif
             if (p_sched->p_thread->unit_def.type ==
                 ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
@@ -811,9 +808,6 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
     } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
         /* The underlying implementation is ULT. */
         if (p_sched->p_thread) {
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            p_sched->p_thread->p_sched = NULL;
-#endif
             ABTI_thread_free(p_local_xstream, p_sched->p_thread);
         }
     }

--- a/src/stream.c
+++ b/src/stream.c
@@ -1793,9 +1793,6 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         /* Now, we free the current main scheduler. p_main_sched->p_thread must
          * be NULL to avoid freeing it in ABTI_sched_discard_and_free(). */
         p_main_sched->p_thread = NULL;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-        p_sched->p_thread->p_sched = p_sched;
-#endif
         abt_errno = ABTI_sched_discard_and_free(*pp_local_xstream, p_main_sched,
                                                 ABT_FALSE);
         ABTI_CHECK_ERROR(abt_errno);

--- a/src/thread.c
+++ b/src/thread.c
@@ -1599,13 +1599,11 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 #endif
     ABTD_atomic_relaxed_store_ptr(&p_newthread->unit_def.p_keytable, NULL);
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
     if (p_sched && unit_type == ABTI_UNIT_TYPE_THREAD_USER) {
         /* Set a destructor for p_sched. */
         ABTI_unit_set_specific(p_local_xstream, &p_newthread->unit_def,
                                &g_thread_sched_key, p_sched);
     }
-#endif
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     ABT_unit_id thread_id = ABTI_thread_get_id(p_newthread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -1600,7 +1600,6 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     ABTD_atomic_relaxed_store_ptr(&p_newthread->unit_def.p_keytable, NULL);
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
 #ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-    p_newthread->p_sched = p_sched;
     if (p_sched && unit_type == ABTI_UNIT_TYPE_THREAD_USER) {
         /* Set a destructor for p_sched. */
         ABTI_unit_set_specific(p_local_xstream, &p_newthread->unit_def,
@@ -2090,9 +2089,6 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             "%stype    : %s\n"
             "%sstate   : %s\n"
             "%slast_ES : %p (%d)\n"
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            "%sp_sched : %p\n"
-#endif
             "%sp_arg   : %p\n"
             "%spool    : %p\n"
             "%srefcount: %u\n"
@@ -2100,11 +2096,7 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             "%skeytable: %p\n",
             prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
             prefix, type, prefix, state, prefix, (void *)p_xstream,
-            xstream_rank,
-#ifndef ABT_CONFIG_DISABLE_STACKABLE_SCHED
-            prefix, (void *)p_thread->p_sched,
-#endif
-            prefix, p_thread->unit_def.p_arg, prefix,
+            xstream_rank, prefix, p_thread->unit_def.p_arg, prefix,
             (void *)p_thread->unit_def.p_pool, prefix,
             p_thread->unit_def.refcount, prefix,
             ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request),

--- a/src/thread.c
+++ b/src/thread.c
@@ -1816,16 +1816,6 @@ int ABTI_thread_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr attr;
 
-    /* If p_sched is reused, ABTI_thread_revive() can be used. */
-    if (p_sched->p_thread) {
-        ABT_sched h_sched = ABTI_sched_get_handle(p_sched);
-        abt_errno = ABTI_thread_revive(p_local_xstream, p_pool,
-                                       (void (*)(void *))p_sched->run,
-                                       (void *)h_sched, p_sched->p_thread);
-        ABTI_CHECK_ERROR(abt_errno);
-        goto fn_exit;
-    }
-
     /* Allocate a ULT object and its stack */
     ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                           ABTI_STACK_TYPE_MALLOC, ABT_FALSE);


### PR DESCRIPTION
This PR refactors code for a stackable scheduler. As a result, a stackable scheduler can be always enabled without performance loss.

Note that a stackable scheduler was enabled by default, so this change does not affect most users (except for small overhead reduction).