### PR TITLE
rename ABTI_thread, ABTI_task, and ABTI_unit

### DIFF
--- a/maint/template.c
+++ b/maint/template.c
@@ -5,7 +5,7 @@
 
 #include "abti.h"
 
-int ABTI_template(ABTI_thread *p_thread, void *p_arg)
+int ABTI_template(ABTI_ythread *p_thread, void *p_arg)
 {
     int abt_errno = ABT_SUCCESS;
 

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -161,8 +161,8 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
         if (p_local_xstream != NULL) {
-            ABTI_unit *p_self = p_local_xstream->p_unit;
-            ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type),
+            ABTI_thread *p_self = p_local_xstream->p_unit;
+            ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_self->type),
                             ABT_ERR_BARRIER);
             p_thread = ABTI_unit_get_thread(p_self);
             type = ABT_UNIT_TYPE_THREAD;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -34,7 +34,7 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
     p_newbarrier->num_waiters = num_waiters;
     p_newbarrier->counter = 0;
     p_newbarrier->waiters =
-        (ABTI_thread **)ABTU_malloc(num_waiters * sizeof(ABTI_thread *));
+        (ABTI_ythread **)ABTU_malloc(num_waiters * sizeof(ABTI_ythread *));
     p_newbarrier->waiter_type =
         (ABT_unit_type *)ABTU_malloc(num_waiters * sizeof(ABT_unit_type));
 
@@ -76,7 +76,7 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
         ABTU_free(p_barrier->waiters);
         ABTU_free(p_barrier->waiter_type);
         p_barrier->waiters =
-            (ABTI_thread **)ABTU_malloc(num_waiters * sizeof(ABTI_thread *));
+            (ABTI_ythread **)ABTU_malloc(num_waiters * sizeof(ABTI_ythread *));
         p_barrier->waiter_type =
             (ABT_unit_type *)ABTU_malloc(num_waiters * sizeof(ABT_unit_type));
     }
@@ -156,7 +156,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
 
     /* If we do not have all the waiters yet */
     if (p_barrier->counter < p_barrier->num_waiters) {
-        ABTI_thread *p_thread;
+        ABTI_ythread *p_thread;
         ABT_unit_type type;
         ABTD_atomic_int32 ext_signal = ABTD_ATOMIC_INT32_STATIC_INITIALIZER(0);
 
@@ -170,7 +170,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
             /* external thread */
             /* Check size if ext_signal can be stored in p_thread. */
             ABTI_STATIC_ASSERT(sizeof(ext_signal) <= sizeof(p_thread));
-            p_thread = (ABTI_thread *)&ext_signal;
+            p_thread = (ABTI_ythread *)&ext_signal;
             type = ABT_UNIT_TYPE_EXT;
         }
 
@@ -199,7 +199,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         /* Signal all the waiting ULTs */
         int i;
         for (i = 0; i < p_barrier->num_waiters - 1; i++) {
-            ABTI_thread *p_thread = p_barrier->waiters[i];
+            ABTI_ythread *p_thread = p_barrier->waiters[i];
             if (p_barrier->waiter_type[i] == ABT_UNIT_TYPE_THREAD) {
                 ABTI_thread_set_ready(p_local_xstream, p_thread);
             } else {

--- a/src/cond.c
+++ b/src/cond.c
@@ -299,7 +299,7 @@ int ABT_cond_signal(ABT_cond cond)
     p_unit->p_next = NULL;
 
     if (ABTI_unit_type_is_thread(p_unit->type)) {
-        ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
+        ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
         ABTI_thread_set_ready(p_local_xstream, p_thread);
     } else {
         /* When the head is an external thread */

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -111,21 +111,21 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
         ABTI_ythread *p_current;
-        ABTI_unit *p_unit;
+        ABTI_thread *p_unit;
 
         if (p_local_xstream != NULL) {
             p_unit = p_local_xstream->p_unit;
-            ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_unit->type),
+            ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_unit->type),
                             ABT_ERR_EVENTUAL);
             p_current = ABTI_unit_get_thread(p_unit);
         } else {
             /* external thread */
             p_current = NULL;
-            p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-            p_unit->type = ABTI_UNIT_TYPE_EXT;
+            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
+            p_unit->type = ABTI_THREAD_TYPE_EXT;
             /* use state for synchronization */
             ABTD_atomic_relaxed_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_BLOCKED);
+                                          ABTI_THREAD_STATE_BLOCKED);
         }
 
         p_unit->p_next = NULL;
@@ -152,7 +152,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
             /* External thread is waiting here. */
             while (ABTD_atomic_acquire_load_int(&p_unit->state) !=
-                   ABTI_UNIT_STATE_READY)
+                   ABTI_THREAD_STATE_READY)
                 ;
             ABTU_free(p_unit);
         }
@@ -247,19 +247,19 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     }
 
     /* Wake up all waiting ULTs */
