### PR TITLE
Refactor the migration feature

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -118,6 +118,7 @@ typedef struct ABTI_pool ABTI_pool;
 typedef struct ABTI_unit ABTI_unit;
 typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_thread ABTI_thread;
+typedef struct ABTI_thread_mig_data ABTI_thread_mig_data;
 typedef enum ABTI_stack_type ABTI_stack_type;
 typedef uint32_t ABTI_unit_type;
 typedef enum ABTI_unit_state ABTI_unit_state;
@@ -348,18 +349,19 @@ struct ABTI_thread_attr {
 #endif
 };
 
+struct ABTI_thread_mig_data {
+    void (*f_migration_cb)(ABT_thread, void *); /* Callback function */
+    void *p_migration_cb_arg;                   /* Callback function argument */
+    ABTD_atomic_ptr
+        p_migration_pool; /* Destination of migration (ABTI_pool *) */
+};
+
 struct ABTI_thread {
     ABTD_thread_context ctx;   /* Context */
     ABTI_unit unit_def;        /* Internal unit definition */
     void *p_stack;             /* Stack address */
     size_t stacksize;          /* Stack size (in bytes) */
     ABTI_stack_type stacktype; /* Stack type */
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    void (*f_migration_cb)(ABT_thread, void *); /* Callback function */
-    void *p_migration_cb_arg;                   /* Callback function argument */
-    ABTD_atomic_ptr
-        p_migration_pool; /* Destination of migration (ABTI_pool *) */
-#endif
 };
 
 struct ABTI_task {
@@ -542,6 +544,8 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 /* User-level Thread (ULT)  */
 int ABTI_thread_migrate_to_pool(ABTI_xstream **pp_local_xstream,
                                 ABTI_thread *p_thread, ABTI_pool *p_pool);
+ABTI_thread_mig_data *ABTI_thread_get_mig_data(ABTI_xstream *p_local_xstream,
+                                               ABTI_thread *p_thread);
 int ABTI_thread_create(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
                        void (*thread_func)(void *), void *arg,
                        ABTI_thread_attr *p_attr, ABTI_thread **pp_newthread);

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -63,37 +63,9 @@ static inline int ABTI_ktable_is_valid(ABTI_ktable *p_ktable)
            ((uintptr_t)(void *)0x0);
 }
 
-static inline ABTI_ktable *
-ABTI_ktable_ensure_allocation(ABTI_xstream *p_local_xstream,
-                              ABTD_atomic_ptr *pp_ktable)
+static inline ABTI_ktable *ABTI_ktable_create(ABTI_xstream *p_local_xstream)
 {
-    ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
-    if (ABTU_likely(ABTI_ktable_is_valid(p_ktable))) {
-        return p_ktable;
-    } else {
-        /* Spinlock pp_ktable */
-        while (1) {
-            if (ABTD_atomic_bool_cas_weak_ptr(pp_ktable, NULL,
-                                              ABTI_KTABLE_LOCKED)) {
-                /* The lock was acquired, so let's allocate this table. */
-                break;
-            } else {
-                /* Failed to take a lock. Check if the value to see if it should
-                 * try to take a lock again. */
-                p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
-                if (p_ktable == NULL) {
-                    /* Try once more. */
-                    continue;
-                }
-                /* It has been locked by another. */
-                while (p_ktable == ABTI_KTABLE_LOCKED) {
-                    ABTD_atomic_pause();
-                    p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
-                }
-                return p_ktable;
-            }
-        }
-    }
+    ABTI_ktable *p_ktable;
     int key_table_size = gp_ABTI_global->key_table_size;
     /* size must be a power of 2. */
     ABTI_ASSERT((key_table_size & (key_table_size - 1)) == 0);
@@ -131,8 +103,6 @@ ABTI_ktable_ensure_allocation(ABTI_xstream *p_local_xstream,
     p_ktable->size = key_table_size;
     ABTI_spinlock_clear(&p_ktable->lock);
     memset(p_ktable->p_elems, 0, sizeof(ABTD_atomic_ptr) * key_table_size);
-    /* Write down the value.  The lock is released here. */
-    ABTD_atomic_release_store_ptr(pp_ktable, p_ktable);
     return p_ktable;
 }
 
@@ -175,12 +145,10 @@ static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
     return p_key->id & (size - 1);
 }
 
