### PR TITLE
error: improve error handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,8 @@ fi
 AC_SUBST([ABT_DEPRECATED])
 # check __attribute__((noreturn))
 AX_GCC_FUNC_ATTRIBUTE(noreturn)
+# check __attribute__((warn_unused_result))
+AX_GCC_FUNC_ATTRIBUTE(warn_unused_result)
 
 dnl ----------------------------------------------------------------------------
 

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -62,7 +62,7 @@ int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
     return ABT_SUCCESS;
 }
 
-int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
+void ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
 {
     /* Request termination */
     pthread_mutex_lock(&p_ctx->state_lock);
@@ -72,16 +72,12 @@ int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx)
     pthread_mutex_unlock(&p_ctx->state_lock);
     /* Join the target thread. */
     int ret = pthread_join(p_ctx->native_thread, NULL);
-    if (ret != 0) {
-        /* This is fatal. */
-        return ABT_ERR_XSTREAM;
-    }
+    ABTI_ASSERT(ret == 0);
     pthread_cond_destroy(&p_ctx->state_cond);
     pthread_mutex_destroy(&p_ctx->state_lock);
-    return ABT_SUCCESS;
 }
 
-int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
+void ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
 {
     /* If not finished, sleep this thread. */
     pthread_mutex_lock(&p_ctx->state_lock);
@@ -95,10 +91,9 @@ int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx)
     }
     ABTI_ASSERT(p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
     pthread_mutex_unlock(&p_ctx->state_lock);
-    return ABT_SUCCESS;
 }
 
-int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx)
+void ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx)
 {
     /* Request restart */
     pthread_mutex_lock(&p_ctx->state_lock);
@@ -106,11 +101,9 @@ int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx)
     p_ctx->state = ABTD_XSTREAM_CONTEXT_STATE_RUNNING;
     pthread_cond_signal(&p_ctx->state_cond);
     pthread_mutex_unlock(&p_ctx->state_lock);
-    return ABT_SUCCESS;
 }
 
-int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx)
+void ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx)
 {
     p_ctx->native_thread = pthread_self();
-    return ABT_SUCCESS;
 }

--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -45,8 +45,9 @@ static void *xstream_context_thread_func(void *arg)
     return NULL;
 }
 
-int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
-                                ABTD_xstream_context *p_ctx)
+ABTU_ret_err int ABTD_xstream_context_create(void *(*f_xstream)(void *),
+                                             void *p_arg,
+                                             ABTD_xstream_context *p_ctx)
 {
     p_ctx->thread_f = f_xstream;
     p_ctx->p_arg = p_arg;

--- a/src/arch/abtd_time.c
+++ b/src/arch/abtd_time.c
@@ -18,17 +18,17 @@ void ABTD_time_init(void)
 }
 
 /* Obtain the time value */
-int ABTD_time_get(ABTD_time *p_time)
+void ABTD_time_get(ABTD_time *p_time)
 {
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
-    clock_gettime(CLOCK_REALTIME, p_time);
+    int ret = clock_gettime(CLOCK_REALTIME, p_time);
+    ABTI_ASSERT(ret == 0);
 #elif defined(ABT_CONFIG_USE_MACH_ABSOLUTE_TIME)
     *p_time = mach_absolute_time();
 #elif defined(ABT_CONFIG_USE_GETTIMEOFDAY)
-    gettimeofday(p_time, NULL);
+    int ret = gettimeofday(p_time, NULL);
+    ABTI_ASSERT(ret == 0);
 #endif
-
-    return ABT_SUCCESS;
 }
 
 /* Read the time value as seconds (double precision) */

--- a/src/global.c
+++ b/src/global.c
@@ -107,7 +107,7 @@ int ABT_init(int argc, char **argv)
 
     /* Start the primary ES */
     ABTI_xstream_start_primary(&p_local_xstream, p_local_xstream,
-                                           p_main_ythread);
+                               p_main_ythread);
 
     if (gp_ABTI_global->print_config == ABT_TRUE) {
         ABTI_info_print_config(stdout);
@@ -198,9 +198,8 @@ int ABT_finalize(void)
     ABTI_ythread_free_main(ABTI_xstream_get_local(p_local_xstream), p_ythread);
 
     /* Free the primary ES */
-    abt_errno = ABTI_xstream_free(ABTI_xstream_get_local(p_local_xstream),
-                                  p_local_xstream, ABT_TRUE);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_xstream_free(ABTI_xstream_get_local(p_local_xstream), p_local_xstream,
+                      ABT_TRUE);
 
     /* Finalize the ES local data */
     ABTI_local_set_xstream(NULL);

--- a/src/global.c
+++ b/src/global.c
@@ -106,9 +106,8 @@ int ABT_init(int argc, char **argv)
     p_local_xstream->p_thread = &p_main_ythread->thread;
 
     /* Start the primary ES */
-    abt_errno = ABTI_xstream_start_primary(&p_local_xstream, p_local_xstream,
+    ABTI_xstream_start_primary(&p_local_xstream, p_local_xstream,
                                            p_main_ythread);
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_start_primary");
 
     if (gp_ABTI_global->print_config == ABT_TRUE) {
         ABTI_info_print_config(stdout);

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -44,8 +44,9 @@ typedef struct ABTD_affinity_cpuset {
 void ABTD_env_init(ABTI_global *p_global);
 
 /* ES Context */
-int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
-                                ABTD_xstream_context *p_ctx);
+ABTU_ret_err int ABTD_xstream_context_create(void *(*f_xstream)(void *),
+                                             void *p_arg,
+                                             ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
@@ -54,10 +55,11 @@ void ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
 /* ES Affinity */
 void ABTD_affinity_init(const char *affinity_str);
 void ABTD_affinity_finalize(void);
-int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,
-                              ABTD_affinity_cpuset *p_cpuset);
-int ABTD_affinity_cpuset_apply(ABTD_xstream_context *p_ctx,
-                               const ABTD_affinity_cpuset *p_cpuset);
+ABTU_ret_err int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,
+                                           ABTD_affinity_cpuset *p_cpuset);
+ABTU_ret_err int
+ABTD_affinity_cpuset_apply(ABTD_xstream_context *p_ctx,
+                           const ABTD_affinity_cpuset *p_cpuset);
 int ABTD_affinity_cpuset_apply_default(ABTD_xstream_context *p_ctx, int rank);
 void ABTD_affinity_cpuset_destroy(ABTD_affinity_cpuset *p_cpuset);
 

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -46,10 +46,10 @@ void ABTD_env_init(ABTI_global *p_global);
 /* ES Context */
 int ABTD_xstream_context_create(void *(*f_xstream)(void *), void *p_arg,
                                 ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
-int ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
+void ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
+void ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
+void ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
+void ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
 
 /* ES Affinity */
 void ABTD_affinity_init(const char *affinity_str);

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -96,7 +96,7 @@ typedef struct timeval ABTD_time;
 #endif
 
 void ABTD_time_init(void);
-int ABTD_time_get(ABTD_time *p_time);
+void ABTD_time_get(ABTD_time *p_time);
 double ABTD_time_read_sec(ABTD_time *p_time);
 
 #endif /* ABTD_H_INCLUDED */

--- a/src/include/abtd_stream.h
+++ b/src/include/abtd_stream.h
@@ -7,8 +7,8 @@
 #define ABTD_STREAM_H_INCLUDED
 
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-static inline int ABTD_xstream_barrier_init(uint32_t num_waiters,
-                                            ABTD_xstream_barrier *p_barrier)
+ABTU_ret_err static inline int
+ABTD_xstream_barrier_init(uint32_t num_waiters, ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_init(p_barrier, NULL, num_waiters);
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;

--- a/src/include/abtd_stream.h
+++ b/src/include/abtd_stream.h
@@ -14,15 +14,16 @@ static inline int ABTD_xstream_barrier_init(uint32_t num_waiters,
     return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
 }
 
-static inline int ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
+static inline void ABTD_xstream_barrier_destroy(ABTD_xstream_barrier *p_barrier)
 {
     int ret = pthread_barrier_destroy(p_barrier);
-    return (ret == 0) ? ABT_SUCCESS : ABT_ERR_XSTREAM_BARRIER;
+    ABTI_ASSERT(ret == 0);
 }
 
-static inline int ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
+static inline void ABTD_xstream_barrier_wait(ABTD_xstream_barrier *p_barrier)
 {
-    return pthread_barrier_wait(p_barrier);
+    int ret = pthread_barrier_wait(p_barrier);
+    ABTI_ASSERT(ret == PTHREAD_BARRIER_SERIAL_THREAD || ret == 0);
 }
 #endif
 

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -28,7 +28,8 @@ static inline void ABTD_ythread_context_make(ABTD_ythread_context *p_ctx,
                                              void *sp, size_t size,
                                              void (*thread_func)(void *))
 {
-    getcontext(&p_ctx->uctx);
+    int ret = getcontext(&p_ctx->uctx);
+    ABTI_ASSERT(ret == 0); /* getcontext() should not return an error. */
     p_ctx->p_ctx = &p_ctx->uctx;
 
     /* uc_link is not used. */
@@ -55,7 +56,9 @@ static inline void ABTD_ythread_context_jump(ABTD_ythread_context *p_old,
                                              void *arg)
 {
     p_new->p_uctx_arg = arg;
-    swapcontext(&p_old->uctx, &p_new->uctx);
+    int ret = swapcontext(&p_old->uctx, &p_new->uctx);
+    /* Fatal.  This out-of-stack error is not recoverable. */
+    ABTI_ASSERT(ret == 0);
 }
 
 ABTU_noreturn static inline void
@@ -63,7 +66,8 @@ ABTD_ythread_context_take(ABTD_ythread_context *p_old,
                           ABTD_ythread_context *p_new, void *arg)
 {
     p_new->p_uctx_arg = arg;
-    setcontext(&p_new->uctx);
+    int ret = setcontext(&p_new->uctx);
+    ABTI_ASSERT(ret == 0); /* setcontext() should not return an error. */
     ABTU_unreachable();
 }
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -525,7 +525,7 @@ void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
                           ABTI_ythread *p_ythread,
                           ABT_sync_event_type sync_event_type, void *p_sync);
 void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread);
-int ABTI_ythread_print_stack(ABTI_ythread *p_ythread, FILE *p_os);
+void ABTI_ythread_print_stack(ABTI_ythread *p_ythread, FILE *p_os);
 
 /* Thread attributes */
 void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -502,7 +502,7 @@ int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
 int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                        void (*thread_func)(void *), void *arg,
                        ABTI_thread *p_thread);
-int ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
+void ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 void ABTI_thread_reset_id(void);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -499,9 +499,9 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 /* Threads */
 int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
                              ABTI_thread_mig_data **pp_mig_data);
-int ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
-                       void (*thread_func)(void *), void *arg,
-                       ABTI_thread *p_thread);
+void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
+                        void (*thread_func)(void *), void *arg,
+                        ABTI_thread *p_thread);
 void ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -446,10 +446,10 @@ extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 /* Execution Stream (ES) */
 int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
 void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