-    ABTI_unit *p_head = p_eventual->p_head;
-    ABTI_unit *p_unit = p_head;
+    ABTI_thread *p_head = p_eventual->p_head;
+    ABTI_thread *p_unit = p_head;
     while (1) {
-        ABTI_unit *p_next = p_unit->p_next;
+        ABTI_thread *p_next = p_unit->p_next;
         p_unit->p_next = NULL;
 
-        if (ABTI_unit_type_is_thread(p_unit->type)) {
+        if (ABTI_thread_type_is_thread(p_unit->type)) {
             ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
             ABTI_thread_set_ready(p_local_xstream, p_thread);
         } else {
             /* When the head is an external thread */
             ABTD_atomic_release_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_READY);
+                                          ABTI_THREAD_STATE_READY);
         }
 
         /* Next ULT */

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -110,7 +110,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
 
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
-        ABTI_thread *p_current;
+        ABTI_ythread *p_current;
         ABTI_unit *p_unit;
 
         if (p_local_xstream != NULL) {
@@ -254,7 +254,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
         p_unit->p_next = NULL;
 
         if (ABTI_unit_type_is_thread(p_unit->type)) {
-            ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
+            ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
             ABTI_thread_set_ready(p_local_xstream, p_thread);
         } else {
             /* When the head is an external thread */

--- a/src/futures.c
+++ b/src/futures.c
@@ -135,12 +135,12 @@ int ABT_future_wait(ABT_future future)
     if (ABTD_atomic_relaxed_load_uint32(&p_future->counter) <
         p_future->compartments) {
         ABTI_ythread *p_current;
-        ABTI_unit *p_unit;
+        ABTI_thread *p_unit;
 
         if (p_local_xstream != NULL) {
             p_unit = p_local_xstream->p_unit;
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-            if (!ABTI_unit_type_is_thread(p_unit->type)) {
+            if (!ABTI_thread_type_is_thread(p_unit->type)) {
                 abt_errno = ABT_ERR_FUTURE;
                 ABTI_spinlock_release(&p_future->lock);
                 goto fn_fail;
@@ -150,11 +150,11 @@ int ABT_future_wait(ABT_future future)
         } else {
             /* external thread */
             p_current = NULL;
-            p_unit = (ABTI_unit *)ABTU_calloc(1, sizeof(ABTI_unit));
-            p_unit->type = ABTI_UNIT_TYPE_EXT;
+            p_unit = (ABTI_thread *)ABTU_calloc(1, sizeof(ABTI_thread));
+            p_unit->type = ABTI_THREAD_TYPE_EXT;
             /* use state for synchronization */
             ABTD_atomic_relaxed_store_int(&p_unit->state,
-                                          ABTI_UNIT_STATE_BLOCKED);
+                                          ABTI_THREAD_STATE_BLOCKED);
         }
 
         p_unit->p_next = NULL;
@@ -180,7 +180,7 @@ int ABT_future_wait(ABT_future future)
 
             /* External thread is waiting here. */
             while (ABTD_atomic_acquire_load_int(&p_unit->state) !=
-                   ABTI_UNIT_STATE_READY)
+                   ABTI_THREAD_STATE_READY)
                 ;
             ABTU_free(p_unit);
         }
@@ -273,19 +273,19 @@ int ABT_future_set(ABT_future future, void *value)
         }
 
         /* Wake up all waiting ULTs */
-        ABTI_unit *p_head = p_future->p_head;
-        ABTI_unit *p_unit = p_head;
+        ABTI_thread *p_head = p_future->p_head;
+        ABTI_thread *p_unit = p_head;
         while (1) {
-            ABTI_unit *p_next = p_unit->p_next;
+            ABTI_thread *p_next = p_unit->p_next;
             p_unit->p_next = NULL;
 
-            if (ABTI_unit_type_is_thread(p_unit->type)) {
+            if (ABTI_thread_type_is_thread(p_unit->type)) {
                 ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
                 ABTI_thread_set_ready(p_local_xstream, p_thread);
             } else {
                 /* When the head is an external thread */
                 ABTD_atomic_release_store_int(&p_unit->state,
-                                              ABTI_UNIT_STATE_READY);
+                                              ABTI_THREAD_STATE_READY);
             }
 
             /* Next ULT */

--- a/src/futures.c
+++ b/src/futures.c
@@ -134,7 +134,7 @@ int ABT_future_wait(ABT_future future)
     ABTI_spinlock_acquire(&p_future->lock);
     if (ABTD_atomic_relaxed_load_uint32(&p_future->counter) <
         p_future->compartments) {
-        ABTI_thread *p_current;
+        ABTI_ythread *p_current;
         ABTI_unit *p_unit;
 
         if (p_local_xstream != NULL) {
@@ -280,7 +280,7 @@ int ABT_future_set(ABT_future future, void *value)
             p_unit->p_next = NULL;
 
             if (ABTI_unit_type_is_thread(p_unit->type)) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
+                ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
                 ABTI_thread_set_ready(p_local_xstream, p_thread);
             } else {
                 /* When the head is an external thread */

--- a/src/global.c
+++ b/src/global.c
@@ -98,7 +98,7 @@ int ABT_init(int argc, char **argv)
     ABTI_local_set_xstream(p_local_xstream);
 
     /* Create the primary ULT, i.e., the main thread */
-    ABTI_thread *p_main_thread;
+    ABTI_ythread *p_main_thread;
     abt_errno = ABTI_thread_create_main(p_local_xstream, p_local_xstream,
                                         &p_main_thread);
     /* Set as if p_local_xstream is currently running the main thread. */
@@ -174,7 +174,7 @@ int ABT_finalize(void)
     ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_main(p_self->type),
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");
-    ABTI_thread *p_thread = ABTI_unit_get_thread(p_self);
+    ABTI_ythread *p_thread = ABTI_unit_get_thread(p_self);
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
     /* Turns off the tool interface */

--- a/src/global.c
+++ b/src/global.c
@@ -102,12 +102,12 @@ int ABT_init(int argc, char **argv)
     abt_errno = ABTI_thread_create_main(p_local_xstream, p_local_xstream,
                                         &p_main_thread);
     /* Set as if p_local_xstream is currently running the main thread. */
-    ABTD_atomic_relaxed_store_int(&p_main_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_RUNNING);
-    p_main_thread->unit_def.p_last_xstream = p_local_xstream;
+    ABTD_atomic_relaxed_store_int(&p_main_thread->thread.state,
+                                  ABTI_THREAD_STATE_RUNNING);
+    p_main_thread->thread.p_last_xstream = p_local_xstream;
     ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_thread_create_main");
     gp_ABTI_global->p_thread_main = p_main_thread;
-    p_local_xstream->p_unit = &p_main_thread->unit_def;
+    p_local_xstream->p_unit = &p_main_thread->thread;
 
     /* Start the primary ES */
     abt_errno = ABTI_xstream_start_primary(&p_local_xstream, p_local_xstream,
@@ -170,8 +170,8 @@ int ABT_finalize(void)
                         ABT_ERR_INV_XSTREAM,
                         "ABT_finalize must be called by the primary ES.");
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_CHECK_TRUE_MSG(ABTI_unit_type_is_thread_main(p_self->type),
+    ABTI_thread *p_self = p_local_xstream->p_unit;
+    ABTI_CHECK_TRUE_MSG(ABTI_thread_type_is_thread_main(p_self->type),
                         ABT_ERR_INV_THREAD,
                         "ABT_finalize must be called by the primary ULT.");
     ABTI_ythread *p_thread = ABTI_unit_get_thread(p_self);
@@ -190,11 +190,11 @@ int ABT_finalize(void)
     if (ABTD_atomic_acquire_load_int(&p_local_xstream->state) !=
         ABT_XSTREAM_STATE_TERMINATED) {
         /* Set the orphan request for the primary ULT */
-        ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_ORPHAN);
+        ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
 
         LOG_DEBUG("[U%" PRIu64 ":E%d] yield to scheduler\n",
                   ABTI_thread_get_id(p_thread),
-                  p_thread->unit_def.p_last_xstream->rank);
+                  p_thread->thread.p_last_xstream->rank);
 
         /* Switch to the parent */
         ABTI_thread_context_switch_to_parent(&p_local_xstream, p_thread,
@@ -204,7 +204,7 @@ int ABT_finalize(void)
         /* Back to the original thread */
         LOG_DEBUG("[U%" PRIu64 ":E%d] resume after yield\n",
                   ABTI_thread_get_id(p_thread),
-                  p_thread->unit_def.p_last_xstream->rank);
+                  p_thread->thread.p_last_xstream->rank);
     }
 
     /* Remove the primary ULT */

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -77,8 +77,8 @@ void ABTD_affinity_list_free(ABTD_affinity_list *p_list);
 
 /* ULT Context */
 #include "abtd_thread.h"
-void ABTD_thread_exit(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread);
-void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_thread *p_thread);
+void ABTD_thread_exit(ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread);
+void ABTD_thread_cancel(ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread);
 
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
 #include <time.h>

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -68,7 +68,7 @@ static void ABTD_thread_context_init_and_call(ABTD_thread_context *p_ctx,
                                               void *arg);
 #endif
 
-void ABTD_thread_print_context(ABTI_thread *p_thread, FILE *p_os, int indent);
+void ABTD_thread_print_context(ABTI_ythread *p_thread, FILE *p_os, int indent);
 
 #ifdef ABT_CONFIG_USE_FCONTEXT
 #include "abtd_fcontext.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -30,19 +30,19 @@
 #define ABTI_SCHED_REQ_FINISH (1 << 0)
 #define ABTI_SCHED_REQ_EXIT (1 << 1)
 
-#define ABTI_UNIT_REQ_JOIN (1 << 0)
-#define ABTI_UNIT_REQ_EXIT (1 << 1)
-#define ABTI_UNIT_REQ_CANCEL (1 << 2)
-#define ABTI_UNIT_REQ_MIGRATE (1 << 3)
-#define ABTI_UNIT_REQ_TERMINATE (1 << 4)
-#define ABTI_UNIT_REQ_BLOCK (1 << 5)
-#define ABTI_UNIT_REQ_ORPHAN (1 << 6)
-#define ABTI_UNIT_REQ_NOPUSH (1 << 7)
-#define ABTI_UNIT_REQ_STOP (ABTI_UNIT_REQ_EXIT | ABTI_UNIT_REQ_TERMINATE)
-#define ABTI_UNIT_REQ_NON_YIELD                                                \
-    (ABTI_UNIT_REQ_EXIT | ABTI_UNIT_REQ_CANCEL | ABTI_UNIT_REQ_MIGRATE |       \
-     ABTI_UNIT_REQ_TERMINATE | ABTI_UNIT_REQ_BLOCK | ABTI_UNIT_REQ_ORPHAN |    \
-     ABTI_UNIT_REQ_NOPUSH)
+#define ABTI_THREAD_REQ_JOIN (1 << 0)
+#define ABTI_THREAD_REQ_EXIT (1 << 1)
+#define ABTI_THREAD_REQ_CANCEL (1 << 2)
+#define ABTI_THREAD_REQ_MIGRATE (1 << 3)
+#define ABTI_THREAD_REQ_TERMINATE (1 << 4)
+#define ABTI_THREAD_REQ_BLOCK (1 << 5)
+#define ABTI_THREAD_REQ_ORPHAN (1 << 6)
+#define ABTI_THREAD_REQ_NOPUSH (1 << 7)
+#define ABTI_THREAD_REQ_STOP (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_TERMINATE)
+#define ABTI_THREAD_REQ_NON_YIELD                                              \
+    (ABTI_THREAD_REQ_EXIT | ABTI_THREAD_REQ_CANCEL | ABTI_THREAD_REQ_MIGRATE | \
+     ABTI_THREAD_REQ_TERMINATE | ABTI_THREAD_REQ_BLOCK |                       \
+     ABTI_THREAD_REQ_ORPHAN | ABTI_THREAD_REQ_NOPUSH)
 
 #define ABTI_THREAD_INIT_ID 0xFFFFFFFFFFFFFFFF
 #define ABTI_TASK_INIT_ID 0xFFFFFFFFFFFFFFFF
@@ -67,26 +67,26 @@ enum ABTI_sched_used {
  * 2 - 5 : USER/MAIN/MAIN_SCHED
  * 5 - 5 : NAMED
  * 6 - 6 : MIGRATABLE */
-#define ABTI_UNIT_TYPE_TASK ((ABTI_unit_type)0x0)
-#define ABTI_UNIT_TYPE_THREAD ((ABTI_unit_type)0x1)
-#define ABTI_UNIT_TYPE_EXT ((ABTI_unit_type)0x2)
-#define ABTI_UNIT_TYPE_THREAD_TYPE_USER ((ABTI_unit_type)(0x1 << 2))
-#define ABTI_UNIT_TYPE_THREAD_TYPE_MAIN ((ABTI_unit_type)(0x1 << 3))
-#define ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED ((ABTI_unit_type)(0x1 << 4))
-#define ABTI_UNIT_TYPE_THREAD_USER                                             \
-    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_USER)
-#define ABTI_UNIT_TYPE_THREAD_MAIN                                             \
-    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_MAIN)
-#define ABTI_UNIT_TYPE_THREAD_MAIN_SCHED                                       \
-    (ABTI_UNIT_TYPE_THREAD + ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED)
-#define ABTI_UNIT_TYPE_NAMED ((ABTI_unit_type)(0x1 << 5))
-#define ABTI_UNIT_TYPE_MIGRATABLE ((ABTI_unit_type)(0x1 << 6))
+#define ABTI_THREAD_TYPE_TASK ((ABTI_thread_type)0x0)
+#define ABTI_THREAD_TYPE_THREAD ((ABTI_thread_type)0x1)
+#define ABTI_THREAD_TYPE_EXT ((ABTI_thread_type)0x2)
+#define ABTI_THREAD_TYPE_THREAD_TYPE_USER ((ABTI_thread_type)(0x1 << 2))
+#define ABTI_THREAD_TYPE_THREAD_TYPE_MAIN ((ABTI_thread_type)(0x1 << 3))
+#define ABTI_THREAD_TYPE_THREAD_TYPE_MAIN_SCHED ((ABTI_thread_type)(0x1 << 4))
+#define ABTI_THREAD_TYPE_THREAD_USER                                           \
+    (ABTI_THREAD_TYPE_THREAD + ABTI_THREAD_TYPE_THREAD_TYPE_USER)
+#define ABTI_THREAD_TYPE_THREAD_MAIN                                           \
+    (ABTI_THREAD_TYPE_THREAD + ABTI_THREAD_TYPE_THREAD_TYPE_MAIN)
+#define ABTI_THREAD_TYPE_THREAD_MAIN_SCHED                                     \
+    (ABTI_THREAD_TYPE_THREAD + ABTI_THREAD_TYPE_THREAD_TYPE_MAIN_SCHED)
+#define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 5))
+#define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 6))
 
-enum ABTI_unit_state {
-    ABTI_UNIT_STATE_READY,
-    ABTI_UNIT_STATE_RUNNING,
-    ABTI_UNIT_STATE_BLOCKED,
-    ABTI_UNIT_STATE_TERMINATED,
+enum ABTI_thread_state {
+    ABTI_THREAD_STATE_READY,
+    ABTI_THREAD_STATE_RUNNING,
+    ABTI_THREAD_STATE_BLOCKED,
+    ABTI_THREAD_STATE_TERMINATED,
 };
 
 enum ABTI_mutex_attr_val {
@@ -115,14 +115,13 @@ typedef enum ABTI_sched_used ABTI_sched_used;
 typedef void *ABTI_sched_id;       /* Scheduler id */
 typedef uintptr_t ABTI_sched_kind; /* Scheduler kind */
 typedef struct ABTI_pool ABTI_pool;
-typedef struct ABTI_unit ABTI_unit;
-typedef ABTI_unit ABTI_task;
+typedef struct ABTI_thread ABTI_thread;
 typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_ythread ABTI_ythread;
 typedef struct ABTI_thread_mig_data ABTI_thread_mig_data;
 typedef enum ABTI_stack_type ABTI_stack_type;
-typedef uint32_t ABTI_unit_type;
-typedef enum ABTI_unit_state ABTI_unit_state;
+typedef uint32_t ABTI_thread_type;
+typedef enum ABTI_thread_state ABTI_thread_state;
 typedef struct ABTI_thread_htable ABTI_thread_htable;
 typedef struct ABTI_thread_queue ABTI_thread_queue;
 typedef struct ABTI_key ABTI_key;
@@ -144,8 +143,8 @@ typedef struct ABTI_tool_context ABTI_tool_context;
 struct ABTI_native_thread_id_opaque;
 typedef struct ABTI_native_thread_id_opaque *ABTI_native_thread_id;
 /* ID associated with work unit (i.e., ULTs, tasklets, and external threads) */
-struct ABTI_unit_id_opaque;
-typedef struct ABTI_unit_id_opaque *ABTI_unit_id;
+struct ABTI_thread_id_opaque;
+typedef struct ABTI_thread_id_opaque *ABTI_thread_id;
 
 /* Architecture-Dependent Definitions */
 #include "abtd.h"
@@ -160,11 +159,11 @@ typedef struct ABTI_spinlock ABTI_spinlock;
 
 /* Definitions */
 struct ABTI_mutex_attr {
-    uint32_t attrs;         /* bit-or'ed attributes */
-    uint32_t nesting_cnt;   /* nesting count */
-    ABTI_unit_id owner_id;  /* owner's ID */
-    uint32_t max_handovers; /* max. # of handovers */
-    uint32_t max_wakeups;   /* max. # of wakeups */
+    uint32_t attrs;          /* bit-or'ed attributes */
+    uint32_t nesting_cnt;    /* nesting count */
+    ABTI_thread_id owner_id; /* owner's ID */
+    uint32_t max_handovers;  /* max. # of handovers */
+    uint32_t max_wakeups;    /* max. # of wakeups */
 };
 
 struct ABTI_mutex {
@@ -254,7 +253,7 @@ struct ABTI_xstream {
     ABTD_xstream_context ctx; /* ES context */
 
     ABTU_align_member_var(ABT_CONFIG_STATIC_CACHELINE_SIZE)
-        ABTI_unit *p_unit; /* Current running ULT/tasklet */
+        ABTI_thread *p_unit; /* Current running ULT/tasklet */
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
     ABTI_mem_pool_local_pool mem_pool_stack;
@@ -321,17 +320,17 @@ struct ABTI_pool {
     ABT_pool_print_all_fn p_print_all;
 };
 
-struct ABTI_unit {
-    ABTI_unit *p_prev;
-    ABTI_unit *p_next;
+struct ABTI_thread {
+    ABTI_thread *p_prev;
+    ABTI_thread *p_next;
     ABTD_atomic_int is_in_pool;   /* Whether this thread is in a pool. */
-    ABTI_unit_type type;          /* Unit type */
+    ABTI_thread_type type;        /* Unit type */
     ABT_unit unit;                /* Unit enclosing this thread */
     ABTI_xstream *p_last_xstream; /* Last ES where it ran */
-    ABTI_unit *p_parent;          /* Parent thread */
-    void (*f_unit)(void *);       /* Thread function */
+    ABTI_thread *p_parent;        /* Parent thread */
+    void (*f_thread)(void *);     /* Thread function */
     void *p_arg;                  /* Thread function argument */
-    ABTD_atomic_int state;        /* State (ABTI_unit_state) */
+    ABTD_atomic_int state;        /* State (ABTI_thread_state) */
     ABTD_atomic_uint32 request;   /* Request */
     ABTI_pool *p_pool;            /* Associated pool */
     ABTD_atomic_ptr p_keytable;   /* Work unit-specific data (ABTI_ktable *) */
@@ -358,7 +357,7 @@ struct ABTI_thread_mig_data {
 
 struct ABTI_ythread {
     ABTD_thread_context ctx;   /* Context */
-    ABTI_unit unit_def;        /* Internal unit definition */
+    ABTI_thread thread;        /* Common thread definition */
     void *p_stack;             /* Stack address */
     size_t stacksize;          /* Stack size (in bytes) */
     ABTI_stack_type stacktype; /* Stack type */
@@ -390,8 +389,8 @@ struct ABTI_cond {
     ABTI_spinlock lock;
     ABTI_mutex *p_waiter_mutex;
     size_t num_waiters;
-    ABTI_unit *p_head; /* Head of waiters */
-    ABTI_unit *p_tail; /* Tail of waiters */
+    ABTI_thread *p_head; /* Head of waiters */
+    ABTI_thread *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_rwlock {
@@ -406,8 +405,8 @@ struct ABTI_eventual {
     ABT_bool ready;
     void *value;
     int nbytes;
-    ABTI_unit *p_head; /* Head of waiters */
-    ABTI_unit *p_tail; /* Tail of waiters */
+    ABTI_thread *p_head; /* Head of waiters */
+    ABTI_thread *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_future {
@@ -416,8 +415,8 @@ struct ABTI_future {
     uint32_t compartments;
     void **array;
     void (*p_callback)(void **arg);
-    ABTI_unit *p_head; /* Head of waiters */
-    ABTI_unit *p_tail; /* Tail of waiters */
+    ABTI_thread *p_head; /* Head of waiters */
+    ABTI_thread *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_barrier {
@@ -435,9 +434,10 @@ struct ABTI_timer {
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
 struct ABTI_tool_context {
-    ABTI_unit *p_caller;
+    ABTI_thread *p_caller;
     ABTI_pool *p_pool;
-    ABTI_unit *p_parent; /* Parent of the target unit.  Used to get the depth */
+    ABTI_thread
+        *p_parent; /* Parent of the target unit.  Used to get the depth */
     ABT_sync_event_type sync_event_type;
     void *p_sync_object; /* ABTI type */
 };
@@ -468,7 +468,7 @@ int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
 int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
                                  ABTI_ythread *p_thread);
 void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
-                                ABTI_task *p_task);
+                                ABTI_thread *p_task);
 int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
                                 ABTI_ythread *p_thread);
 int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
@@ -598,10 +598,10 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
                                        void *p_sync);
 
 /* Tasklet */
-void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_task *p_task);
-void ABTI_task_print(ABTI_task *p_task, FILE *p_os, int indent);
+void ABTI_task_free(ABTI_xstream *p_local_xstream, ABTI_thread *p_task);
+void ABTI_task_print(ABTI_thread *p_task, FILE *p_os, int indent);
 void ABTI_task_reset_id(void);
-ABT_unit_id ABTI_task_get_id(ABTI_task *p_task);
+ABT_unit_id ABTI_task_get_id(ABTI_thread *p_task);
 
 /* Key */
 void ABTI_ktable_free(ABTI_xstream *p_local_xstream, ABTI_ktable *p_ktable);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -124,7 +124,7 @@ typedef uint32_t ABTI_unit_type;
 typedef enum ABTI_unit_state ABTI_unit_state;
 typedef struct ABTI_thread_htable ABTI_thread_htable;
 typedef struct ABTI_thread_queue ABTI_thread_queue;
-typedef struct ABTI_task ABTI_task;
+typedef ABTI_unit ABTI_task;
 typedef struct ABTI_key ABTI_key;
 typedef struct ABTI_ktelem ABTI_ktelem;
 typedef struct ABTI_ktable ABTI_ktable;
@@ -362,10 +362,6 @@ struct ABTI_thread {
     void *p_stack;             /* Stack address */
     size_t stacksize;          /* Stack size (in bytes) */
     ABTI_stack_type stacktype; /* Stack type */
-};
-
-struct ABTI_task {
-    ABTI_unit unit_def; /* Internal unit definition */
 };
 
 struct ABTI_key {

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -63,7 +63,7 @@ static inline int ABTI_cond_wait(ABTI_xstream **pp_local_xstream,
     int abt_errno = ABT_SUCCESS;
 
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    ABTI_thread *p_thread;
+    ABTI_ythread *p_thread;
     ABTI_unit *p_unit;
 
     if (p_local_xstream != NULL) {
@@ -166,7 +166,7 @@ static inline void ABTI_cond_broadcast(ABTI_xstream *p_local_xstream,
         p_unit->p_next = NULL;
 
         if (ABTI_unit_type_is_thread(p_unit->type)) {
-            ABTI_thread *p_thread = ABTI_unit_get_thread(p_unit);
+            ABTI_ythread *p_thread = ABTI_unit_get_thread(p_unit);
             ABTI_thread_set_ready(p_local_xstream, p_thread);
         } else {
             /* When the head is an external thread */

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -108,7 +108,7 @@
 
 #define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_ythread *)NULL) {        \
             abt_errno = ABT_ERR_INV_THREAD;                                    \
             goto fn_fail;                                                      \
         }                                                                      \

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -124,7 +124,7 @@
 
 #define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_task *)NULL) {           \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
             abt_errno = ABT_ERR_INV_TASK;                                      \
             goto fn_fail;                                                      \
         }                                                                      \

--- a/src/include/abti_global.h
+++ b/src/include/abti_global.h
@@ -28,7 +28,7 @@ static inline long ABTI_global_get_sched_sleep_nsec(void)
     return gp_ABTI_global->sched_sleep_nsec;
 }
 
-static inline ABTI_thread *ABTI_global_get_main(void)
+static inline ABTI_ythread *ABTI_global_get_main(void)
 {
     return gp_ABTI_global->p_thread_main;
 }

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -12,7 +12,7 @@
  * used to determine whether the descriptor is allocated externally (i.e.,
  * malloc()) or taken from a memory pool. */
 #define ABTI_MEM_POOL_DESC_SIZE                                                \
-    (((sizeof(ABTI_task) + 4 + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &         \
+    (((sizeof(ABTI_thread) + 4 + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &       \
       (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1))) -                             \
      4)
 
@@ -232,13 +232,13 @@ static inline void ABTI_mem_free_desc(ABTI_xstream *p_local_xstream,
 #endif
 }
 
-static inline ABTI_task *ABTI_mem_alloc_task(ABTI_xstream *p_local_xstream)
+static inline ABTI_thread *ABTI_mem_alloc_task(ABTI_xstream *p_local_xstream)
 {
-    return (ABTI_task *)ABTI_mem_alloc_desc(p_local_xstream);
+    return (ABTI_thread *)ABTI_mem_alloc_desc(p_local_xstream);
 }
 
 static inline void ABTI_mem_free_task(ABTI_xstream *p_local_xstream,
-                                      ABTI_task *p_task)
+                                      ABTI_thread *p_task)
 {
     ABTI_mem_free_desc(p_local_xstream, (void *)p_task);
 }

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -107,14 +107,14 @@ static inline void ABTI_mutex_lock(ABTI_xstream **pp_local_xstream,
                  * other ULT on the same ES, we don't need to change the mutex
                  * state. */
                 if (p_mutex->p_handover) {
-                    ABTI_thread *p_self =
+                    ABTI_ythread *p_self =
                         ABTI_unit_get_thread((*pp_local_xstream)->p_unit);
                     if (p_self == p_mutex->p_handover) {
                         p_mutex->p_handover = NULL;
                         ABTD_atomic_release_store_uint32(&p_mutex->val, 2);
 
                         /* Push the previous ULT to its pool */
-                        ABTI_thread *p_giver = p_mutex->p_giver;
+                        ABTI_ythread *p_giver = p_mutex->p_giver;
                         ABTD_atomic_release_store_int(&p_giver->unit_def.state,
                                                       ABTI_UNIT_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->unit_def.p_pool,

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -73,7 +73,7 @@ static inline void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
     p_pool->p_push(ABTI_pool_get_handle(p_pool), unit);
 }
 
-static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
+static inline void ABTI_pool_add_thread(ABTI_ythread *p_thread)
 {
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
@@ -113,7 +113,7 @@ fn_fail:
     goto fn_exit;
 }
 
-static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
+static inline int ABTI_pool_add_thread(ABTI_ythread *p_thread,
                                        ABTI_native_thread_id producer_id)
 {
     int abt_errno;

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -77,11 +77,11 @@ static inline void ABTI_pool_add_thread(ABTI_ythread *p_thread)
 {
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->thread.state,
+                                  ABTI_THREAD_STATE_READY);
 
     /* Add the ULT to the associated pool */
-    ABTI_pool_push(p_thread->unit_def.p_pool, p_thread->unit_def.unit);
+    ABTI_pool_push(p_thread->thread.p_pool, p_thread->thread.unit);
 }
 
 #define ABTI_POOL_PUSH(p_pool, unit, p_producer) ABTI_pool_push(p_pool, unit)
@@ -120,12 +120,12 @@ static inline int ABTI_pool_add_thread(ABTI_ythread *p_thread,
 
     /* Set the ULT's state as READY. The relaxed version is used since the state
      * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_READY);
+    ABTD_atomic_relaxed_store_int(&p_thread->thread.state,
+                                  ABTI_THREAD_STATE_READY);
 
     /* Add the ULT to the associated pool */
-    abt_errno = ABTI_pool_push(p_thread->unit_def.p_pool,
-                               p_thread->unit_def.unit, producer_id);
+    abt_errno = ABTI_pool_push(p_thread->thread.p_pool, p_thread->thread.unit,
+                               producer_id);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:

--- a/src/include/abti_self.h
+++ b/src/include/abti_self.h
@@ -20,27 +20,28 @@ ABTI_self_get_native_thread_id(ABTI_xstream *p_local_xstream)
     return (ABTI_native_thread_id)p_local_xstream;
 }
 
-static inline ABTI_unit_id ABTI_self_get_unit_id(ABTI_xstream *p_local_xstream)
+static inline ABTI_thread_id
+ABTI_self_get_unit_id(ABTI_xstream *p_local_xstream)
 {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (p_local_xstream == NULL) {
         /* A pointer to a thread local variable is unique to an external thread
          * and its value is different from pointers to ULTs and tasks. */
-        return (ABTI_unit_id)ABTI_local_get_local_ptr();
+        return (ABTI_thread_id)ABTI_local_get_local_ptr();
     }
 #endif
-    return (ABTI_unit_id)p_local_xstream->p_unit;
+    return (ABTI_thread_id)p_local_xstream->p_unit;
 }
 
-static inline ABTI_unit_type ABTI_self_get_type(ABTI_xstream *p_local_xstream)
+static inline ABTI_thread_type ABTI_self_get_type(ABTI_xstream *p_local_xstream)
 {
     ABTI_ASSERT(gp_ABTI_global);
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (p_local_xstream == NULL) {
-        return ABTI_UNIT_TYPE_EXT;
+        return ABTI_THREAD_TYPE_EXT;
     }
 #endif
     if (p_local_xstream->p_unit) {
@@ -49,7 +50,7 @@ static inline ABTI_unit_type ABTI_self_get_type(ABTI_xstream *p_local_xstream)
         /* Since p_local_xstream->p_thread can return NULL during executing
          * ABTI_init(), it should always be safe to say that the type of caller
          * is ULT if the control reaches here. */
-        return ABTI_UNIT_TYPE_THREAD_MAIN;
+        return ABTI_THREAD_TYPE_THREAD_MAIN;
     }
 }
 

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -58,7 +58,7 @@ static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 }
 
 static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
-                                                 ABTI_thread *p_thread)
+                                                 ABTI_ythread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
               p_thread->unit_def.p_last_xstream->rank);

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -61,29 +61,29 @@ static inline void ABTI_xstream_terminate_thread(ABTI_xstream *p_local_xstream,
                                                  ABTI_ythread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
-    if (!(p_thread->unit_def.type & ABTI_UNIT_TYPE_NAMED)) {
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+              p_thread->thread.p_last_xstream->rank);
+    if (!(p_thread->thread.type & ABTI_THREAD_TYPE_NAMED)) {
+        ABTD_atomic_release_store_int(&p_thread->thread.state,
+                                      ABTI_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_local_xstream, p_thread);
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
          * because the ULT can be freed on a different ES.  In other words, we
          * must not access any field of p_thead after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+        ABTD_atomic_release_store_int(&p_thread->thread.state,
+                                      ABTI_THREAD_STATE_TERMINATED);
     }
 }
 
 static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
-                                               ABTI_task *p_task)
+                                               ABTI_thread *p_task)
 {
     LOG_DEBUG("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
               p_task->p_last_xstream->rank);
-    if (!(p_task->type & ABTI_UNIT_TYPE_NAMED)) {
+    if (!(p_task->type & ABTI_THREAD_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_task->state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+                                      ABTI_THREAD_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
     } else {
         /* NOTE: We set the task's state as TERMINATED after checking refcount
@@ -91,7 +91,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
         ABTD_atomic_release_store_int(&p_task->state,
-                                      ABTI_UNIT_STATE_TERMINATED);
+                                      ABTI_THREAD_STATE_TERMINATED);
     }
 }
 

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -80,9 +80,9 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
                                                ABTI_task *p_task)
 {
     LOG_DEBUG("[T%" PRIu64 ":E%d] terminated\n", ABTI_task_get_id(p_task),
-              p_task->unit_def.p_last_xstream->rank);
-    if (!(p_task->unit_def.type & ABTI_UNIT_TYPE_NAMED)) {
-        ABTD_atomic_release_store_int(&p_task->unit_def.state,
+              p_task->p_last_xstream->rank);
+    if (!(p_task->type & ABTI_UNIT_TYPE_NAMED)) {
+        ABTD_atomic_release_store_int(&p_task->state,
                                       ABTI_UNIT_STATE_TERMINATED);
         ABTI_task_free(p_local_xstream, p_task);
     } else {
@@ -90,7 +90,7 @@ static inline void ABTI_xstream_terminate_task(ABTI_xstream *p_local_xstream,
          * because the task can be freed on a different ES.  In other words, we
          * must not access any field of p_task after changing the state to
          * TERMINATED. */
-        ABTD_atomic_release_store_int(&p_task->unit_def.state,
+        ABTD_atomic_release_store_int(&p_task->state,
                                       ABTI_UNIT_STATE_TERMINATED);
     }
 }

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -8,22 +8,22 @@
 
 /* Inlined functions for Tasklet  */
 
-static inline ABTI_task *ABTI_task_get_ptr(ABT_task task)
+static inline ABTI_thread *ABTI_task_get_ptr(ABT_task task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-    ABTI_task *p_task;
+    ABTI_thread *p_task;
     if (task == ABT_TASK_NULL) {
         p_task = NULL;
     } else {
-        p_task = (ABTI_task *)task;
+        p_task = (ABTI_thread *)task;
     }
     return p_task;
 #else
-    return (ABTI_task *)task;
+    return (ABTI_thread *)task;
 #endif
 }
 
-static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
+static inline ABT_task ABTI_task_get_handle(ABTI_thread *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_task h_task;
@@ -38,12 +38,12 @@ static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 #endif
 }
 
-static inline void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_set_request(ABTI_thread *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_task->request, req);
 }
 
-static inline void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
+static inline void ABTI_task_unset_request(ABTI_thread *p_task, uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }

--- a/src/include/abti_task.h
+++ b/src/include/abti_task.h
@@ -40,12 +40,12 @@ static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task)
 
 static inline void ABTI_task_set_request(ABTI_task *p_task, uint32_t req)
 {
-    ABTD_atomic_fetch_or_uint32(&p_task->unit_def.request, req);
+    ABTD_atomic_fetch_or_uint32(&p_task->request, req);
 }
 
 static inline void ABTI_task_unset_request(ABTI_task *p_task, uint32_t req)
 {
-    ABTD_atomic_fetch_and_uint32(&p_task->unit_def.request, ~req);
+    ABTD_atomic_fetch_and_uint32(&p_task->request, ~req);
 }
 
 #endif /* ABTI_TASK_H_INCLUDED */

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -8,22 +8,22 @@
 
 /* Inlined functions for User-level Thread (ULT) */
 
-static inline ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
+static inline ABTI_ythread *ABTI_thread_get_ptr(ABT_thread thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
-    ABTI_thread *p_thread;
+    ABTI_ythread *p_thread;
     if (thread == ABT_THREAD_NULL) {
         p_thread = NULL;
     } else {
-        p_thread = (ABTI_thread *)thread;
+        p_thread = (ABTI_ythread *)thread;
     }
     return p_thread;
 #else
-    return (ABTI_thread *)thread;
+    return (ABTI_ythread *)thread;
 #endif
 }
 
-static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
+static inline ABT_thread ABTI_thread_get_handle(ABTI_ythread *p_thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABT_thread h_thread;
@@ -38,14 +38,14 @@ static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread)
 #endif
 }
 
-static inline ABTI_thread *
+static inline ABTI_ythread *
 ABTI_thread_context_get_thread(ABTD_thread_context *p_ctx)
 {
-    return (ABTI_thread *)(((char *)p_ctx) - offsetof(ABTI_thread, ctx));
+    return (ABTI_ythread *)(((char *)p_ctx) - offsetof(ABTI_ythread, ctx));
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
+static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_ythread *p_thread)
 {
     /*
      * Create a context and switch to it. The flow of the dynamic promotion
@@ -129,7 +129,7 @@ static inline ABT_bool ABTI_thread_is_dynamic_promoted(ABTI_thread *p_thread)
     return ABTD_thread_context_is_dynamic_promoted(&p_thread->ctx);
 }
 
-static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
+static inline void ABTI_thread_dynamic_promote_thread(ABTI_ythread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 "] dynamic-promote ULT\n",
               ABTI_thread_get_id(p_thread));
@@ -140,8 +140,8 @@ static inline void ABTI_thread_dynamic_promote_thread(ABTI_thread *p_thread)
 }
 #endif
 
-static inline ABTI_thread *ABTI_thread_context_switch_to_sibling_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABTI_thread *p_new,
+static inline ABTI_ythread *ABTI_thread_context_switch_to_sibling_internal(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABTI_ythread *p_new,
     ABT_bool is_finish)
 {
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
@@ -172,12 +172,12 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_sibling_internal(
     }
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABT_bool is_finish,
+static inline ABTI_ythread *ABTI_thread_context_switch_to_parent_internal(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABT_bool is_finish,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_ASSERT(ABTI_unit_type_is_thread(p_old->unit_def.type));
-    ABTI_thread *p_new = ABTI_unit_get_thread(p_old->unit_def.p_parent);
+    ABTI_ythread *p_new = ABTI_unit_get_thread(p_old->unit_def.p_parent);
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* Dynamic promotion is unnecessary if p_old will be discarded. */
     if (!is_finish && !ABTI_thread_is_dynamic_promoted(p_old))
@@ -207,8 +207,8 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_parent_internal(
     }
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old, ABTI_thread *p_new)
+static inline ABTI_ythread *ABTI_thread_context_switch_to_child_internal(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABTI_ythread *p_new)
 {
     ABTI_xstream *p_local_xstream;
     p_new->unit_def.p_parent = &p_old->unit_def;
@@ -235,7 +235,7 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
         *pp_local_xstream = p_local_xstream;
         ABTI_unit *p_prev_unit = p_local_xstream->p_unit;
         ABTI_ASSERT(ABTI_unit_type_is_thread(p_prev_unit->type));
-        ABTI_thread *p_prev = ABTI_unit_get_thread(p_prev_unit);
+        ABTI_ythread *p_prev = ABTI_unit_get_thread(p_prev_unit);
         p_local_xstream->p_unit = &p_old->unit_def;
         if (!ABTI_thread_is_dynamic_promoted(p_prev)) {
             ABTI_ASSERT(p_prev == p_new);
@@ -250,7 +250,7 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
             if (p_link) {
                 /* If p_link is set, it means that other ULT has called the
                  * join. */
-                ABTI_thread *p_joiner = ABTI_thread_context_get_thread(p_link);
+                ABTI_ythread *p_joiner = ABTI_thread_context_get_thread(p_link);
                 /* The scheduler may not use a bypass mechanism, so just makes
                  * p_joiner ready. */
                 ABTI_thread_set_ready(p_local_xstream, p_joiner);
@@ -294,17 +294,17 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_child_internal(
 }
 
 /* Return the previous thread. */
-static inline ABTI_thread *
+static inline ABTI_ythread *
 ABTI_thread_context_switch_to_sibling(ABTI_xstream **pp_local_xstream,
-                                      ABTI_thread *p_old, ABTI_thread *p_new)
+                                      ABTI_ythread *p_old, ABTI_ythread *p_new)
 {
     return ABTI_thread_context_switch_to_sibling_internal(pp_local_xstream,
                                                           p_old, p_new,
                                                           ABT_FALSE);
 }
 
-static inline ABTI_thread *ABTI_thread_context_switch_to_parent(
-    ABTI_xstream **pp_local_xstream, ABTI_thread *p_old,
+static inline ABTI_ythread *ABTI_thread_context_switch_to_parent(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     return ABTI_thread_context_switch_to_parent_internal(pp_local_xstream,
@@ -313,9 +313,9 @@ static inline ABTI_thread *ABTI_thread_context_switch_to_parent(
                                                          p_sync);
 }
 
-static inline ABTI_thread *
+static inline ABTI_ythread *
 ABTI_thread_context_switch_to_child(ABTI_xstream **pp_local_xstream,
-                                    ABTI_thread *p_old, ABTI_thread *p_new)
+                                    ABTI_ythread *p_old, ABTI_ythread *p_new)
 {
     return ABTI_thread_context_switch_to_child_internal(pp_local_xstream, p_old,
                                                         p_new);
@@ -323,7 +323,7 @@ ABTI_thread_context_switch_to_child(ABTI_xstream **pp_local_xstream,
 
 ABTU_noreturn static inline void
 ABTI_thread_finish_context_to_sibling(ABTI_xstream *p_local_xstream,
-                                      ABTI_thread *p_old, ABTI_thread *p_new)
+                                      ABTI_ythread *p_old, ABTI_ythread *p_new)
 {
     ABTI_thread_context_switch_to_sibling_internal(&p_local_xstream, p_old,
                                                    p_new, ABT_TRUE);
@@ -332,7 +332,7 @@ ABTI_thread_finish_context_to_sibling(ABTI_xstream *p_local_xstream,
 
 ABTU_noreturn static inline void
 ABTI_thread_finish_context_to_parent(ABTI_xstream *p_local_xstream,
-                                     ABTI_thread *p_old)
+                                     ABTI_ythread *p_old)
 {
     ABTI_thread_context_switch_to_parent_internal(&p_local_xstream, p_old,
                                                   ABT_TRUE,
@@ -345,30 +345,30 @@ ABTU_noreturn static inline void
 ABTI_thread_finish_context_sched_to_main_thread(ABTI_sched *p_main_sched)
 {
     /* The main thread is stored in p_link. */
-    ABTI_thread *p_sched_thread = p_main_sched->p_thread;
+    ABTI_ythread *p_sched_thread = p_main_sched->p_thread;
     ABTI_ASSERT(
         ABTI_unit_type_is_thread_main_sched(p_sched_thread->unit_def.type));
     ABTD_thread_context *p_ctx = &p_sched_thread->ctx;
-    ABTI_thread *p_main_thread = ABTI_thread_context_get_thread(
+    ABTI_ythread *p_main_thread = ABTI_thread_context_get_thread(
         ABTD_atomic_acquire_load_thread_context_ptr(&p_ctx->p_link));
     ABTI_ASSERT(p_main_thread &&
                 ABTI_unit_type_is_thread_main(p_main_thread->unit_def.type));
     ABTD_thread_finish_context(&p_sched_thread->ctx, &p_main_thread->ctx);
 }
 
-static inline void ABTI_thread_set_request(ABTI_thread *p_thread, uint32_t req)
+static inline void ABTI_thread_set_request(ABTI_ythread *p_thread, uint32_t req)
 {
     ABTD_atomic_fetch_or_uint32(&p_thread->unit_def.request, req);
 }
 
-static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
+static inline void ABTI_thread_unset_request(ABTI_ythread *p_thread,
                                              uint32_t req)
 {
     ABTD_atomic_fetch_and_uint32(&p_thread->unit_def.request, ~req);
 }
 
 static inline void ABTI_thread_yield(ABTI_xstream **pp_local_xstream,
-                                     ABTI_thread *p_thread,
+                                     ABTI_ythread *p_thread,
                                      ABT_sync_event_type sync_event_type,
                                      void *p_sync)
 {

--- a/src/include/abti_thread_htable.h
+++ b/src/include/abti_thread_htable.h
@@ -21,18 +21,18 @@ struct ABTI_thread_queue {
     uint32_t num_handovers;
     uint32_t num_threads;
     uint32_t pad0;
-    ABTI_thread *head;
-    ABTI_thread *tail;
+    ABTI_ythread *head;
+    ABTI_ythread *tail;
     char pad1[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) * 3 -
-              sizeof(ABTI_thread *) * 2];
+              sizeof(ABTI_ythread *) * 2];
 
     /* low priority queue */
     ABTD_atomic_uint32 low_mutex; /* can be initialized by just assigning 0*/
     uint32_t low_num_threads;
-    ABTI_thread *low_head;
-    ABTI_thread *low_tail;
+    ABTI_ythread *low_head;
+    ABTI_ythread *low_tail;
     char pad2[64 - sizeof(ABTD_atomic_uint32) - sizeof(uint32_t) -
-              sizeof(ABTI_thread *) * 2];
+              sizeof(ABTI_ythread *) * 2];
 
     /* two doubly-linked lists */
     ABTI_thread_queue *p_h_next;

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -6,7 +6,7 @@
 #ifndef ABTI_TOOL_H_INCLUDED
 #define ABTI_TOOL_H_INCLUDED
 
-static inline ABT_thread ABTI_thread_get_handle(ABTI_thread *p_thread);
+static inline ABT_thread ABTI_thread_get_handle(ABTI_ythread *p_thread);
 static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task);
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -127,7 +127,7 @@ ABTI_tool_event_task_update_callback(ABT_tool_task_callback_fn cb_func,
 #endif /* !ABT_CONFIG_DISABLE_TOOL_INTERFACE */
 
 static inline void ABTI_tool_event_thread_impl(
-    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_thread *p_thread,
+    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_ythread *p_thread,
     ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
@@ -202,7 +202,7 @@ static inline void ABTI_tool_event_task_impl(
 
 static inline void
 ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_ythread *p_thread, ABTI_unit *p_caller,
                                    ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CREATE,
@@ -212,7 +212,7 @@ ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_ythread *p_thread, ABTI_unit *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_JOIN,
                                 p_thread, p_caller, NULL, NULL,
@@ -221,7 +221,7 @@ ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_ythread *p_thread, ABTI_unit *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FREE,
                                 p_thread, p_caller, NULL, NULL,
@@ -230,7 +230,7 @@ ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller,
+                                   ABTI_ythread *p_thread, ABTI_unit *p_caller,
                                    ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_REVIVE,
@@ -240,7 +240,7 @@ ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
-                                ABTI_thread *p_thread, ABTI_unit *p_prev,
+                                ABTI_ythread *p_thread, ABTI_unit *p_prev,
                                 ABTI_unit *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RUN,
@@ -250,7 +250,7 @@ ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_finish_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_parent)
+                                   ABTI_ythread *p_thread, ABTI_unit *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FINISH,
                                 p_thread, NULL, NULL, p_parent,
@@ -259,7 +259,7 @@ ABTI_tool_event_thread_finish_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_cancel_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread)
+                                   ABTI_ythread *p_thread)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CANCEL,
                                 p_thread, NULL, NULL, NULL,
@@ -267,7 +267,7 @@ ABTI_tool_event_thread_cancel_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_thread_yield_impl(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread, ABTI_unit *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     if (ABTD_atomic_relaxed_load_uint32(&p_thread->unit_def.request) &
@@ -286,7 +286,7 @@ static inline void ABTI_tool_event_thread_yield_impl(
 }
 
 static inline void ABTI_tool_event_thread_suspend_impl(
-    ABTI_xstream *p_local_xstream, ABTI_thread *p_thread, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread, ABTI_unit *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_SUSPEND,
@@ -296,7 +296,7 @@ static inline void ABTI_tool_event_thread_suspend_impl(
 
 static inline void
 ABTI_tool_event_thread_resume_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_thread *p_thread, ABTI_unit *p_caller)
+                                   ABTI_ythread *p_thread, ABTI_unit *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RESUME,
                                 p_thread, p_caller, p_thread->unit_def.p_pool,

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -7,7 +7,7 @@
 #define ABTI_TOOL_H_INCLUDED
 
 static inline ABT_thread ABTI_thread_get_handle(ABTI_ythread *p_thread);
-static inline ABT_task ABTI_task_get_handle(ABTI_task *p_task);
+static inline ABT_task ABTI_task_get_handle(ABTI_thread *p_task);
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
 static inline ABTI_tool_context *
@@ -128,7 +128,7 @@ ABTI_tool_event_task_update_callback(ABT_tool_task_callback_fn cb_func,
 
 static inline void ABTI_tool_event_thread_impl(
     ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_ythread *p_thread,
-    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABTI_thread *p_caller, ABTI_pool *p_pool, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -164,8 +164,8 @@ static inline void ABTI_tool_event_thread_impl(
 }
 
 static inline void ABTI_tool_event_task_impl(
-    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_task *p_task,
-    ABTI_unit *p_caller, ABTI_pool *p_pool, ABTI_unit *p_parent,
+    ABTI_xstream *p_local_xstream, uint64_t event_code, ABTI_thread *p_task,
+    ABTI_thread *p_caller, ABTI_pool *p_pool, ABTI_thread *p_parent,
     ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -202,8 +202,8 @@ static inline void ABTI_tool_event_task_impl(
 
 static inline void
 ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_ythread *p_thread, ABTI_unit *p_caller,
-                                   ABTI_pool *p_pool)
+                                   ABTI_ythread *p_thread,
+                                   ABTI_thread *p_caller, ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_CREATE,
                                 p_thread, p_caller, p_pool, NULL,
@@ -212,7 +212,7 @@ ABTI_tool_event_thread_create_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_ythread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_ythread *p_thread, ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_JOIN,
                                 p_thread, p_caller, NULL, NULL,
@@ -221,7 +221,7 @@ ABTI_tool_event_thread_join_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_ythread *p_thread, ABTI_unit *p_caller)
+                                 ABTI_ythread *p_thread, ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FREE,
                                 p_thread, p_caller, NULL, NULL,
@@ -230,8 +230,8 @@ ABTI_tool_event_thread_free_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_ythread *p_thread, ABTI_unit *p_caller,
-                                   ABTI_pool *p_pool)
+                                   ABTI_ythread *p_thread,
+                                   ABTI_thread *p_caller, ABTI_pool *p_pool)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_REVIVE,
                                 p_thread, p_caller, p_pool, NULL,
@@ -240,8 +240,8 @@ ABTI_tool_event_thread_revive_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
-                                ABTI_ythread *p_thread, ABTI_unit *p_prev,
-                                ABTI_unit *p_parent)
+                                ABTI_ythread *p_thread, ABTI_thread *p_prev,
+                                ABTI_thread *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RUN,
                                 p_thread, p_prev, NULL, p_parent,
@@ -250,7 +250,8 @@ ABTI_tool_event_thread_run_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_thread_finish_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_ythread *p_thread, ABTI_unit *p_parent)
+                                   ABTI_ythread *p_thread,
+                                   ABTI_thread *p_parent)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_FINISH,
                                 p_thread, NULL, NULL, p_parent,
@@ -267,45 +268,46 @@ ABTI_tool_event_thread_cancel_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_thread_yield_impl(
-    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread, ABTI_unit *p_parent,
-    ABT_sync_event_type sync_event_type, void *p_sync)
+    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread,
+    ABTI_thread *p_parent, ABT_sync_event_type sync_event_type, void *p_sync)
 {
-    if (ABTD_atomic_relaxed_load_uint32(&p_thread->unit_def.request) &
-        ABTI_UNIT_REQ_BLOCK) {
+    if (ABTD_atomic_relaxed_load_uint32(&p_thread->thread.request) &
+        ABTI_THREAD_REQ_BLOCK) {
         ABTI_tool_event_thread_impl(p_local_xstream,
                                     ABT_TOOL_EVENT_THREAD_SUSPEND, p_thread,
-                                    NULL, p_thread->unit_def.p_pool, p_parent,
+                                    NULL, p_thread->thread.p_pool, p_parent,
                                     sync_event_type, p_sync);
 
     } else {
         ABTI_tool_event_thread_impl(p_local_xstream,
                                     ABT_TOOL_EVENT_THREAD_YIELD, p_thread, NULL,
-                                    p_thread->unit_def.p_pool, p_parent,
+                                    p_thread->thread.p_pool, p_parent,
                                     sync_event_type, p_sync);
     }
 }
 
 static inline void ABTI_tool_event_thread_suspend_impl(
-    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread, ABTI_unit *p_parent,
-    ABT_sync_event_type sync_event_type, void *p_sync)
+    ABTI_xstream *p_local_xstream, ABTI_ythread *p_thread,
+    ABTI_thread *p_parent, ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_SUSPEND,
-                                p_thread, NULL, p_thread->unit_def.p_pool,
+                                p_thread, NULL, p_thread->thread.p_pool,
                                 p_parent, sync_event_type, p_sync);
 }
 
 static inline void
 ABTI_tool_event_thread_resume_impl(ABTI_xstream *p_local_xstream,
-                                   ABTI_ythread *p_thread, ABTI_unit *p_caller)
+                                   ABTI_ythread *p_thread,
+                                   ABTI_thread *p_caller)
 {
     ABTI_tool_event_thread_impl(p_local_xstream, ABT_TOOL_EVENT_THREAD_RESUME,
-                                p_thread, p_caller, p_thread->unit_def.p_pool,
+                                p_thread, p_caller, p_thread->thread.p_pool,
                                 NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
 }
 
 static inline void
 ABTI_tool_event_task_create_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_thread *p_task, ABTI_thread *p_caller,
                                  ABTI_pool *p_pool)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CREATE,
@@ -314,8 +316,8 @@ ABTI_tool_event_task_create_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_join_impl(ABTI_xstream *p_local_xstream,
-                                                  ABTI_task *p_task,
-                                                  ABTI_unit *p_caller)
+                                                  ABTI_thread *p_task,
+                                                  ABTI_thread *p_caller)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_JOIN, p_task,
                               p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
@@ -323,8 +325,8 @@ static inline void ABTI_tool_event_task_join_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_free_impl(ABTI_xstream *p_local_xstream,
-                                                  ABTI_task *p_task,
-                                                  ABTI_unit *p_caller)
+                                                  ABTI_thread *p_task,
+                                                  ABTI_thread *p_caller)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FREE, p_task,
                               p_caller, NULL, NULL, ABT_SYNC_EVENT_TYPE_UNKNOWN,
@@ -333,7 +335,7 @@ static inline void ABTI_tool_event_task_free_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_revive_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_caller,
+                                 ABTI_thread *p_task, ABTI_thread *p_caller,
                                  ABTI_pool *p_pool)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_REVIVE,
@@ -342,8 +344,8 @@ ABTI_tool_event_task_revive_impl(ABTI_xstream *p_local_xstream,
 }
 
 static inline void ABTI_tool_event_task_run_impl(ABTI_xstream *p_local_xstream,
-                                                 ABTI_task *p_task,
-                                                 ABTI_unit *p_parent)
+                                                 ABTI_thread *p_task,
+                                                 ABTI_thread *p_parent)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_RUN, p_task,
                               p_parent, NULL, p_parent,
@@ -352,7 +354,7 @@ static inline void ABTI_tool_event_task_run_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_finish_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task, ABTI_unit *p_parent)
+                                 ABTI_thread *p_task, ABTI_thread *p_parent)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_FINISH,
                               p_task, NULL, NULL, p_parent,
@@ -361,7 +363,7 @@ ABTI_tool_event_task_finish_impl(ABTI_xstream *p_local_xstream,
 
 static inline void
 ABTI_tool_event_task_cancel_impl(ABTI_xstream *p_local_xstream,
-                                 ABTI_task *p_task)
+                                 ABTI_thread *p_task)
 {
     ABTI_tool_event_task_impl(p_local_xstream, ABT_TOOL_EVENT_TASK_CANCEL,
                               p_task, NULL, NULL, NULL,

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -6,7 +6,7 @@
 #ifndef ABTI_UNIT_H_INCLUDED
 #define ABTI_UNIT_H_INCLUDED
 
-/* Inlined functions for ABTI_unit */
+/* Inlined functions for ABTI_thread */
 
 static inline void ABTI_ktable_set(ABTI_xstream *p_local_xstream,
                                    ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key,
@@ -16,16 +16,16 @@ static inline void *ABTI_ktable_get(ABTD_atomic_ptr *pp_ktable,
 static inline int ABTI_ktable_is_valid(ABTI_ktable *p_ktable);
 
 static inline ABT_thread_state
-ABTI_unit_state_get_thread_state(ABTI_unit_state state)
+ABTI_thread_state_get_thread_state(ABTI_thread_state state)
 {
     switch (state) {
-        case ABTI_UNIT_STATE_READY:
+        case ABTI_THREAD_STATE_READY:
             return ABT_THREAD_STATE_READY;
-        case ABTI_UNIT_STATE_RUNNING:
+        case ABTI_THREAD_STATE_RUNNING:
             return ABT_THREAD_STATE_RUNNING;
-        case ABTI_UNIT_STATE_BLOCKED:
+        case ABTI_THREAD_STATE_BLOCKED:
             return ABT_THREAD_STATE_BLOCKED;
-        case ABTI_UNIT_STATE_TERMINATED:
+        case ABTI_THREAD_STATE_TERMINATED:
             return ABT_THREAD_STATE_TERMINATED;
         default:
             ABTI_ASSERT(0);
@@ -34,70 +34,71 @@ ABTI_unit_state_get_thread_state(ABTI_unit_state state)
 }
 
 static inline ABT_task_state
-ABTI_unit_state_get_task_state(ABTI_unit_state state)
+ABTI_thread_state_get_task_state(ABTI_thread_state state)
 {
     switch (state) {
-        case ABTI_UNIT_STATE_READY:
+        case ABTI_THREAD_STATE_READY:
             return ABT_TASK_STATE_READY;
-        case ABTI_UNIT_STATE_RUNNING:
+        case ABTI_THREAD_STATE_RUNNING:
             return ABT_TASK_STATE_RUNNING;
-        case ABTI_UNIT_STATE_TERMINATED:
+        case ABTI_THREAD_STATE_TERMINATED:
             return ABT_TASK_STATE_TERMINATED;
-        case ABTI_UNIT_STATE_BLOCKED:
+        case ABTI_THREAD_STATE_BLOCKED:
         default:
             ABTI_ASSERT(0);
             ABTU_unreachable();
     }
 }
 
-static inline ABT_bool ABTI_unit_type_is_thread(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_thread(ABTI_thread_type type)
 {
-    return (type & ABTI_UNIT_TYPE_THREAD) ? ABT_TRUE : ABT_FALSE;
+    return (type & ABTI_THREAD_TYPE_THREAD) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline ABT_bool ABTI_unit_type_is_task(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_task(ABTI_thread_type type)
 {
-    return (!(type & (ABTI_UNIT_TYPE_THREAD | ABTI_UNIT_TYPE_EXT))) ? ABT_TRUE
-                                                                    : ABT_FALSE;
+    return (!(type & (ABTI_THREAD_TYPE_THREAD | ABTI_THREAD_TYPE_EXT)))
+               ? ABT_TRUE
+               : ABT_FALSE;
 }
 
-static inline ABT_bool ABTI_unit_type_is_ext(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_ext(ABTI_thread_type type)
 {
-    return (type & ABTI_UNIT_TYPE_EXT) ? ABT_TRUE : ABT_FALSE;
+    return (type & ABTI_THREAD_TYPE_EXT) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline ABT_bool ABTI_unit_type_is_thread_user(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_thread_user(ABTI_thread_type type)
 {
-    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_USER) ? ABT_TRUE : ABT_FALSE;
+    return (type & ABTI_THREAD_TYPE_THREAD_TYPE_USER) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline ABT_bool ABTI_unit_type_is_thread_main(ABTI_unit_type type)
+static inline ABT_bool ABTI_thread_type_is_thread_main(ABTI_thread_type type)
 {
-    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
+    return (type & ABTI_THREAD_TYPE_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline ABT_bool ABTI_unit_type_is_thread_main_sched(ABTI_unit_type type)
+static inline ABT_bool
+ABTI_thread_type_is_thread_main_sched(ABTI_thread_type type)
 {
-    return (type & ABTI_UNIT_TYPE_THREAD_TYPE_MAIN_SCHED) ? ABT_TRUE
-                                                          : ABT_FALSE;
+    return (type & ABTI_THREAD_TYPE_THREAD_TYPE_MAIN_SCHED) ? ABT_TRUE
+                                                            : ABT_FALSE;
 }
 
-static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)
+static inline ABT_unit_type ABTI_thread_type_get_type(ABTI_thread_type type)
 {
-    if (ABTI_unit_type_is_thread(type)) {
+    if (ABTI_thread_type_is_thread(type)) {
         return ABT_UNIT_TYPE_THREAD;
-    } else if (ABTI_unit_type_is_task(type)) {
+    } else if (ABTI_thread_type_is_task(type)) {
         return ABT_UNIT_TYPE_TASK;
     } else {
-        ABTI_ASSERT(ABTI_unit_type_is_ext(type));
+        ABTI_ASSERT(ABTI_thread_type_is_ext(type));
         return ABT_UNIT_TYPE_EXT;
     }
 }
 
-static inline ABTI_ythread *ABTI_unit_get_thread(ABTI_unit *p_unit)
+static inline ABTI_ythread *ABTI_unit_get_thread(ABTI_thread *p_unit)
 {
-    return (ABTI_ythread *)(((char *)p_unit) -
-                            offsetof(ABTI_ythread, unit_def));
+    return (ABTI_ythread *)(((char *)p_unit) - offsetof(ABTI_ythread, thread));
 }
 
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -94,9 +94,10 @@ static inline ABT_unit_type ABTI_unit_type_get_type(ABTI_unit_type type)
     }
 }
 
-static inline ABTI_thread *ABTI_unit_get_thread(ABTI_unit *p_unit)
+static inline ABTI_ythread *ABTI_unit_get_thread(ABTI_unit *p_unit)
 {
-    return (ABTI_thread *)(((char *)p_unit) - offsetof(ABTI_thread, unit_def));
+    return (ABTI_ythread *)(((char *)p_unit) -
+                            offsetof(ABTI_ythread, unit_def));
 }
 
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -99,9 +99,4 @@ static inline ABTI_thread *ABTI_unit_get_thread(ABTI_unit *p_unit)
     return (ABTI_thread *)(((char *)p_unit) - offsetof(ABTI_thread, unit_def));
 }
 
-static inline ABTI_task *ABTI_unit_get_task(ABTI_unit *p_unit)
-{
-    return (ABTI_task *)(((char *)p_unit) - offsetof(ABTI_task, unit_def));
-}
-
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/info.c
+++ b/src/info.c
@@ -400,7 +400,7 @@ fn_fail:
 int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
     ABTI_thread_print(p_thread, fp, 0);
@@ -485,7 +485,7 @@ fn_fail:
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
     abt_errno = ABTI_thread_print_stack(p_thread, fp);
@@ -517,7 +517,7 @@ static void ABTI_info_print_unit(void *arg, ABT_unit unit)
     if (type == ABT_UNIT_TYPE_THREAD) {
         fprintf(fp, "=== ULT (%p) ===\n", (void *)unit);
         ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+        ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
         ABT_unit_id thread_id = ABTI_thread_get_id(p_thread);
         fprintf(fp,
                 "id        : %" PRIu64 "\n"

--- a/src/info.c
+++ b/src/info.c
@@ -457,7 +457,7 @@ fn_fail:
 int ABT_info_print_task(FILE *fp, ABT_task task)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
     ABTI_CHECK_NULL_TASK_PTR(p_task);
 
     ABTI_task_print(p_task, fp, 0);

--- a/src/log.c
+++ b/src/log.c
@@ -16,7 +16,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
 
     ABTI_ythread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     char *prefix_fmt = NULL, *prefix = NULL;
     char *newfmt;
     uint64_t tid;
@@ -28,8 +28,8 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
         prefix = "<UNKNOWN> ";
         prefix_fmt = "%s%s";
     } else {
-        ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
-        if (ABTI_unit_type_is_thread(type)) {
+        ABTI_thread_type type = ABTI_self_get_type(p_local_xstream);
+        if (ABTI_thread_type_is_thread(type)) {
             p_thread = ABTI_unit_get_thread(p_local_xstream->p_unit);
             if (p_thread == NULL) {
                 if (p_local_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY) {
@@ -45,7 +45,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
                 prefix_fmt = "<U%" PRIu64 ":E%d> %s";
                 tid = ABTI_thread_get_id(p_thread);
             }
-        } else if (ABTI_unit_type_is_task(type)) {
+        } else if (ABTI_thread_type_is_task(type)) {
             rank = p_local_xstream->rank;
             p_task = p_local_xstream->p_unit;
             prefix_fmt = "<T%" PRIu64 ":E%d> %s";
@@ -90,15 +90,15 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
         return;
 
     ABTI_ythread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->thread.p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_thread->thread.p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] pushed to P%" PRIu64 " "
@@ -137,15 +137,15 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
         return;
 
     ABTI_ythread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->thread.p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_thread->thread.p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] removed from P%" PRIu64 " "
@@ -185,15 +185,15 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
         return;
 
     ABTI_ythread *p_thread = NULL;
-    ABTI_task *p_task = NULL;
+    ABTI_thread *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_thread->unit_def.p_last_xstream) {
+            if (p_thread->thread.p_last_xstream) {
                 LOG_DEBUG("[U%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread),
-                          p_thread->unit_def.p_last_xstream->rank, p_pool->id);
+                          p_thread->thread.p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_DEBUG("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_thread_get_id(p_thread), p_pool->id);

--- a/src/log.c
+++ b/src/log.c
@@ -15,7 +15,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
         return;
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_uninlined();
 
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABTI_task *p_task = NULL;
     char *prefix_fmt = NULL, *prefix = NULL;
     char *newfmt;
@@ -89,7 +89,7 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
 
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABTI_task *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
@@ -136,7 +136,7 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
 
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABTI_task *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
@@ -184,7 +184,7 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
     if (unit == ABT_UNIT_NULL)
         return;
 
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABTI_task *p_task = NULL;
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:

--- a/src/log.c
+++ b/src/log.c
@@ -47,7 +47,7 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
             }
         } else if (ABTI_unit_type_is_task(type)) {
             rank = p_local_xstream->rank;
-            p_task = ABTI_unit_get_task(p_local_xstream->p_unit);
+            p_task = p_local_xstream->p_unit;
             prefix_fmt = "<T%" PRIu64 ":E%d> %s";
             tid = ABTI_task_get_id(p_task);
         } else {
@@ -110,11 +110,11 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 " "
                           "(producer: NT %p)\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_task->p_last_xstream->rank, p_pool->id,
                           (void *)producer_id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] pushed to P%" PRIu64 " "
@@ -157,11 +157,11 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] removed from "
                           "P%" PRIu64 " (consumer: NT %p)\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id,
+                          p_task->p_last_xstream->rank, p_pool->id,
                           (void *)consumer_id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] removed from P%" PRIu64 " "
@@ -202,11 +202,11 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
 
         case ABT_UNIT_TYPE_TASK:
             p_task = ABTI_task_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->unit_def.p_last_xstream) {
+            if (p_task->p_last_xstream) {
                 LOG_DEBUG("[T%" PRIu64 ":E%d] popped from "
                           "P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task),
-                          p_task->unit_def.p_last_xstream->rank, p_pool->id);
+                          p_task->p_last_xstream->rank, p_pool->id);
             } else {
                 LOG_DEBUG("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
                           ABTI_task_get_id(p_task), p_pool->id);

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -47,7 +47,7 @@ void ABTI_mem_init(ABTI_global *p_global)
     size_t thread_stacksize = p_global->thread_stacksize;
     ABTI_ASSERT((thread_stacksize & (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) ==
                 0);
-    size_t stacksize = (thread_stacksize + sizeof(ABTI_thread) +
+    size_t stacksize = (thread_stacksize + sizeof(ABTI_ythread) +
                         ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
                        (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
     if ((stacksize & (2 * ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0) {

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -205,7 +205,7 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
          * low-mutex queue, we give the header ULT a chance to try to get
          * the mutex by context switching to it. */
         ABTI_thread_htable *p_htable = p_mutex->p_htable;
-        ABTI_thread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
+        ABTI_ythread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
         int rank = (int)p_local_xstream->rank;
         ABTI_thread_queue *p_queue = &p_htable->queue[rank];
         if (p_queue->low_num_threads > 0) {
@@ -237,7 +237,7 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
                         ABTD_atomic_release_store_uint32(&p_mutex->val, 2);
 
                         /* Push the previous ULT to its pool */
-                        ABTI_thread *p_giver = p_mutex->p_giver;
+                        ABTI_ythread *p_giver = p_mutex->p_giver;
                         ABTD_atomic_release_store_int(&p_giver->unit_def.state,
                                                       ABTI_UNIT_STATE_READY);
                         ABTI_POOL_PUSH(p_giver->unit_def.p_pool,
@@ -486,8 +486,8 @@ static inline int ABTI_mutex_unlock_se(ABTI_xstream **pp_local_xstream,
                           ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
 #else
     int i;
-    ABTI_thread *p_next = NULL;
-    ABTI_thread *p_thread;
+    ABTI_ythread *p_next = NULL;
+    ABTI_ythread *p_thread;
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_thread_queue *p_queue;
 
@@ -579,7 +579,7 @@ handover:
     ABTI_tool_event_thread_yield(p_local_xstream, p_thread,
                                  p_thread->unit_def.p_parent,
                                  ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
-    ABTI_thread *p_prev =
+    ABTI_ythread *p_prev =
         ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
                                               p_next);
     /* Invoke an event of thread resume and run. */
@@ -689,7 +689,7 @@ void ABTI_mutex_wait(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
 {
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
-    ABTI_thread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
+    ABTI_ythread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
 
     int rank = (int)p_local_xstream->rank;
     ABTI_ASSERT(rank < p_htable->num_rows);
@@ -725,7 +725,7 @@ void ABTI_mutex_wait_low(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
 {
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
-    ABTI_thread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
+    ABTI_ythread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
 
     int rank = (int)p_local_xstream->rank;
     ABTI_ASSERT(rank < p_htable->num_rows);
@@ -759,7 +759,7 @@ void ABTI_mutex_wait_low(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
 void ABTI_mutex_wake_de(ABTI_xstream *p_local_xstream, ABTI_mutex *p_mutex)
 {
     int n;
-    ABTI_thread *p_thread;
+    ABTI_ythread *p_thread;
     ABTI_thread_htable *p_htable = p_mutex->p_htable;
     int num = p_mutex->attr.max_wakeups;
     ABTI_thread_queue *p_start, *p_curr;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -151,7 +151,7 @@ int ABT_mutex_lock(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local_xstream);
+        ABTI_thread_id self_id = ABTI_self_get_unit_id(p_local_xstream);
         if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_lock(&p_local_xstream, p_mutex);
             p_mutex->attr.owner_id = self_id;
@@ -178,8 +178,8 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
 {
 #ifdef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
-    if (ABTI_unit_type_is_thread(type)) {
+    ABTI_thread_type type = ABTI_self_get_type(p_local_xstream);
+    if (ABTI_thread_type_is_thread(type)) {
         LOG_DEBUG("%p: lock_low - try\n", p_mutex);
         while (!ABTD_atomic_bool_cas_strong_uint32(&p_mutex->val, 0, 1)) {
             ABTI_thread_yield(pp_local_xstream,
@@ -196,8 +196,8 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    ABTI_unit_type type = ABTI_self_get_type(p_local_xstream);
-    if (ABTI_unit_type_is_thread(type)) {
+    ABTI_thread_type type = ABTI_self_get_type(p_local_xstream);
+    if (ABTI_thread_type_is_thread(type)) {
         LOG_DEBUG("%p: lock_low - try\n", p_mutex);
         int c;
 
@@ -238,10 +238,10 @@ static inline void ABTI_mutex_lock_low(ABTI_xstream **pp_local_xstream,
 
                         /* Push the previous ULT to its pool */
                         ABTI_ythread *p_giver = p_mutex->p_giver;
-                        ABTD_atomic_release_store_int(&p_giver->unit_def.state,
-                                                      ABTI_UNIT_STATE_READY);
-                        ABTI_POOL_PUSH(p_giver->unit_def.p_pool,
-                                       p_giver->unit_def.unit,
+                        ABTD_atomic_release_store_int(&p_giver->thread.state,
+                                                      ABTI_THREAD_STATE_READY);
+                        ABTI_POOL_PUSH(p_giver->thread.p_pool,
+                                       p_giver->thread.unit,
                                        ABTI_self_get_native_thread_id(
                                            *pp_local_xstream));
                         break;
@@ -291,7 +291,7 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
 
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
-        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local_xstream);
+        ABTI_thread_id self_id = ABTI_self_get_unit_id(p_local_xstream);
         if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_lock_low(&p_local_xstream, p_mutex);
             p_mutex->attr.owner_id = self_id;
@@ -348,7 +348,7 @@ int ABT_mutex_trylock(ABT_mutex mutex)
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
         ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
-        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local_xstream);
+        ABTI_thread_id self_id = ABTI_self_get_unit_id(p_local_xstream);
         if (self_id != p_mutex->attr.owner_id) {
             abt_errno = ABTI_mutex_trylock(p_mutex);
             if (abt_errno == ABT_SUCCESS) {
@@ -400,7 +400,7 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
     } else if (p_mutex->attr.attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
         /* recursive mutex */
         ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
-        ABTI_unit_id self_id = ABTI_self_get_unit_id(p_local_xstream);
+        ABTI_thread_id self_id = ABTI_self_get_unit_id(p_local_xstream);
         if (self_id != p_mutex->attr.owner_id) {
             ABTI_mutex_spinlock(p_mutex);
             p_mutex->attr.owner_id = self_id;
@@ -480,7 +480,7 @@ static inline int ABTI_mutex_unlock_se(ABTI_xstream **pp_local_xstream,
     ABTD_atomic_release_store_uint32(&p_mutex->val, 0);
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     LOG_DEBUG("%p: unlock_se\n", p_mutex);
-    if (ABTI_unit_type_is_thread(ABTI_self_get_type(p_local_xstream)))
+    if (ABTI_thread_type_is_thread(ABTI_self_get_type(p_local_xstream)))
         ABTI_thread_yield(pp_local_xstream,
                           ABTI_unit_get_thread(p_local_xstream->p_unit),
                           ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
@@ -496,7 +496,7 @@ static inline int ABTI_mutex_unlock_se(ABTI_xstream **pp_local_xstream,
      * waiter in the mutex queue.  We can just return. */
     if (ABTD_atomic_fetch_sub_uint32(&p_mutex->val, 1) == 1) {
         LOG_DEBUG("%p: unlock_se\n", p_mutex);
-        if (ABTI_unit_type_is_thread(ABTI_self_get_type(p_local_xstream)))
+        if (ABTI_thread_type_is_thread(ABTI_self_get_type(p_local_xstream)))
             ABTI_thread_yield(pp_local_xstream,
                               ABTI_unit_get_thread(p_local_xstream->p_unit),
                               ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
@@ -568,24 +568,24 @@ handover:
               ABTI_thread_get_id(p_next));
 
     /* yield_to the next ULT */
-    while (ABTD_atomic_acquire_load_uint32(&p_next->unit_def.request) &
-           ABTI_UNIT_REQ_BLOCK)
+    while (ABTD_atomic_acquire_load_uint32(&p_next->thread.request) &
+           ABTI_THREAD_REQ_BLOCK)
         ;
-    ABTI_pool_dec_num_blocked(p_next->unit_def.p_pool);
-    ABTD_atomic_release_store_int(&p_next->unit_def.state,
-                                  ABTI_UNIT_STATE_RUNNING);
-    ABTI_tool_event_thread_resume(p_local_xstream, p_next, &p_thread->unit_def);
+    ABTI_pool_dec_num_blocked(p_next->thread.p_pool);
+    ABTD_atomic_release_store_int(&p_next->thread.state,
+                                  ABTI_THREAD_STATE_RUNNING);
+    ABTI_tool_event_thread_resume(p_local_xstream, p_next, &p_thread->thread);
     /* This works as a "yield" for this thread. */
     ABTI_tool_event_thread_yield(p_local_xstream, p_thread,
-                                 p_thread->unit_def.p_parent,
+                                 p_thread->thread.p_parent,
                                  ABT_SYNC_EVENT_TYPE_MUTEX, (void *)p_mutex);
     ABTI_ythread *p_prev =
         ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
                                               p_next);
     /* Invoke an event of thread resume and run. */
     p_local_xstream = *pp_local_xstream;
-    ABTI_tool_event_thread_run(p_local_xstream, p_thread, &p_prev->unit_def,
-                               p_thread->unit_def.p_parent);
+    ABTI_tool_event_thread_run(p_local_xstream, p_thread, &p_prev->thread,
+                               p_thread->thread.p_parent);
 #endif
 
     return abt_errno;

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -476,7 +476,7 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -22,7 +22,7 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-typedef ABTI_unit unit_t;
+typedef ABTI_thread unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_task unit_get_task(ABT_unit unit);
@@ -440,14 +440,14 @@ static int pool_print_all(ABT_pool pool, void *arg,
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
     unit_t *p_unit = (unit_t *)unit;
-    return ABTI_unit_type_get_type(p_unit->type);
+    return ABTI_thread_type_get_type(p_unit->type);
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_thread(p_unit->type)) {
+    if (ABTI_thread_type_is_thread(p_unit->type)) {
         h_thread = ABTI_thread_get_handle(ABTI_unit_get_thread(p_unit));
     } else {
         h_thread = ABT_THREAD_NULL;
@@ -459,7 +459,7 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_task(p_unit->type)) {
+    if (ABTI_thread_type_is_task(p_unit->type)) {
         h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
@@ -477,23 +477,23 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
-    unit_t *p_unit = &p_thread->unit_def;
+    unit_t *p_unit = &p_thread->thread;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_thread(p_unit->type));
 
     return (ABT_unit)p_unit;
 }
 
 static ABT_unit unit_create_from_task(ABT_task task)
 {
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
     unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_task(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_task(p_unit->type));
 
     return (ABT_unit)p_unit;
 }

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -460,7 +460,7 @@ static ABT_task unit_get_task(ABT_unit unit)
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
     if (ABTI_unit_type_is_task(p_unit->type)) {
-        h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
+        h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -489,7 +489,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 static ABT_unit unit_create_from_task(ABT_task task)
 {
     ABTI_task *p_task = ABTI_task_get_ptr(task);
-    unit_t *p_unit = &p_task->unit_def;
+    unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -350,7 +350,7 @@ static ABT_task unit_get_task(ABT_unit unit)
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
     if (ABTI_unit_type_is_task(p_unit->type)) {
-        h_task = ABTI_task_get_handle(ABTI_unit_get_task(p_unit));
+        h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
     }
@@ -379,7 +379,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
 static ABT_unit unit_create_from_task(ABT_task task)
 {
     ABTI_task *p_task = ABTI_task_get_ptr(task);
-    unit_t *p_unit = &p_task->unit_def;
+    unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -366,7 +366,7 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
     unit_t *p_unit = &p_thread->unit_def;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -18,7 +18,7 @@ static int pool_remove(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-typedef ABTI_unit unit_t;
+typedef ABTI_thread unit_t;
 static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_task unit_get_task(ABT_unit unit);
@@ -330,14 +330,14 @@ static int pool_print_all(ABT_pool pool, void *arg,
 static ABT_unit_type unit_get_type(ABT_unit unit)
 {
     unit_t *p_unit = (unit_t *)unit;
-    return ABTI_unit_type_get_type(p_unit->type);
+    return ABTI_thread_type_get_type(p_unit->type);
 }
 
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
     ABT_thread h_thread;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_thread(p_unit->type)) {
+    if (ABTI_thread_type_is_thread(p_unit->type)) {
         h_thread = ABTI_thread_get_handle(ABTI_unit_get_thread(p_unit));
     } else {
         h_thread = ABT_THREAD_NULL;
@@ -349,7 +349,7 @@ static ABT_task unit_get_task(ABT_unit unit)
 {
     ABT_task h_task;
     unit_t *p_unit = (unit_t *)unit;
-    if (ABTI_unit_type_is_task(p_unit->type)) {
+    if (ABTI_thread_type_is_task(p_unit->type)) {
         h_task = ABTI_task_get_handle(p_unit);
     } else {
         h_task = ABT_TASK_NULL;
@@ -367,23 +367,23 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
-    unit_t *p_unit = &p_thread->unit_def;
+    unit_t *p_unit = &p_thread->thread;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_thread(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_thread(p_unit->type));
 
     return (ABT_unit)p_unit;
 }
 
 static ABT_unit unit_create_from_task(ABT_task task)
 {
-    ABTI_task *p_task = ABTI_task_get_ptr(task);
+    ABTI_thread *p_task = ABTI_task_get_ptr(task);
     unit_t *p_unit = p_task;
     p_unit->p_prev = NULL;
     p_unit->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_unit->is_in_pool, 0);
-    ABTI_ASSERT(ABTI_unit_type_is_task(p_unit->type));
+    ABTI_ASSERT(ABTI_thread_type_is_task(p_unit->type));
 
     return (ABT_unit)p_unit;
 }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -798,8 +798,8 @@ int ABTI_sched_free(ABTI_xstream *p_local_xstream, ABTI_sched *p_sched,
     /* Free the associated work unit */
     if (p_sched->type == ABT_SCHED_TYPE_ULT) {
         if (p_sched->p_thread) {
-            if (ABTI_unit_type_is_thread_main_sched(
-                    p_sched->p_thread->unit_def.type)) {
+            if (ABTI_thread_type_is_thread_main_sched(
+                    p_sched->p_thread->thread.type)) {
                 ABTI_thread_free_main_sched(p_local_xstream, p_sched->p_thread);
             } else {
                 ABTI_thread_free(p_local_xstream, p_sched->p_thread);

--- a/src/self.c
+++ b/src/self.c
@@ -42,8 +42,8 @@ int ABT_self_get_type(ABT_unit_type *type)
     }
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream();
-    ABTI_unit_type raw_type = ABTI_self_get_type(p_local_xstream);
-    *type = ABTI_unit_type_get_type(raw_type);
+    ABTI_thread_type raw_type = ABTI_self_get_type(p_local_xstream);
+    *type = ABTI_thread_type_get_type(raw_type);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* This is when an external thread called this routine. */
     if (*type == ABT_UNIT_TYPE_EXT) {
@@ -94,11 +94,11 @@ int ABT_self_is_primary(ABT_bool *flag)
     }
 #endif
 
-    ABTI_unit *p_unit = p_local_xstream->p_unit;
-    if (ABTI_unit_type_is_thread_main(p_unit->type)) {
+    ABTI_thread *p_unit = p_local_xstream->p_unit;
+    if (ABTI_thread_type_is_thread_main(p_unit->type)) {
         *flag = ABT_TRUE;
     } else {
-        if (!ABTI_unit_type_is_thread(p_unit->type))
+        if (!ABTI_thread_type_is_thread(p_unit->type))
             abt_errno = ABT_ERR_INV_THREAD;
         *flag = ABT_FALSE;
     }
@@ -190,7 +190,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
     }
 #endif
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     ABTI_ASSERT(p_self->p_pool);
     *pool_id = (int)(p_self->p_pool->id);
 
@@ -227,8 +227,9 @@ int ABT_self_suspend(void)
     }
 #endif
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type), ABT_ERR_INV_THREAD);
+    ABTI_thread *p_self = p_local_xstream->p_unit;
+    ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_self->type),
+                    ABT_ERR_INV_THREAD);
     abt_errno = ABTI_thread_set_blocked(ABTI_unit_get_thread(p_self));
     ABTI_CHECK_ERROR(abt_errno);
 
@@ -347,8 +348,8 @@ int ABT_self_is_unnamed(ABT_bool *flag)
     }
 #endif
 
-    *flag = (p_local_xstream->p_unit->type & ABTI_UNIT_TYPE_NAMED) ? ABT_FALSE
-                                                                   : ABT_TRUE;
+    *flag = (p_local_xstream->p_unit->type & ABTI_THREAD_TYPE_NAMED) ? ABT_FALSE
+                                                                     : ABT_TRUE;
 
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
 fn_exit:

--- a/src/stream.c
+++ b/src/stream.c
@@ -261,7 +261,7 @@ int ABTI_xstream_start(ABTI_xstream *p_local_xstream, ABTI_xstream *p_xstream)
         abt_errno =
             ABTI_thread_create_main_sched(p_local_xstream, p_xstream, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched->p_thread->unit_def.p_last_xstream = p_xstream;
+        p_sched->p_thread->thread.p_last_xstream = p_xstream;
 
     } else {
         /* Start the main scheduler on a different ES */
@@ -340,18 +340,18 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     abt_errno =
         ABTI_thread_create_main_sched(*pp_local_xstream, p_xstream, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
-    p_sched->p_thread->unit_def.p_last_xstream = p_xstream;
-    p_thread->unit_def.p_parent = &p_sched->p_thread->unit_def;
+    p_sched->p_thread->thread.p_last_xstream = p_xstream;
+    p_thread->thread.p_parent = &p_sched->p_thread->thread;
 
     /* Start the scheduler by context switching to it */
     LOG_DEBUG("[U%" PRIu64 ":E%d] yield\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              p_thread->thread.p_last_xstream->rank);
     ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
                                          ABT_SYNC_EVENT_TYPE_OTHER, NULL);
 
     /* Back to the main ULT */
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume\n", ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank);
+              p_thread->thread.p_last_xstream->rank);
 
 fn_exit:
     return abt_errno;
@@ -481,10 +481,10 @@ int ABT_xstream_exit(void)
     ABTI_xstream_set_request(p_local_xstream, ABTI_XSTREAM_REQ_EXIT);
 
     /* Wait until the ES terminates */
-    ABTI_unit *p_self = p_local_xstream->p_unit;
+    ABTI_thread *p_self = p_local_xstream->p_unit;
     do {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-        if (!ABTI_unit_type_is_thread(p_self->type)) {
+        if (!ABTI_thread_type_is_thread(p_self->type)) {
             ABTD_atomic_pause();
             continue;
         }
@@ -693,8 +693,9 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
-    ABTI_unit *p_self = p_local_xstream->p_unit;
-    ABTI_CHECK_TRUE(ABTI_unit_type_is_thread(p_self->type), ABT_ERR_INV_THREAD);
+    ABTI_thread *p_self = p_local_xstream->p_unit;
+    ABTI_CHECK_TRUE(ABTI_thread_type_is_thread(p_self->type),
+                    ABT_ERR_INV_THREAD);
 
     /* For now, if the target ES is running, we allow to change the main
      * scheduler of the ES only when the caller is running on the same ES. */
@@ -1007,7 +1008,7 @@ int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
 
     } else if (type == ABT_UNIT_TYPE_TASK) {
         ABT_task task = p_pool->u_get_task(unit);
-        ABTI_task *p_task = ABTI_task_get_ptr(task);
+        ABTI_thread *p_task = ABTI_task_get_ptr(task);
         /* Execute the task */
         ABTI_xstream_schedule_task(*pp_local_xstream, p_task);
 
@@ -1271,14 +1272,14 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
      * the blocked ULT ready. */
     p_local_xstream = *pp_local_xstream;
     if (p_local_xstream) {
-        ABTI_unit *p_self = p_local_xstream->p_unit;
-        if (ABTI_unit_type_is_thread(p_self->type)) {
+        ABTI_thread *p_self = p_local_xstream->p_unit;
+        if (ABTI_thread_type_is_thread(p_self->type)) {
             p_thread = ABTI_unit_get_thread(p_self);
         }
     }
 
     if (p_thread) {
-        ABT_pool_access access = p_thread->unit_def.p_pool->access;
+        ABT_pool_access access = p_thread->thread.p_pool->access;
         if (access == ABT_POOL_ACCESS_MPSC || access == ABT_POOL_ACCESS_MPMC) {
             is_blockable = ABT_TRUE;
         }
@@ -1299,7 +1300,7 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
 
     /* Wait until the target ES terminates */
     if (is_blockable == ABT_TRUE) {
-        ABTI_POOL_SET_CONSUMER(p_thread->unit_def.p_pool,
+        ABTI_POOL_SET_CONSUMER(p_thread->thread.p_pool,
                                ABTI_self_get_native_thread_id(p_local_xstream));
 
         /* Save the caller ULT to set it ready when the ES is terminated */
@@ -1320,7 +1321,7 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
         while (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
                ABT_XSTREAM_STATE_TERMINATED) {
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-            if (!ABTI_unit_type_is_thread(
+            if (!ABTI_thread_type_is_thread(
                     ABTI_self_get_type(p_local_xstream))) {
                 ABTD_atomic_pause();
                 continue;
@@ -1400,7 +1401,7 @@ void ABTI_xstream_schedule(void *p_arg)
 
         /* Execute the run function of scheduler */
         ABTI_sched *p_sched = p_xstream->p_main_sched;
-        ABTI_ASSERT(p_local_xstream->p_unit == &p_sched->p_thread->unit_def);
+        ABTI_ASSERT(p_local_xstream->p_unit == &p_sched->p_thread->thread);
         LOG_DEBUG("[S%" PRIu64 "] start\n", p_sched->id);
         p_sched->run(ABTI_sched_get_handle(p_sched));
         LOG_DEBUG("[S%" PRIu64 "] end\n", p_sched->id);
@@ -1431,7 +1432,7 @@ void ABTI_xstream_schedule(void *p_arg)
     }
 
     ABTI_ASSERT(p_local_xstream->p_unit ==
-                &p_xstream->p_main_sched->p_thread->unit_def);
+                &p_xstream->p_main_sched->p_thread->thread);
 
     /* Set the ES's state as TERMINATED */
     ABTD_atomic_release_store_int(&p_xstream->state,
@@ -1452,8 +1453,8 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    if (ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
-        ABTI_UNIT_REQ_CANCEL) {
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->thread.request) &
+        ABTI_THREAD_REQ_CANCEL) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank);
         ABTD_thread_cancel(p_local_xstream, p_thread);
@@ -1463,8 +1464,8 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    if (ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
-        ABTI_UNIT_REQ_MIGRATE) {
+    if (ABTD_atomic_acquire_load_uint32(&p_thread->thread.request) &
+        ABTI_THREAD_REQ_MIGRATE) {
         abt_errno = ABTI_xstream_migrate_thread(p_local_xstream, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
         goto fn_exit;
@@ -1472,11 +1473,11 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
 #endif
 
     /* Change the last ES */
-    p_thread->unit_def.p_last_xstream = p_local_xstream;
+    p_thread->thread.p_last_xstream = p_local_xstream;
 
     /* Change the ULT state */
-    ABTD_atomic_release_store_int(&p_thread->unit_def.state,
-                                  ABTI_UNIT_STATE_RUNNING);
+    ABTD_atomic_release_store_int(&p_thread->thread.state,
+                                  ABTI_THREAD_STATE_RUNNING);
 
     /* Switch the context */
     LOG_DEBUG("[U%" PRIu64 ":E%d] start running\n",
@@ -1498,52 +1499,52 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
      * (BLOCK, ORPHAN, STOP, and NOPUSH) are written by p_thread. CANCEL might
      * be delayed. */
     uint32_t request =
-        ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request);
-    if (request & ABTI_UNIT_REQ_STOP) {
+        ABTD_atomic_acquire_load_uint32(&p_thread->thread.request);
+    if (request & ABTI_THREAD_REQ_STOP) {
         /* The ULT has completed its execution or it called the exit request. */
         LOG_DEBUG("[U%" PRIu64 ":E%d] %s\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank,
-                  (request & ABTI_UNIT_REQ_TERMINATE
+                  (request & ABTI_THREAD_REQ_TERMINATE
                        ? "finished"
-                       : ((request & ABTI_UNIT_REQ_EXIT) ? "exit called"
-                                                         : "UNKNOWN")));
+                       : ((request & ABTI_THREAD_REQ_EXIT) ? "exit called"
+                                                           : "UNKNOWN")));
         ABTI_xstream_terminate_thread(p_local_xstream, p_thread);
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    } else if (request & ABTI_UNIT_REQ_CANCEL) {
+    } else if (request & ABTI_THREAD_REQ_CANCEL) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] canceled\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank);
         ABTD_thread_cancel(p_local_xstream, p_thread);
         ABTI_xstream_terminate_thread(p_local_xstream, p_thread);
 #endif
-    } else if (!(request & ABTI_UNIT_REQ_NON_YIELD)) {
+    } else if (!(request & ABTI_THREAD_REQ_NON_YIELD)) {
         /* The ULT did not finish its execution.
          * Change the state of current running ULT and
          * add it to the pool again. */
         ABTI_POOL_ADD_THREAD(p_thread,
                              ABTI_self_get_native_thread_id(p_local_xstream));
-    } else if (request & ABTI_UNIT_REQ_BLOCK) {
+    } else if (request & ABTI_THREAD_REQ_BLOCK) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] check blocked\n",
                   ABTI_thread_get_id(p_thread), p_local_xstream->rank);
-        ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_BLOCK);
+        ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_BLOCK);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    } else if (request & ABTI_UNIT_REQ_MIGRATE) {
+    } else if (request & ABTI_THREAD_REQ_MIGRATE) {
         /* This is the case when the ULT requests migration of itself. */
         abt_errno = ABTI_xstream_migrate_thread(p_local_xstream, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
 #endif
-    } else if (request & ABTI_UNIT_REQ_ORPHAN) {
+    } else if (request & ABTI_THREAD_REQ_ORPHAN) {
         /* The ULT is not pushed back to the pool and is disconnected from any
          * pool. */
         LOG_DEBUG("[U%" PRIu64 ":E%d] orphaned\n", ABTI_thread_get_id(p_thread),
                   p_local_xstream->rank);
-        ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_ORPHAN);
-        p_thread->unit_def.p_pool->u_free(&p_thread->unit_def.unit);
-        p_thread->unit_def.p_pool = NULL;
-    } else if (request & ABTI_UNIT_REQ_NOPUSH) {
+        ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_ORPHAN);
+        p_thread->thread.p_pool->u_free(&p_thread->thread.unit);
+        p_thread->thread.p_pool = NULL;
+    } else if (request & ABTI_THREAD_REQ_NOPUSH) {
         /* The ULT is not pushed back to the pool */
         LOG_DEBUG("[U%" PRIu64 ":E%d] not pushed\n",
                   ABTI_thread_get_id(p_thread), p_local_xstream->rank);
-        ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_NOPUSH);
+        ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_NOPUSH);
     } else {
         abt_errno = ABT_ERR_THREAD;
         goto fn_fail;
@@ -1558,11 +1559,11 @@ fn_fail:
 }
 
 void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
-                                ABTI_task *p_task)
+                                ABTI_thread *p_task)
 {
 #ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
     if (ABTD_atomic_acquire_load_uint32(&p_task->request) &
-        ABTI_UNIT_REQ_CANCEL) {
+        ABTI_THREAD_REQ_CANCEL) {
         ABTI_tool_event_task_cancel(p_local_xstream, p_task);
         ABTI_xstream_terminate_task(p_local_xstream, p_task);
         return;
@@ -1570,7 +1571,7 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
 #endif
 
     /* Change the task state */
-    ABTD_atomic_release_store_int(&p_task->state, ABTI_UNIT_STATE_RUNNING);
+    ABTD_atomic_release_store_int(&p_task->state, ABTI_THREAD_STATE_RUNNING);
 
     /* Set the associated ES */
     p_task->p_last_xstream = p_local_xstream;
@@ -1579,7 +1580,7 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
     LOG_DEBUG("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
 
-    ABTI_unit *p_sched_unit = p_local_xstream->p_unit;
+    ABTI_thread *p_sched_unit = p_local_xstream->p_unit;
     p_local_xstream->p_unit = p_task;
     p_task->p_parent = p_sched_unit;
 
@@ -1587,7 +1588,7 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
     ABTI_tool_event_task_run(p_local_xstream, p_task, p_sched_unit);
     LOG_DEBUG("[T%" PRIu64 ":E%d] running\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
-    p_task->f_unit(p_task->p_arg);
+    p_task->f_thread(p_task->p_arg);
     ABTI_tool_event_task_finish(p_local_xstream, p_task, p_sched_unit);
     LOG_DEBUG("[T%" PRIu64 ":E%d] stopped\n", ABTI_task_get_id(p_task),
               p_local_xstream->rank);
@@ -1617,23 +1618,23 @@ int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
     }
 
     /* If request is set, p_migration_pool has a valid pool pointer. */
-    ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->unit_def.request) &
-                ABTI_UNIT_REQ_MIGRATE);
+    ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->thread.request) &
+                ABTI_THREAD_REQ_MIGRATE);
 
     /* Extracting argument in migration request. */
     p_pool = ABTD_atomic_relaxed_load_ptr(&p_mig_data->p_migration_pool);
-    ABTI_thread_unset_request(p_thread, ABTI_UNIT_REQ_MIGRATE);
+    ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
 
     LOG_DEBUG("[U%" PRIu64 "] migration: E%d -> NT %p\n",
               ABTI_thread_get_id(p_thread),
-              p_thread->unit_def.p_last_xstream->rank,
+              p_thread->thread.p_last_xstream->rank,
               (void *)p_pool->consumer_id);
 
     /* Change the associated pool */
-    p_thread->unit_def.p_pool = p_pool;
+    p_thread->thread.p_pool = p_pool;
 
     /* Add the unit to the scheduler's pool */
-    ABTI_POOL_PUSH(p_pool, p_thread->unit_def.unit,
+    ABTI_POOL_PUSH(p_pool, p_thread->thread.unit,
                    ABTI_self_get_native_thread_id(p_local_xstream));
 
     ABTI_pool_dec_num_migrations(p_pool);
@@ -1732,20 +1733,19 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     /* If the caller ULT is associated with a pool of the current main
      * scheduler, it needs to be associated to a pool of new scheduler. */
     for (p = 0; p < p_main_sched->num_pools; p++) {
-        if (p_thread->unit_def.p_pool ==
+        if (p_thread->thread.p_pool ==
             ABTI_pool_get_ptr(p_main_sched->pools[p])) {
             /* Associate the work unit to the first pool of new scheduler */
-            p_thread->unit_def.p_pool->u_free(&p_thread->unit_def.unit);
+            p_thread->thread.p_pool->u_free(&p_thread->thread.unit);
             ABT_thread h_thread = ABTI_thread_get_handle(p_thread);
-            p_thread->unit_def.unit =
-                p_tar_pool->u_create_from_thread(h_thread);
-            p_thread->unit_def.p_pool = p_tar_pool;
+            p_thread->thread.unit = p_tar_pool->u_create_from_thread(h_thread);
+            p_thread->thread.p_pool = p_tar_pool;
             break;
         }
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(ABTI_unit_type_is_thread_main(p_thread->unit_def.type),
+        ABTI_CHECK_TRUE(ABTI_thread_type_is_thread_main(p_thread->thread.type),
                         ABT_ERR_THREAD);
 
         /* Since the primary ES does not finish its execution until ABT_finalize
@@ -1753,7 +1753,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * it is freed in ABT_finalize. */
         p_sched->automatic = ABT_TRUE;
 
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit_def.unit,
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->thread.unit,
                        ABTI_self_get_native_thread_id(*pp_local_xstream));
 
         /* Replace the top scheduler with the new scheduler */
@@ -1780,14 +1780,14 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * the new scheduler starts (see below), it can be scheduled by the new
          * scheduler. When the current ULT resumes its execution, it will free
          * the current main scheduler (see below). */
-        ABTI_POOL_PUSH(p_tar_pool, p_thread->unit_def.unit,
+        ABTI_POOL_PUSH(p_tar_pool, p_thread->thread.unit,
                        ABTI_self_get_native_thread_id(*pp_local_xstream));
 
         /* Set the scheduler */
         p_xstream->p_main_sched = p_sched;
 
         /* Switch to the current main scheduler */
-        ABTI_thread_set_request(p_thread, ABTI_UNIT_REQ_NOPUSH);
+        ABTI_thread_set_request(p_thread, ABTI_THREAD_REQ_NOPUSH);
         ABTI_thread_context_switch_to_parent(pp_local_xstream, p_thread,
                                              ABT_SYNC_EVENT_TYPE_OTHER, NULL);
 
@@ -1878,14 +1878,14 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
         abt_errno = ABTI_thread_create_main_sched(p_local_xstream,
                                                   p_local_xstream, p_sched);
         ABTI_CHECK_ERROR(abt_errno);
-        p_sched->p_thread->unit_def.p_last_xstream = p_local_xstream;
+        p_sched->p_thread->thread.p_last_xstream = p_local_xstream;
     } else {
         ABTI_tool_event_thread_create(p_local_xstream, p_sched->p_thread, NULL,
                                       NULL);
     }
 
     /* Set the sched ULT as the current ULT */
-    p_local_xstream->p_unit = &p_sched->p_thread->unit_def;
+    p_local_xstream->p_unit = &p_sched->p_thread->thread;
 
     /* Execute the main scheduler of this ES */
     LOG_DEBUG("[E%d] start\n", p_local_xstream->rank);

--- a/src/stream.c
+++ b/src/stream.c
@@ -317,7 +317,7 @@ fn_fail:
  * [in] p_thread   the main ULT
  */
 int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
-                               ABTI_xstream *p_xstream, ABTI_thread *p_thread)
+                               ABTI_xstream *p_xstream, ABTI_ythread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
 
@@ -1000,7 +1000,7 @@ int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
 
     if (type == ABT_UNIT_TYPE_THREAD) {
         ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+        ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
         /* Switch the context */
         abt_errno = ABTI_xstream_schedule_thread(pp_local_xstream, p_thread);
         ABTI_CHECK_ERROR(abt_errno);
@@ -1258,7 +1258,7 @@ int ABTI_xstream_join(ABTI_xstream **pp_local_xstream, ABTI_xstream *p_xstream)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream;
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABT_bool is_blockable = ABT_FALSE;
 
     ABTI_CHECK_TRUE_MSG(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
@@ -1422,7 +1422,7 @@ void ABTI_xstream_schedule(void *p_arg)
                  */
                 if (p_xstream->p_req_arg) {
                     ABTI_thread_set_ready(p_local_xstream,
-                                          (ABTI_thread *)p_xstream->p_req_arg);
+                                          (ABTI_ythread *)p_xstream->p_req_arg);
                     p_xstream->p_req_arg = NULL;
                 }
                 break;
@@ -1446,7 +1446,7 @@ void ABTI_xstream_schedule(void *p_arg)
 }
 
 int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
-                                 ABTI_thread *p_thread)
+                                 ABTI_ythread *p_thread)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
@@ -1482,7 +1482,7 @@ int ABTI_xstream_schedule_thread(ABTI_xstream **pp_local_xstream,
     LOG_DEBUG("[U%" PRIu64 ":E%d] start running\n",
               ABTI_thread_get_id(p_thread), p_local_xstream->rank);
 
-    ABTI_thread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
+    ABTI_ythread *p_self = ABTI_unit_get_thread(p_local_xstream->p_unit);
     p_thread =
         ABTI_thread_context_switch_to_child(pp_local_xstream, p_self, p_thread);
     /* The previous ULT (p_thread) may not be the same as one to which the
@@ -1600,7 +1600,7 @@ void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
 }
 
 int ABTI_xstream_migrate_thread(ABTI_xstream *p_local_xstream,
-                                ABTI_thread *p_thread)
+                                ABTI_ythread *p_thread)
 {
 #ifdef ABT_CONFIG_DISABLE_MIGRATION
     return ABT_ERR_MIGRATION_NA;
@@ -1694,7 +1694,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
                                    ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
     int abt_errno = ABT_SUCCESS;
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
     ABTI_sched *p_main_sched;
     ABTI_pool *p_tar_pool = NULL;
     int p;

--- a/src/thread_htable.c
+++ b/src/thread_htable.c
@@ -53,7 +53,7 @@ void ABTI_thread_htable_free(ABTI_thread_htable *p_htable)
 }
 
 void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
-                             ABTI_thread *p_thread)
+                             ABTI_ythread *p_thread)
 {
     ABTI_thread_queue *p_queue;
 
@@ -92,7 +92,7 @@ void ABTI_thread_htable_push(ABTI_thread_htable *p_htable, int idx,
 /* Unlike ABTI_thread_htable_push, this function pushes p_thread to the queue
  * only when the queue is not empty. */
 ABT_bool ABTI_thread_htable_add(ABTI_thread_htable *p_htable, int idx,
-                                ABTI_thread *p_thread)
+                                ABTI_ythread *p_thread)
 {
     ABTI_thread_queue *p_queue;
 
@@ -117,7 +117,7 @@ ABT_bool ABTI_thread_htable_add(ABTI_thread_htable *p_htable, int idx,
 }
 
 void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
-                                 ABTI_thread *p_thread)
+                                 ABTI_ythread *p_thread)
 {
     ABTI_thread_queue *p_queue;
 
@@ -156,7 +156,7 @@ void ABTI_thread_htable_push_low(ABTI_thread_htable *p_htable, int idx,
 /* Unlike ABTI_thread_htable_push_low, this function pushes p_thread to the
  * queue only when the queue is not empty. */
 ABT_bool ABTI_thread_htable_add_low(ABTI_thread_htable *p_htable, int idx,
-                                    ABTI_thread *p_thread)
+                                    ABTI_ythread *p_thread)
 {
     ABTI_thread_queue *p_queue;
 
@@ -180,10 +180,10 @@ ABT_bool ABTI_thread_htable_add_low(ABTI_thread_htable *p_htable, int idx,
     return ABT_TRUE;
 }
 
-ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
-                                    ABTI_thread_queue *p_queue)
+ABTI_ythread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
+                                     ABTI_thread_queue *p_queue)
 {
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
 
     ABTI_thread_queue_acquire_mutex(p_queue);
     if (p_queue->head) {
@@ -203,10 +203,10 @@ ABTI_thread *ABTI_thread_htable_pop(ABTI_thread_htable *p_htable,
     return p_thread;
 }
 
-ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
-                                        ABTI_thread_queue *p_queue)
+ABTI_ythread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
+                                         ABTI_thread_queue *p_queue)
 {
-    ABTI_thread *p_thread = NULL;
+    ABTI_ythread *p_thread = NULL;
 
     ABTI_thread_queue_acquire_low_mutex(p_queue);
     if (p_queue->low_head) {
@@ -228,12 +228,12 @@ ABTI_thread *ABTI_thread_htable_pop_low(ABTI_thread_htable *p_htable,
 
 ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
                                        ABTI_thread_queue *p_queue,
-                                       ABTI_thread *p_thread,
+                                       ABTI_ythread *p_thread,
                                        ABTI_thread_htable *p_htable,
                                        ABT_sync_event_type sync_event_type,
                                        void *p_sync)
 {
-    ABTI_thread *p_target = NULL;
+    ABTI_ythread *p_target = NULL;
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
 
     ABTI_thread_queue_acquire_low_mutex(p_queue);
@@ -266,7 +266,7 @@ ABT_bool ABTI_thread_htable_switch_low(ABTI_xstream **pp_local_xstream,
         ABTI_tool_event_thread_resume(p_local_xstream, p_target,
                                       p_local_xstream ? p_local_xstream->p_unit
                                                       : NULL);
-        ABTI_thread *p_prev =
+        ABTI_ythread *p_prev =
             ABTI_thread_context_switch_to_sibling(pp_local_xstream, p_thread,
                                                   p_target);
         ABTI_tool_event_thread_run(*pp_local_xstream, p_thread,

--- a/src/tool.c
+++ b/src/tool.c
@@ -265,7 +265,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                 *(int *)val = 0;
             } else {
                 int depth = 0;
-                ABTI_unit *p_cur = p_tctx->p_parent;
+                ABTI_thread *p_cur = p_tctx->p_parent;
                 while (p_cur) {
                     depth++;
                     p_cur = p_cur->p_parent;
@@ -276,7 +276,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
         case ABT_TOOL_QUERY_KIND_CALLER_TYPE:
             if (!p_tctx->p_caller) {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_EXT;
-            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
+            } else if (ABTI_thread_type_is_thread(p_tctx->p_caller->type)) {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_THREAD;
             } else {
                 *(ABT_exec_entity_type *)val = ABT_EXEC_ENTITY_TYPE_TASK;
@@ -285,7 +285,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
         case ABT_TOOL_QUERY_KIND_CALLER_HANDLE:
             if (!p_tctx->p_caller) {
                 *(void **)val = NULL;
-            } else if (ABTI_unit_type_is_thread(p_tctx->p_caller->type)) {
+            } else if (ABTI_thread_type_is_thread(p_tctx->p_caller->type)) {
                 *(ABT_thread *)val = ABTI_thread_get_handle(
                     ABTI_unit_get_thread(p_tctx->p_caller));
             } else {
@@ -307,7 +307,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                     break;
                 case ABT_SYNC_EVENT_TYPE_TASK_JOIN:
                     *(ABT_task *)val = ABTI_task_get_handle(
-                        (ABTI_task *)p_tctx->p_sync_object);
+                        (ABTI_thread *)p_tctx->p_sync_object);
                     break;
                 case ABT_SYNC_EVENT_TYPE_MUTEX:
                     *(ABT_mutex *)val = ABTI_mutex_get_handle(

--- a/src/tool.c
+++ b/src/tool.c
@@ -303,7 +303,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                     break;
                 case ABT_SYNC_EVENT_TYPE_THREAD_JOIN:
                     *(ABT_thread *)val = ABTI_thread_get_handle(
-                        (ABTI_thread *)p_tctx->p_sync_object);
+                        (ABTI_ythread *)p_tctx->p_sync_object);
                     break;
                 case ABT_SYNC_EVENT_TYPE_TASK_JOIN:
                     *(ABT_task *)val = ABTI_task_get_handle(

--- a/src/tool.c
+++ b/src/tool.c
@@ -289,8 +289,7 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                 *(ABT_thread *)val = ABTI_thread_get_handle(
                     ABTI_unit_get_thread(p_tctx->p_caller));
             } else {
-                *(ABT_task *)val =
-                    ABTI_task_get_handle(ABTI_unit_get_task(p_tctx->p_caller));
+                *(ABT_task *)val = ABTI_task_get_handle(p_tctx->p_caller);
             }
             break;
         case ABT_TOOL_QUERY_KIND_SYNC_OBJECT_TYPE:

--- a/src/unit.c
+++ b/src/unit.c
@@ -58,6 +58,6 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
         ABTI_ASSERT(type == ABT_UNIT_TYPE_TASK);
         ABT_task task = p_pool->u_get_task(unit);
         ABTI_task *p_task = ABTI_task_get_ptr(task);
-        p_task->unit_def.p_pool = p_pool;
+        p_task->p_pool = p_pool;
     }
 }

--- a/src/unit.c
+++ b/src/unit.c
@@ -52,12 +52,12 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
     if (type == ABT_UNIT_TYPE_THREAD) {
         ABT_thread thread = p_pool->u_get_thread(unit);
         ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
-        p_thread->unit_def.p_pool = p_pool;
+        p_thread->thread.p_pool = p_pool;
 
     } else {
         ABTI_ASSERT(type == ABT_UNIT_TYPE_TASK);
         ABT_task task = p_pool->u_get_task(unit);
-        ABTI_task *p_task = ABTI_task_get_ptr(task);
+        ABTI_thread *p_task = ABTI_task_get_ptr(task);
         p_task->p_pool = p_pool;
     }
 }

--- a/src/unit.c
+++ b/src/unit.c
@@ -51,7 +51,7 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
 
     if (type == ABT_UNIT_TYPE_THREAD) {
         ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+        ABTI_ythread *p_thread = ABTI_thread_get_ptr(thread);
         p_thread->unit_def.p_pool = p_pool;
 
     } else {


### PR DESCRIPTION
This PR renames the structs of work units. Specifically, this PR changes `ABTI_thread`, `ABTI_task`, and `ABTI_unit` as follows:
```c
struct ABTI_unit {
    [...]; // Common variables
};
struct ABTI_thread { // ULT descriptor
    ABTI_unit unit_def;
    [...]; // ULT-specific variables
};
struct ABTI_task { // tasklet descriptor
    ABTI_unit unit_def;
};
```

This PR changes these structures as follows.
```c
struct ABTI_thread { // descriptor for both ULT and tasklet
    [...]; // Common variables
};
struct ABTI_ythread { // ULT-specific descriptor
    ABTI_thread thread;
    [...]; // ULT-specific variables
};
```
The point of this change is to make it clear that both ULTs and tasklet are "threads" (`ABTI_thread`) while ULTs are special threads in terms of yieldability (thus yieldable thread: `ABTI_ythread`). This relation should be elegantly represented with inheritance, but this PR uses composition instead since C does not support such.

This is prerequisite for #227.