### PR TITLE
error: improve error handling

### DIFF
--- a/src/arch/abtd_time.c
+++ b/src/arch/abtd_time.c
@@ -20,8 +20,6 @@ void ABTD_time_init(void)
 /* Obtain the time value */
 int ABTD_time_get(ABTD_time *p_time)
 {
-    int abt_errno = ABT_SUCCESS;
-
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
     clock_gettime(CLOCK_REALTIME, p_time);
 #elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
@@ -30,7 +28,7 @@ int ABTD_time_get(ABTD_time *p_time)
     gettimeofday(p_time, NULL);
 #endif
 
-    return abt_errno;
+    return ABT_SUCCESS;
 }
 
 /* Read the time value as seconds (double precision) */

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -29,6 +29,7 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
     ABTI_barrier *p_newbarrier;
 
     p_newbarrier = (ABTI_barrier *)ABTU_malloc(sizeof(ABTI_barrier));
+    ABTI_CHECK_TRUE(p_newbarrier != NULL, ABT_ERR_MEM);
 
     ABTI_spinlock_clear(&p_newbarrier->lock);
     p_newbarrier->num_waiters = num_waiters;
@@ -41,7 +42,12 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
     /* Return value */
     *newbarrier = ABTI_barrier_get_handle(p_newbarrier);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/cond.c
+++ b/src/cond.c
@@ -29,12 +29,18 @@ int ABT_cond_create(ABT_cond *newcond)
     ABTI_cond *p_newcond;
 
     p_newcond = (ABTI_cond *)ABTU_malloc(sizeof(ABTI_cond));
+    ABTI_CHECK_TRUE(p_newcond != NULL, ABT_ERR_MEM);
     ABTI_cond_init(p_newcond);
 
     /* Return value */
     *newcond = ABTI_cond_get_handle(p_newcond);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -35,6 +35,7 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
     ABTI_eventual *p_eventual;
 
     p_eventual = (ABTI_eventual *)ABTU_malloc(sizeof(ABTI_eventual));
+    ABTI_CHECK_TRUE(p_eventual != NULL, ABT_ERR_MEM);
     ABTI_spinlock_clear(&p_eventual->lock);
     p_eventual->ready = ABT_FALSE;
     p_eventual->nbytes = nbytes;
@@ -44,7 +45,12 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
 
     *neweventual = ABTI_eventual_get_handle(p_eventual);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/futures.c
+++ b/src/futures.c
@@ -60,6 +60,7 @@ int ABT_future_create(uint32_t compartments, void (*cb_func)(void **arg),
     ABTI_future *p_future;
 
     p_future = (ABTI_future *)ABTU_malloc(sizeof(ABTI_future));
+    ABTI_CHECK_TRUE(p_future != NULL, ABT_ERR_MEM);
     ABTI_spinlock_clear(&p_future->lock);
     ABTD_atomic_relaxed_store_uint32(&p_future->counter, 0);
     p_future->compartments = compartments;
@@ -70,7 +71,12 @@ int ABT_future_create(uint32_t compartments, void (*cb_func)(void **arg),
 
     *newfuture = ABTI_future_get_handle(p_future);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -472,7 +472,7 @@ int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
                                    ABTI_xstream *p_xstream,
                                    ABTI_sched *p_sched);
-int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched);
+void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void *ABTI_xstream_launch_main_sched(void *p_arg);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -517,14 +517,6 @@ int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
 void ABTI_pool_free(ABTI_pool *p_pool);
 int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def);
 int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def);
-#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-int ABTI_pool_set_consumer(ABTI_pool *p_pool,
-                           ABTI_native_thread_id consumer_id);
-#endif
-#ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-int ABTI_pool_set_producer(ABTI_pool *p_pool,
-                           ABTI_native_thread_id producer_id);
-#endif
 int ABTI_pool_accept_migration(ABTI_pool *p_pool, ABTI_pool *source);
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
@@ -609,11 +601,11 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_log.h"
 #include "abti_local.h"
 #include "abti_global.h"
+#include "abti_self.h"
 #include "abti_pool.h"
 #include "abti_sched.h"
 #include "abti_config.h"
 #include "abti_stream.h"
-#include "abti_self.h"
 #include "abti_thread.h"
 #include "abti_tool.h"
 #include "abti_ythread.h"

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -60,8 +60,6 @@ static inline ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
                                  ABTI_mutex *p_mutex)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_ythread *p_ythread = NULL;
     ABTI_thread *p_thread;
 
@@ -89,8 +87,7 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
             ABTI_spinlock_release(&p_cond->lock);
             if (!p_ythread)
                 ABTU_free(p_thread);
-            abt_errno = ABT_ERR_INV_MUTEX;
-            goto fn_fail;
+            return ABT_ERR_INV_MUTEX;
         }
     }
 
@@ -136,13 +133,7 @@ static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
 
     /* Lock the mutex again */
     ABTI_mutex_lock(pp_local, p_mutex);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -101,6 +101,13 @@
         }                                                                      \
     } while (0)
 
+#define ABTI_CHECK_ERROR_RET(abt_errno)                                        \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+            return abt_errno;                                                  \
+        }                                                                      \
+    } while (0)
+
 #define ABTI_CHECK_TRUE(cond, val)                                             \
     do {                                                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
@@ -123,6 +130,16 @@
             !(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE)) {                     \
             abt_errno = (err);                                                 \
             goto fn_fail;                                                      \
+        }                                                                      \
+        *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
+    } while (0)
+
+#define ABTI_CHECK_YIELDABLE_RET(p_thread, pp_ythread, err)                    \
+    do {                                                                       \
+        ABTI_thread *p_tmp = (p_thread);                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            !(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE)) {                     \
+            return (err);                                                      \
         }                                                                      \
         *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
     } while (0)

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -341,4 +341,10 @@
         }                                                                      \
     } while (0)
 
+#define HANDLE_ERROR_FUNC_WITH_CODE_RET(n)                                     \
+    do {                                                                       \
+        HANDLE_ERROR_FUNC_WITH_CODE(n);                                        \
+        return n;                                                              \
+    } while (0)
+
 #endif /* ABTI_ERROR_H_INCLUDED */

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -29,7 +29,8 @@
 
 #define ABTI_SETUP_WITH_INIT_CHECK()                                           \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && gp_ABTI_global == NULL) {           \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(gp_ABTI_global == NULL)) {                           \
             abt_errno = ABT_ERR_UNINITIALIZED;                                 \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -39,7 +40,8 @@
     do {                                                                       \
         ABTI_xstream *p_local_xstream_tmp =                                    \
             ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
-        if (ABTI_IS_EXT_THREAD_ENABLED && p_local_xstream_tmp == NULL) {       \
+        if (ABTI_IS_EXT_THREAD_ENABLED &&                                      \
+            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
             abt_errno = ABT_ERR_INV_XSTREAM;                                   \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -54,7 +56,7 @@
         ABTI_xstream *p_local_xstream_tmp =                                    \
             ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
         if (ABTI_IS_ERROR_CHECK_ENABLED && ABTI_IS_EXT_THREAD_ENABLED &&       \
-            p_local_xstream_tmp == NULL) {                                     \
+            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
             abt_errno = ABT_ERR_INV_XSTREAM;                                   \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -64,7 +66,8 @@
         }                                                                      \
         ABTI_thread *p_thread_tmp = p_local_xstream_tmp->p_thread;             \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            !(p_thread_tmp->type & ABTI_THREAD_TYPE_YIELDABLE)) {              \
+            ABTU_unlikely(                                                     \
+                !(p_thread_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {         \
             abt_errno = ABT_ERR_INV_THREAD;                                    \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -88,14 +91,16 @@
 
 #define ABTI_CHECK_ERROR(abt_errno)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
             goto fn_fail;                                                      \
         }                                                                      \
     } while (0)
 
 #define ABTI_CHECK_ERROR_MSG(abt_errno, msg)                                   \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
             HANDLE_ERROR(msg);                                                 \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -103,14 +108,15 @@
 
 #define ABTI_CHECK_ERROR_RET(abt_errno)                                        \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
             return abt_errno;                                                  \
         }                                                                      \
     } while (0)
 
 #define ABTI_CHECK_TRUE(cond, val)                                             \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
             abt_errno = (val);                                                 \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -118,7 +124,7 @@
 
 #define ABTI_CHECK_TRUE_RET(cond, val)                                         \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
             return (val);                                                      \
         }                                                                      \
     } while (0)