-                               ABTI_xstream *p_xstream,
-                               ABTI_ythread *p_ythread);
-int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                      ABT_bool force_free);
+                                ABTI_xstream *p_xstream,
+                                ABTI_ythread *p_ythread);
+void ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
+                       ABT_bool force_free);
 void ABTI_xstream_schedule(void *p_arg);
 int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
                           ABTI_pool *p_pool);
@@ -467,8 +467,8 @@ void ABTI_sched_exit(ABTI_sched *p_sched);
 int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                             ABT_pool *pools, ABT_sched_config config,
                             ABTI_sched **pp_newsched);
-int ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
-                    ABT_bool force_free);
+void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
+                     ABT_bool force_free);
 int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);
 ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched);
 size_t ABTI_sched_get_size(ABTI_sched *p_sched);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -451,8 +451,8 @@ void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
 void ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
                        ABT_bool force_free);
 void ABTI_xstream_schedule(void *p_arg);
-int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
-                          ABTI_pool *p_pool);
+void ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
+                           ABTI_pool *p_pool);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -445,7 +445,7 @@ extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 
 /* Execution Stream (ES) */
 int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
-int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
+void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
                                ABTI_xstream *p_xstream,
                                ABTI_ythread *p_ythread);
 int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -167,12 +167,12 @@ struct ABTI_mutex {
 };
 
 struct ABTI_global {
-    int max_xstreams;            /* Max. size of p_xstreams */
-    int num_xstreams;            /* Current # of ESs */
-    ABTI_xstream **p_xstreams;   /* ES array */
-    ABTI_spinlock xstreams_lock; /* Spinlock protecting p_xstreams. Any write
-                                  * to p_xstreams and p_xstreams[*] requires a
-                                  * lock. Dereference does not require a lock.*/
+    int max_xstreams;             /* Largest rank used in Argobots. */
+    int num_xstreams;             /* Current # of ESs */
+    ABTI_xstream *p_xstream_head; /* List of ESs (head). The list is sorted. */
+    ABTI_spinlock
+        xstream_list_lock; /* Spinlock protecting ES list. Any read and
+                            * write to this list requires a lock.*/
 
     int num_cores;                /* Number of CPU cores */
     ABT_bool set_affinity;        /* Whether CPU affinity is used */
@@ -232,6 +232,10 @@ struct ABTI_local_func {
 };
 
 struct ABTI_xstream {
+    /* Linked list to manage all execution streams. */
+    ABTI_xstream *p_prev;
+    ABTI_xstream *p_next;
+
     int rank;                 /* Rank */
     ABTI_xstream_type type;   /* Type */
     ABTD_atomic_int state;    /* State (ABT_xstream_state) */
@@ -438,9 +442,6 @@ extern ABTI_local_func gp_ABTI_local_func;
 
 /* ES Local Data */
 extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
-
-/* Global */
-void ABTI_global_update_max_xstreams(int new_size);
 
 /* Execution Stream (ES) */
 int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -444,7 +444,7 @@ extern ABTI_local_func gp_ABTI_local_func;
 extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 
 /* Execution Stream (ES) */
-int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
+ABTU_ret_err int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
 void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
                                 ABTI_xstream *p_xstream,
                                 ABTI_ythread *p_ythread);
@@ -464,12 +464,14 @@ ABT_sched_def *ABTI_sched_get_prio_def(void);
 ABT_sched_def *ABTI_sched_get_randws_def(void);
 void ABTI_sched_finish(ABTI_sched *p_sched);
 void ABTI_sched_exit(ABTI_sched *p_sched);
-int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
-                            ABT_pool *pools, ABT_sched_config config,
-                            ABTI_sched **pp_newsched);
+ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
+                                         ABT_pool *pools,
+                                         ABT_sched_config config,
+                                         ABTI_sched **pp_newsched);
 void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
                      ABT_bool force_free);
-int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *, ABTI_pool **);
+ABTU_ret_err int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *,
+                                               ABTI_pool **);
 ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched);
 size_t ABTI_sched_get_size(ABTI_sched *p_sched);
 size_t ABTI_sched_get_total_size(ABTI_sched *p_sched);
@@ -479,17 +481,22 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
 void ABTI_sched_reset_id(void);
 
 /* Scheduler config */
-int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
-                           void **variables);
-int ABTI_sched_config_read_global(ABT_sched_config config,
-                                  ABT_pool_access *access, ABT_bool *automatic);
+ABTU_ret_err int ABTI_sched_config_read(ABT_sched_config config, int type,
+                                        int num_vars, void **variables);
+ABTU_ret_err int ABTI_sched_config_read_global(ABT_sched_config config,
+                                               ABT_pool_access *access,
+                                               ABT_bool *automatic);
 
 /* Pool */
-int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
-                           ABT_bool automatic, ABTI_pool **pp_newpool);
+ABTU_ret_err int ABTI_pool_create_basic(ABT_pool_kind kind,
+                                        ABT_pool_access access,
+                                        ABT_bool automatic,
+                                        ABTI_pool **pp_newpool);
 void ABTI_pool_free(ABTI_pool *p_pool);
-int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def);
-int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def);
+ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
+                                        ABT_pool_def *p_def);
+ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
+                                             ABT_pool_def *p_def);
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
 
@@ -497,8 +504,9 @@ void ABTI_pool_reset_id(void);
 void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 
 /* Threads */
-int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
-                             ABTI_thread_mig_data **pp_mig_data);
+ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_local *p_local,
+                                          ABTI_thread *p_thread,
+                                          ABTI_thread_mig_data **pp_mig_data);
 void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                         void (*thread_func)(void *), void *arg,
                         ABTI_thread *p_thread);
@@ -509,14 +517,18 @@ void ABTI_thread_reset_id(void);
 ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
 
 /* Yieldable threads */
-int ABTI_ythread_create_root(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                             ABTI_ythread **pp_root_ythread);
-int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                             ABTI_ythread **p_ythread);
-int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                                   ABTI_sched *p_sched);
-int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
-                              ABTI_sched *p_sched);
+ABTU_ret_err int ABTI_ythread_create_root(ABTI_local *p_local,
+                                          ABTI_xstream *p_xstream,
+                                          ABTI_ythread **pp_root_ythread);
+ABTU_ret_err int ABTI_ythread_create_main(ABTI_local *p_local,
+                                          ABTI_xstream *p_xstream,
+                                          ABTI_ythread **p_ythread);
+ABTU_ret_err int ABTI_ythread_create_main_sched(ABTI_local *p_local,
+                                                ABTI_xstream *p_xstream,
+                                                ABTI_sched *p_sched);
+ABTU_ret_err int ABTI_ythread_create_sched(ABTI_local *p_local,
+                                           ABTI_pool *p_pool,
+                                           ABTI_sched *p_sched);
 ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
                                      ABTI_ythread *p_ythread);
 void ABTI_ythread_free_main(ABTI_local *p_local, ABTI_ythread *p_ythread);