-static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
-                                   ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key,
-                                   void *value)
+static inline void ABTI_ktable_set_impl(ABTI_xstream *p_local_xstream,
+                                        ABTI_ktable *p_ktable, ABTI_key *p_key,
+                                        void *value, ABT_bool is_safe)
 {
-    ABTI_ktable *p_ktable =
-        ABTI_ktable_ensure_allocation(p_local_xstream, pp_ktable);
     uint32_t idx;
     ABTD_atomic_ptr *pp_elem;
     ABTI_ktelem *p_elem;
@@ -200,12 +168,14 @@ static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
     }
 
     /* The table does not have the same key */
-    ABTI_spinlock_acquire(&p_ktable->lock);
+    if (is_safe)
+        ABTI_spinlock_acquire(&p_ktable->lock);
     /* The linked list might have been extended. */
     p_elem = (ABTI_ktelem *)ABTD_atomic_acquire_load_ptr(pp_elem);
     while (p_elem) {
         if (p_elem->key_id == key_id) {
-            ABTI_spinlock_release(&p_ktable->lock);
+            if (is_safe)
+                ABTI_spinlock_release(&p_ktable->lock);
             p_elem->value = value;
             return;
         }
@@ -223,7 +193,56 @@ static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
     p_elem->value = value;
     ABTD_atomic_relaxed_store_ptr(&p_elem->p_next, NULL);
     ABTD_atomic_release_store_ptr(pp_elem, p_elem);
-    ABTI_spinlock_release(&p_ktable->lock);
+    if (is_safe)
+        ABTI_spinlock_release(&p_ktable->lock);
+}
+
+static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
+                                   ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key,
+                                   void *value)
+{
+    ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
+    if (ABTU_unlikely(!ABTI_ktable_is_valid(p_ktable))) {
+        /* Spinlock pp_ktable */
+        while (1) {
+            if (ABTD_atomic_bool_cas_weak_ptr(pp_ktable, NULL,
+                                              ABTI_KTABLE_LOCKED)) {
+                /* The lock was acquired, so let's allocate this table. */
+                p_ktable = ABTI_ktable_create(p_local_xstream);
+                /* Write down the value.  The lock is released here. */
+                ABTD_atomic_release_store_ptr(pp_ktable, p_ktable);
+                break;
+            } else {
+                /* Failed to take a lock. Check if the value to see if it should
+                 * try to take a lock again. */
+                p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
+                if (p_ktable == NULL) {
+                    /* Try once more. */
+                    continue;
+                }
+                /* It has been locked by another. */
+                while (p_ktable == ABTI_KTABLE_LOCKED) {
+                    ABTD_atomic_pause();
+                    p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
+                }
+                /* p_ktable has been allocated by another. */
+                break;
+            }
+        }
+    }
+    ABTI_ktable_set_impl(p_local_xstream, p_ktable, p_key, value, ABT_TRUE);
+}
+
+static inline void ABTI_ktable_set_unsafe(ABTI_xstream *p_local_xstream,
+                                          ABTI_ktable **pp_ktable,
+                                          ABTI_key *p_key, void *value)
+{
+    ABTI_ktable *p_ktable = *pp_ktable;
+    if (!p_ktable) {
+        p_ktable = ABTI_ktable_create(p_local_xstream);
+        *pp_ktable = p_ktable;
+    }
+    ABTI_ktable_set_impl(p_local_xstream, p_ktable, p_key, value, ABT_FALSE);
 }
 
 static inline void *ABTI_ktable_get(ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key)

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -45,7 +45,8 @@ static inline ABT_key ABTI_key_get_handle(ABTI_key *p_key)
     }
 
 #define ABTI_KEY_ID_STACKABLE_SCHED 0
-#define ABTI_KEY_ID_END_ 1
+#define ABTI_KEY_ID_MIGRATION 1
+#define ABTI_KEY_ID_END_ 2
 
 typedef struct ABTI_ktable_mem_header {
     struct ABTI_ktable_mem_header *p_next;

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -8,13 +8,11 @@
 
 /* Inlined functions for ABTI_unit */
 
-static inline ABTI_ktable *
-ABTI_ktable_ensure_allocation(ABTI_xstream *p_local_xstream,
-                              ABTD_atomic_ptr *pp_ktable);
 static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
-                                   ABTI_ktable *p_ktable, ABTI_key *p_key,
+                                   ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key,
                                    void *value);
-static inline void *ABTI_ktable_get(ABTI_ktable *p_ktable, ABTI_key *p_key);
+static inline void *ABTI_ktable_get(ABTD_atomic_ptr *pp_ktable,
+                                    ABTI_key *p_key);
 static inline int ABTI_ktable_is_valid(ABTI_ktable *p_ktable);
 
 static inline ABT_thread_state
