### PR TITLE
unit: embed refcount and migratable

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -171,7 +171,7 @@ int ABT_finalize(void)
                         "ABT_finalize must be called by the primary ES.");
 
     ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_CHECK_TRUE_MSG(p_self->type == ABTI_UNIT_TYPE_THREAD_MAIN,
+    ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_main(p_self->type),
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");
     ABTI_thread *p_thread = ABTI_unit_get_thread(p_self);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -65,7 +65,8 @@ enum ABTI_sched_used {
 
 /* 0 - 2 : TASK/THREAD/EXT
  * 2 - 5 : USER/MAIN/MAIN_SCHED
- * 5 - 5 : NAMED */
+ * 5 - 5 : NAMED
+ * 6 - 6 : MIGRATABLE */
 #define ABTI_UNIT_TYPE_TASK ((ABTI_unit_type)0x0)
 #define ABTI_UNIT_TYPE_THREAD ((ABTI_unit_type)0x1)
 #define ABTI_UNIT_TYPE_EXT ((ABTI_unit_type)0x2)
@@ -79,6 +80,7 @@ enum ABTI_sched_used {
 #define ABTI_UNIT_TYPE_THREAD_MAIN_SCHED                                       \
     (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED)
 #define ABTI_UNIT_TYPE_NAMED ((ABTI_unit_type)(0x1 << 5))
+#define ABTI_UNIT_TYPE_MIGRATABLE ((ABTI_unit_type)(0x1 << 6))
 
 enum ABTI_unit_state {
     ABTI_UNIT_STATE_READY,
@@ -333,9 +335,6 @@ struct ABTI_unit {
     ABTI_pool *p_pool;            /* Associated pool */
     ABTD_atomic_ptr p_keytable;   /* Work unit-specific data (ABTI_ktable *) */
     ABT_unit_id id;               /* ID */
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABT_bool migratable; /* Migratability */
-#endif
 };
 
 struct ABTI_thread_attr {

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -64,13 +64,21 @@ enum ABTI_sched_used {
 };
 
 /* 0 - 2 : TASK/THREAD/EXT
- * 2 - 4 : USER/MAIN_SCHED/MAIN */
+ * 2 - 5 : USER/MAIN/MAIN_SCHED
+ * 5 - 5 : NAMED */
 #define ABTI_UNIT_TYPE_TASK ((ABTI_unit_type)0x0)
 #define ABTI_UNIT_TYPE_THREAD ((ABTI_unit_type)0x1)
-#define ABTI_UNIT_TYPE_THREAD_USER (ABTI_UNIT_TYPE_THREAD + (0x0 << 2))
-#define ABTI_UNIT_TYPE_THREAD_MAIN_SCHED (ABTI_UNIT_TYPE_THREAD + (0x1 << 2))
-#define ABTI_UNIT_TYPE_THREAD_MAIN (ABTI_UNIT_TYPE_THREAD + (0x2 << 2))
 #define ABTI_UNIT_TYPE_EXT ((ABTI_unit_type)0x2)
+#define ABTI_UNIT_TYPE_THREAD_TYPE_USER ((ABTI_unit_type)(0x1 << 2))
+#define ABTI_UNIT_TYPE_THREAD_TYPE_MAIN ((ABTI_unit_type)(0x1 << 3))
+#define ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED ((ABTI_unit_type)(0x1 << 4))
+#define ABTI_UNIT_TYPE_THREAD_USER                                             \
+    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_USER)
+#define ABTI_UNIT_TYPE_THREAD_MAIN                                             \
+    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_MAIN)
+#define ABTI_UNIT_TYPE_THREAD_MAIN_SCHED                                       \
+    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED)
+#define ABTI_UNIT_TYPE_NAMED ((ABTI_unit_type)(0x1 << 5))
 
 enum ABTI_unit_state {
     ABTI_UNIT_STATE_READY,
@@ -325,7 +333,6 @@ struct ABTI_unit {
     ABTI_pool *p_pool;            /* Associated pool */
     ABTD_atomic_ptr p_keytable;   /* Work unit-specific data (ABTI_ktable *) */
     ABT_unit_id id;               /* ID */
-    uint32_t refcount;            /* Reference count */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABT_bool migratable; /* Migratability */
 #endif

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -63,13 +63,14 @@ enum ABTI_sched_used {
     ABTI_SCHED_IN_POOL
 };
 
-enum ABTI_unit_type {
-    ABTI_UNIT_TYPE_TASK = 0x0,
-    ABTI_UNIT_TYPE_THREAD_USER = 0x1 + (0x0 << 2),
-    ABTI_UNIT_TYPE_THREAD_MAIN_SCHED = 0x1 + (0x1 << 2),
-    ABTI_UNIT_TYPE_THREAD_MAIN = 0x1 + (0x2 << 2),
-    ABTI_UNIT_TYPE_EXT = 0x2,
-};
+/* 0 - 2 : TASK/THREAD/EXT
+ * 2 - 4 : USER/MAIN_SCHED/MAIN */
+#define ABTI_UNIT_TYPE_TASK ((ABTI_unit_type)0x0)
+#define ABTI_UNIT_TYPE_THREAD ((ABTI_unit_type)0x1)
+#define ABTI_UNIT_TYPE_THREAD_USER (ABTI_UNIT_TYPE_THREAD + (0x0 << 2))
+#define ABTI_UNIT_TYPE_THREAD_MAIN_SCHED (ABTI_UNIT_TYPE_THREAD + (0x1 << 2))
+#define ABTI_UNIT_TYPE_THREAD_MAIN (ABTI_UNIT_TYPE_THREAD + (0x2 << 2))
+#define ABTI_UNIT_TYPE_EXT ((ABTI_unit_type)0x2)
 
 enum ABTI_unit_state {
     ABTI_UNIT_STATE_READY,
@@ -108,7 +109,7 @@ typedef struct ABTI_unit ABTI_unit;
 typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_thread ABTI_thread;
 typedef enum ABTI_stack_type ABTI_stack_type;
-typedef enum ABTI_unit_type ABTI_unit_type;
+typedef uint32_t ABTI_unit_type;
 typedef enum ABTI_unit_state ABTI_unit_state;
 typedef struct ABTI_thread_htable ABTI_thread_htable;
 typedef struct ABTI_thread_queue ABTI_thread_queue;

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -84,11 +84,6 @@ ABTI_mem_alloc_thread_default(ABTI_xstream *p_local_xstream)
     /* Initialize members of ABTI_thread_attr. */
     p_thread->p_stack = p_stack;
     p_thread->stacksize = stacksize;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_thread->unit_def.migratable = ABT_TRUE;
-    p_thread->f_migration_cb = NULL;
-    p_thread->p_migration_cb_arg = NULL;
-#endif
     ABTI_VALGRIND_REGISTER_STACK(p_thread->p_stack, p_thread->stacksize);
     return p_thread;
 }
@@ -116,11 +111,6 @@ ABTI_mem_alloc_thread_mempool(ABTI_xstream *p_local_xstream,
     /* Copy members of p_attr. */
     p_thread->p_stack = p_stack;
     p_thread->stacksize = stacksize;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_thread->unit_def.migratable = p_attr->migratable;
-    p_thread->f_migration_cb = p_attr->f_cb;
-    p_thread->p_migration_cb_arg = p_attr->p_cb_arg;
-#endif
     ABTI_VALGRIND_REGISTER_STACK(p_thread->p_stack, p_thread->stacksize);
     return p_thread;
 }
@@ -137,11 +127,6 @@ ABTI_mem_alloc_thread_malloc(ABTI_thread_attr *p_attr)
     p_thread->stacktype = ABTI_STACK_TYPE_MALLOC;
     p_thread->stacksize = stacksize;
     p_thread->p_stack = p_stack;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_thread->unit_def.migratable = p_attr->migratable;
-    p_thread->f_migration_cb = p_attr->f_cb;
-    p_thread->p_migration_cb_arg = p_attr->p_cb_arg;
-#endif
     ABTI_VALGRIND_REGISTER_STACK(p_thread->p_stack, p_thread->stacksize);
     return p_thread;
 }
@@ -154,11 +139,6 @@ static inline ABTI_thread *ABTI_mem_alloc_thread_user(ABTI_thread_attr *p_attr)
     p_thread->stacktype = ABTI_STACK_TYPE_USER;
     p_thread->stacksize = p_attr->stacksize;
     p_thread->p_stack = p_attr->p_stack;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_thread->unit_def.migratable = p_attr->migratable;
-    p_thread->f_migration_cb = p_attr->f_cb;
-    p_thread->p_migration_cb_arg = p_attr->p_cb_arg;
-#endif
     ABTI_VALGRIND_REGISTER_STACK(p_thread->p_stack, p_thread->stacksize);
     return p_thread;
 }
@@ -171,35 +151,7 @@ static inline ABTI_thread *ABTI_mem_alloc_thread_main(ABTI_thread_attr *p_attr)
     p_thread->stacktype = ABTI_STACK_TYPE_MAIN;
     p_thread->stacksize = p_attr->stacksize;
     p_thread->p_stack = p_attr->p_stack;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_thread->unit_def.migratable = p_attr->migratable;
-    p_thread->f_migration_cb = p_attr->f_cb;
-    p_thread->p_migration_cb_arg = p_attr->p_cb_arg;
-#endif
     return p_thread;
-}
-
-static inline ABTI_thread *ABTI_mem_alloc_thread(ABTI_xstream *p_local_xstream,
-                                                 ABTI_thread_attr *p_attr)
-{
-    if (!p_attr) {
-        return ABTI_mem_alloc_thread_default(p_local_xstream);
-    }
-    ABTI_stack_type stacktype = p_attr->stacktype;
-    if (stacktype == ABTI_STACK_TYPE_MEMPOOL) {
-#ifdef ABT_CONFIG_USE_MEM_POOL
-        return ABTI_mem_alloc_thread_mempool(p_local_xstream, p_attr);
-#else
-        return ABTI_mem_alloc_thread_malloc(p_attr);
-#endif
-    } else if (stacktype == ABTI_STACK_TYPE_MALLOC) {
-        return ABTI_mem_alloc_thread_malloc(p_attr);
-    } else if (stacktype == ABTI_STACK_TYPE_USER) {
-        return ABTI_mem_alloc_thread_user(p_attr);
-    } else {
-        ABTI_ASSERT(stacktype == ABTI_STACK_TYPE_MAIN);
-        return ABTI_mem_alloc_thread_main(p_attr);
-    }
 }
 
 static inline void ABTI_mem_free_thread(ABTI_xstream *p_local_xstream,

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -62,7 +62,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);
-    if (p_thread->unit_def.refcount == 0) {
+    if (!(p_thread->unit_def.type & ABTI_UNIT_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_thread->unit_def.state,
                                       ABTI_UNIT_STATE_TERMINATED);
         ABTI_thread_free(p_local_xstream, p_thread);
@@ -81,7 +81,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
 {
     LOG_DEBUG("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->unit_def.p_last_xstream->rank);
-    if (p_task->unit_def.refcount == 0) {
+    if (!(p_task->unit_def.type & ABTI_UNIT_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_task->unit_def.state,
                                       ABTI_UNIT_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -346,13 +346,13 @@ ABTI_thread_finish_context_sched_to_main_thread(ABTI_sched *p_main_sched)
 {
     /* The main thread is stored in p_link. */
     ABTI_thread *p_sched_thread = p_main_sched->p_thread;
-    ABTI_ASSERT(p_sched_thread->unit_def.type ==
-                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED);
+    ABTI_ASSERT(
+        ABTI_unit_type_is_thread_main_sched(p_sched_thread->unit_def.type));
     ABTD_thread_context *p_ctx = &p_sched_thread->ctx;
     ABTI_thread *p_main_thread = ABTI_thread_context_get_thread(
         ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link));
     ABTI_ASSERT(p_main_thread &&
-                p_main_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_MAIN);
+                ABTI_unit_type_is_thread_main(p_main_thread->unit_def.type));
     ABTD_thread_finish_context(&p_sched_thread->ctx, &p_main_thread->ctx);
 }
 

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -54,12 +54,7 @@ ABTI_unit_state_get_task_state(ABTI_unit_state state)
 
 static inline ABT_bool ABTI_unit_type_is_thread(ABTI_unit_type type)
 {
-    ABTI_STATIC_ASSERT(!(ABTI_UNIT_TYPE_TASK & 0x1));
-    ABTI_STATIC_ASSERT(!(ABTI_UNIT_TYPE_EXT & 0x1));
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_MAIN_SCHED & 0x1);
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_USER & 0x1);
-    ABTI_STATIC_ASSERT(ABTI_UNIT_TYPE_THREAD_MAIN & 0x1);
-    return (type & 0x1) ? ABT_TRUE : ABT_FALSE;
+    return (type & ABTI_UNIT_TYPE_THREAD) ? ABT_TRUE : ABT_FALSE;
 }
 
 static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -57,14 +57,41 @@ static inline ABT_bool ABTI_unit_type_is_thread(ABTI_unit_type type)
     return (type & ABTI_UNIT_TYPE_THREAD) ? ABT_TRUE : ABT_FALSE;
 }
 
+static inline ABT_bool ABTI_unit_type_is_task(ABTI_unit_type type)
+{
+    return (!(type & (ABTI_UNIT_TYPE_THREAD | ABTI_UNIT_TYPE_EXT))) ? ABT_TRUE
+                                                                    : ABT_FALSE;
+}
+
+static inline ABT_bool ABTI_unit_type_is_ext(ABTI_unit_type type)
+{
+    return (type & ABTI_UNIT_TYPE_EXT) ? ABT_TRUE : ABT_FALSE;
+}
+
+static inline ABT_bool ABTI_unit_type_is_thread_user(ABTI_unit_type type)
+{
+    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_USER) ? ABT_TRUE : ABT_FALSE;
+}
+
+static inline ABT_bool ABTI_unit_type_is_thread_main(ABTI_unit_type type)
+{
+    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
+}
+
+static inline ABT_bool ABTI_unit_type_is_thread_main_sched(ABTI_unit_type type)
+{
+    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED) ? ABT_TRUE
+                                                          : ABT_FALSE;
+}
+
 static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)
 {
     if (ABTI_unit_type_is_thread(type)) {
         return ABT_UNIT_TYPE_THREAD;
-    } else if (type == ABTI_UNIT_TYPE_TASK) {
+    } else if (ABTI_unit_type_is_task(type)) {
         return ABT_UNIT_TYPE_TASK;
     } else {
-        ABTI_ASSERT(type == ABTI_UNIT_TYPE_EXT);
+        ABTI_ASSERT(ABTI_unit_type_is_ext(type));
         return ABT_UNIT_TYPE_EXT;
     }
 }