@@ -127,7 +133,7 @@
     do {                                                                       \
         ABTI_thread *p_tmp = (p_thread);                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            !(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE)) {                     \
+            ABTU_unlikely(!(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {      \
             abt_errno = (err);                                                 \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -138,7 +144,7 @@
     do {                                                                       \
         ABTI_thread *p_tmp = (p_thread);                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            !(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE)) {                     \
+            ABTU_unlikely(!(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {      \
             return (err);                                                      \
         }                                                                      \
         *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
@@ -146,7 +152,7 @@
 
 #define ABTI_CHECK_TRUE_MSG(cond, val, msg)                                    \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
             abt_errno = (val);                                                 \
             HANDLE_ERROR(msg);                                                 \
             goto fn_fail;                                                      \
@@ -155,7 +161,7 @@
 
 #define ABTI_CHECK_TRUE_MSG_RET(cond, val, msg)                                \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !(cond)) {                          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
             HANDLE_ERROR(msg);                                                 \
             return (val);                                                      \
         }                                                                      \
@@ -163,7 +169,8 @@
 
 #define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                         \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_xstream *)NULL) {        \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_xstream *)NULL)) {                        \
             abt_errno = ABT_ERR_INV_XSTREAM;                                   \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -171,7 +178,8 @@
 
 #define ABTI_CHECK_NULL_POOL_PTR(p)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_pool *)NULL) {           \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_pool *)NULL)) {                           \
             abt_errno = ABT_ERR_INV_POOL;                                      \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -179,7 +187,8 @@
 
 #define ABTI_CHECK_NULL_SCHED_PTR(p)                                           \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_sched *)NULL) {          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_sched *)NULL)) {                          \
             abt_errno = ABT_ERR_INV_SCHED;                                     \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -187,7 +196,8 @@
 
 #define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
             abt_errno = ABT_ERR_INV_THREAD;                                    \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -195,7 +205,8 @@
 
 #define ABTI_CHECK_NULL_YTHREAD_PTR(p)                                         \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_ythread *)NULL) {        \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_ythread *)NULL)) {                        \
             abt_errno = ABT_ERR_INV_THREAD;                                    \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -203,7 +214,8 @@
 
 #define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                     \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread_attr *)NULL) {    \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread_attr *)NULL)) {                    \
             abt_errno = ABT_ERR_INV_THREAD_ATTR;                               \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -211,7 +223,8 @@
 
 #define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_thread *)NULL) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
             abt_errno = ABT_ERR_INV_TASK;                                      \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -219,7 +232,8 @@
 
 #define ABTI_CHECK_NULL_KEY_PTR(p)                                             \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_key *)NULL) {            \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_key *)NULL)) {                            \
             abt_errno = ABT_ERR_INV_KEY;                                       \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -227,7 +241,8 @@
 
 #define ABTI_CHECK_NULL_MUTEX_PTR(p)                                           \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex *)NULL) {          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_mutex *)NULL)) {                          \
             abt_errno = ABT_ERR_INV_MUTEX;                                     \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -235,7 +250,8 @@
 
 #define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                      \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_mutex_attr *)NULL) {     \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_mutex_attr *)NULL)) {                     \
             abt_errno = ABT_ERR_INV_MUTEX_ATTR;                                \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -243,7 +259,8 @@
 
 #define ABTI_CHECK_NULL_COND_PTR(p)                                            \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_cond *)NULL) {           \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_cond *)NULL)) {                           \
             abt_errno = ABT_ERR_INV_COND;                                      \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -251,7 +268,8 @@
 
 #define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                          \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_rwlock *)NULL) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_rwlock *)NULL)) {                         \
             abt_errno = ABT_ERR_INV_RWLOCK;                                    \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -259,7 +277,8 @@
 
 #define ABTI_CHECK_NULL_FUTURE_PTR(p)                                          \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_future *)NULL) {         \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_future *)NULL)) {                         \
             abt_errno = ABT_ERR_INV_FUTURE;                                    \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -267,7 +286,8 @@
 
 #define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                        \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_eventual *)NULL) {       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_eventual *)NULL)) {                       \
             abt_errno = ABT_ERR_INV_EVENTUAL;                                  \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -275,7 +295,8 @@
 
 #define ABTI_CHECK_NULL_BARRIER_PTR(p)                                         \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_barrier *)NULL) {        \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_barrier *)NULL)) {                        \
             abt_errno = ABT_ERR_INV_BARRIER;                                   \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -284,7 +305,7 @@
 #define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)                                 \
     do {                                                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            p == (ABTI_xstream_barrier *)NULL) {                               \
+            ABTU_unlikely(p == (ABTI_xstream_barrier *)NULL)) {                \
             abt_errno = ABT_ERR_INV_BARRIER;                                   \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -292,7 +313,8 @@
 
 #define ABTI_CHECK_NULL_TIMER_PTR(p)                                           \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_timer *)NULL) {          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_timer *)NULL)) {                          \
             abt_errno = ABT_ERR_INV_TIMER;                                     \
             goto fn_fail;                                                      \
         }                                                                      \
@@ -300,7 +322,8 @@
 
 #define ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p)                                    \
     do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p == (ABTI_tool_context *)NULL) {   \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_tool_context *)NULL)) {                   \
             abt_errno = ABT_ERR_INV_TOOL_CONTEXT;                              \
             goto fn_fail;                                                      \
         }                                                                      \

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -11,18 +11,17 @@
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 
 void ABTI_log_debug(FILE *fh, const char *format, ...);
-void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
-                        ABTI_native_thread_id producer_id);
-void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                          ABTI_native_thread_id consumer_id);
+void ABTI_log_pool_push(ABTI_local *p_local, ABTI_pool *p_pool, ABT_unit unit);
+void ABTI_log_pool_remove(ABTI_local *p_local, ABTI_pool *p_pool,
+                          ABT_unit unit);
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
 
 #define LOG_DEBUG(fmt, ...) ABTI_log_debug(stderr, fmt, __VA_ARGS__)
 
-#define LOG_DEBUG_POOL_PUSH(p_pool, unit, produer_id)                          \
-    ABTI_log_pool_push(p_pool, unit, produer_id)
-#define LOG_DEBUG_POOL_REMOVE(p_pool, unit, consumer_id)                       \
-    ABTI_log_pool_remove(p_pool, unit, consumer_id)
+#define LOG_DEBUG_POOL_PUSH(p_local, p_pool, unit)                             \
+    ABTI_log_pool_push(p_local, p_pool, unit)
+#define LOG_DEBUG_POOL_REMOVE(p_local, p_pool, unit)                           \
+    ABTI_log_pool_remove(p_local, p_pool, unit)
 #define LOG_DEBUG_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
 
 #else

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -92,7 +92,6 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
     }
     LOG_DEBUG("%p: lock - acquired\n", p_mutex);
 #else
-    int abt_errno;
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
     LOG_DEBUG("%p: lock - try\n", p_mutex);
@@ -117,10 +116,8 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                     ABTI_ythread *p_giver = p_mutex->p_giver;
                     ABTD_atomic_release_store_int(&p_giver->thread.state,
                                                   ABTI_THREAD_STATE_READY);
-                    abt_errno =
-                        ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
-                                       p_giver->thread.unit);
-                    ABTI_CHECK_ERROR(abt_errno);
+                    ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
+                                   p_giver->thread.unit);
                     break;
                 }
             }
@@ -129,13 +126,7 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
         }
     }
     LOG_DEBUG("%p: lock - acquired\n", p_mutex);
-
-fn_exit:
     return;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 #endif
 }
 

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -117,8 +117,10 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
                     ABTI_ythread *p_giver = p_mutex->p_giver;
                     ABTD_atomic_release_store_int(&p_giver->thread.state,
                                                   ABTI_THREAD_STATE_READY);
-                    ABTI_POOL_PUSH(p_giver->thread.p_pool, p_giver->thread.unit,
-                                   ABTI_self_get_native_thread_id(*pp_local));
+                    abt_errno =
+                        ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
+                                       p_giver->thread.unit);
+                    ABTI_CHECK_ERROR(abt_errno);
                     break;
                 }
             }

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -6,6 +6,18 @@
 #ifndef ABTI_POOL_H_INCLUDED
 #define ABTI_POOL_H_INCLUDED
 
+#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
+#define ABTI_IS_POOL_PRODUCER_CHECK_ENABLED 0
+#else
+#define ABTI_IS_POOL_PRODUCER_CHECK_ENABLED 1
+#endif
+
+#ifdef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
+#define ABTI_IS_POOL_CONSUMER_CHECK_ENABLED 0
+#else
+#define ABTI_IS_POOL_CONSUMER_CHECK_ENABLED 1
+#endif
+
 /* Inlined functions for Pool */
 
 static inline ABTI_pool *ABTI_pool_get_ptr(ABT_pool pool)
@@ -62,43 +74,161 @@ static inline void ABTI_pool_dec_num_migrations(ABTI_pool *p_pool)
     ABTD_atomic_fetch_sub_int32(&p_pool->num_migrations, 1);
 }
 
