### PR TITLE
xstream: introduce a root thread

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -75,16 +75,17 @@ enum ABTI_sched_used {
 
 #define ABTI_THREAD_TYPE_EXT ((ABTI_thread_type)0)
 #define ABTI_THREAD_TYPE_THREAD ((ABTI_thread_type)(0x1 << 0))
-#define ABTI_THREAD_TYPE_MAIN ((ABTI_thread_type)(0x1 << 1))
-#define ABTI_THREAD_TYPE_MAIN_SCHED ((ABTI_thread_type)(0x1 << 2))
-#define ABTI_THREAD_TYPE_YIELDABLE ((ABTI_thread_type)(0x1 << 3))
-#define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 4))
-#define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 5))
+#define ABTI_THREAD_TYPE_ROOT ((ABTI_thread_type)(0x1 << 1))
+#define ABTI_THREAD_TYPE_MAIN ((ABTI_thread_type)(0x1 << 2))
+#define ABTI_THREAD_TYPE_MAIN_SCHED ((ABTI_thread_type)(0x1 << 3))
+#define ABTI_THREAD_TYPE_YIELDABLE ((ABTI_thread_type)(0x1 << 4))
+#define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 5))
+#define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 6))
 
 #define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC ((ABTI_thread_type)(0x1 << 7))
-#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC ((ABTI_thread_type)(0x1 << 6))
-#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 8))
-#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 9))
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC ((ABTI_thread_type)(0x1 << 8))
+#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 9))
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 10))
 
 #define ABTI_THREAD_TYPES_MEM                                                  \
     (ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC | ABTI_THREAD_TYPE_MEM_MALLOC_DESC |    \
@@ -246,6 +247,10 @@ struct ABTI_xstream {
     void *p_req_arg;            /* Request argument */
 
     ABTD_xstream_context ctx; /* ES context */
+
+    ABTI_ythread
+        *p_root_ythread; /* Root thread that schedulers the main scheduler. */
+    ABTI_pool *p_root_pool; /* Root pool that stores the main scheduler. */
 
     ABTU_align_member_var(ABT_CONFIG_STATIC_CACHELINE_SIZE)
         ABTI_thread *p_thread; /* Current running ULT/tasklet */
@@ -457,7 +462,6 @@ void ABTI_xstream_schedule(void *p_arg);
 int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
                           ABTI_pool *p_pool);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
-void *ABTI_xstream_launch_main_sched(void *p_arg);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);
 
@@ -503,12 +507,17 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 /* Threads */
 int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
                              ABTI_thread_mig_data **pp_mig_data);
+int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
+                       void (*thread_func)(void *), void *arg,
+                       ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 void ABTI_thread_reset_id(void);
 ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
 
 /* Yieldable threads */
+int ABTI_ythread_create_root(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                             ABTI_ythread **pp_root_ythread);
 int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
                              ABTI_ythread **p_ythread);
 int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
@@ -516,8 +525,8 @@ int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
 int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
                               ABTI_sched *p_sched);
 void ABTI_ythread_free_main(ABTI_local *p_local, ABTI_ythread *p_ythread);
-void ABTI_ythread_free_main_sched(ABTI_local *p_local, ABTI_ythread *p_ythread);
-int ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);
+void ABTI_ythread_free_root(ABTI_local *p_local, ABTI_ythread *p_ythread);
+void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);
 void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
                           ABTI_ythread *p_ythread,
                           ABT_sync_event_type sync_event_type, void *p_sync);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -235,7 +235,6 @@ struct ABTI_xstream {
     int rank;                 /* Rank */
     ABTI_xstream_type type;   /* Type */
     ABTD_atomic_int state;    /* State (ABT_xstream_state) */
-    ABTI_sched **scheds;      /* Stack of running schedulers */
     ABTI_sched *p_main_sched; /* Main scheduler, which is the bottom of the
                                * linked list of schedulers */
     ABTD_xstream_context ctx; /* ES context */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -35,10 +35,6 @@
 /* Constants */
 #define ABTI_SCHED_NUM_PRIO 3
 
-#define ABTI_XSTREAM_REQ_JOIN (1 << 0)
-#define ABTI_XSTREAM_REQ_TERMINATE (1 << 1)
-#define ABTI_XSTREAM_REQ_CANCEL (1 << 2)
-
 #define ABTI_SCHED_REQ_FINISH (1 << 0)
 #define ABTI_SCHED_REQ_EXIT (1 << 1)
 
@@ -242,10 +238,6 @@ struct ABTI_xstream {
     ABTI_sched **scheds;      /* Stack of running schedulers */
     ABTI_sched *p_main_sched; /* Main scheduler, which is the bottom of the
                                * linked list of schedulers */
-
-    ABTD_atomic_uint32 request; /* Request */
-    void *p_req_arg;            /* Request argument */
-
     ABTD_xstream_context ctx; /* ES context */
 
     ABTI_ythread
@@ -510,6 +502,7 @@ int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
 int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                        void (*thread_func)(void *), void *arg,
                        ABTI_thread *p_thread);
+int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 void ABTI_thread_reset_id(void);
@@ -524,6 +517,8 @@ int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
                                    ABTI_sched *p_sched);
 int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
                               ABTI_sched *p_sched);
+ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
+                                     ABTI_ythread *p_ythread);
 void ABTI_ythread_free_main(ABTI_local *p_local, ABTI_ythread *p_ythread);
 void ABTI_ythread_free_root(ABTI_local *p_local, ABTI_ythread *p_ythread);
 void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -48,6 +48,10 @@ static inline int ABTI_sched_discard_and_free(ABTI_local *p_local,
     if (p_sched->automatic == ABT_TRUE || force_free) {
         int abt_errno = ABTI_sched_free(p_local, p_sched, force_free);
         ABTI_CHECK_ERROR_RET(abt_errno);
+    } else {
+        /* Threads should be discarded here. */
+        ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
+        p_sched->p_ythread = NULL;
     }
     return ABT_SUCCESS;
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -38,18 +38,6 @@ static inline ABT_xstream ABTI_xstream_get_handle(ABTI_xstream *p_xstream)
 #endif
 }
 
-static inline void ABTI_xstream_set_request(ABTI_xstream *p_xstream,
-                                            uint32_t req)
-{
-    ABTD_atomic_fetch_or_uint32(&p_xstream->request, req);
-}
-
-static inline void ABTI_xstream_unset_request(ABTI_xstream *p_xstream,
-                                              uint32_t req)
-{
-    ABTD_atomic_fetch_and_uint32(&p_xstream->request, ~req);
-}
-
 /* Get the first pool of the main scheduler. */
 static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
 {

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -170,6 +170,10 @@ static inline void ABTI_tool_event_thread_impl(
                 p_local_xstream ? ABTI_xstream_get_handle(p_local_xstream)
                                 : ABT_XSTREAM_NULL;
             if (p_ythread) {
+                if (p_ythread->thread.type & ABTI_THREAD_TYPE_ROOT) {
+                    /* Root thread should not be visible to users. */
+                    return;
+                }
                 ABT_thread h_thread = ABTI_ythread_get_handle(p_ythread);
                 ABT_tool_context h_tctx = ABTI_tool_context_get_handle(&tctx);
                 cb_func_thread(h_thread, h_xstream, event_code, h_tctx,

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -347,20 +347,6 @@ ABTI_ythread_finish_context_to_parent(ABTI_xstream *p_local_xstream,
     ABTU_unreachable();
 }
 
-ABTU_noreturn static inline void
-ABTI_ythread_finish_context_sched_to_main_thread(ABTI_sched *p_main_sched)
-{
-    /* The main thread is stored in p_link. */
-    ABTI_ythread *p_sched_ythread = p_main_sched->p_ythread;
-    ABTI_ASSERT(p_sched_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED);
-    ABTD_ythread_context *p_ctx = &p_sched_ythread->ctx;
-    ABTI_ythread *p_main_ythread = ABTI_ythread_context_get_ythread(
-        ABTD_atomic_acquire_load_ythread_context_ptr(&p_ctx->p_link));
-    ABTI_ASSERT(p_main_ythread &&
-                (p_main_ythread->thread.type & ABTI_THREAD_TYPE_MAIN));
-    ABTD_ythread_finish_context(&p_sched_ythread->ctx, &p_main_ythread->ctx);
-}
-
 static inline void ABTI_ythread_yield(ABTI_xstream **pp_local_xstream,
                                       ABTI_ythread *p_ythread,
                                       ABT_sync_event_type sync_event_type,

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -609,19 +609,8 @@ int ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
     ABTU_free(p_sched->pools);
 
     /* Free the associated work unit */
-    if (p_sched->type == ABT_SCHED_TYPE_ULT) {
-        if (p_sched->p_ythread) {
-            if (p_sched->p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED) {
-                ABTI_ythread_free_main_sched(p_local, p_sched->p_ythread);
-            } else {
-                ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
-            }
-        }
-    } else if (p_sched->type == ABT_SCHED_TYPE_TASK) {
-        /* The underlying implementation is ULT. */
-        if (p_sched->p_ythread) {
-            ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
-        }
+    if (p_sched->p_ythread) {
+        ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
     }
 
     LOG_DEBUG("[S%" PRIu64 "] freed\n", p_sched->id);

--- a/src/self.c
+++ b/src/self.c
@@ -188,9 +188,7 @@ int ABT_self_suspend(void)
     ABTI_ythread *p_self;
     ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(&p_local_xstream, &p_self);
 
-    abt_errno = ABTI_ythread_set_blocked(p_self);
-    ABTI_CHECK_ERROR(abt_errno);
-
+    ABTI_ythread_set_blocked(p_self);
     ABTI_ythread_suspend(&p_local_xstream, p_self, ABT_SYNC_EVENT_TYPE_USER,
                          NULL);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1155,9 +1155,6 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
     ABTI_ythread_free_root(p_local, p_xstream->p_root_ythread);
     ABTI_pool_free(p_xstream->p_root_pool);
 
-    /* Free the array of sched contexts */
-    ABTU_free(p_xstream->scheds);
-
     /* Free the context if a given xstream is secondary. */
     if (p_xstream->type == ABTI_XSTREAM_TYPE_SECONDARY) {
         int abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
@@ -1262,7 +1259,6 @@ static int xstream_create(ABTI_sched *p_sched, ABTI_xstream_type xstream_type,
     p_newxstream->type = xstream_type;
     ABTD_atomic_relaxed_store_int(&p_newxstream->state,
                                   ABT_XSTREAM_STATE_RUNNING);
-    p_newxstream->scheds = NULL;
     p_newxstream->p_main_sched = NULL;
     p_newxstream->p_thread = NULL;
     ABTI_mem_init_local(p_newxstream);

--- a/src/thread.c
+++ b/src/thread.c
@@ -11,12 +11,11 @@ static inline int ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
                                  ABTI_thread_type thread_type,
                                  ABTI_sched *p_sched, ABT_bool push_pool,
                                  ABTI_ythread **pp_newthread);
-static int thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
-                         void (*thread_func)(void *), void *arg,
-                         ABTI_thread *p_thread);
 static inline int thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 static inline void thread_free(ABTI_local *p_local, ABTI_thread *p_thread,
                                ABT_bool free_unit);
+static void thread_root_func(void *arg);
+static void thread_main_sched_func(void *arg);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
 static int thread_migrate_to_xstream(ABTI_local **pp_local,
                                      ABTI_thread *p_thread,
@@ -285,7 +284,7 @@ int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = thread_revive(p_local, p_pool, thread_func, arg, p_thread);
+    abt_errno = ABTI_thread_revive(p_local, p_pool, thread_func, arg, p_thread);
     ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:
@@ -1570,6 +1569,62 @@ fn_fail:
 /* Private APIs                                                              */
 /*****************************************************************************/
 
+int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
+                       void (*thread_func)(void *), void *arg,
+                       ABTI_thread *p_thread)
+{
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
+                            ABT_THREAD_STATE_TERMINATED,
+                        ABT_ERR_INV_THREAD);
+
+    p_thread->f_thread = thread_func;
+    p_thread->p_arg = arg;
+
+    ABTD_atomic_relaxed_store_int(&p_thread->state, ABT_THREAD_STATE_READY);
+    ABTD_atomic_relaxed_store_uint32(&p_thread->request, 0);
+    p_thread->p_last_xstream = NULL;
+    p_thread->p_parent = NULL;
+
+    ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
+    if (p_thread->p_pool != p_pool) {
+        /* Free the unit for the old pool */
+        p_thread->p_pool->u_free(&p_thread->unit);
+
+        /* Set the new pool */
+        p_thread->p_pool = p_pool;
+
+        /* Create a wrapper unit */
+        if (p_ythread) {
+            ABT_thread h_thread = ABTI_ythread_get_handle(p_ythread);
+            p_thread->unit = p_pool->u_create_from_thread(h_thread);
+        } else {
+            ABT_task task = ABTI_thread_get_handle(p_thread);
+            p_thread->unit = p_pool->u_create_from_task(task);
+        }
+    }
+
+    if (p_ythread) {
+        /* Create a ULT context */
+        size_t stacksize = p_ythread->stacksize;
+        ABTD_ythread_context_create(NULL, stacksize, p_ythread->p_stack,
+                                    &p_ythread->ctx);
+    }
+
+    /* Invoke a thread revive event. */
+    ABTI_tool_event_thread_revive(p_local, p_thread,
+                                  ABTI_local_get_xstream_or_null(p_local)
+                                      ? ABTI_local_get_xstream(p_local)
+                                            ->p_thread
+                                      : NULL,
+                                  p_pool);
+
+    LOG_DEBUG("[U%" PRIu64 "] revived\n", ABTI_thread_get_id(p_thread));
+
+    /* Add this thread to the pool */
+    ABTI_pool_push(p_pool, p_thread->unit);
+    return ABT_SUCCESS;
+}
+
 int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
                              ABTI_ythread **p_ythread)
 {
@@ -1597,43 +1652,46 @@ int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
     return ABT_SUCCESS;
 }
 
-/* This routine is to create a ULT for the main scheduler of ES. */
-int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                                   ABTI_sched *p_sched)
+int ABTI_ythread_create_root(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                             ABTI_ythread **pp_root_ythread)
 {
+    ABTI_thread_attr attr;
     /* Create a ULT context */
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        /* Create a ULT object and its stack */
-        ABTI_ythread *p_newthread;
-        ABTI_thread_attr attr;
+        /* Create a thread with its stack */
         ABTI_thread_attr_init(&attr, NULL, gp_ABTI_global->sched_stacksize,
                               ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK,
                               ABT_FALSE);
-        int abt_errno = ythread_create(p_local, NULL, ABTI_xstream_schedule,
-                                       (void *)p_xstream, &attr,
-                                       ABTI_THREAD_TYPE_YIELDABLE |
-                                           ABTI_THREAD_TYPE_MAIN_SCHED,
-                                       p_sched, ABT_FALSE, &p_newthread);
-        ABTI_CHECK_ERROR_RET(abt_errno);
-        /* When the main scheduler is terminated, the control will jump to the
-         * primary ULT. */
-        ABTI_ythread *p_main_ythread = gp_ABTI_global->p_main_ythread;
-        ABTD_atomic_relaxed_store_ythread_context_ptr(&p_newthread->ctx.p_link,
-                                                      &p_main_ythread->ctx);
-        p_sched->p_ythread = p_newthread;
     } else {
-        /* For secondary ESs, the stack of OS thread is used for the main
-         * scheduler's ULT. */
-        ABTI_thread_attr attr;
+        /* For secondary ESs, the stack of an OS thread is used. */
         ABTI_thread_attr_init(&attr, NULL, 0, ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC,
                               ABT_FALSE);
-        int abt_errno = ythread_create(p_local, NULL, ABTI_xstream_schedule,
-                                       (void *)p_xstream, &attr,
-                                       ABTI_THREAD_TYPE_YIELDABLE |
-                                           ABTI_THREAD_TYPE_MAIN_SCHED,
-                                       p_sched, ABT_FALSE, &p_sched->p_ythread);
-        ABTI_CHECK_ERROR_RET(abt_errno);
     }
+    ABTI_ythread *p_root_ythread;
+    int abt_errno =
+        ythread_create(p_local, NULL, thread_root_func, NULL, &attr,
+                       ABTI_THREAD_TYPE_YIELDABLE | ABTI_THREAD_TYPE_ROOT, NULL,
+                       ABT_FALSE, &p_root_ythread);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    *pp_root_ythread = p_root_ythread;
+    return ABT_SUCCESS;
+}
+
+int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                                   ABTI_sched *p_sched)
+{
+    ABTI_thread_attr attr;
+
+    /* Allocate a ULT object and its stack */
+    ABTI_thread_attr_init(&attr, NULL, gp_ABTI_global->sched_stacksize,
+                          ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK, ABT_FALSE);
+    int abt_errno =
+        ythread_create(p_local, p_xstream->p_root_pool, thread_main_sched_func,
+                       NULL, &attr,
+                       ABTI_THREAD_TYPE_YIELDABLE |
+                           ABTI_THREAD_TYPE_MAIN_SCHED | ABTI_THREAD_TYPE_NAMED,
+                       p_sched, ABT_TRUE, &p_sched->p_ythread);
+    ABTI_CHECK_ERROR_RET(abt_errno);
     return ABT_SUCCESS;
 }
 
@@ -1658,7 +1716,9 @@ int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] freed\n", ABTI_thread_get_id(p_thread),
-              p_thread->p_last_xstream ? p_thread->p_last_xstream->rank : -1);
+              ABTI_local_get_xstream_or_null(p_local)
+                  ? ABTI_local_get_xstream(p_local)->rank
+                  : -1);
     thread_free(p_local, p_thread, ABT_TRUE);
 }
 