--- a/src/log.c
+++ b/src/log.c
@@ -45,7 +45,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
                 prefix_fmt = "<U%" PRIu64 ":E%d> %s";
                 tid = ABTI_thread_get_id(p_thread);
             }
-        } else if (type == ABTI_UNIT_TYPE_TASK) {
+        } else if (ABTI_unit_type_is_task(type)) {
             rank = p_local_xstream->rank;
             p_task = ABTI_unit_get_task(p_local_xstream->p_unit);
             prefix_fmt = "<T%" PRIu64 ":E%d> %s";

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -459,7 +459,7 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (p_unit->type == ABTI_UNIT_TYPE_TASK) {
+    if (ABTI_unit_type_is_task(p_unit->type)) {
         h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
     } else {
         h_task = ABT_TASK_NULL;
@@ -493,7 +493,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(p_unit->type == ABTI_UNIT_TYPE_TASK);
+    ABTI_ASSERT(ABTI_unit_type_is_task(p_unit->type));
 
     return (ABT_unit)p_unit;
 }

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -349,7 +349,7 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (p_unit->type == ABTI_UNIT_TYPE_TASK) {
+    if (ABTI_unit_type_is_task(p_unit->type)) {
         h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
     } else {
         h_task = ABT_TASK_NULL;
@@ -383,7 +383,7 @@ static ABT_unit unit_create_from_task(ABT_task task)
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(p_unit->type == ABTI_UNIT_TYPE_TASK);
+    ABTI_ASSERT(ABTI_unit_type_is_task(p_unit->type));
 
     return (ABT_unit)p_unit;
 }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -798,8 +798,8 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
     /* Free the associated work unit */
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         if (p_sched->p_thread) {
-            if (p_sched->p_thread->unit_def.type ==
-                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
+            if (ABTI_unit_type_is_thread_main_sched(
+                    p_sched->p_thread->unit_def.type)) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
             } else {
                 ABTI_thread_free(p_local_xstream, p_sched->p_thread);

--- a/src/self.c
+++ b/src/self.c
@@ -95,7 +95,7 @@ int ABT_self_is_primary(ABT_bool *flag)
 #endif
 
     ABTI_unit *p_unit = p_local_xstream->p_unit;
-    if (p_unit->type == ABTI_UNIT_TYPE_THREAD_MAIN) {
+    if (ABTI_unit_type_is_thread_main(p_unit->type)) {
         *flag = ABT_TRUE;
     } else {
         if (!ABTI_unit_type_is_thread(p_unit->type))
@@ -347,7 +347,8 @@ int ABT_self_is_unnamed(ABT_bool *flag)
     }
 #endif
 
-    *flag = (p_local_xstream->p_unit->refcount == 0) ? ABT_TRUE : ABT_FALSE;
+    *flag = (p_local_xstream->p_unit->type & ABTI_UNIT_TYPE_NAMED) ? ABT_FALSE
+                                                                   : ABT_TRUE;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
 fn_exit:

--- a/src/stream.c
+++ b/src/stream.c
@@ -1744,7 +1744,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_MAIN,
+        ABTI_CHECK_TRUE(ABTI_unit_type_is_thread_main(p_thread->unit_def.type),
                         ABT_ERR_THREAD);
 
         /* Since the primary ES does not finish its execution until ABT_finalize

--- a/src/task.c
+++ b/src/task.c
@@ -527,7 +527,11 @@ int ABT_task_set_migratable(ABT_task task, ABT_bool flag)
     ABTI_task *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
-    p_task->unit_def.migratable = flag;
+    if (flag) {
+        p_task->unit_def.type |= ABTI_UNIT_TYPE_MIGRATABLE;
+    } else {
+        p_task->unit_def.type &= ~ABTI_UNIT_TYPE_MIGRATABLE;
+    }
 
 fn_exit:
     return abt_errno;
@@ -561,7 +565,8 @@ int ABT_task_is_migratable(ABT_task task, ABT_bool *flag)
     ABTI_task *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
-    *flag = p_task->unit_def.migratable;
+    *flag = (p_task->unit_def.type & ABTI_UNIT_TYPE_MIGRATABLE) ? ABT_TRUE
+                                                                : ABT_FALSE;
 
 fn_exit:
     return abt_errno;
@@ -780,16 +785,17 @@ static int ABTI_task_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newtask->unit_def.p_arg = arg;
     p_newtask->unit_def.p_pool = p_pool;
     ABTD_atomic_relaxed_store_ptr(&p_newtask->unit_def.p_keytable, NULL);
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    p_newtask->unit_def.migratable = ABT_TRUE;
-#endif
     p_newtask->unit_def.id = ABTI_TASK_INIT_ID;
 
     /* Create a wrapper work unit */
     h_newtask = ABTI_task_get_handle(p_newtask);
-    p_newtask->unit_def.type =
+    ABTI_unit_type unit_type =
         refcount ? (ABTI_UNIT_TYPE_TASK | ABTI_UNIT_TYPE_NAMED)
                  : ABTI_UNIT_TYPE_TASK;
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+    unit_type |= ABTI_UNIT_TYPE_MIGRATABLE;
+#endif
+    p_newtask->unit_def.type = unit_type;
     p_newtask->unit_def.unit = p_pool->u_create_from_task(h_newtask);
 
     ABTI_tool_event_task_create(p_local_xstream, p_newtask,
@@ -928,21 +934,14 @@ void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent)
             "%sstate     : %s\n"
             "%sES        : %p (%d)\n"
             "%spool      : %p\n"
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-            "%smigratable: %s\n"
-#endif
             "%srequest   : 0x%x\n"
             "%sp_arg     : %p\n"
             "%skeytable  : %p\n",
             prefix, (void *)p_task, prefix, ABTI_task_get_id(p_task), prefix,
             state, prefix, (void *)p_task->unit_def.p_last_xstream,
-            xstream_rank, prefix, (void *)p_task->unit_def.p_pool,
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-            prefix,
-            (p_task->unit_def.migratable == ABT_TRUE) ? "TRUE" : "FALSE",
-#endif
-            prefix, ABTD_atomic_acquire_load_uint32(&p_task->unit_def.request),
-            prefix, p_task->unit_def.p_arg, prefix,
+            xstream_rank, prefix, (void *)p_task->unit_def.p_pool, prefix,
+            ABTD_atomic_acquire_load_uint32(&p_task->unit_def.request), prefix,
+            p_task->unit_def.p_arg, prefix,
             ABTD_atomic_acquire_load_ptr(&p_task->unit_def.p_keytable));
 
 fn_exit:

--- a/src/thread.c
+++ b/src/thread.c
@@ -9,9 +9,8 @@ static inline int
 ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                             void (*thread_func)(void *), void *arg,
                             ABTI_thread_attr *p_attr, ABTI_unit_type unit_type,
-                            ABTI_sched *p_sched, int refcount,
-                            ABTI_xstream *p_parent_xstream, ABT_bool push_pool,
-                            ABTI_thread **pp_newthread);
+                            ABTI_sched *p_sched, ABTI_xstream *p_parent_xstream,
+                            ABT_bool push_pool, ABTI_thread **pp_newthread);
 static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                               void (*thread_func)(void *), void *arg,
                               ABTI_thread *p_thread);
@@ -68,12 +67,14 @@ int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    int refcount = (newthread != NULL) ? 1 : 0;
+    ABTI_unit_type unit_type =
+        (newthread != NULL)
+            ? (ABTI_UNIT_TYPE_THREAD_USER | ABTI_UNIT_TYPE_NAMED)
+            : ABTI_UNIT_TYPE_THREAD_USER;
     abt_errno =
         ABTI_thread_create_internal(p_local_xstream, p_pool, thread_func, arg,
-                                    ABTI_thread_attr_get_ptr(attr),
-                                    ABTI_UNIT_TYPE_THREAD_USER, NULL, refcount,
-                                    NULL, ABT_TRUE, &p_newthread);
+                                    ABTI_thread_attr_get_ptr(attr), unit_type,
+                                    NULL, NULL, ABT_TRUE, &p_newthread);
 
     /* Return value */
     if (newthread)
@@ -142,12 +143,14 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
 
     /* TODO: need to consider the access type of target pool */
     ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
-    int refcount = (newthread != NULL) ? 1 : 0;
+    ABTI_unit_type unit_type =
+        (newthread != NULL)
+            ? (ABTI_UNIT_TYPE_THREAD_USER | ABTI_UNIT_TYPE_NAMED)
+            : ABTI_UNIT_TYPE_THREAD_USER;
     abt_errno =
         ABTI_thread_create_internal(p_local_xstream, p_pool, thread_func, arg,
-                                    ABTI_thread_attr_get_ptr(attr),
-                                    ABTI_UNIT_TYPE_THREAD_USER, NULL, refcount,
-                                    NULL, ABT_TRUE, &p_newthread);
+                                    ABTI_thread_attr_get_ptr(attr), unit_type,
+                                    NULL, NULL, ABT_TRUE, &p_newthread);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -214,7 +217,7 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
             abt_errno =
                 ABTI_thread_create_internal(p_local_xstream, p_pool, thread_f,
                                             arg, ABTI_thread_attr_get_ptr(attr),
-                                            ABTI_UNIT_TYPE_THREAD_USER, NULL, 0,
+                                            ABTI_UNIT_TYPE_THREAD_USER, NULL,
                                             NULL, ABT_TRUE, &p_newthread);
             ABTI_CHECK_ERROR(abt_errno);
         }