-#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-static inline void ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit)
+/* Set the associated consumer ES of a pool. This function has no effect on
+ * pools of shared-read access mode. If a pool is private-read to an ES, we
+ * check that the previous value of "consumer_id" is the same as the argument of
+ * the function "consumer_id"
+ * */
+#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
+static inline int
+ABTI_pool_set_consumer_common_impl(ABTI_pool *p_pool,
+                                   ABTI_native_thread_id consumer_id)
 {
-    LOG_DEBUG_POOL_PUSH(p_pool, unit,
-                        ABTI_self_get_native_thread_id(
-                            ABTI_local_get_xstream()));
+    int abt_errno = ABT_SUCCESS;
+    switch (p_pool->access) {
+        case ABT_POOL_ACCESS_PRIV:
+#ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
+            ABTI_CHECK_TRUE(!p_pool->producer_id ||
+                                p_pool->producer_id == consumer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+#endif
+            ABTI_CHECK_TRUE(!p_pool->consumer_id ||
+                                p_pool->consumer_id == consumer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+            p_pool->consumer_id = consumer_id;
+            break;
 
-    /* Push unit into pool */
-    p_pool->p_push(ABTI_pool_get_handle(p_pool), unit);
+        case ABT_POOL_ACCESS_SPSC:
+        case ABT_POOL_ACCESS_MPSC:
+            ABTI_CHECK_TRUE(!p_pool->consumer_id ||
+                                p_pool->consumer_id == consumer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+            /* NB: as we do not want to use a mutex, the function can be wrong
+             * here */
+            p_pool->consumer_id = consumer_id;
+            break;
+
+        case ABT_POOL_ACCESS_SPMC:
+        case ABT_POOL_ACCESS_MPMC:
+            p_pool->consumer_id = consumer_id;
+            break;
+
+        default:
+            abt_errno = ABT_ERR_INV_POOL_ACCESS;
+            ABTI_CHECK_ERROR(abt_errno);
+    }
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
-static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
+static inline int ABTI_pool_set_consumer_id(ABTI_pool *p_pool,
+                                            ABTI_native_thread_id consumer_id)
 {
-    /* Set the ULT's state as READY. The relaxed version is used since the state
-     * is synchronized by the following pool operation. */
-    ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_THREAD_STATE_READY);
+    if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 0)
+        return ABT_SUCCESS;
+    return ABTI_pool_set_consumer_common_impl(p_pool, consumer_id);
+}
+#endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
 
-    /* Add the ULT to the associated pool */
-    ABTI_pool_push(p_thread->p_pool, p_thread->unit);
+static inline int ABTI_pool_set_consumer_impl(ABTI_local *p_local,
+                                              ABTI_pool *p_pool)
+{
+#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
+    if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 0)
+        return ABT_SUCCESS;
+    ABTI_native_thread_id consumer_id = ABTI_self_get_native_thread_id(p_local);
+    return ABTI_pool_set_consumer_common_impl(p_pool, consumer_id);
+#else
+    return ABT_SUCCESS;
+#endif
 }
 
-#define ABTI_POOL_PUSH(p_pool, unit, p_producer) ABTI_pool_push(p_pool, unit)
+#define ABTI_pool_set_consumer(p_local, p_pool)                                \
+    ABTI_pool_set_consumer_impl(ABTI_IS_POOL_CONSUMER_CHECK_ENABLED            \
+                                    ? (p_local)                                \
+                                    : NULL,                                    \
+                                p_pool)
 
-#define ABTI_POOL_ADD_THREAD(p_thread, p_producer)                             \
-    ABTI_pool_add_thread(p_thread)
+/* Set the associated producer ES of a pool. This function has no effect on
+ * pools of shared-write access mode. If a pool is private-write to an ES, we
+ * check that the previous value of "producer_id" is the same as the argument of
+ * the function "producer_id"
+ * */
+static inline int ABTI_pool_set_producer_impl(ABTI_local *p_local,
+                                              ABTI_pool *p_pool)
+{
+#ifndef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
+    int abt_errno = ABT_SUCCESS;
 
-#else /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
+    if (ABTD_atomic_acquire_load_int32(&p_pool->num_scheds) == 0) {
+        return abt_errno;
+    }
 
-static inline int ABTI_pool_push(ABTI_pool *p_pool, ABT_unit unit,
-                                 ABTI_native_thread_id producer_id)
+    ABTI_native_thread_id producer_id = ABTI_self_get_native_thread_id(p_local);
+    switch (p_pool->access) {
+        case ABT_POOL_ACCESS_PRIV:
+#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
+            ABTI_CHECK_TRUE(!p_pool->consumer_id ||
+                                p_pool->consumer_id == producer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+#endif
+            ABTI_CHECK_TRUE(!p_pool->producer_id ||
+                                p_pool->producer_id == producer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+            p_pool->producer_id = producer_id;
+            break;
+
+        case ABT_POOL_ACCESS_SPSC:
+        case ABT_POOL_ACCESS_SPMC:
+            ABTI_CHECK_TRUE(!p_pool->producer_id ||
+                                p_pool->producer_id == producer_id,
+                            ABT_ERR_INV_POOL_ACCESS);
+            /* NB: as we do not want to use a mutex, the function can be wrong
+             * here */
+            p_pool->producer_id = producer_id;
+            break;
+
+        case ABT_POOL_ACCESS_MPSC:
+        case ABT_POOL_ACCESS_MPMC:
+            p_pool->producer_id = producer_id;
+            break;
+
+        default:
+            abt_errno = ABT_ERR_INV_POOL_ACCESS;
+            ABTI_CHECK_ERROR(abt_errno);
+    }
+
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
+#else
+    return ABT_SUCCESS;
+#endif
+}
+
+#define ABTI_pool_set_producer(p_local, p_pool)                                \
+    ABTI_pool_set_producer_impl(ABTI_IS_POOL_PRODUCER_CHECK_ENABLED            \
+                                    ? (p_local)                                \
+                                    : NULL,                                    \
+                                p_pool)
+
+static inline int ABTI_pool_push_impl(ABTI_local *p_local, ABTI_pool *p_pool,
+                                      ABT_unit unit)
 {
     int abt_errno = ABT_SUCCESS;
 
-    LOG_DEBUG_POOL_PUSH(p_pool, unit, producer_id);
+    LOG_DEBUG_POOL_PUSH(p_local, p_pool, unit);
 
     /* Save the producer ES information in the pool */
-    abt_errno = ABTI_pool_set_producer(p_pool, producer_id);
+    abt_errno = ABTI_pool_set_producer(p_local, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Push unit into pool */
@@ -112,8 +242,13 @@ fn_fail:
     goto fn_exit;
 }
 
-static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
-                                       ABTI_native_thread_id producer_id)
+#define ABTI_pool_push(p_local, p_pool, unit)                                  \
+    ABTI_pool_push_impl(ABTI_IS_POOL_PRODUCER_CHECK_ENABLED ? (p_local)        \
+                                                            : NULL,            \
+                        p_pool, unit)
+
+static inline int ABTI_pool_add_thread_impl(ABTI_local *p_local,
+                                            ABTI_thread *p_thread)
 {
     int abt_errno;
 
@@ -122,7 +257,7 @@ static inline int ABTI_pool_add_thread(ABTI_thread *p_thread,
     ABTD_atomic_relaxed_store_int(&p_thread->state, ABTI_THREAD_STATE_READY);
 
     /* Add the ULT to the associated pool */
-    abt_errno = ABTI_pool_push(p_thread->p_pool, p_thread->unit, producer_id);
+    abt_errno = ABTI_pool_push(p_local, p_thread->p_pool, p_thread->unit);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:
@@ -133,54 +268,19 @@ fn_fail:
     goto fn_exit;
 }
 
-#define ABTI_POOL_PUSH(p_pool, unit, producer_id)                              \
-    do {                                                                       \
-        abt_errno = ABTI_pool_push(p_pool, unit, producer_id);                 \
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_pool_push");                     \
-    } while (0)
+#define ABTI_pool_add_thread(p_local, p_thread)                                \
+    ABTI_pool_add_thread_impl(ABTI_IS_POOL_PRODUCER_CHECK_ENABLED ? (p_local)  \
+                                                                  : NULL,      \
+                              p_thread)
 
-#define ABTI_POOL_ADD_THREAD(p_thread, producer_id)                            \
-    do {                                                                       \
-        abt_errno = ABTI_pool_add_thread(p_thread, producer_id);               \
-        ABTI_CHECK_ERROR(abt_errno);                                           \
-    } while (0)
-
-#endif /* ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK */
-
-#ifdef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
+static inline int ABTI_pool_remove_impl(ABTI_local *p_local, ABTI_pool *p_pool,
+                                        ABT_unit unit)
 {
     int abt_errno = ABT_SUCCESS;
 
-    LOG_DEBUG_POOL_REMOVE(p_pool, unit,
-                          ABTI_self_get_native_thread_id(
-                              ABTI_local_get_xstream()));
+    LOG_DEBUG_POOL_REMOVE(p_local, p_pool, unit);
 
-    abt_errno = p_pool->p_remove(ABTI_pool_get_handle(p_pool), unit);
-    ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-#define ABTI_POOL_REMOVE(p_pool, unit, consumer_id)                            \
-    ABTI_pool_remove(p_pool, unit)
-#define ABTI_POOL_SET_CONSUMER(p_pool, consumer_id)
-
-#else /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
-
-static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                                   ABTI_native_thread_id consumer_id)
-{
-    int abt_errno = ABT_SUCCESS;
-
-    LOG_DEBUG_POOL_REMOVE(p_pool, unit, consumer_id);
-
-    abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);
+    abt_errno = ABTI_pool_set_consumer(p_local, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno = p_pool->p_remove(ABTI_pool_get_handle(p_pool), unit);
@@ -194,15 +294,10 @@ fn_fail:
     goto fn_exit;
 }
 
-#define ABTI_POOL_REMOVE(p_pool, unit, consumer_id)                            \
-    ABTI_pool_remove(p_pool, unit, consumer_id)
-#define ABTI_POOL_SET_CONSUMER(p_pool, consumer_id)                            \
-    do {                                                                       \
-        abt_errno = ABTI_pool_set_consumer(p_pool, consumer_id);               \
-        ABTI_CHECK_ERROR(abt_errno);                                           \
-    } while (0)
-
-#endif /* ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK */
+#define ABTI_pool_remove(p_local, p_pool, unit)                                \
+    ABTI_pool_remove_impl(ABTI_IS_POOL_CONSUMER_CHECK_ENABLED ? (p_local)      \
+                                                              : NULL,          \
+                          p_pool, unit)
 
 static inline ABT_unit ABTI_pool_pop_wait(ABTI_pool *p_pool, double time_secs)
 {

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -44,12 +44,12 @@ static inline int ABTI_sched_discard_and_free(ABTI_local *p_local,
                                               ABTI_sched *p_sched,
                                               ABT_bool force_free)
 {
-    int abt_errno = ABT_SUCCESS;
     p_sched->used = ABTI_SCHED_NOT_USED;
     if (p_sched->automatic == ABT_TRUE || force_free) {
-        abt_errno = ABTI_sched_free(p_local, p_sched, force_free);
+        int abt_errno = ABTI_sched_free(p_local, p_sched, force_free);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
-    return abt_errno;
+    return ABT_SUCCESS;
 }
 
 static inline void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)

--- a/src/key.c
+++ b/src/key.c
@@ -45,12 +45,18 @@ int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
     ABTI_key *p_newkey;
 
     p_newkey = (ABTI_key *)ABTU_malloc(sizeof(ABTI_key));
+    ABTI_CHECK_TRUE(p_newkey != NULL, ABT_ERR_MEM);
     p_newkey->f_destructor = destructor;
     p_newkey->id = ABTD_atomic_fetch_add_uint32(&g_key_id, 1);
     /* Return value */
     *newkey = ABTI_key_get_handle(p_newkey);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/log.c
+++ b/src/log.c
@@ -71,14 +71,14 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
     ABTU_free(newfmt);
 }
 
-void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
-                        ABTI_native_thread_id producer_id)
+void ABTI_log_pool_push(ABTI_local *p_local, ABTI_pool *p_pool, ABT_unit unit)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
 
     ABTI_ythread *p_ythread = NULL;
     ABTI_thread *p_task = NULL;
+    ABTI_native_thread_id producer_id = ABTI_self_get_native_thread_id(p_local);
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_ythread = ABTI_ythread_get_ptr(p_pool->u_get_thread(unit));
@@ -118,14 +118,14 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit,
     }
 }
 
-void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit,
-                          ABTI_native_thread_id consumer_id)
+void ABTI_log_pool_remove(ABTI_local *p_local, ABTI_pool *p_pool, ABT_unit unit)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
 
     ABTI_ythread *p_ythread = NULL;
     ABTI_thread *p_task = NULL;
+    ABTI_native_thread_id consumer_id = ABTI_self_get_native_thread_id(p_local);
     switch (p_pool->u_get_type(unit)) {
         case ABT_UNIT_TYPE_THREAD:
             p_ythread = ABTI_ythread_get_ptr(p_pool->u_get_thread(unit));

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -194,7 +194,6 @@ static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
         ABTI_mutex_spinlock(p_mutex);
     }
 #else
-    int abt_errno = ABT_SUCCESS;
     /* Only ULTs can yield when the mutex has been locked. For others,
      * just call mutex_spinlock. */
     if (p_ythread) {
@@ -239,10 +238,8 @@ static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
                         ABTI_ythread *p_giver = p_mutex->p_giver;
                         ABTD_atomic_release_store_int(&p_giver->thread.state,
                                                       ABTI_THREAD_STATE_READY);
-                        abt_errno =
-                            ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
-                                           p_giver->thread.unit);
-                        ABTI_CHECK_ERROR(abt_errno);
+                        ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
+                                       p_giver->thread.unit);
                         break;
                     }
                 }
@@ -255,12 +252,7 @@ static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
         ABTI_mutex_spinlock(p_mutex);
     }
 
-fn_exit:
     return;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 #endif
 }
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -239,10 +239,10 @@ static inline void ABTI_mutex_lock_low(ABTI_local **pp_local,
                         ABTI_ythread *p_giver = p_mutex->p_giver;
                         ABTD_atomic_release_store_int(&p_giver->thread.state,
                                                       ABTI_THREAD_STATE_READY);
-                        ABTI_POOL_PUSH(p_giver->thread.p_pool,
-                                       p_giver->thread.unit,
-                                       ABTI_self_get_native_thread_id(
-                                           *pp_local));
+                        abt_errno =
+                            ABTI_pool_push(*pp_local, p_giver->thread.p_pool,
+                                           p_giver->thread.unit);
+                        ABTI_CHECK_ERROR(abt_errno);
                         break;
                     }
                 }

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -38,12 +38,18 @@ int ABT_mutex_create(ABT_mutex *newmutex)
     ABTI_mutex *p_newmutex;
 
     p_newmutex = (ABTI_mutex *)ABTU_calloc(1, sizeof(ABTI_mutex));