@@ -530,12 +542,13 @@ void ABTI_ythread_print_stack(ABTI_ythread *p_ythread, FILE *p_os);
 
 /* Thread attributes */
 void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent);
-int ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
-                         ABTI_thread_attr **pp_dup_attr);
+ABTU_ret_err int
+ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
+                     ABTI_thread_attr **pp_dup_attr) ABTU_ret_err;
 
 /* Thread hash table */
-int ABTI_ythread_htable_create(uint32_t num_rows,
-                               ABTI_ythread_htable **pp_htable);
+ABTU_ret_err int ABTI_ythread_htable_create(uint32_t num_rows,
+                                            ABTI_ythread_htable **pp_htable);
 void ABTI_ythread_htable_free(ABTI_ythread_htable *p_htable);
 void ABTI_ythread_htable_push(ABTI_ythread_htable *p_htable, int idx,
                               ABTI_ythread *p_ythread);

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -57,8 +57,8 @@ static inline ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 #endif
 }
 
-static inline int ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond,
-                                 ABTI_mutex *p_mutex)
+ABTU_ret_err static inline int
+ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 {
     ABTI_ythread *p_ythread = NULL;
     ABTI_thread *p_thread;

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -64,8 +64,8 @@ static inline int ABTI_ktable_is_valid(ABTI_ktable *p_ktable)
            ((uintptr_t)(void *)0x0);
 }
 
