### PR TITLE
thread: improve ABTI_thread_create() and ABTI_thread_free()

### DIFF
--- a/src/include/abtd_ythread.h
+++ b/src/include/abtd_ythread.h
@@ -17,28 +17,22 @@ void ABTD_ythread_func_wrapper(void *p_arg);
 void ABTD_ythread_terminate_no_arg();
 #endif
 
-static inline int ABTD_ythread_context_create(ABTD_ythread_context *p_link,
-                                              size_t stacksize, void *p_stack,
-                                              ABTD_ythread_context *p_newctx)
+static inline void ABTD_ythread_context_create(ABTD_ythread_context *p_link,
+                                               size_t stacksize, void *p_stack,
+                                               ABTD_ythread_context *p_newctx)
 {
-    int abt_errno = ABT_SUCCESS;
-    void *p_stacktop;
-
     /* ABTD_ythread_context_make uses the top address of stack.
        Note that the parameter, p_stack, points to the bottom of stack. */
-    p_stacktop = (void *)(((char *)p_stack) + stacksize);
+    void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
 
     ABTD_ythread_context_make(p_newctx, p_stacktop, stacksize,
                               ABTD_ythread_func_wrapper);
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_newctx->p_link, p_link);
-
-    return abt_errno;
 }
 
-static inline int
+static inline void
 ABTD_ythread_context_invalidate(ABTD_ythread_context *p_newctx)
 {
-    int abt_errno = ABT_SUCCESS;
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
     /* p_ctx is used to check whether the context requires dynamic promotion is
      * necessary or not, so this value must not be NULL. */
@@ -47,34 +41,32 @@ ABTD_ythread_context_invalidate(ABTD_ythread_context *p_newctx)
     p_newctx->p_ctx = NULL;
 #endif
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_newctx->p_link, NULL);
-    return abt_errno;
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
-static inline int ABTD_ythread_context_init(ABTD_ythread_context *p_link,
-                                            ABTD_ythread_context *p_newctx)
+static inline void ABTD_ythread_context_init(ABTD_ythread_context *p_link,
+                                             ABTD_ythread_context *p_newctx)
 {
-    int abt_errno = ABT_SUCCESS;
     p_newctx->p_ctx = NULL;
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_newctx->p_link, p_link);
-    return abt_errno;
 }
 
-static inline int
+static inline void
 ABTD_ythread_context_arm_ythread(size_t stacksize, void *p_stack,
                                  ABTD_ythread_context *p_newctx)
 {
-    /* This function *arms* the dynamic promotion thread (initialized by
+    /*
+     * This function *arms* the dynamic promotion thread (initialized by
      * ABTD_ythread_context_init) as if it were created by
      * ABTD_ythread_context_create; this function fully creates the context
-     * so that the thread can be run by ABTD_ythread_context_jump. */
-    int abt_errno = ABT_SUCCESS;
-    /* ABTD_ythread_context_make uses the top address of stack.
-       Note that the parameter, p_stack, points to the bottom of stack. */
+     * so that the thread can be run by ABTD_ythread_context_jump.
+     *
+     * ABTD_ythread_context_make uses the top address of stack.
+     * Note that the parameter, p_stack, points to the bottom of stack.
+     */
     void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     ABTD_ythread_context_make(p_newctx, p_stacktop, stacksize,
                               ABTD_ythread_func_wrapper);
-    return abt_errno;
 }
 #endif
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -77,14 +77,14 @@ enum ABTI_sched_used {
 #define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 4))
 #define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 5))
 
-#define ABTI_THREAD_TYPE_STACK_MEMPOOL ((ABTI_thread_type)(0x1 << 6))
-#define ABTI_THREAD_TYPE_STACK_MALLOC ((ABTI_thread_type)(0x1 << 7))
-#define ABTI_THREAD_TYPE_STACK_USER ((ABTI_thread_type)(0x1 << 8))
-#define ABTI_THREAD_TYPE_STACK_MAIN ((ABTI_thread_type)(0x1 << 9))
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC ((ABTI_thread_type)(0x1 << 6))
+#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 7))
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 8))
 