+    ABTI_CHECK_TRUE(p_newmutex != NULL, ABT_ERR_MEM);
     ABTI_mutex_init(p_newmutex);
 
     /* Return value */
     *newmutex = ABTI_mutex_get_handle(p_newmutex);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -29,6 +29,7 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
     ABTI_mutex_attr *p_newattr;
 
     p_newattr = (ABTI_mutex_attr *)ABTU_malloc(sizeof(ABTI_mutex_attr));
+    ABTI_CHECK_TRUE(p_newattr != NULL, ABT_ERR_MEM);
 
     /* Default values */
     p_newattr->attrs = ABTI_MUTEX_ATTR_NONE;
@@ -40,7 +41,12 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
     /* Return value */
     *newattr = ABTI_mutex_attr_get_handle(p_newattr);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -27,16 +27,18 @@ int ABT_rwlock_create(ABT_rwlock *newrwlock)
     ABTI_rwlock *p_newrwlock;
 
     p_newrwlock = (ABTI_rwlock *)ABTU_malloc(sizeof(ABTI_rwlock));
-    if (p_newrwlock == NULL) {
-        abt_errno = ABT_ERR_MEM;
-    } else {
-        ABTI_rwlock_init(p_newrwlock);
-    }
+    ABTI_CHECK_TRUE(p_newrwlock != NULL, ABT_ERR_MEM);
+    ABTI_rwlock_init(p_newrwlock);
 
     /* Return value */
     *newrwlock = ABTI_rwlock_get_handle(p_newrwlock);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -117,7 +117,7 @@ static void sched_run(ABT_sched sched)
         }
         /* if we attempted event_freq pops, check for events */
         if (pop_count >= event_freq) {
-            ABTI_xstream_check_events(p_local_xstream, sched);
+            ABTI_xstream_check_events(p_local_xstream, p_sched);
             ABTI_local *p_local = ABTI_xstream_get_local(p_local_xstream);
             if (ABTI_sched_has_to_stop(&p_local, p_sched) == ABT_TRUE)
                 break;

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -133,7 +133,7 @@ static void sched_run(ABT_sched sched)
          * should check events regardless of work_count in that case for them to
          * be processed in a timely manner. */
         if (!run_cnt_nowait || (++work_count >= event_freq)) {
-            ABTI_xstream_check_events(p_local_xstream, sched);
+            ABTI_xstream_check_events(p_local_xstream, p_sched);
             ABTI_local *p_local = ABTI_xstream_get_local(p_local_xstream);
             if (ABTI_sched_has_to_stop(&p_local, p_sched) == ABT_TRUE)
                 break;

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -222,7 +222,6 @@ size_t ABTI_sched_config_type_size(ABT_sched_config_type type)
 int ABTI_sched_config_read_global(ABT_sched_config config,
                                   ABT_pool_access *access, ABT_bool *automatic)
 {
-    int abt_errno = ABT_SUCCESS;
     int num_vars = 2;
     /* We use XXX_i variables because va_list converts these types into int */
     int access_i = -1;
@@ -232,21 +231,16 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
     variables[(ABT_sched_config_access.idx + 2) * (-1)] = &access_i;
     variables[(ABT_sched_config_automatic.idx + 2) * (-1)] = &automatic_i;
 
-    abt_errno = ABTI_sched_config_read(config, 0, num_vars, variables);
+    int abt_errno = ABTI_sched_config_read(config, 0, num_vars, variables);
     ABTU_free(variables);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     if (access_i != -1)
         *access = (ABT_pool_access)access_i;
     if (automatic_i != -1)
         *automatic = (ABT_bool)automatic_i;
 
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /* type is 0 if we read the private parameters, else 1 */

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -103,7 +103,7 @@ static void sched_run(ABT_sched sched)
         }
 
         if (++work_count >= event_freq) {
-            ABTI_xstream_check_events(p_local_xstream, sched);
+            ABTI_xstream_check_events(p_local_xstream, p_sched);
             ABTI_local *p_local = ABTI_xstream_get_local(p_local_xstream);
             if (ABTI_sched_has_to_stop(&p_local, p_sched) == ABT_TRUE)
                 break;

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -107,7 +107,7 @@ static void sched_run(ABT_sched sched)
         }
 
         if (++work_count >= p_data->event_freq) {
-            ABTI_xstream_check_events(p_local_xstream, sched);
+            ABTI_xstream_check_events(p_local_xstream, p_sched);
             ABTI_local *p_local = ABTI_xstream_get_local(p_local_xstream);
             if (ABTI_sched_has_to_stop(&p_local, p_sched) == ABT_TRUE)
                 break;

--- a/src/stream.c
+++ b/src/stream.c
@@ -62,7 +62,6 @@ fn_fail:
 
 int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_newxstream;
 
     p_newxstream = (ABTI_xstream *)ABTU_malloc(sizeof(ABTI_xstream));
@@ -80,46 +79,34 @@ int ABTI_xstream_create(ABTI_sched *p_sched, ABTI_xstream **pp_xstream)
     ABTI_mem_init_local(p_newxstream);
 
     /* Set the main scheduler */
-    abt_errno = ABTI_xstream_init_main_sched(p_newxstream, p_sched);
-    ABTI_CHECK_ERROR(abt_errno);
+    int abt_errno = ABTI_xstream_init_main_sched(p_newxstream, p_sched);
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     LOG_DEBUG("[E%d] created\n", p_newxstream->rank);
 
     /* Return value */
     *pp_xstream = p_newxstream;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_xstream *p_newxstream;
     ABTI_sched *p_sched;
 
     /* For the primary ES, a default scheduler is created. */
     abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
                                         ABT_SCHED_CONFIG_NULL, &p_sched);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     abt_errno = ABTI_xstream_create(p_sched, &p_newxstream);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     p_newxstream->type = ABTI_XSTREAM_TYPE_PRIMARY;
 
     *pp_xstream = p_newxstream;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -244,43 +231,36 @@ fn_fail:
 
 int ABTI_xstream_start(ABTI_local *p_local, ABTI_xstream *p_xstream)
 {
-    int abt_errno = ABT_SUCCESS;
-
     /* The ES's state must be RUNNING */
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
                 ABT_XSTREAM_STATE_RUNNING);
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
+        int abt_errno;
         LOG_DEBUG("[E%d] start\n", p_xstream->rank);
 
         abt_errno = ABTD_xstream_context_set_self(&p_xstream->ctx);
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_set_self");
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
         /* Create the main sched ULT */
         ABTI_sched *p_sched = p_xstream->p_main_sched;
         abt_errno = ABTI_ythread_create_main_sched(p_local, p_xstream, p_sched);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
         p_sched->p_ythread->thread.p_last_xstream = p_xstream;
 
     } else {
         /* Start the main scheduler on a different ES */
-        abt_errno =
+        int abt_errno =
             ABTD_xstream_context_create(ABTI_xstream_launch_main_sched,
                                         (void *)p_xstream, &p_xstream->ctx);
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_create");
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
         ABTD_affinity_cpuset_apply_default(&p_xstream->ctx, p_xstream->rank);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -315,7 +295,7 @@ fn_fail:
 int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
                                ABTI_xstream *p_xstream, ABTI_ythread *p_ythread)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
 
     /* The ES's state must be running here. */
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
@@ -324,7 +304,7 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     LOG_DEBUG("[E%d] start\n", p_xstream->rank);
 
     abt_errno = ABTD_xstream_context_set_self(&p_xstream->ctx);
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_set_self");
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
@@ -336,7 +316,7 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     abt_errno = ABTI_ythread_create_main_sched(ABTI_xstream_get_local(
                                                    *pp_local_xstream),
                                                p_xstream, p_sched);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_CHECK_ERROR_RET(abt_errno);
     p_sched->p_ythread->thread.p_last_xstream = p_xstream;
     p_ythread->thread.p_parent = &p_sched->p_ythread->thread;
 
@@ -351,13 +331,7 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     LOG_DEBUG("[U%" PRIu64 ":E%d] resume\n",
               ABTI_thread_get_id(&p_ythread->thread),
               p_ythread->thread.p_last_xstream->rank);
-
-fn_exit:
     return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 }
 
 /**
@@ -981,16 +955,15 @@ fn_fail:
 int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
                           ABTI_pool *p_pool)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABT_unit_type type = p_pool->u_get_type(unit);
 
     if (type == ABT_UNIT_TYPE_THREAD) {
         ABT_thread thread = p_pool->u_get_thread(unit);
         ABTI_ythread *p_ythread = ABTI_ythread_get_ptr(thread);
         /* Switch the context */
-        abt_errno = ABTI_xstream_schedule_ythread(pp_local_xstream, p_ythread);
-        ABTI_CHECK_ERROR(abt_errno);
+        int abt_errno =
+            ABTI_xstream_schedule_ythread(pp_local_xstream, p_ythread);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
     } else if (type == ABT_UNIT_TYPE_TASK) {
         ABT_task task = p_pool->u_get_task(unit);
@@ -999,16 +972,9 @@ int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
         ABTI_xstream_schedule_task(*pp_local_xstream, p_task);
 
     } else {
-        HANDLE_ERROR("Not supported type!");
-        ABTI_CHECK_TRUE(0, ABT_ERR_INV_UNIT);
+        return ABT_ERR_INV_UNIT;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -1030,8 +996,10 @@ int ABT_xstream_check_events(ABT_sched sched)
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
-    abt_errno = ABTI_xstream_check_events(p_local_xstream, sched);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+
+    ABTI_xstream_check_events(p_local_xstream, p_sched);
 
 fn_exit:
     return abt_errno;
@@ -1041,12 +1009,8 @@ fn_fail:
     goto fn_exit;
 }
 
-int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
+void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
-    int abt_errno = ABT_SUCCESS;
-    ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
-    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
-
     ABTI_info_check_print_all_thread_stacks();
 
     uint32_t request = ABTD_atomic_acquire_load_uint32(&p_xstream->request);
@@ -1058,13 +1022,6 @@ int ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABT_sched sched)
         (request & ABTI_XSTREAM_REQ_CANCEL)) {
         ABTI_sched_exit(p_sched);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 }
 
 /**
@@ -1234,12 +1191,11 @@ fn_fail:
 
 int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_bool is_blockable = ABT_FALSE;
 
-    ABTI_CHECK_TRUE_MSG(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
-                        ABT_ERR_INV_XSTREAM,
-                        "The primary ES cannot be joined.");
+    /* The primary ES cannot be joined. */
+    ABTI_CHECK_TRUE_RET(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
+                        ABT_ERR_INV_XSTREAM);
 
     /* When the associated pool of the caller ULT has multiple-writer access
      * mode, the ULT can be blocked. Otherwise, the access mode, if it is a
@@ -1253,9 +1209,9 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         /* The target ES must not be the same as the caller ULT's ES if the
          * access mode of the associated pool is not MPMC. */
         if (access != ABT_POOL_ACCESS_MPMC) {
-            ABTI_CHECK_TRUE_MSG(p_xstream != p_local_xstream,
-                                ABT_ERR_INV_XSTREAM,
-                                "The target ES should be different.");
+            /* The target ES should be different. */
+            ABTI_CHECK_TRUE_RET(p_xstream != p_local_xstream,
+                                ABT_ERR_INV_XSTREAM);
         }
         p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
         if (p_ythread) {
@@ -1266,62 +1222,52 @@ int ABTI_xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
         }
     }
 