-static inline int ABTI_ktable_create(ABTI_local *p_local,
-                                     ABTI_ktable **pp_ktable)
+ABTU_ret_err static inline int ABTI_ktable_create(ABTI_local *p_local,
+                                                  ABTI_ktable **pp_ktable)
 {
     ABTI_ktable *p_ktable;
     int key_table_size = gp_ABTI_global->key_table_size;
@@ -114,9 +114,10 @@ static inline int ABTI_ktable_create(ABTI_local *p_local,
     return ABT_SUCCESS;
 }
 
-static inline int ABTI_ktable_alloc_elem(ABTI_local *p_local,
-                                         ABTI_ktable *p_ktable, size_t size,
-                                         void **pp_mem)
+ABTU_ret_err static inline int ABTI_ktable_alloc_elem(ABTI_local *p_local,
+                                                      ABTI_ktable *p_ktable,
+                                                      size_t size,
+                                                      void **pp_mem)
 {
     ABTI_ASSERT((size & (ABTU_MAX_ALIGNMENT - 1)) == 0);
     size_t extra_mem_size = p_ktable->extra_mem_size;
@@ -162,9 +163,9 @@ static inline uint32_t ABTI_ktable_get_idx(ABTI_key *p_key, int size)
     return p_key->id & (size - 1);
 }
 
-static inline int ABTI_ktable_set_impl(ABTI_local *p_local,
-                                       ABTI_ktable *p_ktable, ABTI_key *p_key,
-                                       void *value, ABT_bool is_safe)
+ABTU_ret_err static inline int
+ABTI_ktable_set_impl(ABTI_local *p_local, ABTI_ktable *p_ktable,
+                     ABTI_key *p_key, void *value, ABT_bool is_safe)
 {
     uint32_t idx;
     ABTD_atomic_ptr *pp_elem;
@@ -220,9 +221,9 @@ static inline int ABTI_ktable_set_impl(ABTI_local *p_local,
     return ABT_SUCCESS;
 }
 
-static inline int ABTI_ktable_set(ABTI_local *p_local,
-                                  ABTD_atomic_ptr *pp_ktable, ABTI_key *p_key,
-                                  void *value)
+ABTU_ret_err static inline int ABTI_ktable_set(ABTI_local *p_local,
+                                               ABTD_atomic_ptr *pp_ktable,
+                                               ABTI_key *p_key, void *value)
 {
     int abt_errno;
     ABTI_ktable *p_ktable = ABTD_atomic_acquire_load_ptr(pp_ktable);
@@ -261,9 +262,10 @@ static inline int ABTI_ktable_set(ABTI_local *p_local,
     return ABT_SUCCESS;
 }
 
-static inline int ABTI_ktable_set_unsafe(ABTI_local *p_local,
-                                         ABTI_ktable **pp_ktable,
-                                         ABTI_key *p_key, void *value)
+ABTU_ret_err static inline int ABTI_ktable_set_unsafe(ABTI_local *p_local,
+                                                      ABTI_ktable **pp_ktable,
+                                                      ABTI_key *p_key,
+                                                      void *value)
 {
     int abt_errno;
     ABTI_ktable *p_ktable = *pp_ktable;

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -30,7 +30,8 @@ void ABTI_mem_finalize_local(ABTI_xstream *p_local_xstream);
 int ABTI_mem_check_lp_alloc(int lp_alloc);
 
 /* Inline functions */
-static inline int ABTI_mem_alloc_nythread_malloc(ABTI_thread **pp_thread)
+ABTU_ret_err static inline int
+ABTI_mem_alloc_nythread_malloc(ABTI_thread **pp_thread)
 {
     ABTI_thread *p_thread;
     int abt_errno =
@@ -42,8 +43,8 @@ static inline int ABTI_mem_alloc_nythread_malloc(ABTI_thread **pp_thread)
 }
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-static inline int ABTI_mem_alloc_nythread_mempool(ABTI_local *p_local,
-                                                  ABTI_thread **pp_thread)
+ABTU_ret_err static inline int
+ABTI_mem_alloc_nythread_mempool(ABTI_local *p_local, ABTI_thread **pp_thread)
 {
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_or_null(p_local);
     if (ABTI_IS_EXT_THREAD_ENABLED && p_local_xstream == NULL) {
@@ -61,8 +62,8 @@ static inline int ABTI_mem_alloc_nythread_mempool(ABTI_local *p_local,
 }
 #endif
 
-static inline int ABTI_mem_alloc_nythread(ABTI_local *p_local,
-                                          ABTI_thread **pp_thread)
+ABTU_ret_err static inline int ABTI_mem_alloc_nythread(ABTI_local *p_local,
+                                                       ABTI_thread **pp_thread)
 {
 #ifdef ABT_CONFIG_USE_MEM_POOL
     return ABTI_mem_alloc_nythread_mempool(p_local, pp_thread);
@@ -97,7 +98,7 @@ static inline void ABTI_mem_free_nythread(ABTI_local *p_local,
 }
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-static inline int ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
+ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
     ABTI_mem_pool_local_pool *p_mem_pool_stack, size_t stacksize,
     ABTI_ythread **pp_ythread, void **pp_stack)
 {
@@ -113,7 +114,7 @@ static inline int ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
 }
 #endif
 
-static inline int ABTI_mem_alloc_ythread_malloc_desc_stack_impl(
+ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack_impl(
     size_t stacksize, ABTI_ythread **pp_ythread, void **pp_stack)
 {
     /* stacksize must be a multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE. */
@@ -130,8 +131,8 @@ static inline int ABTI_mem_alloc_ythread_malloc_desc_stack_impl(
     return ABT_SUCCESS;
 }
 
-static inline int ABTI_mem_alloc_ythread_default(ABTI_local *p_local,
-                                                 ABTI_ythread **pp_ythread)
+ABTU_ret_err static inline int
+ABTI_mem_alloc_ythread_default(ABTI_local *p_local, ABTI_ythread **pp_ythread)
 {
     size_t stacksize = gp_ABTI_global->thread_stacksize;
     ABTI_ythread *p_ythread;
@@ -167,7 +168,7 @@ static inline int ABTI_mem_alloc_ythread_default(ABTI_local *p_local,
 }
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
+ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
     ABTI_local *p_local, ABTI_thread_attr *p_attr, ABTI_ythread **pp_ythread)
 {
     size_t stacksize = gp_ABTI_global->thread_stacksize;
@@ -196,7 +197,7 @@ static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
 }
 #endif
 
-static inline int
+ABTU_ret_err static inline int
 ABTI_mem_alloc_ythread_malloc_desc_stack(ABTI_thread_attr *p_attr,
                                          ABTI_ythread **pp_ythread)
 {
@@ -217,9 +218,8 @@ ABTI_mem_alloc_ythread_malloc_desc_stack(ABTI_thread_attr *p_attr,
     return ABT_SUCCESS;
 }
 
-static inline int ABTI_mem_alloc_ythread_mempool_desc(ABTI_local *p_local,
-                                                      ABTI_thread_attr *p_attr,
-                                                      ABTI_ythread **pp_ythread)
+ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc(
+    ABTI_local *p_local, ABTI_thread_attr *p_attr, ABTI_ythread **pp_ythread)
 {
     ABTI_ythread *p_ythread;
     if (sizeof(ABTI_ythread) <= ABTI_MEM_POOL_DESC_ELEM_SIZE) {
@@ -295,7 +295,8 @@ static inline void ABTI_mem_free_thread(ABTI_local *p_local,
  * allocated externally (i.e., malloc()) or taken from a memory pool. */
 #define ABTI_MEM_POOL_DESC_SIZE (ABTI_MEM_POOL_DESC_ELEM_SIZE - 4)
 
-static inline int ABTI_mem_alloc_desc(ABTI_local *p_local, void **pp_desc)
+ABTU_ret_err static inline int ABTI_mem_alloc_desc(ABTI_local *p_local,
+                                                   void **pp_desc)
 {
 #ifndef ABT_CONFIG_USE_MEM_POOL
     return ABTU_malloc(ABTI_MEM_POOL_DESC_SIZE, pp_desc);

--- a/src/include/abti_mem_pool.h
+++ b/src/include/abti_mem_pool.h
@@ -110,8 +110,8 @@ int ABTI_mem_pool_take_bucket(ABTI_mem_pool_global_pool *p_global_pool,
 void ABTI_mem_pool_return_bucket(ABTI_mem_pool_global_pool *p_global_pool,
                                  ABTI_mem_pool_header *bucket);
 
-static inline int ABTI_mem_pool_alloc(ABTI_mem_pool_local_pool *p_local_pool,
-                                      void **p_mem)
+ABTU_ret_err static inline int
+ABTI_mem_pool_alloc(ABTI_mem_pool_local_pool *p_local_pool, void **p_mem)
 {
     size_t bucket_index = p_local_pool->bucket_index;
     ABTI_mem_pool_header *cur_bucket = p_local_pool->buckets[bucket_index];

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -36,7 +36,7 @@ static inline ABT_mutex ABTI_mutex_get_handle(ABTI_mutex *p_mutex)
 #endif
 }
 
-static inline int ABTI_mutex_init(ABTI_mutex *p_mutex)
+ABTU_ret_err static inline int ABTI_mutex_init(ABTI_mutex *p_mutex)
 {
     ABTD_atomic_relaxed_store_uint32(&p_mutex->val, 0);
     p_mutex->attr.attrs = ABTI_MUTEX_ATTR_NONE;

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -77,7 +77,8 @@ static inline void ABTI_pool_add_thread(ABTI_thread *p_thread)
     ABTI_pool_push(p_thread->p_pool, p_thread->unit);
 }
 
-static inline int ABTI_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
+ABTU_ret_err static inline int ABTI_pool_remove(ABTI_pool *p_pool,
+                                                ABT_unit unit)
 {
     LOG_DEBUG_POOL_REMOVE(p_pool, unit);
     return p_pool->p_remove(ABTI_pool_get_handle(p_pool), unit);

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -40,20 +40,18 @@ static inline ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 
 /* Set `used` of p_sched to NOT_USED and free p_sched if its `automatic` is
  * ABT_TRUE, which means it is safe to free p_sched inside the runtime. */
-static inline int ABTI_sched_discard_and_free(ABTI_local *p_local,
-                                              ABTI_sched *p_sched,
-                                              ABT_bool force_free)
+static inline void ABTI_sched_discard_and_free(ABTI_local *p_local,
+                                               ABTI_sched *p_sched,
+                                               ABT_bool force_free)
 {
     p_sched->used = ABTI_SCHED_NOT_USED;
     if (p_sched->automatic == ABT_TRUE || force_free) {
-        int abt_errno = ABTI_sched_free(p_local, p_sched, force_free);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_sched_free(p_local, p_sched, force_free);
     } else {
         /* Threads should be discarded here. */
         ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
         p_sched->p_ythread = NULL;
     }
-    return ABT_SUCCESS;
 }
 
 static inline void ABTI_sched_set_request(ABTI_sched *p_sched, uint32_t req)

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -45,6 +45,12 @@
          ? ABTU_alignof(long double)                                           \
          : ABTU_alignof(long long))
 
+#ifdef HAVE_FUNC_ATTRIBUTE_WARN_UNUSED_RESULT
+#define ABTU_ret_err __attribute__((warn_unused_result))
+#else
+#define ABTU_ret_err
+#endif
+
 /*
  * An attribute to hint an alignment of a member variable.
  * Usage:
@@ -101,7 +107,8 @@
 
 /* Utility Functions */
 
-static inline int ABTU_memalign(size_t alignment, size_t size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_memalign(size_t alignment, size_t size,
+                                             void **p_ptr)
 {
     void *ptr;
     int ret = posix_memalign(&ptr, alignment, size);
@@ -119,7 +126,7 @@ static inline void ABTU_free(void *ptr)
 
 #ifdef ABT_CONFIG_USE_ALIGNED_ALLOC
 
-static inline int ABTU_malloc(size_t size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_malloc(size_t size, void **p_ptr)
 {
     /* Round up to the smallest multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE
      * which is greater than or equal to size in order to avoid any
@@ -129,7 +136,8 @@ static inline int ABTU_malloc(size_t size, void **p_ptr)
     return ABTU_memalign(ABT_CONFIG_STATIC_CACHELINE_SIZE, size, p_ptr);
 }
 
-static inline int ABTU_calloc(size_t num, size_t size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_calloc(size_t num, size_t size,
+                                           void **p_ptr)
 {
     void *ptr;
     int ret = ABTU_malloc(num * size, &ptr);
@@ -141,7 +149,8 @@ static inline int ABTU_calloc(size_t num, size_t size, void **p_ptr)
     return ABT_SUCCESS;
 }
 
-static inline int ABTU_realloc(size_t old_size, size_t new_size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_realloc(size_t old_size, size_t new_size,
+                                            void **p_ptr)
 {
     void *new_ptr, *old_ptr = *p_ptr;
     int ret = ABTU_malloc(new_size, &new_ptr);
@@ -156,7 +165,7 @@ static inline int ABTU_realloc(size_t old_size, size_t new_size, void **p_ptr)
 
 #else /* ABT_CONFIG_USE_ALIGNED_ALLOC */
 
-static inline int ABTU_malloc(size_t size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_malloc(size_t size, void **p_ptr)
 {
     void *ptr = malloc(size);
     if (ABTI_IS_ERROR_CHECK_ENABLED && ptr == NULL) {
@@ -166,7 +175,8 @@ static inline int ABTU_malloc(size_t size, void **p_ptr)
     return ABT_SUCCESS;
 }
 
-static inline int ABTU_calloc(size_t num, size_t size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_calloc(size_t num, size_t size,
+                                           void **p_ptr)
 {
     void *ptr = calloc(num, size);
     if (ABTI_IS_ERROR_CHECK_ENABLED && ptr == NULL) {
@@ -176,7 +186,8 @@ static inline int ABTU_calloc(size_t num, size_t size, void **p_ptr)
     return ABT_SUCCESS;
 }
 
-static inline int ABTU_realloc(size_t old_size, size_t new_size, void **p_ptr)
+ABTU_ret_err static inline int ABTU_realloc(size_t old_size, size_t new_size,
+                                            void **p_ptr)
 {
     (void)old_size;
     void *ptr = realloc(*p_ptr, new_size);
@@ -199,10 +210,11 @@ typedef enum ABTU_MEM_LARGEPAGE_TYPE {
 /* Returns 1 if a given large page type is supported. */
 int ABTU_is_supported_largepage_type(size_t size, size_t alignment_hint,
                                      ABTU_MEM_LARGEPAGE_TYPE requested);
-int ABTU_alloc_largepage(size_t size, size_t alignment_hint,
-                         const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
-                         int num_requested_types,
-                         ABTU_MEM_LARGEPAGE_TYPE *p_actual, void **p_ptr);
+ABTU_ret_err int
+ABTU_alloc_largepage(size_t size, size_t alignment_hint,
+                     const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
+                     int num_requested_types, ABTU_MEM_LARGEPAGE_TYPE *p_actual,
+                     void **p_ptr);
 void ABTU_free_largepage(void *ptr, size_t size, ABTU_MEM_LARGEPAGE_TYPE type);
 
 #endif /* ABTU_H_INCLUDED */

--- a/src/info.c
+++ b/src/info.c
@@ -814,25 +814,17 @@ static void info_print_unit(void *arg, ABT_unit unit)
 ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
                                                          ABTI_pool *p_pool)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_pool pool = ABTI_pool_get_handle(p_pool);
 
     if (!p_pool->p_print_all) {
-        abt_errno = ABT_ERR_POOL;
-        goto fn_fail;
+        return ABT_ERR_POOL;
     }
     fprintf(fp, "== pool (%p) ==\n", (void *)p_pool);
     struct info_print_unit_arg_t arg;
     arg.fp = fp;
     arg.pool = pool;
     p_pool->p_print_all(pool, &arg, info_print_unit);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 ABTU_ret_err static inline int

--- a/src/info.c
+++ b/src/info.c
@@ -5,7 +5,8 @@
 
 #include "abti.h"
 
-static int info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool);
+ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
+                                                         ABTI_pool *p_pool);
 static void info_trigger_print_all_thread_stacks(
     FILE *fp, double timeout, void (*cb_func)(ABT_bool, void *), void *arg);
 
@@ -582,10 +583,10 @@ struct info_pool_set_t {
     size_t len;
 };
 
-static int info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool);
-static inline int info_initialize_pool_set(struct info_pool_set_t *p_set);
-static inline int info_add_pool_set(ABT_pool pool,
-                                    struct info_pool_set_t *p_set);
+ABTU_ret_err static inline int
+info_initialize_pool_set(struct info_pool_set_t *p_set);
+ABTU_ret_err static inline int info_add_pool_set(ABT_pool pool,
+                                                 struct info_pool_set_t *p_set);
 static inline void info_finalize_pool_set(struct info_pool_set_t *p_set);
 
 #define PRINT_STACK_FLAG_UNSET 0
@@ -810,7 +811,8 @@ static void info_print_unit(void *arg, ABT_unit unit)
     }
 }
 
-static int info_print_thread_stacks_in_pool(FILE *fp, ABTI_pool *p_pool)
+ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
+                                                         ABTI_pool *p_pool)
 {
     int abt_errno = ABT_SUCCESS;
     ABT_pool pool = ABTI_pool_get_handle(p_pool);
@@ -833,7 +835,8 @@ fn_fail:
     goto fn_exit;
 }
 
-static inline int info_initialize_pool_set(struct info_pool_set_t *p_set)
+ABTU_ret_err static inline int
+info_initialize_pool_set(struct info_pool_set_t *p_set)
 {
     size_t default_len = 16;
     int abt_errno =
@@ -849,8 +852,8 @@ static inline void info_finalize_pool_set(struct info_pool_set_t *p_set)
     ABTU_free(p_set->pools);
 }
 
-static inline int info_add_pool_set(ABT_pool pool,
-                                    struct info_pool_set_t *p_set)
+ABTU_ret_err static inline int info_add_pool_set(ABT_pool pool,
+                                                 struct info_pool_set_t *p_set)
 {
     size_t i;
     for (i = 0; i < p_set->num; i++) {

--- a/src/info.c
+++ b/src/info.c
@@ -484,7 +484,7 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
     ABTI_ythread *p_ythread;
     ABTI_CHECK_YIELDABLE(p_thread, &p_ythread, ABT_ERR_INV_THREAD);
 
-    abt_errno = ABTI_ythread_print_stack(p_ythread, fp);
+    ABTI_ythread_print_stack(p_ythread, fp);
 
 fn_exit:
     return abt_errno;
@@ -801,9 +801,7 @@ static void info_print_unit(void *arg, ABT_unit unit)
                 "stack     : %p\n"
                 "stacksize : %" PRIu64 "\n",
                 p_ythread->p_stack, (uint64_t)p_ythread->stacksize);
-        int abt_errno = ABTI_ythread_print_stack(p_ythread, fp);
-        if (abt_errno != ABT_SUCCESS)
-            fprintf(fp, "Failed to print stack.\n");
+        ABTI_ythread_print_stack(p_ythread, fp);
     } else if (type == ABT_UNIT_TYPE_TASK) {
         fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);
     } else {

--- a/src/mem/mem_pool.c
+++ b/src/mem/mem_pool.c
@@ -159,8 +159,9 @@ void ABTI_mem_pool_destroy_local_pool(ABTI_mem_pool_local_pool *p_local_pool)
     }
 }
 
-int ABTI_mem_pool_take_bucket(ABTI_mem_pool_global_pool *p_global_pool,
-                              ABTI_mem_pool_header **p_bucket)
+ABTU_ret_err int
+ABTI_mem_pool_take_bucket(ABTI_mem_pool_global_pool *p_global_pool,
+                          ABTI_mem_pool_header **p_bucket)
 {
     /* Try to get a bucket. */
     ABTI_sync_lifo_element *p_popped_bucket_lifo_elem =

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -44,7 +44,8 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 }
 
 /* Obtain the FIFO pool definition according to the access type */
-int ABTI_pool_get_fifo_def(ABT_pool_access access, ABT_pool_def *p_def)
+ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
+                                        ABT_pool_def *p_def)
 {
     int abt_errno = ABT_SUCCESS;
 

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -39,7 +39,8 @@ static inline data_t *pool_get_data_ptr(void *p_data)
     return (data_t *)p_data;
 }
 
-int ABTI_pool_get_fifo_wait_def(ABT_pool_access access, ABT_pool_def *p_def)
+ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
+                                             ABT_pool_def *p_def)
 {
     p_def->access = access;
     p_def->p_init = pool_init;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -5,8 +5,8 @@
 
 #include "abti.h"
 
-static int pool_create(ABT_pool_def *def, ABT_pool_config config,
-                       ABT_bool automatic, ABTI_pool **pp_newpool);
+ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
+                                    ABT_bool automatic, ABTI_pool **pp_newpool);
 
 /** @defgroup POOL Pool
  * This group is for Pool.
@@ -326,7 +326,8 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    ABTI_pool_remove(p_pool, unit);
+    abt_errno = ABTI_pool_remove(p_pool, unit);
+    ABTI_CHECK_ERROR(abt_errno);
 
 fn_exit:
     return abt_errno;
@@ -513,8 +514,10 @@ fn_fail:
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-int ABTI_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
-                           ABT_bool automatic, ABTI_pool **pp_newpool)
+ABTU_ret_err int ABTI_pool_create_basic(ABT_pool_kind kind,
+                                        ABT_pool_access access,
+                                        ABT_bool automatic,
+                                        ABTI_pool **pp_newpool)
 {
     int abt_errno;
     ABT_pool_def def;
@@ -606,8 +609,8 @@ void ABTI_pool_reset_id(void)
 /*****************************************************************************/
 
 static inline uint64_t pool_get_new_id(void);
-static int pool_create(ABT_pool_def *def, ABT_pool_config config,
-                       ABT_bool automatic, ABTI_pool **pp_newpool)
+ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
+                                    ABT_bool automatic, ABTI_pool **pp_newpool)
 {
     int abt_errno;
     ABTI_pool *p_pool;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -65,7 +65,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     /* Set the variables from the config */
     void *p_event_freq = &p_data->event_freq;
-    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTU_free(p_data);
+        goto fn_fail;
+    }
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -59,7 +59,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     /* Set the variables from the config */
     void *p_event_freq = &p_data->event_freq;
-    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTU_free(p_data);
+        goto fn_fail;
+    }
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -219,8 +219,9 @@ int ABT_sched_config_free(ABT_sched_config *config)
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-int ABTI_sched_config_read_global(ABT_sched_config config,
-                                  ABT_pool_access *access, ABT_bool *automatic)
+ABTU_ret_err int ABTI_sched_config_read_global(ABT_sched_config config,
+                                               ABT_pool_access *access,
+                                               ABT_bool *automatic)
 {
     int abt_errno;
     int num_vars = 2;
@@ -248,8 +249,8 @@ int ABTI_sched_config_read_global(ABT_sched_config config,
 }
 
 /* type is 0 if we read the private parameters, else 1 */
-int ABTI_sched_config_read(ABT_sched_config config, int type, int num_vars,
-                           void **variables)
+ABTU_ret_err int ABTI_sched_config_read(ABT_sched_config config, int type,
+                                        int num_vars, void **variables)
 {
     size_t offset = 0;
     int num_params;

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -56,7 +56,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     /* Set the variables from the config */
     void *p_event_freq = &p_data->event_freq;
-    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTU_free(p_data);
+        goto fn_fail;
+    }
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -53,7 +53,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     /* Set the variables from the config */
     void *p_event_freq = &p_data->event_freq;
-    ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTU_free(p_data);
+        goto fn_fail;
+    }
 
     /* Save the list of pools */
     num_pools = p_sched->num_pools;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -5,9 +5,10 @@
 
 #include "abti.h"
 
-static int sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
-                        ABT_sched_config config, ABT_bool automatic,
-                        ABTI_sched **pp_newsched);
+ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
+                                     ABT_pool *pools, ABT_sched_config config,
+                                     ABT_bool automatic,
+                                     ABTI_sched **pp_newsched);
 static inline ABTI_sched_kind sched_get_kind(ABT_sched_def *def);
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
 static inline uint64_t sched_get_new_id(void);
@@ -449,9 +450,10 @@ void ABTI_sched_exit(ABTI_sched *p_sched)
     ABTI_sched_set_request(p_sched, ABTI_SCHED_REQ_EXIT);
 }
 
-int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
-                            ABT_pool *pools, ABT_sched_config config,
-                            ABTI_sched **pp_newsched)
+ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
+                                         ABT_pool *pools,
+                                         ABT_sched_config config,
+                                         ABTI_sched **pp_newsched)
 {
     int abt_errno;
     ABT_pool_access access;
@@ -661,8 +663,9 @@ ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched)
 }
 
 /* Get the pool suitable for receiving a migrating ULT */
-int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
-                                  ABTI_pool **pp_pool)
+ABTU_ret_err int ABTI_sched_get_migration_pool(ABTI_sched *p_sched,
+                                               ABTI_pool *source_pool,
+                                               ABTI_pool **pp_pool)
 {
     ABT_sched sched = ABTI_sched_get_handle(p_sched);
 
@@ -826,9 +829,10 @@ static inline ABTI_sched_kind sched_get_kind(ABT_sched_def *def)
     return (ABTI_sched_kind)def;
 }
 
-static int sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
-                        ABT_sched_config config, ABT_bool automatic,
-                        ABTI_sched **pp_newsched)
+ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
+                                     ABT_pool *pools, ABT_sched_config config,
+                                     ABT_bool automatic,
+                                     ABTI_sched **pp_newsched)
 {
     ABTI_sched *p_sched;
     int p, abt_errno;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -458,6 +458,8 @@ int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     ABT_pool_kind kind = ABT_POOL_FIFO;
     ABT_bool automatic;
 
+    ABTI_CHECK_TRUE_RET(!pools || num_pools > 0, ABT_ERR_SCHED);
+
     /* We set the access to the default one */
     access = ABT_POOL_ACCESS_MPSC;
     /* TODO: the default value is different from ABT_sched_create().
@@ -666,13 +668,13 @@ int ABTI_sched_get_migration_pool(ABTI_sched *p_sched, ABTI_pool *source_pool,
 
     /* Find a pool.  If get_migr_pool is not defined, we pick the first pool */
     if (p_sched->get_migr_pool == NULL) {
-        if (ABTI_IS_ERROR_CHECK_ENABLED && p_sched->num_pools == 0) {
-            return ABT_ERR_INV_POOL;
-        } else {
-            *pp_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
-        }
+        *pp_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
     } else {
-        *pp_pool = ABTI_pool_get_ptr(p_sched->get_migr_pool(sched));
+        ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->get_migr_pool(sched));
+        if (ABTI_IS_ERROR_CHECK_ENABLED && p_pool == NULL) {
+            return ABT_ERR_SCHED;
+        }
+        *pp_pool = p_pool;
     }
     return ABT_SUCCESS;
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -15,7 +15,7 @@ static inline int xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
                                            ABTI_ythread *p_ythread);
 static inline void xstream_schedule_task(ABTI_xstream *p_local_xstream,
                                          ABTI_thread *p_task);
-static int xstream_init_main_sched(ABTI_xstream *p_xstream,
+static void xstream_init_main_sched(ABTI_xstream *p_xstream,
                                    ABTI_sched *p_sched);
 static int xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
                                      ABTI_xstream *p_xstream,
@@ -1255,8 +1255,7 @@ static int xstream_create(ABTI_sched *p_sched, ABTI_xstream_type xstream_type,
     ABTI_mem_init_local(p_newxstream);
 
     /* Set the main scheduler */
-    abt_errno = xstream_init_main_sched(p_newxstream, p_sched);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    xstream_init_main_sched(p_newxstream, p_sched);
 
     /* Create the root thread. */
     abt_errno =
@@ -1518,20 +1517,15 @@ static int xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
 }
 #endif
 
-static int xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
+static void xstream_init_main_sched(ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
     ABTI_ASSERT(p_xstream->p_main_sched == NULL);
-
     /* The main scheduler will to be a ULT, not a tasklet */
     p_sched->type = ABT_SCHED_TYPE_ULT;
-
     /* Set the scheduler as a main scheduler */
     p_sched->used = ABTI_SCHED_MAIN;
-
     /* Set the scheduler */
     p_xstream->p_main_sched = p_sched;
-
-    return ABT_SUCCESS;
 }
 
 static int xstream_update_main_sched(ABTI_xstream **pp_local_xstream,

--- a/src/stream.c
+++ b/src/stream.c
@@ -5,10 +5,12 @@
 
 #include "abti.h"
 
-static int xstream_create(ABTI_sched *p_sched, ABTI_xstream_type xstream_type,
-                          int rank, ABTI_xstream **pp_xstream);
-static int xstream_start(ABTI_xstream *p_xstream);
-static int xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream);
+ABTU_ret_err static int xstream_create(ABTI_sched *p_sched,
+                                       ABTI_xstream_type xstream_type, int rank,
+                                       ABTI_xstream **pp_xstream);
+ABTU_ret_err static int xstream_start(ABTI_xstream *p_xstream);
+ABTU_ret_err static int xstream_join(ABTI_local **pp_local,
+                                     ABTI_xstream *p_xstream);
 static ABT_bool xstream_set_new_rank(ABTI_xstream *p_newxstream, int rank);
 static void xstream_return_rank(ABTI_xstream *p_xstream);
 static inline void xstream_schedule_ythread(ABTI_xstream **pp_local_xstream,
@@ -17,12 +19,13 @@ static inline void xstream_schedule_task(ABTI_xstream *p_local_xstream,
                                          ABTI_thread *p_task);
 static void xstream_init_main_sched(ABTI_xstream *p_xstream,
                                     ABTI_sched *p_sched);
-static int xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
-                                     ABTI_xstream *p_xstream,
-                                     ABTI_sched *p_sched);
+ABTU_ret_err static int
+xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
+                          ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 static void *xstream_launch_root_ythread(void *p_xstream);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static int xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread);
+ABTU_ret_err static int xstream_migrate_thread(ABTI_local *p_local,
+                                               ABTI_thread *p_thread);
 #endif
 
 /** @defgroup ES Execution Stream (ES)
@@ -1033,7 +1036,7 @@ fn_fail:
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
+ABTU_ret_err int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
 {
     int abt_errno;
     ABTI_xstream *p_newxstream;
@@ -1225,8 +1228,9 @@ static void *xstream_launch_root_ythread(void *p_xstream)
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-static int xstream_create(ABTI_sched *p_sched, ABTI_xstream_type xstream_type,
-                          int rank, ABTI_xstream **pp_xstream)
+ABTU_ret_err static int xstream_create(ABTI_sched *p_sched,
+                                       ABTI_xstream_type xstream_type, int rank,
+                                       ABTI_xstream **pp_xstream)
 {
     int abt_errno;
     ABTI_xstream *p_newxstream;
@@ -1277,7 +1281,7 @@ static int xstream_create(ABTI_sched *p_sched, ABTI_xstream_type xstream_type,
     return ABT_SUCCESS;
 }
 
-static int xstream_start(ABTI_xstream *p_xstream)
+ABTU_ret_err static int xstream_start(ABTI_xstream *p_xstream)
 {
     /* The ES's state must be RUNNING */
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
@@ -1296,7 +1300,8 @@ static int xstream_start(ABTI_xstream *p_xstream)
     return ABT_SUCCESS;
 }
 