@@ -230,8 +233,9 @@ int ABT_thread_create_many(int num, ABT_pool *pool_list,
             abt_errno =
                 ABTI_thread_create_internal(p_local_xstream, p_pool, thread_f,
                                             arg, ABTI_thread_attr_get_ptr(attr),
-                                            ABTI_UNIT_TYPE_THREAD_USER, NULL, 1,
-                                            NULL, ABT_TRUE, &p_newthread);
+                                            ABTI_UNIT_TYPE_THREAD_USER |
+                                                ABTI_UNIT_TYPE_NAMED,
+                                            NULL, NULL, ABT_TRUE, &p_newthread);
             newthread_list[i] = ABTI_thread_get_handle(p_newthread);
             /* TODO: Release threads that have been already created. */
             ABTI_CHECK_ERROR(abt_errno);
@@ -318,9 +322,7 @@ int ABT_thread_free(ABT_thread *thread)
                         ABT_ERR_INV_THREAD,
                         "The current thread cannot be freed.");
 
-    ABTI_CHECK_TRUE_MSG(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                            p_thread->unit_def.type !=
-                                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be freed explicitly.");
 
@@ -487,9 +489,7 @@ int ABT_thread_cancel(ABT_thread thread)
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    ABTI_CHECK_TRUE_MSG(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                            p_thread->unit_def.type !=
-                                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                         ABT_ERR_INV_THREAD,
                         "The main thread cannot be canceled.");
 
@@ -972,9 +972,7 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     /* checking for cases when migration is not allowed */
-    ABTI_CHECK_TRUE(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                        p_thread->unit_def.type !=
-                            ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->unit_def.state) !=
                         ABTI_UNIT_STATE_TERMINATED,
@@ -1177,7 +1175,7 @@ int ABT_thread_set_migratable(ABT_thread thread, ABT_bool flag)
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    if (p_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_USER) {
+    if (ABTI_unit_type_is_thread_user(p_thread->unit_def.type)) {
         p_thread->unit_def.migratable = flag;
     }
 
@@ -1250,8 +1248,8 @@ int ABT_thread_is_primary(ABT_thread thread, ABT_bool *flag)
     p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    *flag = (p_thread->unit_def.type == ABTI_UNIT_TYPE_THREAD_MAIN) ? ABT_TRUE
-                                                                    : ABT_FALSE;
+    *flag = ABTI_unit_type_is_thread_main(p_thread->unit_def.type) ? ABT_TRUE
+                                                                   : ABT_FALSE;
 
 fn_exit:
     return abt_errno;
@@ -1281,7 +1279,8 @@ int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *flag)
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    *flag = (p_thread->unit_def.refcount == 0) ? ABT_TRUE : ABT_FALSE;
+    *flag =
+        (p_thread->unit_def.type & ABTI_UNIT_TYPE_NAMED) ? ABT_FALSE : ABT_TRUE;
 
 fn_exit:
     return abt_errno;
@@ -1549,9 +1548,8 @@ static inline int
 ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                             void (*thread_func)(void *), void *arg,
                             ABTI_thread_attr *p_attr, ABTI_unit_type unit_type,
-                            ABTI_sched *p_sched, int refcount,
-                            ABTI_xstream *p_parent_xstream, ABT_bool push_pool,
-                            ABTI_thread **pp_newthread)
+                            ABTI_sched *p_sched, ABTI_xstream *p_parent_xstream,
+                            ABT_bool push_pool, ABTI_thread **pp_newthread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newthread;
@@ -1559,8 +1557,8 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 
     /* Allocate a ULT object and its stack, then create a thread context. */
     p_newthread = ABTI_mem_alloc_thread(p_local_xstream, p_attr);