@@ -1670,15 +1730,9 @@ void ABTI_ythread_free_main(ABTI_local *p_local, ABTI_ythread *p_ythread)
     thread_free(p_local, p_thread, ABT_FALSE);
 }
 
-void ABTI_ythread_free_main_sched(ABTI_local *p_local, ABTI_ythread *p_ythread)
+void ABTI_ythread_free_root(ABTI_local *p_local, ABTI_ythread *p_ythread)
 {
-    ABTI_thread *p_thread = &p_ythread->thread;
-    LOG_DEBUG("[U%" PRIu64 ":E%d] main sched ULT freed\n",
-              ABTI_thread_get_id(p_thread),
-              ABTI_local_get_xstream_or_null(p_local)
-                  ? ABTI_local_get_xstream(p_local)->rank
-                  : -1);
-    thread_free(p_local, p_thread, ABT_FALSE);
+    thread_free(p_local, &p_ythread->thread, ABT_FALSE);
 }
 
 int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
@@ -1859,7 +1913,7 @@ static inline int ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
 #endif
     }
 
-    if (thread_type & (ABTI_THREAD_TYPE_MAIN | ABTI_THREAD_TYPE_MAIN_SCHED)) {
+    if (thread_type & (ABTI_THREAD_TYPE_MAIN | ABTI_THREAD_TYPE_ROOT)) {
         if (p_newthread->p_stack == NULL) {
             /* We don't need to initialize the context if a thread will run on
              * OS-level threads. Invalidate the context here. */
@@ -2028,62 +2082,6 @@ static void thread_key_destructor_migration(void *p_value)
 {
     ABTI_thread_mig_data *p_mig_data = (ABTI_thread_mig_data *)p_value;
     ABTU_free(p_mig_data);
-}
-
-static int thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
-                         void (*thread_func)(void *), void *arg,
-                         ABTI_thread *p_thread)
-{
-    ABTI_CHECK_TRUE_RET(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
-                            ABT_THREAD_STATE_TERMINATED,
-                        ABT_ERR_INV_THREAD);
-
-    p_thread->f_thread = thread_func;
-    p_thread->p_arg = arg;
-
-    ABTD_atomic_relaxed_store_int(&p_thread->state, ABT_THREAD_STATE_READY);
-    ABTD_atomic_relaxed_store_uint32(&p_thread->request, 0);
-    p_thread->p_last_xstream = NULL;
-    p_thread->p_parent = NULL;
-
-    ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
-    if (p_thread->p_pool != p_pool) {
-        /* Free the unit for the old pool */
-        p_thread->p_pool->u_free(&p_thread->unit);
-
-        /* Set the new pool */
-        p_thread->p_pool = p_pool;
-
-        /* Create a wrapper unit */
-        if (p_ythread) {
-            ABT_thread h_thread = ABTI_ythread_get_handle(p_ythread);
-            p_thread->unit = p_pool->u_create_from_thread(h_thread);
-        } else {
-            ABT_task task = ABTI_thread_get_handle(p_thread);
-            p_thread->unit = p_pool->u_create_from_task(task);
-        }
-    }
-
-    if (p_ythread) {
-        /* Create a ULT context */
-        size_t stacksize = p_ythread->stacksize;
-        ABTD_ythread_context_create(NULL, stacksize, p_ythread->p_stack,
-                                    &p_ythread->ctx);
-    }
-
-    /* Invoke a thread revive event. */
-    ABTI_tool_event_thread_revive(p_local, p_thread,
-                                  ABTI_local_get_xstream_or_null(p_local)
-                                      ? ABTI_local_get_xstream(p_local)
-                                            ->p_thread
-                                      : NULL,
-                                  p_pool);
-
-    LOG_DEBUG("[U%" PRIu64 "] revived\n", ABTI_thread_get_id(p_thread));
-
-    /* Add this thread to the pool */
-    ABTI_pool_push(p_pool, p_thread->unit);
-    return ABT_SUCCESS;
 }
 
 static inline int thread_join(ABTI_local **pp_local, ABTI_thread *p_thread)
@@ -2261,6 +2259,89 @@ fn_exit:
                                           ->p_thread
                                     : NULL);
     return ABT_SUCCESS;
+}
+
+static void thread_root_func(void *arg)
+{
+    /* root thread is working on a special context, so it should not rely on
+     * functionality that needs yield. */
+    ABTI_local *p_local = ABTI_local_get_local();
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream(p_local);
+    ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_local_xstream->state) ==
+                ABT_XSTREAM_STATE_RUNNING);
+
+    ABTI_ythread *p_root_ythread = p_local_xstream->p_root_ythread;
+    p_local_xstream->p_thread = &p_root_ythread->thread;
+    ABTI_pool *p_root_pool = p_local_xstream->p_root_pool;
+
+    do {
+        ABT_unit unit = ABTI_pool_pop(p_root_pool);
+        if (unit != ABT_UNIT_NULL) {
+            ABTI_xstream *p_xstream = p_local_xstream;
+            ABTI_xstream_run_unit(&p_xstream, unit, p_root_pool);
+            /* The root thread must be executed on the same execution stream. */
+            ABTI_ASSERT(p_xstream == p_local_xstream);
+        }
+    } while (ABTI_pool_get_total_size(p_root_pool) > 0);
+    /* The main scheduler thread finishes. */
+
+    /* Set the ES's state as TERMINATED */
+    ABTD_atomic_release_store_int(&p_local_xstream->state,
+                                  ABT_XSTREAM_STATE_TERMINATED);
+
+    if (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
+        /* Let us jump back to the main thread (then finalize Argobots) */
+        ABTD_ythread_finish_context(&p_root_ythread->ctx,
+                                    &gp_ABTI_global->p_main_ythread->ctx);
+    }
+}
+
+static void thread_main_sched_func(void *arg)
+{
+    ABTI_local *p_local = ABTI_local_get_local();
+    ABTI_xstream *p_local_xstream = ABTI_local_get_xstream(p_local);
+
+    while (1) {
+        /* Execute the run function of scheduler */
+        ABTI_sched *p_sched = p_local_xstream->p_main_sched;
+        ABTI_ASSERT(p_local_xstream->p_thread == &p_sched->p_ythread->thread);
+
+        LOG_DEBUG("[S%" PRIu64 "] start\n", p_sched->id);
+
+        p_sched->run(ABTI_sched_get_handle(p_sched));
+        /* The main scheduler must be executed on the same execution stream. */
+        ABTI_ASSERT(p_local == ABTI_local_get_local_uninlined());
+
+        LOG_DEBUG("[S%" PRIu64 "] end\n", p_sched->id);
+
+        uint32_t request =
+            ABTD_atomic_acquire_load_uint32(&p_local_xstream->request);
+
+        /* If there is an exit or a cancel request, the ES terminates
+         * regardless of remaining work units. */
+        if ((request & ABTI_XSTREAM_REQ_TERMINATE) ||
+            (request & ABTI_XSTREAM_REQ_CANCEL))
+            break;
+
+        /* When join is requested, the ES terminates after finishing
+         * execution of all work units. */
+        if (request & ABTI_XSTREAM_REQ_JOIN) {
+            if (ABTI_sched_get_effective_size(p_local,
+                                              p_local_xstream->p_main_sched) ==
+                0) {
+                /* If a ULT has been blocked on the join call, we make it ready
+                 */
+                if (p_local_xstream->p_req_arg) {
+                    ABTI_ythread_set_ready(p_local,
+                                           (ABTI_ythread *)
+                                               p_local_xstream->p_req_arg);
+                    p_local_xstream->p_req_arg = NULL;
+                }
+                break;
+            }
+        }
+    }
+    /* Finish this thread and goes back to the root thread. */
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION

--- a/src/tool.c
+++ b/src/tool.c
@@ -272,7 +272,8 @@ static inline int tool_query(ABTI_tool_context *p_tctx,
                     depth++;
                     p_cur = p_cur->p_parent;
                 }
-                *(int *)val = depth;
+                /* We do not count the root thread, so -1. */
+                *(int *)val = depth - 1;
             }
             break;
         case ABT_TOOL_QUERY_KIND_CALLER_TYPE:

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -5,11 +5,10 @@
 
 #include "abti.h"
 