-static int xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
+ABTU_ret_err static int xstream_join(ABTI_local **pp_local,
+                                     ABTI_xstream *p_xstream)
 {
     /* The primary ES cannot be joined. */
     ABTI_CHECK_TRUE_RET(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
@@ -1482,7 +1487,8 @@ static inline void xstream_schedule_task(ABTI_xstream *p_local_xstream,
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static int xstream_migrate_thread(ABTI_local *p_local, ABTI_thread *p_thread)
+ABTU_ret_err static int xstream_migrate_thread(ABTI_local *p_local,
+                                               ABTI_thread *p_thread)
 {
     int abt_errno;
     ABTI_pool *p_pool;
@@ -1532,9 +1538,9 @@ static void xstream_init_main_sched(ABTI_xstream *p_xstream,
     p_xstream->p_main_sched = p_sched;
 }
 
-static int xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
-                                     ABTI_xstream *p_xstream,
-                                     ABTI_sched *p_sched)
+ABTU_ret_err static int
+xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
+                          ABTI_xstream *p_xstream, ABTI_sched *p_sched)
 {
     ABTI_ythread *p_ythread = NULL;
     ABTI_sched *p_main_sched;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1303,6 +1303,11 @@ static int xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
     /* The primary ES cannot be joined. */
     ABTI_CHECK_TRUE_RET(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
                         ABT_ERR_INV_XSTREAM);
+    /* The main scheduler cannot join itself. */
+    ABTI_CHECK_TRUE_RET(!ABTI_local_get_xstream_or_null(*pp_local) ||
+                            &p_xstream->p_main_sched->p_ythread->thread !=
+                                ABTI_local_get_xstream(*pp_local)->p_thread,
+                        ABT_ERR_INV_THREAD);
 
     /* Wait until the target ES terminates */
     ABTI_sched_finish(p_xstream->p_main_sched);

--- a/src/stream.c
+++ b/src/stream.c
@@ -210,8 +210,7 @@ int ABT_xstream_revive(ABT_xstream xstream)
     ABTI_CHECK_ERROR(abt_errno);
 
     ABTD_atomic_relaxed_store_int(&p_xstream->state, ABT_XSTREAM_STATE_RUNNING);
-    abt_errno = ABTD_xstream_context_revive(&p_xstream->ctx);
-    ABTI_CHECK_ERROR(abt_errno);
+    ABTD_xstream_context_revive(&p_xstream->ctx);
 
 fn_exit:
     return abt_errno;
@@ -1052,10 +1051,9 @@ int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
 }
 
 /* This routine starts the primary ES. It should be called in ABT_init. */
-int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
+void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
                                ABTI_xstream *p_xstream, ABTI_ythread *p_ythread)
 {
-    int abt_errno;
     /* p_ythread must be the main thread. */
     ABTI_ASSERT(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN);
     /* The ES's state must be running here. */
@@ -1064,8 +1062,7 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
 
     LOG_DEBUG("[E%d] start\n", p_xstream->rank);
 
-    abt_errno = ABTD_xstream_context_set_self(&p_xstream->ctx);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTD_xstream_context_set_self(&p_xstream->ctx);
 
     /* Set the CPU affinity for the ES */
     if (gp_ABTI_global->set_affinity == ABT_TRUE) {
@@ -1079,8 +1076,6 @@ int ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     /* Come back to the main thread.  Now this thread is executed on top of the
      * main scheduler, which is running on the root thread. */
     (*pp_local_xstream)->p_thread = &p_ythread->thread;
-
-    return abt_errno;
 }
 
 int ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
@@ -1155,8 +1150,7 @@ int ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
 
     /* Free the context if a given xstream is secondary. */
     if (p_xstream->type == ABTI_XSTREAM_TYPE_SECONDARY) {
-        int abt_errno = ABTD_xstream_context_free(&p_xstream->ctx);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTD_xstream_context_free(&p_xstream->ctx);
     }
 
     ABTU_free(p_xstream);
@@ -1319,12 +1313,10 @@ static int xstream_join(ABTI_local **pp_local, ABTI_xstream *p_xstream)
     ABTI_thread_join(pp_local, &p_xstream->p_main_sched->p_ythread->thread);
 
     /* Normal join request */
-    int abt_errno = ABTD_xstream_context_join(&p_xstream->ctx);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTD_xstream_context_join(&p_xstream->ctx);
 
     ABTI_ASSERT(ABTD_atomic_acquire_load_int(&p_xstream->state) ==
                 ABT_XSTREAM_STATE_TERMINATED);
-
     return ABT_SUCCESS;
 }
 

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -36,7 +36,10 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
 
     p_newbarrier->num_waiters = num_waiters;
     abt_errno = ABTD_xstream_barrier_init(num_waiters, &p_newbarrier->bar);
-    ABTI_CHECK_ERROR(abt_errno);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTU_free(p_newbarrier);
+        goto fn_fail;
+    }
 
     /* Return value */
     *newbarrier = ABTI_xstream_barrier_get_handle(p_newbarrier);