-    if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
+    if (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
         ABT_XSTREAM_STATE_TERMINATED) {
-        goto fn_join;
-    }
+        /* Wait until the target ES terminates */
+        if (is_blockable == ABT_TRUE) {
+            ABTI_pool_set_consumer(ABTI_xstream_get_local(p_local_xstream),
+                                   p_ythread->thread.p_pool);
 
-    /* Wait until the target ES terminates */
-    if (is_blockable == ABT_TRUE) {
-        ABTI_pool_set_consumer(ABTI_xstream_get_local(p_local_xstream),
-                               p_ythread->thread.p_pool);
+            /* Save the caller ULT to set it ready when the ES is terminated */
+            p_xstream->p_req_arg = (void *)p_ythread;
+            ABTI_ythread_set_blocked(p_ythread);
 
-        /* Save the caller ULT to set it ready when the ES is terminated */
-        p_xstream->p_req_arg = (void *)p_ythread;
-        ABTI_ythread_set_blocked(p_ythread);
+            /* Set the join request */
+            ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        /* Set the join request */
-        ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
+            /* If the caller is a ULT, it is blocked here */
+            ABTI_ythread_suspend(&p_local_xstream, p_ythread,
+                                 ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
+                                 (void *)p_xstream);
+            *pp_local = ABTI_xstream_get_local(p_local_xstream);
+        } else {
+            /* Set the join request */
+            ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
 
-        /* If the caller is a ULT, it is blocked here */
-        ABTI_ythread_suspend(&p_local_xstream, p_ythread,
-                             ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
-                             (void *)p_xstream);
-        *pp_local = ABTI_xstream_get_local(p_local_xstream);
-    } else {
-        /* Set the join request */
-        ABTI_xstream_set_request(p_xstream, ABTI_XSTREAM_REQ_JOIN);
-
-        while (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
-               ABT_XSTREAM_STATE_TERMINATED) {
-            if (p_ythread) {
-                ABTI_ythread_yield(&p_local_xstream, p_ythread,
-                                   ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
-                                   (void *)p_xstream);
-                *pp_local = ABTI_xstream_get_local(p_local_xstream);
-            } else {
-                ABTD_atomic_pause();
+            while (ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+                   ABT_XSTREAM_STATE_TERMINATED) {
+                if (p_ythread) {
+                    ABTI_ythread_yield(&p_local_xstream, p_ythread,
+                                       ABT_SYNC_EVENT_TYPE_XSTREAM_JOIN,
+                                       (void *)p_xstream);
+                    *pp_local = ABTI_xstream_get_local(p_local_xstream);
+                } else {
+                    ABTD_atomic_pause();
+                }
             }
         }
     }
 
-fn_join:
     /* Normal join request */
-    abt_errno = ABTD_xstream_context_join(&p_xstream->ctx);
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTD_xstream_context_join");
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    goto fn_exit;
+    int abt_errno = ABTD_xstream_context_join(&p_xstream->ctx);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    return ABT_SUCCESS;
 }
 
 int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
                       ABT_bool force_free)
 {
-    int abt_errno = ABT_SUCCESS;
-
     LOG_DEBUG("[E%d] freed\n", p_xstream->rank);
 
     /* Clean up memory pool. */
@@ -1334,9 +1280,9 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
     /* Free the scheduler */
     ABTI_sched *p_cursched = p_xstream->p_main_sched;
     if (p_cursched != NULL) {
-        abt_errno =
+        int abt_errno =
             ABTI_sched_discard_and_free(p_local, p_cursched, force_free);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
 
     /* Free the array of sched contexts */
@@ -1344,18 +1290,12 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
 
     /* Free the context if a given xstream is secondary. */
     if (p_xstream->type == ABTI_XSTREAM_TYPE_SECONDARY) {
-        abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
-        ABTI_CHECK_ERROR(abt_errno);
+        int abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
 
     ABTU_free(p_xstream);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /* The main scheduler of each ES executes this routine. */
@@ -1421,7 +1361,6 @@ void ABTI_xstream_schedule(void *p_arg)
 int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
                                   ABTI_ythread *p_ythread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
 
 #ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
@@ -1433,18 +1372,18 @@ int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
         ABTD_ythread_cancel(p_local_xstream, p_ythread);
         ABTI_xstream_terminate_thread(ABTI_xstream_get_local(p_local_xstream),
                                       &p_ythread->thread);
-        goto fn_exit;
+        return ABT_SUCCESS;
     }
 #endif
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
         ABTI_THREAD_REQ_MIGRATE) {
-        abt_errno =
+        int abt_errno =
             ABTI_xstream_migrate_thread(ABTI_xstream_get_local(p_local_xstream),
                                         &p_ythread->thread);
-        ABTI_CHECK_ERROR(abt_errno);
-        goto fn_exit;
+        ABTI_CHECK_ERROR_RET(abt_errno);
+        return ABT_SUCCESS;
     }
 #endif
 
@@ -1460,8 +1399,8 @@ int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
               ABTI_thread_get_id(&p_ythread->thread), p_local_xstream->rank);
 
     ABTI_ythread *p_self;
-    ABTI_CHECK_YIELDABLE(p_local_xstream->p_thread, &p_self,
-                         ABT_ERR_INV_THREAD);
+    ABTI_CHECK_YIELDABLE_RET(p_local_xstream->p_thread, &p_self,
+                             ABT_ERR_INV_THREAD);
     p_ythread = ABTI_ythread_context_switch_to_child(pp_local_xstream, p_self,
                                                      p_ythread);
     /* The previous ULT (p_ythread) may not be the same as one to which the
@@ -1501,10 +1440,10 @@ int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
         /* The ULT did not finish its execution.
          * Change the state of current running ULT and
          * add it to the pool again. */
-        abt_errno =
+        int abt_errno =
             ABTI_pool_add_thread(ABTI_xstream_get_local(p_local_xstream),
                                  &p_ythread->thread);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     } else if (request & ABTI_THREAD_REQ_BLOCK) {
         LOG_DEBUG("[U%" PRIu64 ":E%d] check blocked\n",
                   ABTI_thread_get_id(&p_ythread->thread),
@@ -1513,10 +1452,10 @@ int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     } else if (request & ABTI_THREAD_REQ_MIGRATE) {
         /* This is the case when the ULT requests migration of itself. */
-        abt_errno =
+        int abt_errno =
             ABTI_xstream_migrate_thread(ABTI_xstream_get_local(p_local_xstream),
                                         &p_ythread->thread);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 #endif
     } else if (request & ABTI_THREAD_REQ_ORPHAN) {
         /* The ULT is not pushed back to the pool and is disconnected from any
@@ -1534,16 +1473,9 @@ int ABTI_xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
                   p_local_xstream->rank);
         ABTI_thread_unset_request(&p_ythread->thread, ABTI_THREAD_REQ_NOPUSH);
     } else {
-        abt_errno = ABT_ERR_THREAD;
-        goto fn_fail;
+        return ABT_ERR_THREAD;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 void ABTI_xstream_schedule_task(ABTI_xstream *p_local_xstream,
@@ -1596,7 +1528,6 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
 #ifdef ABT_CONFIG_DISABLE_MIGRATION
     return ABT_ERR_MIGRATION_NA;
 #else
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool;
 
     ABTI_thread_mig_data *p_mig_data =
@@ -1626,26 +1557,19 @@ int ABTI_xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
     p_thread->p_pool = p_pool;
 
     /* Add the unit to the scheduler's pool */
-    abt_errno = ABTI_pool_push(p_local, p_pool, p_thread->unit);
+    int abt_errno = ABTI_pool_push(p_local, p_pool, p_thread->unit);
+    /* Check the push.
+     * TODO: this error is fatal.  It needs to be handled smartly. */
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     ABTI_pool_dec_num_migrations(p_pool);
 
-    /* Check the push */
-    ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #endif
 }
 
 int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_ASSERT(p_xstream->p_main_sched == NULL);
 
 #ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
@@ -1654,9 +1578,9 @@ int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
      * with another associated pool, and set the right value if it is okay  */
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
-        abt_errno =
+        int abt_errno =
             ABTI_pool_set_consumer(ABTI_xstream_get_local(p_xstream), p_pool);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
 #endif
 
@@ -1669,22 +1593,13 @@ int ABTI_xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
     /* Set the scheduler */
     p_xstream->p_main_sched = p_sched;
 
-#ifndef ABT_CONFIG_DISABLE_POOL_CONSUMER_CHECK
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-#else
-    return abt_errno;
-#endif
+    return ABT_SUCCESS;
 }
 
 int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
                                    ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_ythread *p_ythread = NULL;
     ABTI_sched *p_main_sched;
     ABTI_pool *p_tar_pool = NULL;
@@ -1697,7 +1612,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         abt_errno =
             ABTI_pool_set_consumer(ABTI_xstream_get_local(p_xstream), p_pool);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
 #endif
 
@@ -1711,13 +1626,12 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     if (p_main_sched == NULL) {
         /* Set the scheduler */
         p_xstream->p_main_sched = p_sched;
-
-        goto fn_exit;
+        return ABT_SUCCESS;
     }
 
     /* If the ES has a main scheduler, we have to free it */
-    ABTI_CHECK_YIELDABLE((*pp_local_xstream)->p_thread, &p_ythread,
-                         ABT_ERR_INV_THREAD);
+    ABTI_CHECK_YIELDABLE_RET((*pp_local_xstream)->p_thread, &p_ythread,
+                             ABT_ERR_INV_THREAD);
     p_tar_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
 
     /* If the caller ULT is associated with a pool of the current main
@@ -1735,8 +1649,8 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     }
 
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN,
-                        ABT_ERR_THREAD);
+        ABTI_CHECK_TRUE_RET(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN,
+                            ABT_ERR_THREAD);
 
         /* Since the primary ES does not finish its execution until ABT_finalize
          * is called, its main scheduler needs to be automatically freed when
@@ -1745,7 +1659,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
 
         abt_errno = ABTI_pool_push(ABTI_xstream_get_local(*pp_local_xstream),
                                    p_tar_pool, p_ythread->thread.unit);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
         /* Replace the top scheduler with the new scheduler */
         p_xstream->p_main_sched = p_sched;