-int ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
+void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
 {
-    /* The main sched cannot be blocked */
-    ABTI_CHECK_TRUE_RET(!(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
-                        ABT_ERR_THREAD);
+    /* The root thread cannot be blocked */
+    ABTI_ASSERT(!(p_ythread->thread.type & ABTI_THREAD_TYPE_ROOT));
 
     /* To prevent the scheduler from adding the ULT to the pool */
     ABTI_thread_set_request(&p_ythread->thread, ABTI_THREAD_REQ_BLOCK);
@@ -25,7 +24,6 @@ int ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
     LOG_DEBUG("[U%" PRIu64 ":E%d] blocked\n",
               ABTI_thread_get_id(&p_ythread->thread),
               p_ythread->thread.p_last_xstream->rank);
-    return ABT_SUCCESS;
 }
 
 /* NOTE: This routine should be called after ABTI_ythread_set_blocked. */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -35,6 +35,7 @@ basic/sched_set_main
 basic/sched_stack
 basic/sched_config
 basic/sched_user_ws
+basic/main_sched
 basic/mutex
 basic/mutex_prio
 basic/mutex_recursive

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -40,6 +40,7 @@ TESTS = \
 	sched_stack \
 	sched_config \
 	sched_user_ws \
+	main_sched \
 	mutex \
 	mutex_prio \
 	mutex_recursive \
@@ -113,6 +114,7 @@ sched_set_main_SOURCES = sched_set_main.c
 sched_stack_SOURCES = sched_stack.c
 sched_config_SOURCES = sched_config.c
 sched_user_ws_SOURCES = sched_user_ws.c
+main_sched_SOURCES = main_sched.c
 mutex_SOURCES = mutex.c
 mutex_prio_SOURCES = mutex_prio.c
 mutex_recursive_SOURCES = mutex_recursive.c
@@ -174,6 +176,7 @@ testing:
 	./sched_stack
 	./sched_config
 	./sched_user_ws
+	./main_sched
 	./mutex
 	./mutex_prio
 	./mutex_recursive

--- a/test/basic/main_sched.c
+++ b/test/basic/main_sched.c
@@ -1,0 +1,178 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if main schedulers work as normal threads. */
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define NUM_LOCKS 10
+
+static int num_xstreams = DEFAULT_NUM_XSTREAMS;
+ABT_barrier g_barrier;
+ABT_mutex g_mutex;
+static int g_val = 0;
+
+static int sched_init(ABT_sched sched, ABT_sched_config config)
+{
+    return ABT_SUCCESS;
+}
+
+static void sched_run(ABT_sched sched)
+{
+    int ret, i, rank;
+    ABT_pool pool;
+
+    ret = ABT_sched_get_pools(sched, 1, 0, &pool);
+    ATS_ERROR(ret, "ABT_sched_get_pools");
+    ret = ABT_xstream_self_rank(&rank);
+    ATS_ERROR(ret, "ABT_xstream_self_rank");
+
+    /* The main scheduler can yield. */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_thread_yield();
+        ATS_ERROR(ret, "ABT_thread_yield");
+    }
+
+    /* The main scheduler can barrier. */
+    for (i = 0; i < num_xstreams; i++) {
+        printf("END1! %d - %d\n", i, rank);
+        ret = ABT_barrier_wait(g_barrier);
+        ATS_ERROR(ret, "ABT_barrier_wait");
+        if (i == rank)
+            g_val++;
+    }
+    printf("END1! %d\n", rank);
+    ret = ABT_barrier_wait(g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_wait");
+
+    /* The main scheduler can lock a mutex. */
+    for (i = 0; i < NUM_LOCKS; i++) {
+        ret = ABT_mutex_lock(g_mutex);
+        ATS_ERROR(ret, "ABT_mutex_lock");
+        g_val++;
+        ret = ABT_mutex_unlock(g_mutex);
+        ATS_ERROR(ret, "ABT_mutex_unlock");
+    }
+    printf("END2! %d\n", rank);
+    while (1) {
+        /* Normal scheduling. */
+        ABT_unit unit;
+        ABT_bool stop;
+        ABT_pool_pop(pool, &unit);
+        if (unit != ABT_UNIT_NULL) {
+            ABT_xstream_run_unit(unit, pool);
+        }
+        ret = ABT_sched_has_to_stop(sched, &stop);
+        ATS_ERROR(ret, "ABT_sched_has_to_stop");
+        if (stop == ABT_TRUE)
+            break;
+        ret = ABT_xstream_check_events(sched);
+        ATS_ERROR(ret, "ABT_xstream_check_events");
+    }
+}
+
+static int sched_free(ABT_sched sched)
+{
+    return ABT_SUCCESS;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    if (argc > 1) {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+    }
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(1, "num_xstreams=%d\n", num_xstreams);
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+
+    /* Create pools */
+    ABT_pool *pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &pools[i]);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    }
+
+    /* Create schedulers */
+    ABT_sched_def sched_def = { .type = ABT_SCHED_TYPE_ULT,
+                                .init = sched_init,
+                                .run = sched_run,
+                                .free = sched_free,
+                                .get_migr_pool = NULL };
+
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * num_xstreams);
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_sched_create(&sched_def, 1, &pools[i], ABT_SCHED_CONFIG_NULL,
+                               &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create");
+    }
+
+    /* Create a barrier. */
+    ret = ABT_barrier_create(num_xstreams, &g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+
+    /* Create a mutex */
+    ret = ABT_mutex_create(&g_mutex);
+    ATS_ERROR(ret, "ABT_mutex_create");
+
+    /* Create execution streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(scheds[i], &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+    /* Update the main scheduler of the primary execution stream after creating
+     * the other execution streams. */
+    ret = ABT_xstream_set_main_sched(xstreams[0], scheds[0]);
+    ATS_ERROR(ret, "ABT_xstream_set_main_sched");
+
+    /* Join and free the execution streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+    /* Free the barrier */
+    ret = ABT_barrier_free(&g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Free the mutex */
+    ret = ABT_mutex_free(&g_mutex);
+    ATS_ERROR(ret, "ABT_mutex_free");
+
+    /* Free the schedulers.  Note that we do not need to free the scheduler for
+     * the primary ES, i.e., xstreams[0], because its scheduler will be freed
+     * automatically in ABT_finalize(). */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_sched_free(&scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+    ATS_ERROR(ret, "ATS_finalize");
+
+    free(scheds);
+    free(xstreams);
+    free(pools);
+
+    /* Check g_val */
+    assert(g_val == num_xstreams * (NUM_LOCKS + 1));
+    return ABT_SUCCESS;
+}

--- a/test/basic/xstream_rank.c
+++ b/test/basic/xstream_rank.c
@@ -46,9 +46,15 @@ int main(int argc, char *argv[])
     }
 
     /* Test an invalid rank, which is already taken */
-    ABT_xstream tmp;
-    ret = ABT_xstream_create_with_rank(ABT_SCHED_NULL, 0, &tmp);
-    assert(ret == ABT_ERR_INV_XSTREAM_RANK);
+    ABT_bool is_check_error = ABT_FALSE;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR,
+                                (void *)&is_check_error);
+    ATS_ERROR(ret, "ABT_info_query_config");
+    if (is_check_error) {
+        ABT_xstream tmp;
+        ret = ABT_xstream_create_with_rank(ABT_SCHED_NULL, 0, &tmp);
+        assert(ret == ABT_ERR_INV_XSTREAM_RANK);
+    }
 
     /* Join and free ESs */
     for (i = 1; i < num_xstreams; i++) {


### PR DESCRIPTION
## Problem

Main schedulers are running on yieldable `ABTI_thread`, but they cannot yield because these schedulers do not have parent threads. Main schedulers, therefore, cannot run synchronization operations that might call yield; for example, main schedulers cannot call `ABT_mutex_lock()`, `ABT_thread_yield()` and `ABT_thread_join()`.

This restriction was not clearly explained.  Some functions return an error code while others silently cause a fatal error.  For proper error handling, this behavior must be clarified.

## What this PR does.

This PR introduces a root thread that schedules a main scheduler.  This fix makes all the user-visible "ULT"-based threads (or yieldable-threads, or user-visible `ABTI_ythread`) truly yieldable.  This fix cleans up some existing code as well.

Nonetheless, users are not recommended to block main schedulers at all; it can easily cause a deadlock. Please run these operations on main schedulers only if you fully understand what scheduling would happen when some main schedulers block.

Note that root threads cannot yield since they do have parents, but users are not aware of it since they are not visible to users (maybe using a tool interface it can be exposed, which should be fixed in the future),

### The other possible solution

I did not choose the other possible solution, which prevents main schedulers from executing all the synchronization functions by adding a flag check because it makes user-visible yieldable threads virtually non-yieldable. For clearer semantics, it is better to make all the yieldable threads yieldable.

### Performance/API Impact

The performance/API impact is negligible.  The error handling has been modified, but I do not think any users rely on error codes returned from blocking operations on main schedulers that are customized by users.  This PR, however, significantly changes the internal logic of execution stream state management, so it might introduce a new bug (although this PR has been carefully tested).  Please let us know if this PR breaks your code.