@@ -72,9 +75,7 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
-    abt_errno = ABTD_xstream_barrier_destroy(&p_barrier->bar);
-    ABTI_CHECK_ERROR(abt_errno);
-
+    ABTD_xstream_barrier_destroy(&p_barrier->bar);
     ABTU_free(p_barrier);
 
     /* Return value */

--- a/src/task.c
+++ b/src/task.c
@@ -5,10 +5,10 @@
 
 #include "abti.h"
 
-static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
-                       void (*task_func)(void *), void *arg,
-                       ABTI_sched *p_sched, int refcount,
-                       ABTI_thread **pp_newtask);
+ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                                    void (*task_func)(void *), void *arg,
+                                    ABTI_sched *p_sched, int refcount,
+                                    ABTI_thread **pp_newtask);
 
 /** @defgroup TASK Tasklet
  * This group is for Tasklet.
@@ -475,10 +475,10 @@ int ABT_task_get_specific(ABT_task task, ABT_key key, void **value);
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
-                       void (*task_func)(void *), void *arg,
-                       ABTI_sched *p_sched, int refcount,
-                       ABTI_thread **pp_newtask)
+ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+                                    void (*task_func)(void *), void *arg,
+                                    ABTI_sched *p_sched, int refcount,
+                                    ABTI_thread **pp_newtask)
 {
     ABTI_thread *p_newtask;
     ABT_task h_newtask;

--- a/src/thread.c
+++ b/src/thread.c
@@ -5,23 +5,23 @@
 
 #include "abti.h"
 
-static inline int ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
-                                 void (*thread_func)(void *), void *arg,
-                                 ABTI_thread_attr *p_attr,
-                                 ABTI_thread_type thread_type,
-                                 ABTI_sched *p_sched, ABT_bool push_pool,
-                                 ABTI_ythread **pp_newthread);
+ABTU_ret_err static inline int
+ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
+               void (*thread_func)(void *), void *arg, ABTI_thread_attr *p_attr,
+               ABTI_thread_type thread_type, ABTI_sched *p_sched,
+               ABT_bool push_pool, ABTI_ythread **pp_newthread);
 static inline void thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 static inline void thread_free(ABTI_local *p_local, ABTI_thread *p_thread,
                                ABT_bool free_unit);
 static void thread_root_func(void *arg);
 static void thread_main_sched_func(void *arg);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static int thread_migrate_to_xstream(ABTI_local **pp_local,
-                                     ABTI_thread *p_thread,
-                                     ABTI_xstream *p_xstream);
-static int thread_migrate_to_pool(ABTI_local **p_local, ABTI_thread *p_thread,
-                                  ABTI_pool *p_pool);
+ABTU_ret_err static int thread_migrate_to_xstream(ABTI_local **pp_local,
+                                                  ABTI_thread *p_thread,
+                                                  ABTI_xstream *p_xstream);
+ABTU_ret_err static int thread_migrate_to_pool(ABTI_local **p_local,
+                                               ABTI_thread *p_thread,
+                                               ABTI_pool *p_pool);
 #endif
 static inline ABT_unit_id thread_get_new_id(void);
 
@@ -1612,8 +1612,9 @@ void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTI_pool_push(p_pool, p_thread->unit);
 }
 
-int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                             ABTI_ythread **p_ythread)
+ABTU_ret_err int ABTI_ythread_create_main(ABTI_local *p_local,
+                                          ABTI_xstream *p_xstream,
+                                          ABTI_ythread **p_ythread)
 {
     ABTI_thread_attr attr;
     ABTI_pool *p_pool;
@@ -1639,8 +1640,9 @@ int ABTI_ythread_create_main(ABTI_local *p_local, ABTI_xstream *p_xstream,
     return ABT_SUCCESS;
 }
 
-int ABTI_ythread_create_root(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                             ABTI_ythread **pp_root_ythread)
+ABTU_ret_err int ABTI_ythread_create_root(ABTI_local *p_local,
+                                          ABTI_xstream *p_xstream,
+                                          ABTI_ythread **pp_root_ythread)
 {
     ABTI_thread_attr attr;
     /* Create a ULT context */
