### PR TITLE
util: remove ABTU_get_int_len()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,9 +788,6 @@ AS_IF([test "x$have_alignof" = "xc11"],
       [AC_DEFINE(ABT_CONFIG_HAVE_ALIGNOF_C11, 1,
                  [Define to 1 if you have the `alignof' operator.])])
 
-# check math library
-AC_CHECK_LIB([m], [log10])
-
 # check if MAP_ANONYMOUS or MAP_ANON is defined
 AC_TRY_COMPILE([
 #include <stdio.h>

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -182,6 +182,4 @@ void ABTU_free_largepage(void *ptr, size_t size, ABTU_MEM_LARGEPAGE_TYPE type);
 /* The caller should free the memory returned. */
 char *ABTU_get_indent_str(int indent);
 
-int ABTU_get_int_len(size_t num);
-
 #endif /* ABTU_H_INCLUDED */

--- a/src/log.c
+++ b/src/log.c
@@ -19,7 +19,6 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     char *newfmt;
     uint64_t tid;
     int rank;
-    int tid_len = 0, rank_len = 0;
     size_t newfmt_len;
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_or_null(p_local);
@@ -46,9 +45,9 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     }
 
     if (prefix == NULL) {
-        tid_len = ABTU_get_int_len(tid);
-        rank_len = ABTU_get_int_len(rank);
-        newfmt_len = 6 + tid_len + rank_len + strlen(format);
+        /* Both tid and rank are less than 42 characters in total. */
+        const int len_tid_rank = 50;
+        newfmt_len = 6 + len_tid_rank + strlen(format);
         newfmt = (char *)ABTU_malloc(newfmt_len + 1);
         sprintf(newfmt, prefix_fmt, tid, rank, format);
     } else {

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -4,8 +4,6 @@
  */
 
 #include "abtu.h"
-#include <math.h>
-#include <ctype.h>
 
 /* \c ABTU_get_indent_str() returns a white-space string with the length of
  * \c indent.  The caller should free the memory returned. */
@@ -17,10 +15,4 @@ char *ABTU_get_indent_str(int indent)
         memset(space, ' ', indent);
     space[indent] = '\0';
     return space;
-}
-
-/* \c ABTU_get_int_len() returns the string length of the integer \c num. */
-int ABTU_get_int_len(size_t num)
-{
-    return (num == 0) ? 1 : (int)(log10(num) + 1);
 }

--- a/test/Makefile.mk
+++ b/test/Makefile.mk
@@ -5,7 +5,7 @@
 
 AM_CPPFLAGS = $(DEPS_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)/src/include -I$(top_srcdir)/test/util
-AM_LDFLAGS = $(DEPS_LDFLAGS)
+AM_LDFLAGS = $(DEPS_LDFLAGS) -lm
 
 libabt = $(top_builddir)/src/libabt.la
 libutil = $(top_builddir)/test/util/libutil.la


### PR DESCRIPTION
Only `ABTU_get_int_len()` uses on a math library in Argobots, but this function is not very necessary.  This patch removes it.

Note that it can remove the math library dependency (`-lm`) from Argobots.