-    if ((unit_type == ABTI_UNIT_TYPE_THREAD_MAIN ||
-         unit_type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) &&
+    if ((ABTI_unit_type_is_thread_main(unit_type) ||
+         ABTI_unit_type_is_thread_main_sched(unit_type)) &&
         p_newthread->p_stack == NULL) {
         /* We don't need to initialize the context of 1. the main thread, and
          * 2. the main scheduler thread which runs on OS-level threads
@@ -1592,14 +1590,13 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newthread->unit_def.p_last_xstream = NULL;
     p_newthread->unit_def.p_parent = NULL;
     p_newthread->unit_def.p_pool = p_pool;
-    p_newthread->unit_def.refcount = refcount;
     p_newthread->unit_def.type = unit_type;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTD_atomic_relaxed_store_ptr(&p_newthread->p_migration_pool, NULL);
 #endif
     ABTD_atomic_relaxed_store_ptr(&p_newthread->unit_def.p_keytable, NULL);
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
-    if (p_sched && unit_type == ABTI_UNIT_TYPE_THREAD_USER) {
+    if (p_sched && ABTI_unit_type_is_thread_user(unit_type)) {
         /* Set a destructor for p_sched. */
         ABTI_unit_set_specific(p_local_xstream, &p_newthread->unit_def,
                                &g_thread_sched_key, p_sched);
@@ -1607,10 +1604,10 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     ABT_unit_id thread_id = ABTI_thread_get_id(p_newthread);
-    if (unit_type == ABTI_UNIT_TYPE_THREAD_MAIN) {
+    if (ABTI_unit_type_is_thread_main(unit_type)) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] main ULT created\n", thread_id,
                   p_parent_xstream ? p_parent_xstream->rank : 0);
-    } else if (unit_type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
+    } else if (ABTI_unit_type_is_thread_main_sched(unit_type)) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] main sched ULT created\n", thread_id,
                   p_parent_xstream ? p_parent_xstream->rank : 0);
     } else {
@@ -1636,9 +1633,9 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
             ABTI_pool_push(p_pool, p_newthread->unit_def.unit,
                            ABTI_self_get_native_thread_id(p_local_xstream));
         if (abt_errno != ABT_SUCCESS) {
-            if (unit_type == ABTI_UNIT_TYPE_THREAD_MAIN) {
+            if (ABTI_unit_type_is_thread_main(unit_type)) {
                 ABTI_thread_free_main(p_local_xstream, p_newthread);
-            } else if (unit_type == ABTI_UNIT_TYPE_THREAD_MAIN_SCHED) {
+            } else if (ABTI_unit_type_is_thread_main_sched(unit_type)) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_newthread);
             } else {
                 ABTI_thread_free(p_local_xstream, p_newthread);
@@ -1667,11 +1664,13 @@ int ABTI_thread_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                        ABTI_thread_attr *p_attr, ABTI_thread **pp_newthread)
 {
     int abt_errno = ABT_SUCCESS;
-    int refcount = (pp_newthread != NULL) ? 1 : 0;
-    abt_errno =
-        ABTI_thread_create_internal(p_local_xstream, p_pool, thread_func, arg,
-                                    p_attr, ABTI_UNIT_TYPE_THREAD_USER, NULL,
-                                    refcount, NULL, ABT_TRUE, pp_newthread);
+    ABTI_unit_type unit_type =
+        (pp_newthread != NULL)
+            ? (ABTI_UNIT_TYPE_THREAD_USER | ABTI_UNIT_TYPE_NAMED)
+            : ABTI_UNIT_TYPE_THREAD_USER;
+    abt_errno = ABTI_thread_create_internal(p_local_xstream, p_pool,
+                                            thread_func, arg, p_attr, unit_type,
+                                            NULL, NULL, ABT_TRUE, pp_newthread);
     return abt_errno;
 }
 
@@ -1687,9 +1686,7 @@ int ABTI_thread_migrate_to_pool(ABTI_xstream **pp_local_xstream,
                                                p_thread->unit_def.p_pool) ==
                         ABT_TRUE,
                     ABT_ERR_INV_POOL);