@@ -1754,13 +1668,13 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         abt_errno = ABTI_sched_discard_and_free(ABTI_xstream_get_local(
                                                     *pp_local_xstream),
                                                 p_main_sched, ABT_FALSE);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
         /* Start the primary ES again because we have to create a sched ULT for
          * the new scheduler */
         abt_errno =
             ABTI_xstream_start_primary(pp_local_xstream, p_xstream, p_ythread);
-        ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_start");
+        ABTI_CHECK_ERROR_RET(abt_errno);
     } else {
         /* Finish the current main scheduler */
         ABTI_sched_set_request(p_main_sched, ABTI_SCHED_REQ_FINISH);
@@ -1774,7 +1688,7 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
          * the current main scheduler (see below). */
         abt_errno = ABTI_pool_push(ABTI_xstream_get_local(*pp_local_xstream),
                                    p_tar_pool, p_ythread->thread.unit);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
         /* Set the scheduler */
         p_xstream->p_main_sched = p_sched;
@@ -1790,15 +1704,9 @@ int ABTI_xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         abt_errno = ABTI_sched_discard_and_free(ABTI_xstream_get_local(
                                                     *pp_local_xstream),
                                                 p_main_sched, ABT_FALSE);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
@@ -1860,7 +1768,6 @@ fn_exit:
 
 void *ABTI_xstream_launch_main_sched(void *p_arg)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_local_xstream = (ABTI_xstream *)p_arg;
 
     /* Initialization of the local variables */
@@ -1869,10 +1776,16 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
     /* Create the main sched ULT if not created yet */
     ABTI_sched *p_sched = p_local_xstream->p_main_sched;
     if (!p_sched->p_ythread) {
-        abt_errno = ABTI_ythread_create_main_sched(ABTI_xstream_get_local(
-                                                       p_local_xstream),
-                                                   p_local_xstream, p_sched);
-        ABTI_CHECK_ERROR(abt_errno);
+        int abt_errno =
+            ABTI_ythread_create_main_sched(ABTI_xstream_get_local(
+                                               p_local_xstream),
+                                           p_local_xstream, p_sched);
+        if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+            /* This error is fatal.
+             * TODO: tell this error to the parent function. */
+            ABTI_ASSERT(0);
+            return NULL;
+        }
         p_sched->p_ythread->thread.p_last_xstream = p_local_xstream;
     } else {
         ABTI_tool_event_thread_create(ABTI_xstream_get_local(p_local_xstream),
@@ -1899,13 +1812,7 @@ void *ABTI_xstream_launch_main_sched(void *p_arg)
 
     /* Reset the current ES and its local info. */
     ABTI_local_set_xstream(NULL);
-
-fn_exit:
     return NULL;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 }
 
 /*****************************************************************************/

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -86,7 +86,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -125,7 +125,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -158,6 +158,6 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }

--- a/src/task.c
+++ b/src/task.c
@@ -480,10 +480,8 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
                             ABTI_sched *p_sched, int refcount,
                             ABTI_thread **pp_newtask)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_newtask;
     ABT_task h_newtask;
-    ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     /* Allocate a task object */
     p_newtask = ABTI_mem_alloc_nythread(p_local);
@@ -518,19 +516,14 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     LOG_DEBUG("[T%" PRIu64 "] created\n", ABTI_thread_get_id(p_newtask));
 
     /* Add this task to the scheduler's pool */
-    abt_errno = ABTI_pool_push(p_local, p_pool, p_newtask->unit);
+    int abt_errno = ABTI_pool_push(p_local, p_pool, p_newtask->unit);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTI_thread_free(p_local, p_newtask);
-        goto fn_fail;
+        return abt_errno;
     }
 
     /* Return value */
     *pp_newtask = p_newtask;
 
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -518,16 +518,11 @@ static int ABTI_task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     LOG_DEBUG("[T%" PRIu64 "] created\n", ABTI_thread_get_id(p_newtask));
 
     /* Add this task to the scheduler's pool */
-#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    ABTI_pool_push(p_pool, p_newtask->unit);
-#else
-    abt_errno = ABTI_pool_push(p_pool, p_newtask->unit,
-                               ABTI_self_get_native_thread_id(p_local));
-    if (abt_errno != ABT_SUCCESS) {
+    abt_errno = ABTI_pool_push(p_local, p_pool, p_newtask->unit);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTI_thread_free(p_local, p_newtask);
         goto fn_fail;
     }
-#endif
 
     /* Return value */
     *pp_newtask = p_newtask;

--- a/src/thread.c
+++ b/src/thread.c
@@ -1561,7 +1561,6 @@ static inline int ABTI_ythread_create_internal(
     ABTI_sched *p_sched, ABTI_xstream *p_parent_xstream, ABT_bool push_pool,
     ABTI_ythread **pp_newthread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_ythread *p_newthread;
     ABT_thread h_newthread;
     ABTI_ktable *p_keytable = NULL;
@@ -1671,7 +1670,8 @@ static inline int ABTI_ythread_create_internal(
     if (push_pool) {
         p_newthread->thread.unit = p_pool->u_create_from_thread(h_newthread);
         /* Add this thread to the pool */
-        abt_errno = ABTI_pool_push(p_local, p_pool, p_newthread->thread.unit);
+        int abt_errno =
+            ABTI_pool_push(p_local, p_pool, p_newthread->thread.unit);
         if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
             if (thread_type & ABTI_THREAD_TYPE_MAIN) {
                 ABTI_ythread_free_main(p_local, p_newthread);
@@ -1680,7 +1680,8 @@ static inline int ABTI_ythread_create_internal(
             } else {
                 ABTI_thread_free(p_local, &p_newthread->thread);
             }
-            goto fn_fail;
+            *pp_newthread = NULL;
+            return abt_errno;
         }
     } else {
         p_newthread->thread.unit = ABT_UNIT_NULL;
@@ -1688,54 +1689,41 @@ static inline int ABTI_ythread_create_internal(
 
     /* Return value */
     *pp_newthread = p_newthread;
-
-#ifdef ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK
-    return abt_errno;
-#else
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    *pp_newthread = NULL;
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-#endif
+    return ABT_SUCCESS;
 }
 
 int ABTI_ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
                         void (*thread_func)(void *), void *arg,
                         ABTI_thread_attr *p_attr, ABTI_ythread **pp_newthread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_type unit_type =
         (pp_newthread != NULL)
             ? (ABTI_THREAD_TYPE_YIELDABLE | ABTI_THREAD_TYPE_NAMED)
             : ABTI_THREAD_TYPE_YIELDABLE;
-    abt_errno = ABTI_ythread_create_internal(p_local, p_pool, thread_func, arg,
-                                             p_attr, unit_type, NULL, NULL,
-                                             ABT_TRUE, pp_newthread);
-    return abt_errno;
+    int abt_errno = ABTI_ythread_create_internal(p_local, p_pool, thread_func,
+                                                 arg, p_attr, unit_type, NULL,
+                                                 NULL, ABT_TRUE, pp_newthread);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    return ABT_SUCCESS;
 }
 
 int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
                                 ABTI_pool *p_pool)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    int abt_errno = ABT_SUCCESS;
-
     /* checking for cases when migration is not allowed */
-    ABTI_CHECK_TRUE(ABTI_pool_accept_migration(p_pool, p_thread->p_pool) ==
-                        ABT_TRUE,
-                    ABT_ERR_INV_POOL);
-    ABTI_CHECK_TRUE(!(p_thread->type &
-                      (ABTI_THREAD_TYPE_MAIN | ABTI_THREAD_TYPE_MAIN_SCHED)),
-                    ABT_ERR_INV_THREAD);
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) !=
-                        ABTI_THREAD_STATE_TERMINATED,
-                    ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTI_pool_accept_migration(p_pool, p_thread->p_pool) ==
+                            ABT_TRUE,
+                        ABT_ERR_INV_POOL);
+    ABTI_CHECK_TRUE_RET(!(p_thread->type & (ABTI_THREAD_TYPE_MAIN |
+                                            ABTI_THREAD_TYPE_MAIN_SCHED)),
+                        ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                            ABTI_THREAD_STATE_TERMINATED,
+                        ABT_ERR_INV_THREAD);
 
     /* checking for migration to the same pool */
-    ABTI_CHECK_TRUE(p_thread->p_pool != p_pool, ABT_ERR_MIGRATION_TARGET);
+    ABTI_CHECK_TRUE_RET(p_thread->p_pool != p_pool, ABT_ERR_MIGRATION_TARGET);
 
     /* adding request to the thread.  p_migration_pool must be updated before
      * setting the request since the target thread would read p_migration_pool
@@ -1760,14 +1748,7 @@ int ABTI_thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
             *pp_local = ABTI_xstream_get_local(p_local_xstream);
         }
     }
-    goto fn_exit;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
     return ABT_ERR_MIGRATION_NA;
 #endif
@@ -1792,9 +1773,7 @@ ABTI_thread_mig_data *ABTI_thread_get_mig_data(ABTI_local *p_local,
 int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
                              ABTI_ythread **p_ythread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr attr;
-    ABTI_ythread *p_newthread;
     ABTI_pool *p_pool;
 
     /* Get the first pool of ES */
@@ -1810,104 +1789,76 @@ int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
      * so that the scheduler can schedule the main ULT when the main ULT is
      * context switched to the scheduler for the first time. */
     ABT_bool push_pool = ABT_TRUE;
-    abt_errno =
+    int abt_errno =
         ABTI_ythread_create_internal(p_local, p_pool, NULL, NULL, &attr,
                                      ABTI_THREAD_TYPE_YIELDABLE |
                                          ABTI_THREAD_TYPE_MAIN,
-                                     NULL, p_xstream, push_pool, &p_newthread);
-    ABTI_CHECK_ERROR(abt_errno);
-
-    /* Return value */
-    *p_ythread = p_newthread;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    *p_ythread = NULL;
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+                                     NULL, p_xstream, push_pool, p_ythread);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    return ABT_SUCCESS;
 }
 
 /* This routine is to create a ULT for the main scheduler of ES. */
 int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
                                    ABTI_sched *p_sched)
 {
-    int abt_errno = ABT_SUCCESS;
-    ABTI_ythread *p_newthread;
-
     /* Create a ULT context */
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
         /* Create a ULT object and its stack */
+        ABTI_ythread *p_newthread;
         ABTI_thread_attr attr;
         ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                               ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK,
                               ABT_FALSE);
-        ABTI_ythread *p_main_ythread = ABTI_global_get_main();
-        abt_errno =
+        int abt_errno =
             ABTI_ythread_create_internal(p_local, NULL, ABTI_xstream_schedule,
                                          (void *)p_xstream, &attr,
                                          ABTI_THREAD_TYPE_YIELDABLE |
                                              ABTI_THREAD_TYPE_MAIN_SCHED,
                                          p_sched, p_xstream, ABT_FALSE,
                                          &p_newthread);