@@ -1664,8 +1666,9 @@ int ABTI_ythread_create_root(ABTI_local *p_local, ABTI_xstream *p_xstream,
     return ABT_SUCCESS;
 }
 
-int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                                   ABTI_sched *p_sched)
+ABTU_ret_err int ABTI_ythread_create_main_sched(ABTI_local *p_local,
+                                                ABTI_xstream *p_xstream,
+                                                ABTI_sched *p_sched)
 {
     ABTI_thread_attr attr;
 
@@ -1683,8 +1686,9 @@ int ABTI_ythread_create_main_sched(ABTI_local *p_local, ABTI_xstream *p_xstream,
 }
 
 /* This routine is to create a ULT for the scheduler. */
-int ABTI_ythread_create_sched(ABTI_local *p_local, ABTI_pool *p_pool,
-                              ABTI_sched *p_sched)
+ABTU_ret_err int ABTI_ythread_create_sched(ABTI_local *p_local,
+                                           ABTI_pool *p_pool,
+                                           ABTI_sched *p_sched)
 {
     ABTI_thread_attr attr;
 
@@ -1738,8 +1742,9 @@ ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
     ABTU_unreachable();
 }
 
-int ABTI_thread_get_mig_data(ABTI_local *p_local, ABTI_thread *p_thread,
-                             ABTI_thread_mig_data **pp_mig_data)
+ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_local *p_local,
+                                          ABTI_thread *p_thread,
+                                          ABTI_thread_mig_data **pp_mig_data)
 {
     ABTI_thread_mig_data *p_mig_data =
         (ABTI_thread_mig_data *)ABTI_ktable_get(&p_thread->p_keytable,
@@ -1844,12 +1849,11 @@ ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread)
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-static inline int ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
-                                 void (*thread_func)(void *), void *arg,
-                                 ABTI_thread_attr *p_attr,
-                                 ABTI_thread_type thread_type,
-                                 ABTI_sched *p_sched, ABT_bool push_pool,
-                                 ABTI_ythread **pp_newthread)
+ABTU_ret_err static inline int
+ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
+               void (*thread_func)(void *), void *arg, ABTI_thread_attr *p_attr,
+               ABTI_thread_type thread_type, ABTI_sched *p_sched,
+               ABT_bool push_pool, ABTI_ythread **pp_newthread)
 {
     int abt_errno;
     ABTI_ythread *p_newthread;
@@ -2001,8 +2005,9 @@ static inline int ythread_create(ABTI_local *p_local, ABTI_pool *p_pool,
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static int thread_migrate_to_pool(ABTI_local **pp_local, ABTI_thread *p_thread,
-                                  ABTI_pool *p_pool)
+ABTU_ret_err static int thread_migrate_to_pool(ABTI_local **pp_local,
+                                               ABTI_thread *p_thread,
+                                               ABTI_pool *p_pool)
 {
     /* checking for cases when migration is not allowed */
     ABTI_CHECK_TRUE_RET(!(p_thread->type & (ABTI_THREAD_TYPE_MAIN |
@@ -2337,9 +2342,9 @@ static void thread_main_sched_func(void *arg)
 }
 
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-static int thread_migrate_to_xstream(ABTI_local **pp_local,
-                                     ABTI_thread *p_thread,
-                                     ABTI_xstream *p_xstream)
+ABTU_ret_err static int thread_migrate_to_xstream(ABTI_local **pp_local,
+                                                  ABTI_thread *p_thread,
+                                                  ABTI_xstream *p_xstream)
 {
     int abt_errno;
     /* checking for cases when migration is not allowed */

--- a/src/thread.c
+++ b/src/thread.c
@@ -2366,26 +2366,23 @@ ABTU_ret_err static int thread_migrate_to_xstream(ABTI_local **pp_local,
                         ABT_ERR_INV_THREAD);
 
     /* We need to find the target scheduler */
-    ABTI_pool *p_pool = NULL;
-    ABTI_sched *p_sched = NULL;
-    do {
-        /* We check the state of the ES */
-        ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
-                                ABT_XSTREAM_STATE_TERMINATED,
-                            ABT_ERR_INV_XSTREAM);
-        /* The migration target should be the main scheduler since it is
-         * hard to guarantee the lifetime of the stackable scheduler. */
-        p_sched = p_xstream->p_main_sched;
+    /* We check the state of the ES */
+    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_xstream->state) !=
+                            ABT_XSTREAM_STATE_TERMINATED,
+                        ABT_ERR_INV_XSTREAM);
+    /* The migration target should be the main scheduler since it is
+     * hard to guarantee the lifetime of the stackable scheduler. */
+    ABTI_sched *p_sched = p_xstream->p_main_sched;
 
-        /* We check the state of the sched */
-        /* Find a pool */
-        abt_errno =
-            ABTI_sched_get_migration_pool(p_sched, p_thread->p_pool, &p_pool);
-        ABTI_CHECK_ERROR_RET(abt_errno);
-        /* We set the migration counter to prevent the scheduler from
-         * stopping */
-        ABTI_pool_inc_num_migrations(p_pool);
-    } while (p_pool == NULL);
+    /* We check the state of the sched */
+    /* Find a pool */
+    ABTI_pool *p_pool = NULL;
+    abt_errno =
+        ABTI_sched_get_migration_pool(p_sched, p_thread->p_pool, &p_pool);
+    ABTI_CHECK_ERROR_RET(abt_errno);
+    /* We set the migration counter to prevent the scheduler from
+     * stopping */
+    ABTI_pool_inc_num_migrations(p_pool);
 
     abt_errno = thread_migrate_to_pool(pp_local, p_thread, p_pool);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {

--- a/src/thread.c
+++ b/src/thread.c
@@ -77,6 +77,7 @@ int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
     abt_errno = ythread_create(p_local, p_pool, thread_func, arg,
                                ABTI_thread_attr_get_ptr(attr), unit_type, NULL,
                                ABT_TRUE, &p_newthread);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
     if (newthread)

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -359,8 +359,8 @@ void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent)
     fflush(p_os);
 }
 
-int ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
-                         ABTI_thread_attr **pp_dup_attr)
+ABTU_ret_err int ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
+                                      ABTI_thread_attr **pp_dup_attr)
 {
     ABTI_thread_attr *p_dup_attr;
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -5,7 +5,7 @@
 
 #include "abti.h"
 
-static int timer_alloc(ABTI_timer **pp_newtimer);
+ABTU_ret_err static int timer_alloc(ABTI_timer **pp_newtimer);
 
 /** @defgroup TIMER  Timer
  * This group is for Timer.
@@ -344,7 +344,7 @@ fn_fail:
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-static int timer_alloc(ABTI_timer **pp_newtimer)
+ABTU_ret_err static int timer_alloc(ABTI_timer **pp_newtimer)
 {
     /* We use libc malloc/free for ABT_timer because ABTU_malloc/free might
      * need the initialization of Argobots if they are not the same as libc

--- a/src/tool.c
+++ b/src/tool.c
@@ -6,8 +6,9 @@
 #include "abti.h"
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-static inline int tool_query(ABTI_tool_context *p_tctx,
-                             ABT_tool_query_kind query_kind, void *val);
+ABTU_ret_err static inline int tool_query(ABTI_tool_context *p_tctx,
+                                          ABT_tool_query_kind query_kind,
+                                          void *val);
 #endif
 
 /** @defgroup Tool interface
@@ -255,8 +256,8 @@ fn_fail:
 /*****************************************************************************/
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-static inline int tool_query(ABTI_tool_context *p_tctx,
-                             ABT_tool_query_kind query_kind, void *val)
+ABTU_ret_err static inline int
+tool_query(ABTI_tool_context *p_tctx, ABT_tool_query_kind query_kind, void *val)
 {
     switch (query_kind) {
         case ABT_TOOL_QUERY_KIND_POOL:

--- a/src/util/largepage.c
+++ b/src/util/largepage.c
@@ -86,10 +86,11 @@ int ABTU_is_supported_largepage_type(size_t size, size_t alignment_hint,
     return 0;
 }
 
-int ABTU_alloc_largepage(size_t size, size_t alignment_hint,
-                         const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
-                         int num_requested_types,
-                         ABTU_MEM_LARGEPAGE_TYPE *p_actual, void **p_ptr)
+ABTU_ret_err int
+ABTU_alloc_largepage(size_t size, size_t alignment_hint,
+                     const ABTU_MEM_LARGEPAGE_TYPE *requested_types,
+                     int num_requested_types, ABTU_MEM_LARGEPAGE_TYPE *p_actual,
+                     void **p_ptr)
 {
     int i;
     void *ptr = NULL;

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -82,14 +82,14 @@ void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
     ABTI_pool_dec_num_blocked(p_pool);
 }
 
-ABTU_no_sanitize_address int ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
-                                                      FILE *p_os)
+ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
+                                                       FILE *p_os)
 {
     void *p_stack = p_ythread->p_stack;
     size_t i, j, stacksize = p_ythread->stacksize;
     if (stacksize == 0 || p_stack == NULL) {
         /* Some threads do not have p_stack (e.g., the main thread) */
-        return ABT_SUCCESS;
+        return;
     }
 
     char buffer[32];
@@ -131,5 +131,4 @@ ABTU_no_sanitize_address int ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
                 fprintf(p_os, "\n");
         }
     }