@@ -104,26 +102,6 @@ static inline ABTI_thread *ABTI_unit_get_thread(ABTI_unit *p_unit)
 static inline ABTI_task *ABTI_unit_get_task(ABTI_unit *p_unit)
 {
     return (ABTI_task *)(((char *)p_unit) - offsetof(ABTI_task, unit_def));
-}
-
-static inline void ABTI_unit_set_specific(ABTI_xstream *p_local_xstream,
-                                          ABTI_unit *p_unit, ABTI_key *p_key,
-                                          void *value)
-{
-    ABTI_ktable *p_ktable =
-        ABTI_ktable_ensure_allocation(p_local_xstream, &p_unit->p_keytable);
-    /* Save the value in the key-value table */
-    ABTI_ktable_set(p_local_xstream, p_ktable, p_key, value);
-}
-
-static inline void *ABTI_unit_get_specific(ABTI_unit *p_unit, ABTI_key *p_key)
-{
-    ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(&p_unit->p_keytable);
-    if (ABTI_ktable_is_valid(p_ktable)) {
-        /* Retrieve the value from the key-value table */
-        return ABTI_ktable_get(p_ktable, p_key);
-    }
-    return NULL;
 }
 
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/key.c
+++ b/src/key.c
@@ -110,8 +110,8 @@ int ABT_key_set(ABT_key key, void *value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer. */
-    ABTI_unit_set_specific(p_local_xstream, p_local_xstream->p_unit, p_key,
-                           value);
+    ABTI_ktable_set(p_local_xstream, &p_local_xstream->p_unit->p_keytable,
+                    p_key, value);
 fn_exit:
     return abt_errno;
 
@@ -148,7 +148,7 @@ int ABT_key_get(ABT_key key, void **value)
     ABTI_CHECK_TRUE(p_local_xstream != NULL, ABT_ERR_INV_XSTREAM);
 
     /* Obtain the key-value table pointer */
-    *value = ABTI_unit_get_specific(p_local_xstream->p_unit, p_key);
+    *value = ABTI_ktable_get(&p_local_xstream->p_unit->p_keytable, p_key);
 
 fn_exit:
     return abt_errno;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1609,10 +1609,12 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
     int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool;
 
+    ABTI_thread_mig_data *p_mig_data =
+        ABTI_thread_get_mig_data(p_local_xstream, p_thread);
     /* callback function */
-    if (p_thread->f_migration_cb) {
+    if (p_mig_data->f_migration_cb) {
         ABT_thread thread = ABTI_thread_get_handle(p_thread);
-        p_thread->f_migration_cb(thread, p_thread->p_migration_cb_arg);
+        p_mig_data->f_migration_cb(thread, p_mig_data->p_migration_cb_arg);
     }
 
     /* If request is set, p_migration_pool has a valid pool pointer. */
@@ -1620,7 +1622,7 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
                 ABTI_UNIT_REQ_MIGRATE);
 
     /* Extracting argument in migration request. */
-    p_pool = ABTD_atomic_relaxed_load_ptr(&p_thread->p_migration_pool);
+    p_pool = ABTD_atomic_relaxed_load_ptr(&p_mig_data->p_migration_pool);
     ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
     LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",

--- a/src/task.c
+++ b/src/task.c
@@ -715,7 +715,8 @@ int ABT_task_set_specific(ABT_task task, ABT_key key, void *value)
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
     /* Set the value. */
-    ABTI_unit_set_specific(p_local_xstream, &p_task->unit_def, p_key, value);
+    ABTI_ktable_set(p_local_xstream, &p_task->unit_def.p_keytable, p_key,
+                    value);
 fn_exit:
     return abt_errno;
 
@@ -750,7 +751,7 @@ int ABT_task_get_specific(ABT_task task, ABT_key key, void **value)
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
     /* Get the value. */
-    *value = ABTI_unit_get_specific(&p_task->unit_def, p_key);
+    *value = ABTI_ktable_get(&p_task->unit_def.p_keytable, p_key);
 fn_exit:
     return abt_errno;
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1563,6 +1563,7 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newthread;
     ABT_thread h_newthread;
+    ABTI_ktable *p_keytable = NULL;
 
     /* Allocate a ULT object and its stack, then create a thread context. */
     if (!p_attr) {
@@ -1633,13 +1634,14 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTD_atomic_relaxed_store_ptr(&p_newthread->p_migration_pool, NULL);
 #endif
-    ABTD_atomic_relaxed_store_ptr(&p_newthread->unit_def.p_keytable, NULL);
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
     if (p_sched && ABTI_unit_type_is_thread_user(unit_type)) {
         /* Set a destructor for p_sched. */
-        ABTI_ktable_set(p_local_xstream, &p_newthread->unit_def.p_keytable,
-                        &g_thread_sched_key, p_sched);
+        ABTI_ktable_set_unsafe(p_local_xstream, &p_keytable,
+                               &g_thread_sched_key, p_sched);
     }
+    ABTD_atomic_relaxed_store_ptr(&p_newthread->unit_def.p_keytable,
+                                  p_keytable);
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
     ABT_unit_id thread_id = ABTI_thread_get_id(p_newthread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -30,6 +30,10 @@ static void key_destructor_stackable_sched(void *p_value);
 static ABTI_key g_thread_sched_key =
     ABTI_KEY_STATIC_INITIALIZER(key_destructor_stackable_sched,
                                 ABTI_KEY_ID_STACKABLE_SCHED);
+static void key_destructor_migration(void *p_value);
+static ABTI_key g_thread_mig_data_key =
+    ABTI_KEY_STATIC_INITIALIZER(key_destructor_migration,
+                                ABTI_KEY_ID_MIGRATION);
 
 /** @defgroup ULT User-level Thread (ULT)
  * This group is for User-level Thread (ULT).
@@ -1136,12 +1140,14 @@ int ABT_thread_set_callback(ABT_thread thread,
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     int abt_errno = ABT_SUCCESS;
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
-    p_thread->f_migration_cb = cb_func;
-    p_thread->p_migration_cb_arg = cb_arg;
-
+    ABTI_thread_mig_data *p_mig_data =
+        ABTI_thread_get_mig_data(p_local_xstream, p_thread);
+    p_mig_data->f_migration_cb = cb_func;
+    p_mig_data->p_migration_cb_arg = cb_arg;
 fn_exit:
     return abt_errno;
 
@@ -1534,8 +1540,16 @@ int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
     thread_attr.migratable =
         (p_thread->unit_def.type & ABTI_UNIT_TYPE_MIGRATABLE) ? ABT_TRUE
                                                               : ABT_FALSE;
-    thread_attr.f_cb = p_thread->f_migration_cb;
-    thread_attr.p_cb_arg = p_thread->p_migration_cb_arg;
+    ABTI_thread_mig_data *p_mig_data =
+        (ABTI_thread_mig_data *)ABTI_ktable_get(&p_thread->unit_def.p_keytable,
+                                                &g_thread_mig_data_key);
+    if (p_mig_data) {
+        thread_attr.f_cb = p_mig_data->f_migration_cb;
+        thread_attr.p_cb_arg = p_mig_data->p_migration_cb_arg;
+    } else {
+        thread_attr.f_cb = NULL;
+        thread_attr.p_cb_arg = NULL;
+    }
 #endif
     p_attr = ABTI_thread_attr_dup(&thread_attr);
 
@@ -1570,8 +1584,6 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         p_newthread = ABTI_mem_alloc_thread_default(p_local_xstream);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
         unit_type |= ABTI_UNIT_TYPE_MIGRATABLE;
-        p_newthread->f_migration_cb = NULL;
-        p_newthread->p_migration_cb_arg = NULL;
 #endif
     } else {
         ABTI_stack_type stacktype = p_attr->stacktype;
@@ -1592,8 +1604,14 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
         }
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
         unit_type |= p_attr->migratable ? ABTI_UNIT_TYPE_MIGRATABLE : 0;
-        p_newthread->f_migration_cb = p_attr->f_cb;
-        p_newthread->p_migration_cb_arg = p_attr->p_cb_arg;
+        if (p_attr->f_cb) {
+            ABTI_thread_mig_data *p_mig_data = (ABTI_thread_mig_data *)
+                ABTU_calloc(1, sizeof(ABTI_thread_mig_data));
+            p_mig_data->f_migration_cb = p_attr->f_cb;
+            p_mig_data->p_migration_cb_arg = p_attr->p_cb_arg;
+            ABTI_ktable_set_unsafe(p_local_xstream, &p_keytable,
+                                   &g_thread_mig_data_key, (void *)p_mig_data);
+        }
 #endif
     }
 
@@ -1631,9 +1649,6 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newthread->unit_def.p_parent = NULL;
     p_newthread->unit_def.p_pool = p_pool;
     p_newthread->unit_def.type = unit_type;
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-    ABTD_atomic_relaxed_store_ptr(&p_newthread->p_migration_pool, NULL);
-#endif
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
     if (p_sched && ABTI_unit_type_is_thread_user(unit_type)) {
         /* Set a destructor for p_sched. */
@@ -1742,7 +1757,11 @@ int ABTI_thread_migrate_to_pool(ABTI_xstream **pp_local_xstream,
      * after ABTI_UNIT_REQ_MIGRATE.  The update must be "atomic" (but does not
      * require acq-rel) since two threads can update the pointer value
      * simultaneously. */
-    ABTD_atomic_relaxed_store_ptr(&p_thread->p_migration_pool, (void *)p_pool);
+    ABTI_thread_mig_data *p_mig_data =
+        ABTI_thread_get_mig_data(p_local_xstream, p_thread);
+    ABTD_atomic_relaxed_store_ptr(&p_mig_data->p_migration_pool,
+                                  (void *)p_pool);
+
     ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
 
     /* yielding if it is the same thread */
@@ -1762,6 +1781,22 @@ fn_fail:
 #else
     return ABT_ERR_MIGRATION_NA;
 #endif
+}
+
+ABTI_thread_mig_data *ABTI_thread_get_mig_data(ABTI_xstream *p_local_xstream,
+                                               ABTI_thread *p_thread)
+{
+    ABTI_thread_mig_data *p_mig_data =
+        (ABTI_thread_mig_data *)ABTI_ktable_get(&p_thread->unit_def.p_keytable,
+                                                &g_thread_mig_data_key);
+    if (!p_mig_data) {
+        p_mig_data =
+            (ABTI_thread_mig_data *)ABTU_calloc(1,
+                                                sizeof(ABTI_thread_mig_data));
+        ABTI_ktable_set(p_local_xstream, &p_thread->unit_def.p_keytable,
+                        &g_thread_mig_data_key, (void *)p_mig_data);
+    }
+    return p_mig_data;
 }
 
 int ABTI_thread_create_main(ABTI_xstream *p_local_xstream,
@@ -2245,6 +2280,12 @@ static void key_destructor_stackable_sched(void *p_value)
         p_sched->p_thread = NULL;
         ABTI_sched_free(ABTI_local_get_xstream_uninlined(), p_sched, ABT_FALSE);
     }
+}
+
+static void key_destructor_migration(void *p_value)
+{
+    ABTI_thread_mig_data *p_mig_data = (ABTI_thread_mig_data *)p_value;
+    ABTU_free(p_mig_data);
 }
 
 static int ABTI_thread_revive(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,

--- a/src/thread.c
+++ b/src/thread.c
@@ -1458,7 +1458,9 @@ int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value)
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
     /* Set the value. */
-    ABTI_unit_set_specific(p_local_xstream, &p_thread->unit_def, p_key, value);
+    ABTI_ktable_set(p_local_xstream, &p_thread->unit_def.p_keytable, p_key,
+                    value);
+
 fn_exit:
     return abt_errno;
 
@@ -1493,7 +1495,7 @@ int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value)
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
     /* Get the value. */
-    *value = ABTI_unit_get_specific(&p_thread->unit_def, p_key);
+    *value = ABTI_ktable_get(&p_thread->unit_def.p_keytable, p_key);
 fn_exit:
     return abt_errno;
 
@@ -1635,8 +1637,8 @@ ABTI_thread_create_internal(ABTI_xstream *p_local_xstream, ABTI_pool *p_pool,
     p_newthread->unit_def.id = ABTI_THREAD_INIT_ID;
     if (p_sched && ABTI_unit_type_is_thread_user(unit_type)) {
         /* Set a destructor for p_sched. */
-        ABTI_unit_set_specific(p_local_xstream, &p_newthread->unit_def,
-                               &g_thread_sched_key, p_sched);
+        ABTI_ktable_set(p_local_xstream, &p_newthread->unit_def.p_keytable,
+                        &g_thread_sched_key, p_sched);
     }
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG


### PR DESCRIPTION
This PR refactors the migration feature. Specifically, this PR removes `f_migration_cb`, `p_migration_cb_arg`, and `p_migration_pool` from `ABTI_pool`. This is mainly for code cleanup.

Note that this PR does not change the functionality but degrades the performance of migration while slightly reducing the overheads of ULTs overall. I believe the migration feature is rarely used and, even if it is used, not performance critical. Nevertheless, if one heavily uses this feature, please let us know so that we can optimize the migration feature.
  