-        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_CHECK_ERROR_RET(abt_errno);
         /* When the main scheduler is terminated, the control will jump to the
          * primary ULT. */
+        ABTI_ythread *p_main_ythread = ABTI_global_get_main();
         ABTD_atomic_relaxed_store_ythread_context_ptr(&p_newthread->ctx.p_link,
                                                       &p_main_ythread->ctx);
+        p_sched->p_ythread = p_newthread;
     } else {
         /* For secondary ESs, the stack of OS thread is used for the main
          * scheduler's ULT. */
         ABTI_thread_attr attr;
         ABTI_thread_attr_init(&attr, NULL, 0, ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC,
                               ABT_FALSE);
-        abt_errno =
+        int abt_errno =
             ABTI_ythread_create_internal(p_local, NULL, ABTI_xstream_schedule,
                                          (void *)p_xstream, &attr,
                                          ABTI_THREAD_TYPE_YIELDABLE |
                                              ABTI_THREAD_TYPE_MAIN_SCHED,
                                          p_sched, p_xstream, ABT_FALSE,
-                                         &p_newthread);
-        ABTI_CHECK_ERROR(abt_errno);
+                                         &p_sched->p_ythread);
+        ABTI_CHECK_ERROR_RET(abt_errno);
     }
-
-    /* Return value */
-    p_sched->p_ythread = p_newthread;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /* This routine is to create a ULT for the scheduler. */
 int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
                               ABTI_sched *p_sched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr attr;
 
     /* Allocate a ULT object and its stack */
     ABTI_thread_attr_init(&attr, NULL, ABTI_global_get_sched_stacksize(),
                           ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK, ABT_FALSE);
-    abt_errno =
+    int abt_errno =
         ABTI_ythread_create_internal(p_local, p_pool,
                                      (void (*)(void *))p_sched->run,
                                      (void *)ABTI_sched_get_handle(p_sched),
                                      &attr, ABTI_THREAD_TYPE_YIELDABLE, p_sched,
                                      NULL, ABT_TRUE, &p_sched->p_ythread);
-    ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    p_sched->p_ythread = NULL;
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    return ABT_SUCCESS;
 }
 
 static inline void ABTI_thread_free_impl(ABTI_local *p_local,
@@ -1985,62 +1936,60 @@ void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
 
     if (p_thread == NULL) {
         fprintf(p_os, "%s== NULL thread ==\n", prefix);
-        goto fn_exit;
-    }
-
-    ABTI_xstream *p_xstream = p_thread->p_last_xstream;
-    int xstream_rank = p_xstream ? p_xstream->rank : 0;
-    char *type, *yieldable, *state;
-
-    if (p_thread->type & ABTI_THREAD_TYPE_MAIN) {
-        type = "MAIN";
-    } else if (p_thread->type & ABTI_THREAD_TYPE_MAIN_SCHED) {
-        type = "MAIN_SCHED";
     } else {
-        type = "USER";
-    }
-    if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
-        yieldable = "yes";
-    } else {
-        yieldable = "no";
-    }
-    switch (ABTD_atomic_acquire_load_int(&p_thread->state)) {
-        case ABTI_THREAD_STATE_READY:
-            state = "READY";
-            break;
-        case ABTI_THREAD_STATE_RUNNING:
-            state = "RUNNING";
-            break;
-        case ABTI_THREAD_STATE_BLOCKED:
-            state = "BLOCKED";
-            break;
-        case ABTI_THREAD_STATE_TERMINATED:
-            state = "TERMINATED";
-            break;
-        default:
-            state = "UNKNOWN";
-            break;
+        ABTI_xstream *p_xstream = p_thread->p_last_xstream;
+        int xstream_rank = p_xstream ? p_xstream->rank : 0;
+        char *type, *yieldable, *state;
+
+        if (p_thread->type & ABTI_THREAD_TYPE_MAIN) {
+            type = "MAIN";
+        } else if (p_thread->type & ABTI_THREAD_TYPE_MAIN_SCHED) {
+            type = "MAIN_SCHED";
+        } else {
+            type = "USER";
+        }
+        if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
+            yieldable = "yes";
+        } else {
+            yieldable = "no";
+        }
+        switch (ABTD_atomic_acquire_load_int(&p_thread->state)) {
+            case ABTI_THREAD_STATE_READY:
+                state = "READY";
+                break;
+            case ABTI_THREAD_STATE_RUNNING:
+                state = "RUNNING";
+                break;
+            case ABTI_THREAD_STATE_BLOCKED:
+                state = "BLOCKED";
+                break;
+            case ABTI_THREAD_STATE_TERMINATED:
+                state = "TERMINATED";
+                break;
+            default:
+                state = "UNKNOWN";
+                break;
+        }
+
+        fprintf(p_os,
+                "%s== Thread (%p) ==\n"
+                "%sid        : %" PRIu64 "\n"
+                "%stype      : %s\n"
+                "%syieldable : %s\n"
+                "%sstate     : %s\n"
+                "%slast_ES   : %p (%d)\n"
+                "%sp_arg     : %p\n"
+                "%spool      : %p\n"
+                "%srequest   : 0x%x\n"
+                "%skeytable  : %p\n",
+                prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
+                prefix, type, prefix, yieldable, prefix, state, prefix,
+                (void *)p_xstream, xstream_rank, prefix, p_thread->p_arg,
+                prefix, (void *)p_thread->p_pool, prefix,
+                ABTD_atomic_acquire_load_uint32(&p_thread->request), prefix,
+                ABTD_atomic_acquire_load_ptr(&p_thread->p_keytable));
     }
 
-    fprintf(p_os,
-            "%s== Thread (%p) ==\n"
-            "%sid        : %" PRIu64 "\n"
-            "%stype      : %s\n"
-            "%syieldable : %s\n"
-            "%sstate     : %s\n"
-            "%slast_ES   : %p (%d)\n"
-            "%sp_arg     : %p\n"
-            "%spool      : %p\n"
-            "%srequest   : 0x%x\n"
-            "%skeytable  : %p\n",
-            prefix, (void *)p_thread, prefix, ABTI_thread_get_id(p_thread),
-            prefix, type, prefix, yieldable, prefix, state, prefix,
-            (void *)p_xstream, xstream_rank, prefix, p_thread->p_arg, prefix,
-            (void *)p_thread->p_pool, prefix,
-            ABTD_atomic_acquire_load_uint32(&p_thread->request), prefix,
-            ABTD_atomic_acquire_load_ptr(&p_thread->p_keytable));
-
-fn_exit:
     fflush(p_os);
     ABTU_free(prefix);
 }
@@ -2089,11 +2038,9 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                               void (*thread_func)(void *), void *arg,
                               ABTI_thread *p_thread)
 {
-    int abt_errno = ABT_SUCCESS;
-
-    ABTI_CHECK_TRUE(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
-                        ABTI_THREAD_STATE_TERMINATED,
-                    ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
+                            ABTI_THREAD_STATE_TERMINATED,
+                        ABT_ERR_INV_THREAD);
 
     p_thread->f_thread = thread_func;
     p_thread->p_arg = arg;
@@ -2139,37 +2086,30 @@ static int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     LOG_DEBUG("[U%" PRIu64 "] revived\n", ABTI_thread_get_id(p_thread));
 
     /* Add this thread to the pool */
-    abt_errno = ABTI_pool_push(p_local, p_pool, p_thread->unit);
-    ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    int abt_errno = ABTI_pool_push(p_local, p_pool, p_thread->unit);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    return ABT_SUCCESS;
 }
 
 static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
 {
-    int abt_errno = ABT_SUCCESS;
-
     if (ABTD_atomic_acquire_load_int(&p_thread->state) ==
         ABTI_THREAD_STATE_TERMINATED) {
         goto fn_exit;
     }
 
-    ABTI_CHECK_TRUE_MSG(!(p_thread->type & (ABTI_THREAD_TYPE_MAIN |
+    /* The main ULT cannot be joined. */
+    ABTI_CHECK_TRUE_RET(!(p_thread->type & (ABTI_THREAD_TYPE_MAIN |
                                             ABTI_THREAD_TYPE_MAIN_SCHED)),
-                        ABT_ERR_INV_THREAD, "The main ULT cannot be joined.");
+                        ABT_ERR_INV_THREAD);
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_or_null(*pp_local);
     if (ABTI_IS_EXT_THREAD_ENABLED && !p_local_xstream)
         goto busywait_based;
 
     ABTI_thread *p_self_thread = p_local_xstream->p_thread;
-    ABTI_CHECK_TRUE_MSG(p_thread != p_self_thread, ABT_ERR_INV_THREAD,
-                        "The target ULT should be different.");
+    /* The target ULT should be different. */
+    ABTI_CHECK_TRUE_RET(p_thread != p_self_thread, ABT_ERR_INV_THREAD);
 
     ABTI_ythread *p_self = ABTI_thread_get_ythread_or_null(p_self_thread);
     if (!p_self)
@@ -2209,9 +2149,10 @@ static inline int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
          * underestimate the number of units in a pool. */
         ABTI_pool_inc_num_blocked(p_self->thread.p_pool);
         /* Remove the target ULT from the pool */
-        abt_errno =
+        int abt_errno =
             ABTI_pool_remove(ABTI_xstream_get_local(p_local_xstream),
                              p_ythread->thread.p_pool, p_ythread->thread.unit);
+        ABTI_CHECK_ERROR_RET(abt_errno);
 
         /* Set the link in the context for the target ULT.  Since p_link will be
          * referenced by p_self, this update does not require release store. */
@@ -2320,18 +2261,12 @@ busywait_based:
     }
 
 fn_exit:
-    if (abt_errno == ABT_SUCCESS) {
-        ABTI_tool_event_thread_join(*pp_local, p_thread,
-                                    ABTI_local_get_xstream_or_null(*pp_local)
-                                        ? ABTI_local_get_xstream(*pp_local)
-                                              ->p_thread
-                                        : NULL);
-    }
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    ABTI_tool_event_thread_join(*pp_local, p_thread,
+                                ABTI_local_get_xstream_or_null(*pp_local)
+                                    ? ABTI_local_get_xstream(*pp_local)
+                                          ->p_thread
+                                    : NULL);
+    return ABT_SUCCESS;
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
@@ -2339,59 +2274,45 @@ static int ABTI_thread_migrate_to_xstream(ABTI_local **pp_local,
                                           ABTI_thread *p_thread,
                                           ABTI_xstream *p_xstream)
 {
-    int abt_errno = ABT_SUCCESS;
-
     /* checking for cases when migration is not allowed */
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
-                        ABT_XSTREAM_STATE_TERMINATED,
-                    ABT_ERR_INV_XSTREAM);
-    ABTI_CHECK_TRUE(!(p_thread->type &
-                      (ABTI_THREAD_TYPE_MAIN | ABTI_THREAD_TYPE_MAIN_SCHED)),
-                    ABT_ERR_INV_THREAD);
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->state) !=
-                        ABTI_THREAD_STATE_TERMINATED,
-                    ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+                            ABT_XSTREAM_STATE_TERMINATED,
+                        ABT_ERR_INV_XSTREAM);
+    ABTI_CHECK_TRUE_RET(!(p_thread->type & (ABTI_THREAD_TYPE_MAIN |
+                                            ABTI_THREAD_TYPE_MAIN_SCHED)),
+                        ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_thread->state) !=
+                            ABTI_THREAD_STATE_TERMINATED,
+                        ABT_ERR_INV_THREAD);
 
     /* We need to find the target scheduler */
     ABTI_pool *p_pool = NULL;
     ABTI_sched *p_sched = NULL;
     do {
         /* We check the state of the ES */
-        if (ABTD_atomic_acquire_load_int(&p_xstream->state) ==
-            ABT_XSTREAM_STATE_TERMINATED) {
-            abt_errno = ABT_ERR_INV_XSTREAM;
-            goto fn_fail;
-
-        } else {
-            /* The migration target should be the main scheduler since it is
-             * hard to guarantee the lifetime of the stackable scheduler. */
-            p_sched = p_xstream->p_main_sched;
-        }
+        ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+                                ABT_XSTREAM_STATE_TERMINATED,
+                            ABT_ERR_INV_XSTREAM);
+        /* The migration target should be the main scheduler since it is
+         * hard to guarantee the lifetime of the stackable scheduler. */
+        p_sched = p_xstream->p_main_sched;
 
         /* We check the state of the sched */
         /* Find a pool */
         ABTI_sched_get_migration_pool(p_sched, p_thread->p_pool, &p_pool);