-    ABTI_CHECK_TRUE(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                        p_thread->unit_def.type !=
-                            ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->unit_def.state) !=
                         ABTI_UNIT_STATE_TERMINATED,
@@ -1748,8 +1745,8 @@ int ABTI_thread_create_main(ABTI_xstream *p_local_xstream,
     ABT_bool push_pool = ABT_TRUE;
     abt_errno =
         ABTI_thread_create_internal(p_local_xstream, p_pool, NULL, NULL, &attr,
-                                    ABTI_UNIT_TYPE_THREAD_MAIN, NULL, 0,
-                                    p_xstream, push_pool, &p_newthread);
+                                    ABTI_UNIT_TYPE_THREAD_MAIN, NULL, p_xstream,
+                                    push_pool, &p_newthread);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -1783,7 +1780,7 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_local_xstream,
                                         ABTI_xstream_schedule,
                                         (void *)p_xstream, &attr,
                                         ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
-                                        p_sched, 0, p_xstream, ABT_FALSE,
+                                        p_sched, p_xstream, ABT_FALSE,
                                         &p_newthread);
         ABTI_CHECK_ERROR(abt_errno);
         /* When the main scheduler is terminated, the control will jump to the
@@ -1800,7 +1797,7 @@ int ABTI_thread_create_main_sched(ABTI_xstream *p_local_xstream,
                                         ABTI_xstream_schedule,
                                         (void *)p_xstream, &attr,
                                         ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
-                                        p_sched, 0, p_xstream, ABT_FALSE,
+                                        p_sched, p_xstream, ABT_FALSE,
                                         &p_newthread);
         ABTI_CHECK_ERROR(abt_errno);
     }
@@ -1831,7 +1828,7 @@ int ABTI_thread_create_sched(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                                     (void (*)(void *))p_sched->run,
                                     (void *)ABTI_sched_get_handle(p_sched),
                                     &attr, ABTI_UNIT_TYPE_THREAD_USER, p_sched,
-                                    0, NULL, ABT_TRUE, &p_sched->p_thread);
+                                    NULL, ABT_TRUE, &p_sched->p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:
@@ -1933,7 +1930,8 @@ int ABTI_thread_set_blocked(ABTI_thread *p_thread)
     int abt_errno = ABT_SUCCESS;
 
     /* The main sched cannot be blocked */