-    return ABT_SUCCESS;
 }

--- a/src/ythread_htable.c
+++ b/src/ythread_htable.c
@@ -6,8 +6,8 @@
 #include "abti.h"
 #include "abti_ythread_htable.h"
 
-int ABTI_ythread_htable_create(uint32_t num_rows,
-                               ABTI_ythread_htable **pp_htable)
+ABTU_ret_err int ABTI_ythread_htable_create(uint32_t num_rows,
+                                            ABTI_ythread_htable **pp_htable)
 {
     ABTI_STATIC_ASSERT(sizeof(ABTI_ythread_queue) == 192);
 


### PR DESCRIPTION
This PR addresses #116. This PR improves error handling (including out-of-memory errors) of functions that are frequently used in user programs. Specifically, all the functions that might return errors will be decorated with `warn_unused_return`, so Argobots developers are more aware of error handling.  This PR, however, does not fix all the functions.

1. When `ABT_init()`, `ABT_finalize()`, and `ABT_xstream_create()` fail, the runtime state becomes unstable.
2. Some functions called in `ABT_init()` do not handle out-of-memory errors.
3. `ABT_thread_create_many()`, `ABT_thread_join_many()`, and `ABT_thread_free_many()` are not atomic; they can partially create, join, or free threads.

I believe, however, this patch covers most functions.  Because the remaining functions are large and complicated, further improvement requires tests that can check error paths, which is the future work but so far of lower priority.

This PR fixes #96.