-        if (p_pool == NULL) {
-            abt_errno = ABT_ERR_INV_POOL;
-            goto fn_fail;
-        }
+        ABTI_CHECK_TRUE_RET(p_pool != NULL, ABT_ERR_INV_POOL);
         /* We set the migration counter to prevent the scheduler from
          * stopping */
         ABTI_pool_inc_num_migrations(p_pool);
     } while (p_pool == NULL);
 
-    abt_errno = ABTI_thread_migrate_to_pool(pp_local, p_thread, p_pool);
-    if (abt_errno != ABT_SUCCESS) {
+    int abt_errno = ABTI_thread_migrate_to_pool(pp_local, p_thread, p_pool);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTI_pool_dec_num_migrations(p_pool);
-        goto fn_fail;
+        return abt_errno;
     }
 
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 #endif
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -364,15 +364,22 @@ fn_fail:
  */
 int ABT_thread_free_many(int num, ABT_thread *thread_list)
 {
+    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     int i;
 
     for (i = 0; i < num; i++) {
         ABTI_thread *p_thread = ABTI_thread_get_ptr(thread_list[i]);
-        ABTI_thread_join(&p_local, p_thread);
+        abt_errno = ABTI_thread_join(&p_local, p_thread);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTI_thread_free(p_local, p_thread);
     }
-    return ABT_SUCCESS;
+fn_exit:
+    return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**
@@ -478,7 +485,7 @@ fn_fail:
 int ABT_thread_cancel(ABT_thread thread)
 {
 #ifdef ABT_CONFIG_DISABLE_THREAD_CANCEL
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #else
     int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
@@ -924,7 +931,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_MIGRATION_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_MIGRATION_NA);
 #endif
 }
 
@@ -985,7 +992,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_MIGRATION_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_MIGRATION_NA);
 #endif
 }
 
@@ -1030,7 +1037,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_MIGRATION_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_MIGRATION_NA);
 #endif
 }
 
@@ -1102,7 +1109,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_MIGRATION_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_MIGRATION_NA);
 #endif
 }
 
@@ -1140,7 +1147,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -1182,7 +1189,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -1217,7 +1224,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -29,6 +29,7 @@ int ABT_thread_attr_create(ABT_thread_attr *newattr)
     ABTI_thread_attr *p_newattr;
 
     p_newattr = (ABTI_thread_attr *)ABTU_malloc(sizeof(ABTI_thread_attr));
+    ABTI_CHECK_TRUE(p_newattr, ABT_ERR_MEM);
 
     /* Default values */
     ABTI_thread_attr_init(p_newattr, NULL, ABTI_global_get_thread_stacksize(),
@@ -37,7 +38,12 @@ int ABT_thread_attr_create(ABT_thread_attr *newattr)
     /* Return value */
     *newattr = ABTI_thread_attr_get_handle(p_newattr);
 
+fn_exit:
     return abt_errno;
+
+fn_fail:
+    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
+    goto fn_exit;
 }
 
 /**
@@ -264,7 +270,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -301,7 +307,7 @@ fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 #else
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #endif
 }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -346,21 +346,14 @@ fn_fail:
 
 int ABTI_timer_create(ABTI_timer **pp_newtimer)
 {
-    int abt_errno = ABT_SUCCESS;
-
     /* We use libc malloc/free for ABT_timer because ABTU_malloc/free might
      * need the initialization of Argobots if they are not the same as libc
      * malloc/free.  This is to allow ABT_timer to be used irrespective of
      * Argobots initialization. */
     ABTI_timer *p_newtimer = (ABTI_timer *)malloc(sizeof(ABTI_timer));
-    ABTI_CHECK_TRUE(p_newtimer != NULL, ABT_ERR_MEM);
+    ABTI_CHECK_TRUE_RET(p_newtimer != NULL, ABT_ERR_MEM);
 
     *pp_newtimer = p_newtimer;
 
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/tool.c
+++ b/src/tool.c
@@ -45,7 +45,7 @@ int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
                                       void *user_arg)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #else
     if (cb_func == NULL)
         event_mask_thread = ABT_TOOL_EVENT_THREAD_NONE;
@@ -87,7 +87,7 @@ int ABT_tool_register_task_callback(ABT_tool_task_callback_fn cb_func,
                                     uint64_t event_mask_task, void *user_arg)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #else
     if (cb_func == NULL)
         event_mask_task = ABT_TOOL_EVENT_TASK_NONE;
@@ -195,7 +195,7 @@ int ABT_tool_query_thread(ABT_tool_context context, uint64_t event_thread,
                           ABT_tool_query_kind query_kind, void *val)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #else
     int abt_errno = ABT_SUCCESS;
 
@@ -232,7 +232,7 @@ int ABT_tool_query_task(ABT_tool_context context, uint64_t event_task,
                         ABT_tool_query_kind query_kind, void *val)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    return ABT_ERR_FEATURE_NA;
+    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
 #else
     int abt_errno = ABT_SUCCESS;
 

--- a/src/tool.c
+++ b/src/tool.c
@@ -254,8 +254,6 @@ fn_fail:
 static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
                                   ABT_tool_query_kind query_kind, void *val)
 {
-    int abt_errno = ABT_SUCCESS;
-
     switch (query_kind) {
         case ABT_TOOL_QUERY_KIND_POOL:
             *(ABT_pool *)val = ABTI_pool_get_handle(p_tctx->p_pool);
@@ -338,8 +336,8 @@ static inline int ABTI_tool_query(ABTI_tool_context *p_tctx,
             }
             break;
         default:
-            abt_errno = ABT_ERR_OTHER;
+            return ABT_ERR_OTHER;
     }
-    return abt_errno;
+    return ABT_SUCCESS;
 }
 #endif

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -89,8 +89,8 @@ int ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
     ABTI_pool *p_pool = p_ythread->thread.p_pool;
 
     /* Add the ULT to its associated pool */
-    ABTI_POOL_ADD_THREAD(&p_ythread->thread,
-                         ABTI_self_get_native_thread_id(p_local));
+    abt_errno = ABTI_pool_add_thread(p_local, &p_ythread->thread);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Decrease the number of blocked threads */
     ABTI_pool_dec_num_blocked(p_pool);

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -7,11 +7,9 @@
 
 int ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
 {
-    int abt_errno = ABT_SUCCESS;
-
     /* The main sched cannot be blocked */
-    ABTI_CHECK_TRUE(!(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
-                    ABT_ERR_THREAD);
+    ABTI_CHECK_TRUE_RET(!(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
+                        ABT_ERR_THREAD);
 
     /* To prevent the scheduler from adding the ULT to the pool */
     ABTI_thread_set_request(&p_ythread->thread, ABTI_THREAD_REQ_BLOCK);
@@ -27,13 +25,7 @@ int ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
     LOG_DEBUG("[U%" PRIu64 ":E%d] blocked\n",
               ABTI_thread_get_id(&p_ythread->thread),
               p_ythread->thread.p_last_xstream->rank);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /* NOTE: This routine should be called after ABTI_ythread_set_blocked. */
@@ -59,12 +51,11 @@ void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
 
 int ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
 {
-    int abt_errno = ABT_SUCCESS;
-
     /* The ULT should be in BLOCKED state. */
-    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_ythread->thread.state) ==
-                        ABTI_THREAD_STATE_BLOCKED,
-                    ABT_ERR_THREAD);
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(
+                            &p_ythread->thread.state) ==
+                            ABTI_THREAD_STATE_BLOCKED,
+                        ABT_ERR_THREAD);
 
     /* We should wait until the scheduler of the blocked ULT resets the BLOCK
      * request. Otherwise, the ULT can be pushed to a pool here and be
@@ -89,18 +80,12 @@ int ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
     ABTI_pool *p_pool = p_ythread->thread.p_pool;
 
     /* Add the ULT to its associated pool */
-    abt_errno = ABTI_pool_add_thread(p_local, &p_ythread->thread);
-    ABTI_CHECK_ERROR(abt_errno);
+    int abt_errno = ABTI_pool_add_thread(p_local, &p_ythread->thread);
+    ABTI_CHECK_ERROR_RET(abt_errno);
 
     /* Decrease the number of blocked threads */
     ABTI_pool_dec_num_blocked(p_pool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 ABTU_no_sanitize_address int ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
@@ -110,7 +95,7 @@ ABTU_no_sanitize_address int ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
     size_t i, j, stacksize = p_ythread->stacksize;
     if (stacksize == 0 || p_stack == NULL) {
         /* Some threads do not have p_stack (e.g., the main thread) */
-        return ABT_ERR_THREAD;
+        return ABT_SUCCESS;
     }
 
     char buffer[32];


### PR DESCRIPTION
This PR cleans up error handling in Argobots. Specifically, this PR forces Argobots to call `HANDLE_ERROR_FUNC_WITH_CODE()` only once when an error happens.

This PR is not expected to affect the performance (or maybe slightly improve the performance by `ABTU_unlikely()`).