-    ABTI_CHECK_TRUE(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE(!ABTI_unit_type_is_thread_main_sched(
+                        p_thread->unit_def.type),
                     ABT_ERR_THREAD);
 
     /* To prevent the scheduler from adding the ULT to the pool */
@@ -2049,19 +2047,14 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
     int xstream_rank = p_xstream ? p_xstream->rank : 0;
     char *type, *state;
 
-    switch (p_thread->unit_def.type) {
-        case ABTI_UNIT_TYPE_THREAD_MAIN:
-            type = "MAIN";
-            break;
-        case ABTI_UNIT_TYPE_THREAD_MAIN_SCHED:
-            type = "MAIN_SCHED";
-            break;
-        case ABTI_UNIT_TYPE_THREAD_USER:
-            type = "USER";
-            break;
-        default:
-            type = "UNKNOWN";
-            break;
+    if (ABTI_unit_type_is_thread_main(p_thread->unit_def.type)) {
+        type = "MAIN";
+    } else if (ABTI_unit_type_is_thread_main_sched(p_thread->unit_def.type)) {
+        type = "MAIN_SCHED";
+    } else if (ABTI_unit_type_is_thread_user(p_thread->unit_def.type)) {
+        type = "USER";
+    } else {
+        type = "UNKNOWN";
     }
     switch (ABTD_atomic_acquire_load_int(&p_thread->unit_def.state)) {
         case ABTI_UNIT_STATE_READY:
@@ -2089,14 +2082,12 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
             "%slast_ES : %p (%d)\n"
             "%sp_arg   : %p\n"
             "%spool    : %p\n"
-            "%srefcount: %u\n"
             "%srequest : 0x%x\n"
             "%skeytable: %p\n",
             prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
             prefix, type, prefix, state, prefix, (void *)p_xstream,
             xstream_rank, prefix, p_thread->unit_def.p_arg, prefix,
             (void *)p_thread->unit_def.p_pool, prefix,
-            p_thread->unit_def.refcount, prefix,
             ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request),
             prefix,
             ABTD_atomic_acquire_load_ptr(&p_thread->unit_def.p_keytable));
@@ -2240,8 +2231,6 @@ static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     ABTD_atomic_relaxed_store_uint32(&p_thread->unit_def.request, 0);
     p_thread->unit_def.p_last_xstream = NULL;
     p_thread->unit_def.p_parent = NULL;
-    p_thread->unit_def.refcount = 1;
-    p_thread->unit_def.type = ABTI_UNIT_TYPE_THREAD_USER;
 
     if (p_thread->unit_def.p_pool != p_pool) {
         /* Free the unit for the old pool */
@@ -2290,9 +2279,7 @@ static inline int ABTI_thread_join(ABTI_xstream **pp_local_xstream,
         goto fn_exit;
     }
 
-    ABTI_CHECK_TRUE_MSG(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                            p_thread->unit_def.type !=
-                                ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                         ABT_ERR_INV_THREAD, "The main ULT cannot be joined.");
 
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
@@ -2462,9 +2449,7 @@ static int ABTI_thread_migrate_to_xstream(ABTI_xstream **pp_local_xstream,
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
                         ABT_XSTREAM_STATE_TERMINATED,
                     ABT_ERR_INV_XSTREAM);
-    ABTI_CHECK_TRUE(p_thread->unit_def.type != ABTI_UNIT_TYPE_THREAD_MAIN &&
-                        p_thread->unit_def.type !=
-                            ABTI_UNIT_TYPE_THREAD_MAIN_SCHED,
+    ABTI_CHECK_TRUE(ABTI_unit_type_is_thread_user(p_thread->unit_def.type),
                     ABT_ERR_INV_THREAD);
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->unit_def.state) !=
                         ABTI_UNIT_STATE_TERMINATED,


### PR DESCRIPTION
This PR embeds `refcount` and `migratable` in `ABTI_unit_type`. This can make the struct size of `ABTI_unit` smaller. This change is necessary for the future commit.

This PR does affect the existing code. 