-#define ABTI_THREAD_TYPES_STACK                                                \
-    (ABTI_THREAD_TYPE_STACK_MEMPOOL | ABTI_THREAD_TYPE_STACK_MALLOC |          \
-     ABTI_THREAD_TYPE_STACK_USER | ABTI_THREAD_TYPE_STACK_MAIN)
+#define ABTI_THREAD_TYPES_MEM                                                  \
+    (ABTI_THREAD_TYPE_MEM_MALLOC_DESC |                                        \
+     ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK |                                 \
+     ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK)
 
 enum ABTI_thread_state {
     ABTI_THREAD_STATE_READY,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -77,12 +77,13 @@ enum ABTI_sched_used {
 #define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 4))
 #define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 5))
 
+#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC ((ABTI_thread_type)(0x1 << 7))
 #define ABTI_THREAD_TYPE_MEM_MALLOC_DESC ((ABTI_thread_type)(0x1 << 6))
-#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 7))
-#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 8))
+#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 8))
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 9))
 
 #define ABTI_THREAD_TYPES_MEM                                                  \
-    (ABTI_THREAD_TYPE_MEM_MALLOC_DESC |                                        \
+    (ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC | ABTI_THREAD_TYPE_MEM_MALLOC_DESC |    \
      ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK |                                 \
      ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK)
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -77,6 +77,15 @@ enum ABTI_sched_used {
 #define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 4))
 #define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 5))
 
+#define ABTI_THREAD_TYPE_STACK_MEMPOOL ((ABTI_thread_type)(0x1 << 6))
+#define ABTI_THREAD_TYPE_STACK_MALLOC ((ABTI_thread_type)(0x1 << 7))
+#define ABTI_THREAD_TYPE_STACK_USER ((ABTI_thread_type)(0x1 << 8))
+#define ABTI_THREAD_TYPE_STACK_MAIN ((ABTI_thread_type)(0x1 << 9))
+
+#define ABTI_THREAD_TYPES_STACK                                                \
+    (ABTI_THREAD_TYPE_STACK_MEMPOOL | ABTI_THREAD_TYPE_STACK_MALLOC |          \
+     ABTI_THREAD_TYPE_STACK_USER | ABTI_THREAD_TYPE_STACK_MAIN)
+
 enum ABTI_thread_state {
     ABTI_THREAD_STATE_READY,
     ABTI_THREAD_STATE_RUNNING,
@@ -87,13 +96,6 @@ enum ABTI_thread_state {
 enum ABTI_mutex_attr_val {
     ABTI_MUTEX_ATTR_NONE = 0,
     ABTI_MUTEX_ATTR_RECURSIVE = 1 << 0
-};
-
-enum ABTI_stack_type {
-    ABTI_STACK_TYPE_MEMPOOL = 0, /* Stack taken from the memory pool */
-    ABTI_STACK_TYPE_MALLOC,      /* Stack allocated by malloc in Argobots */
-    ABTI_STACK_TYPE_USER,        /* Stack given by a user */
-    ABTI_STACK_TYPE_MAIN,        /* Stack of a main ULT. */
 };
 
 /* Macro functions */
@@ -115,7 +117,6 @@ typedef struct ABTI_thread ABTI_thread;
 typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_ythread ABTI_ythread;
 typedef struct ABTI_thread_mig_data ABTI_thread_mig_data;
-typedef enum ABTI_stack_type ABTI_stack_type;
 typedef uint32_t ABTI_thread_type;
 typedef enum ABTI_thread_state ABTI_thread_state;
 typedef struct ABTI_ythread_htable ABTI_ythread_htable;
@@ -334,9 +335,9 @@ struct ABTI_thread {
 };
 
 struct ABTI_thread_attr {
-    void *p_stack;             /* Stack address */
-    size_t stacksize;          /* Stack size (in bytes) */
-    ABTI_stack_type stacktype; /* Stack type */
+    void *p_stack;                /* Stack address */
+    size_t stacksize;             /* Stack size (in bytes) */
+    ABTI_thread_type thread_type; /* Thread type */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABT_bool migratable;              /* Migratability */
     void (*f_cb)(ABT_thread, void *); /* Callback function */
@@ -352,11 +353,10 @@ struct ABTI_thread_mig_data {
 };
 
 struct ABTI_ythread {
-    ABTI_thread thread;        /* Common thread definition */
-    ABTD_ythread_context ctx;  /* Context */
-    void *p_stack;             /* Stack address */
-    size_t stacksize;          /* Stack size (in bytes) */
-    ABTI_stack_type stacktype; /* Stack type */
+    ABTI_thread thread;       /* Common thread definition */
+    ABTD_ythread_context ctx; /* Context */
+    void *p_stack;            /* Stack address */
+    size_t stacksize;         /* Stack size (in bytes) */
 };
 
 struct ABTI_key {

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -51,12 +51,12 @@ static inline void ABTI_thread_attr_init_migration(ABTI_thread_attr *p_attr,
 
 static inline void ABTI_thread_attr_init(ABTI_thread_attr *p_attr,
                                          void *p_stack, size_t stacksize,
-                                         ABTI_stack_type stacktype,
+                                         ABTI_thread_type thread_type,
                                          ABT_bool migratable)
 {
     p_attr->p_stack = p_stack;
     p_attr->stacksize = stacksize;
-    p_attr->stacktype = stacktype;
+    p_attr->thread_type = thread_type;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_attr_init_migration(p_attr, migratable);
 #endif

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -63,12 +63,12 @@ void ABTI_mem_init(ABTI_global *p_global)
                                    num_requested_types,
                                    gp_ABTI_global->mem_page_size);
     /* The last four bytes will be used to store a mempool flag */
-    ABTI_STATIC_ASSERT(((ABTI_MEM_POOL_DESC_SIZE + 4) &
+    ABTI_STATIC_ASSERT((ABTI_MEM_POOL_DESC_ELEM_SIZE &
                         (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0);
     ABTI_mem_pool_init_global_pool(&p_global->mem_pool_desc,
                                    p_global->mem_max_descs /
                                        ABT_MEM_POOL_MAX_LOCAL_BUCKETS,
-                                   ABTI_MEM_POOL_DESC_SIZE + 4, 0,
+                                   ABTI_MEM_POOL_DESC_ELEM_SIZE, 0,
                                    p_global->mem_page_size, requested_types,
                                    num_requested_types,
                                    gp_ABTI_global->mem_page_size);

--- a/src/task.c
+++ b/src/task.c
@@ -486,7 +486,7 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     /* Allocate a task object */
-    p_newtask = ABTI_mem_alloc_task(p_local);
+    p_newtask = ABTI_mem_alloc_nythread(p_local);
 
     p_newtask->p_last_xstream = NULL;
     p_newtask->p_parent = NULL;
@@ -506,7 +506,7 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     thread_type |= ABTI_THREAD_TYPE_MIGRATABLE;
 #endif
-    p_newtask->type = thread_type;
+    p_newtask->type |= thread_type;
     p_newtask->unit = p_pool->u_create_from_task(h_newtask);
 
     ABTI_tool_event_thread_create(p_local, p_newtask,

--- a/src/thread.c
+++ b/src/thread.c
@@ -1603,24 +1603,23 @@ static inline int ABTI_ythread_create_internal(
         /* We don't need to initialize the context of 1. the main thread, and
          * 2. the main scheduler thread which runs on OS-level threads
          * (p_stack == NULL). Invalidate the context here. */
-        abt_errno = ABTD_ythread_context_invalidate(&p_newthread->ctx);
+        ABTD_ythread_context_invalidate(&p_newthread->ctx);
     } else if (p_sched == NULL) {
 #if ABT_CONFIG_THREAD_TYPE != ABT_THREAD_TYPE_DYNAMIC_PROMOTION
         size_t stack_size = p_newthread->stacksize;
         void *p_stack = p_newthread->p_stack;
-        abt_errno = ABTD_ythread_context_create(NULL, stack_size, p_stack,
-                                                &p_newthread->ctx);
+        ABTD_ythread_context_create(NULL, stack_size, p_stack,
+                                    &p_newthread->ctx);
 #else
         /* The context is not fully created now. */
-        abt_errno = ABTD_ythread_context_init(NULL, &p_newthread->ctx);
+        ABTD_ythread_context_init(NULL, &p_newthread->ctx);
 #endif
     } else {
         size_t stack_size = p_newthread->stacksize;
         void *p_stack = p_newthread->p_stack;
-        abt_errno = ABTD_ythread_context_create(NULL, stack_size, p_stack,
-                                                &p_newthread->ctx);
+        ABTD_ythread_context_create(NULL, stack_size, p_stack,
+                                    &p_newthread->ctx);
     }
-    ABTI_CHECK_ERROR(abt_errno);
     p_newthread->thread.f_thread = thread_func;
     p_newthread->thread.p_arg = arg;
 
@@ -1689,6 +1688,9 @@ static inline int ABTI_ythread_create_internal(
     /* Return value */
     *pp_newthread = p_newthread;
 
+#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
+    return abt_errno;
+#else
 fn_exit:
     return abt_errno;
 
@@ -1696,6 +1698,7 @@ fn_fail:
     *pp_newthread = NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
+#endif
 }
 
 int ABTI_ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
@@ -2120,10 +2123,8 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     if (p_ythread) {
         /* Create a ULT context */
         size_t stacksize = p_ythread->stacksize;
-        abt_errno =
-            ABTD_ythread_context_create(NULL, stacksize, p_ythread->p_stack,
-                                        &p_ythread->ctx);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTD_ythread_context_create(NULL, stacksize, p_ythread->p_stack,
+                                    &p_ythread->ctx);
     }
 
     /* Invoke a thread revive event. */

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -32,7 +32,7 @@ int ABT_thread_attr_create(ABT_thread_attr *newattr)
 
     /* Default values */
     ABTI_thread_attr_init(p_newattr, NULL, ABTI_global_get_thread_stacksize(),
-                          ABTI_THREAD_TYPE_STACK_MEMPOOL, ABT_TRUE);
+                          ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK, ABT_TRUE);
 
     /* Return value */
     *newattr = ABTI_thread_attr_get_handle(p_newattr);
@@ -107,16 +107,16 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
             abt_errno = ABT_ERR_OTHER;
             goto fn_fail;
         }
-        new_thread_type = ABTI_THREAD_TYPE_STACK_USER;
+        new_thread_type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC;
     } else {
         if (stacksize == ABTI_global_get_thread_stacksize()) {
-            new_thread_type = ABTI_THREAD_TYPE_STACK_MEMPOOL;
+            new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
         } else {
-            new_thread_type = ABTI_THREAD_TYPE_STACK_MALLOC;
+            new_thread_type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
         }
     }
     /* Unset the stack type and set new_thread_type. */
-    p_attr->thread_type &= ~ABTI_THREAD_TYPES_STACK;
+    p_attr->thread_type &= ~ABTI_THREAD_TYPES_MEM;
     p_attr->thread_type |= new_thread_type;
 
     p_attr->p_stack = stackaddr;
@@ -186,12 +186,12 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
     p_attr->stacksize = stacksize;
     ABTI_thread_type new_thread_type;
     if (stacksize == ABTI_global_get_thread_stacksize()) {
-        new_thread_type = ABTI_THREAD_TYPE_STACK_MEMPOOL;
+        new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
     } else {
-        new_thread_type = ABTI_THREAD_TYPE_STACK_MALLOC;
+        new_thread_type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
     }
     /* Unset the stack type and set new_thread_type. */
-    p_attr->thread_type &= ~ABTI_THREAD_TYPES_STACK;
+    p_attr->thread_type &= ~ABTI_THREAD_TYPES_MEM;
     p_attr->thread_type |= new_thread_type;
 
 fn_exit:
@@ -328,14 +328,12 @@ void ABTI_thread_attr_get_str(ABTI_thread_attr *p_attr, char *p_buf)
     }
 
     char *stacktype;
-    if (p_attr->thread_type & ABTI_THREAD_TYPE_STACK_MEMPOOL) {
-        stacktype = "MEMPOOL";
-    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_STACK_MALLOC) {
-        stacktype = "MALLOC";
-    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_STACK_USER) {
-        stacktype = "USER";
-    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_STACK_MAIN) {
-        stacktype = "MAIN";
+    if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MALLOC_DESC) {
+        stacktype = "MALLOC_DESC";
+    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK) {
+        stacktype = "MEMPOOL_DESC_STACK";
+    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK) {
+        stacktype = "MALLOC_DESC_STACK";
     } else {
         stacktype = "UNKNOWN";
     }

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -107,7 +107,7 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
             abt_errno = ABT_ERR_OTHER;
             goto fn_fail;
         }
-        new_thread_type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC;
+        new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC;
     } else {
         if (stacksize == ABTI_global_get_thread_stacksize()) {
             new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
@@ -188,7 +188,7 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
     if (stacksize == ABTI_global_get_thread_stacksize()) {
         new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
     } else {
-        new_thread_type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
+        new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
     }
     /* Unset the stack type and set new_thread_type. */
     p_attr->thread_type &= ~ABTI_THREAD_TYPES_MEM;
@@ -328,7 +328,9 @@ void ABTI_thread_attr_get_str(ABTI_thread_attr *p_attr, char *p_buf)
     }
 
     char *stacktype;
-    if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MALLOC_DESC) {
+    if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC) {
+        stacktype = "MEMPOOL_DESC";
+    } else if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MALLOC_DESC) {
         stacktype = "MALLOC_DESC";
     } else if (p_attr->thread_type & ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK) {
         stacktype = "MEMPOOL_DESC_STACK";


### PR DESCRIPTION
This patch improves functions called in `ABTI_thread_create()` and `ABTI_thread_free()`.

Note that `sizeof(ABTI_ythread)` on most architectures including x86/64, POWER9, and 64-bit ARM becomes 128 bytes after this patch (*if `fcontext` is enabled, a compiler is GCC compatible in terms of structure alignment, and the pointer size is 8 bytes (64-bit OS)).
