### PR TITLE
info: support stack unwinding

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,16 @@ AC_ARG_WITH([hugetlbfs],
     AS_HELP_STRING([--with-hugetlbfs=PATH],
         [specify path where hugetlbfs include directory and lib directory can be found]))
 
+# --with-libunwind
+AC_ARG_WITH([libunwind],
+    AS_HELP_STRING([--with-libunwind=PATH],
+        [specify path where libunwind include directory and lib directory can be found]))
+
+# --enable-stack-unwind
+AC_ARG_ENABLE([stack-unwind],
+    AS_HELP_STRING([--enable-stack-unwind],
+                   [enable stack unwinding, which is disabled by default.]))
+
 # --with-papi
 AC_ARG_WITH([papi],
     AS_HELP_STRING([--with-papi=PATH],
@@ -730,6 +740,23 @@ if test "x$with_hugetlbfs" != "x"; then
     AC_CHECK_LIB(hugetlbfs, get_huge_pages)
 fi
 
+# --enable-stack-unwind
+if test "x$enable_stack_unwind" = "xyes"; then
+    # --with-libunwind
+    if test "x$with_libunwind" != "x"; then
+        PAC_PREPEND_FLAG([-I${with_libunwind}/include], [CFLAGS])
+        PAC_PREPEND_FLAG([-Wl,-rpath,${with_libunwind}/lib -L${with_libunwind}/lib], [LDFLAGS])
+    fi
+    AC_CHECK_HEADERS(libunwind.h)
+    AC_CHECK_LIB(unwind, unw_backtrace)
+    if test x"$ac_cv_header_libunwind_h" = x"yes" -a x"$ac_cv_lib_unwind_unw_backtrace" = x"yes" ; then
+        AC_DEFINE(ABT_CONFIG_ENABLE_STACK_UNWIND, 1, [Define to use the stack unwinding feature.])
+        PAC_PREPEND_FLAG([-lunwind], [LDFLAGS])
+    else
+        AC_MSG_ERROR([libunwind is not found.  Either remove --enable-stack-unwind or \
+set --with-libunwind=LIBUNWIND_PREFIX_PATH.])
+    fi
+fi
 
 # --with-papi
 PAPI_CFLAGS=""

--- a/src/arch/fcontext/jump_x86_64_sysv_elf_gas.S
+++ b/src/arch/fcontext/jump_x86_64_sysv_elf_gas.S
@@ -133,6 +133,26 @@ init_and_call_fcontext:
 .size init_and_call_fcontext,.-init_and_call_fcontext
 #endif
 
+.text
+.globl peek_fcontext
+.type peek_fcontext,@function
+.align 16
+peek_fcontext:
+    /* temporarily move RSP (pointing to context-data) to R12 (callee-saved) */
+    pushq  %r12
+    movq   %rsp, %r12
+    /* restore RSP (pointing to context-data) from RDI */
+    movq   %rdi, %rsp
+    /* RSP is already 16-byte aligned, so we can call a peek funciton here
+     * rsi(rdx) => second_arg(third_arg) */
+    movq   %rdx, %rdi
+    callq *%rsi
+    /* restore callee-saved registers. */
+    movq   %r12, %rsp
+    popq   %r12
+    ret
+.size peek_fcontext,.-peek_fcontext
+
 /* Mark that we don't need executable stack.  */
 #ifndef __SUNPRO_C
 .section .note.GNU-stack,"",%progbits

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -226,6 +226,8 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_FCONTEXT,
     /* Whether dynamic promotion is used for context switch or not */
     ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION,
+    /* Whether the stack unwinding feature is enabled or not */
+    ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND,
 };
 
 enum ABT_tool_query_kind {

--- a/src/include/abtd_context.h
+++ b/src/include/abtd_context.h
@@ -15,6 +15,11 @@
 #include <ucontext.h>
 #endif
 
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
+/* Peek context is needed only for stack unwinding. */
+#define ABT_CONFIG_ENABLE_PEEK_CONTEXT
+#endif
+
 typedef struct ABTD_ythread_context ABTD_ythread_context;
 
 typedef struct ABTD_ythread_context_atomic_ptr {
@@ -47,16 +52,7 @@ static inline void ABTD_atomic_release_store_ythread_context_ptr(
     ABTD_atomic_release_store_ptr(&ptr->val, (void *)p_ctx);
 }
 
-struct ABTD_ythread_context {
-    void *p_ctx;                            /* actual context of fcontext, or a
-                                             * pointer to uctx */
-    ABTD_ythread_context_atomic_ptr p_link; /* pointer to scheduler context */
-#ifndef ABT_CONFIG_USE_FCONTEXT
-    ucontext_t uctx;               /* ucontext entity pointed by p_ctx */
-    void (*f_uctx_thread)(void *); /* root function called by ucontext */
-    void *p_uctx_arg;              /* argument for root function */
-#endif
-};
+struct ABTD_ythread_context;
 
 static void ABTD_ythread_context_make(ABTD_ythread_context *p_ctx, void *sp,
                                       size_t size, void (*thread_func)(void *));
@@ -70,6 +66,11 @@ static void ABTD_ythread_context_init_and_call(ABTD_ythread_context *p_ctx,
                                                void *sp,
                                                void (*thread_func)(void *),
                                                void *arg);
+#endif
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+static inline void ABTD_ythread_context_peek(ABTD_ythread_context *p_ctx,
+                                             void (*peek_func)(void *),
+                                             void *arg);
 #endif
 
 void ABTD_ythread_print_context(ABTI_ythread *p_ythread, FILE *p_os,

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -23,25 +23,89 @@ void init_and_call_fcontext(void *p_arg, void (*f_thread)(void *),
                             void *p_stacktop, fcontext_t *old);
 #endif
 
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) && defined(__x86_64__)
+/* We implement peek_fcontext only for x86-64. */
+void peek_fcontext(fcontext_t new, void (*peek_func)(void *),
+                   void *arg) ABT_API_PRIVATE;
+#define ABTD_SUPPORT_PEEK_FCONTEXT 1
+#endif /* defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) && defined(__x86_64__) */
+
+struct ABTD_ythread_context {
+    void *p_ctx;                            /* actual context of fcontext, or a
+                                             * pointer to uctx */
+    ABTD_ythread_context_atomic_ptr p_link; /* pointer to scheduler context */
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+    void (*thread_func)(void *);
+    void *arg;
+    void (*peek_func)(void *);
+    void *peek_arg;
+    void *p_peek_ctx;
+    ABT_bool is_peeked;
+#endif
+};
+
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+static inline void ABTDI_fcontext_check_peeked(ABTD_ythread_context *p_self)
+{
+    /* Check if this thread is called only for peeked */
+    while (ABTU_unlikely(p_self->is_peeked)) {
+        p_self->peek_func(p_self->peek_arg);
+        /* Reset the flag. */
+        p_self->is_peeked = ABT_FALSE;
+        jump_fcontext(&p_self->p_ctx, p_self->p_peek_ctx, NULL);
+    }
+}
+
+static inline void ABTDI_fcontext_wrapper(void *arg)
+{
+    ABTD_ythread_context *p_self = (ABTD_ythread_context *)arg;
+    ABTDI_fcontext_check_peeked(p_self);
+    p_self->thread_func(p_self->arg);
+}
+#endif
+
 static inline void ABTD_ythread_context_make(ABTD_ythread_context *p_ctx,
                                              void *sp, size_t size,
                                              void (*thread_func)(void *))
 {
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+    p_ctx->thread_func = thread_func;
+    p_ctx->is_peeked = ABT_FALSE;
+    p_ctx->p_ctx = make_fcontext(sp, size, ABTDI_fcontext_wrapper);
+#else
     p_ctx->p_ctx = make_fcontext(sp, size, thread_func);
+#endif
 }
 
 static inline void ABTD_ythread_context_jump(ABTD_ythread_context *p_old,
                                              ABTD_ythread_context *p_new,
                                              void *arg)
 {
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+    p_new->arg = arg;
+    p_old->is_peeked = ABT_FALSE;
+    jump_fcontext(&p_old->p_ctx, p_new->p_ctx, p_new);
+    ABTDI_fcontext_check_peeked(p_old);
+#else
     jump_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
+#endif
 }
 
 ABTU_noreturn static inline void
 ABTD_ythread_context_take(ABTD_ythread_context *p_old,
                           ABTD_ythread_context *p_new, void *arg)
 {
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+    p_new->arg = arg;
+    take_fcontext(&p_old->p_ctx, p_new->p_ctx, p_new);
+#else
     take_fcontext(&p_old->p_ctx, p_new->p_ctx, arg);
+#endif
     ABTU_unreachable();
 }
 
@@ -50,8 +114,31 @@ static inline void
 ABTD_ythread_context_init_and_call(ABTD_ythread_context *p_ctx, void *sp,
                                    void (*thread_func)(void *), void *arg)
 {
+#if defined(ABT_CONFIG_ENABLE_PEEK_CONTEXT) &&                                 \
+    !defined(ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT)
+    p_ctx->is_peeked = ABT_FALSE;
     init_and_call_fcontext(arg, thread_func, sp, &p_ctx->p_ctx);
+    ABTDI_fcontext_check_peeked(p_ctx);
+#else
+    init_and_call_fcontext(arg, thread_func, sp, &p_ctx->p_ctx);
+#endif
 }
 #endif
+
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+static inline void ABTD_ythread_context_peek(ABTD_ythread_context *p_ctx,
+                                             void (*peek_func)(void *),
+                                             void *arg)
+{
+#ifdef ABTD_CONTEXT_SUPPORT_PEEK_FCONTEXT
+    peek_fcontext(p_ctx->p_ctx, peek_func, *arg);
+#else
+    p_ctx->peek_arg = arg;
+    p_ctx->peek_func = peek_func;
+    p_ctx->is_peeked = ABT_TRUE;
+    jump_fcontext(&p_ctx->p_peek_ctx, p_ctx->p_ctx, p_ctx);
+#endif
+}
+#endif /*!ABT_CONFIG_ENABLE_PEEK_CONTEXT */
 
 #endif /* ABTD_FCONTEXT_H_INCLUDED */

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -6,6 +6,35 @@
 #ifndef ABTD_UCONTEXT_H_INCLUDED
 #define ABTD_UCONTEXT_H_INCLUDED
 
+struct ABTD_ythread_context {
+    void *p_ctx;                            /* actual context of fcontext, or a
+                                             * pointer to uctx */
+    ABTD_ythread_context_atomic_ptr p_link; /* pointer to scheduler context */
+    ucontext_t uctx;               /* ucontext entity pointed by p_ctx */
+    void (*f_uctx_thread)(void *); /* root function called by ucontext */
+    void *p_uctx_arg;              /* argument for root function */
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+    void (*peek_func)(void *);
+    void *peek_arg;
+    ucontext_t *p_peek_uctx;
+    ABT_bool is_peeked;
+#endif
+};
+
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+static inline void ABTDI_ucontext_check_peeked(ABTD_ythread_context *p_self)
+{
+    /* Check if this thread is called only for peeked */
+    while (ABTU_unlikely(p_self->is_peeked)) {
+        p_self->peek_func(p_self->peek_arg);
+        /* Reset the flag. */
+        p_self->is_peeked = ABT_FALSE;
+        int ret = swapcontext(&p_self->uctx, p_self->p_peek_uctx);
+        ABTI_ASSERT(ret == 0); /* Fatal. */
+    }
+}
+#endif
+
 static void ABTD_ucontext_wrapper(int arg1, int arg2)
 {
     ABTD_ythread_context *p_self;
@@ -17,6 +46,11 @@ static void ABTD_ucontext_wrapper(int arg1, int arg2)
 #else
 #error "Unknown pointer size."
 #endif
+
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+    ABTDI_ucontext_check_peeked(p_self);
+#endif
+
     p_self->f_uctx_thread(p_self->p_uctx_arg);
     /* ABTD_ythread_context_jump or take must be called at the end of
      * f_uctx_thread, */
@@ -49,16 +83,25 @@ static inline void ABTD_ythread_context_make(ABTD_ythread_context *p_ctx,
 #else
 #error "Unknown pointer size."
 #endif
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+    p_ctx->is_peeked = ABT_FALSE;
+#endif
 }
 
 static inline void ABTD_ythread_context_jump(ABTD_ythread_context *p_old,
                                              ABTD_ythread_context *p_new,
                                              void *arg)
 {
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+    p_old->is_peeked = ABT_FALSE;
+#endif
     p_new->p_uctx_arg = arg;
     int ret = swapcontext(&p_old->uctx, &p_new->uctx);
     /* Fatal.  This out-of-stack error is not recoverable. */
     ABTI_ASSERT(ret == 0);
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+    ABTDI_ucontext_check_peeked(p_old);
+#endif
 }
 
 ABTU_noreturn static inline void
@@ -70,6 +113,21 @@ ABTD_ythread_context_take(ABTD_ythread_context *p_old,
     ABTI_ASSERT(ret == 0); /* setcontext() should not return an error. */
     ABTU_unreachable();
 }
+
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+static inline void ABTD_ythread_context_peek(ABTD_ythread_context *p_ctx,
+                                             void (*peek_func)(void *),
+                                             void *arg)
+{
+    ucontext_t self_uctx;
+    p_ctx->peek_arg = arg;
+    p_ctx->peek_func = peek_func;
+    p_ctx->p_peek_uctx = &self_uctx;
+    p_ctx->is_peeked = ABT_TRUE;
+    int ret = swapcontext(&self_uctx, &p_ctx->uctx);
+    ABTI_ASSERT(ret == 0);
+}
+#endif
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
 #error "ABTD_ythread_context_make_and_call is not implemented."

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -299,6 +299,21 @@ static inline ABTI_ythread *ABTI_ythread_context_switch_to_child_internal(
     }
 }
 
+#ifdef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+static inline void ABTI_ythread_context_peek(ABTI_ythread *p_ythread,
+                                             void (*peek_func)(void *),
+                                             void *arg)
+{
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+    if (!ABTI_ythread_is_dynamic_promoted(p_ythread)) {
+        ABTD_ythread_context_arm_ythread(p_ythread->stacksize,
+                                         p_ythread->p_stack, &p_ythread->ctx);
+    }
+#endif
+    ABTD_ythread_context_peek(&p_ythread->ctx, peek_func, arg);
+}
+#endif
+
 /* Return the previous thread. */
 static inline ABTI_ythread *
 ABTI_ythread_context_switch_to_sibling(ABTI_xstream **pp_local_xstream,

--- a/src/info.c
+++ b/src/info.c
@@ -111,6 +111,10 @@ static void info_trigger_print_all_thread_stacks(
  * - ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION
  *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
  *   set to \c *val if dynamic promotion is used.  Otherwise, ABT_FALSE is set.
+ * - ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND
+ *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
+ *   set to \c *val if the stack unwinding feature is enabled.  Otherwise,
+ *   ABT_FALSE is set.
  *
  * @param[in]  query_kind  query kind
  * @param[out] val         a pointer to a result
@@ -247,6 +251,13 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             break;
         case ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION:
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
+            *((ABT_bool *)val) = ABT_TRUE;
+#else
+            *((ABT_bool *)val) = ABT_FALSE;
+#endif
+            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND:
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
             *((ABT_bool *)val) = ABT_TRUE;
 #else
             *((ABT_bool *)val) = ABT_FALSE;

--- a/src/info.c
+++ b/src/info.c
@@ -811,11 +811,6 @@ static void info_print_unit(void *arg, ABT_unit unit)
                 "id        : %" PRIu64 "\n"
                 "ctx       : %p\n",
                 (uint64_t)thread_id, (void *)&p_ythread->ctx);
-        ABTD_ythread_print_context(p_ythread, fp, 2);
-        fprintf(fp,
-                "stack     : %p\n"
-                "stacksize : %" PRIu64 "\n",
-                p_ythread->p_stack, (uint64_t)p_ythread->stacksize);
         ABTI_ythread_print_stack(p_ythread, fp);
     } else if (type == ABT_UNIT_TYPE_TASK) {
         fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);

--- a/src/info.c
+++ b/src/info.c
@@ -600,11 +600,11 @@ void ABTI_info_check_print_all_thread_stacks(void)
             fprintf(print_stack_fp, "ABT_info_trigger_print_all_thread_stacks: "
                                     "failed because of an internal error.\n");
         }
+        fflush(print_stack_fp);
         /* Release the lock that protects ES data. */
         ABTI_spinlock_release(&gp_ABTI_global->xstream_list_lock);
         if (print_cb_func)
             print_cb_func(force_print, print_arg);
-        fflush(print_stack_fp);
         /* Update print_stack_flag to 3. */
         ABTD_atomic_release_store_int(&print_stack_flag,
                                       PRINT_STACK_FLAG_FINALIZE);

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -5,6 +5,21 @@
 
 #include "abti.h"
 
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
+
+#ifndef ABT_CONFIG_ENABLE_PEEK_CONTEXT
+#error "ABT_CONFIG_ENABLE_PEEK_CONTEXT must be enabled"
+#endif
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+struct unwind_stack_t {
+    FILE *fp;
+};
+static void ythread_unwind_stack(void *arg);
+
+#endif
+
 void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
 {
     /* The root thread cannot be blocked */
@@ -85,6 +100,18 @@ void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
 ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
                                                        FILE *p_os)
 {
+    ABTD_ythread_print_context(p_ythread, p_os, 0);
+    fprintf(p_os,
+            "stack     : %p\n"
+            "stacksize : %" PRIu64 "\n",
+            p_ythread->p_stack, (uint64_t)p_ythread->stacksize);
+
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
+    struct unwind_stack_t arg;
+    arg.fp = p_os;
+    ABTI_ythread_context_peek(p_ythread, ythread_unwind_stack, &arg);
+#endif
+
     void *p_stack = p_ythread->p_stack;
     size_t i, j, stacksize = p_ythread->stacksize;
     if (stacksize == 0 || p_stack == NULL) {
@@ -135,3 +162,54 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
     }
     fflush(p_os);
 }
+
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
+ABTU_no_sanitize_address static int ythread_unwind_stack_impl(FILE *fp)
+{
+    unw_cursor_t cursor;
+    unw_context_t uc;
+    unw_word_t ip, sp;
+    int ret, level = -1;
+
+    ret = unw_getcontext(&uc);
+    if (ret != 0)
+        return ABT_ERR_OTHER;
+
+    ret = unw_init_local(&cursor, &uc);
+    if (ret != 0)
+        return ABT_ERR_OTHER;
+
+    while (unw_step(&cursor) > 0 && level < 50) {
+        level++;
+
+        ret = unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        if (ret != 0)
+            return ABT_ERR_OTHER;
+
+        ret = unw_get_reg(&cursor, UNW_REG_SP, &sp);
+        if (ret != 0)
+            return ABT_ERR_OTHER;
+
+        char proc_name[256];
+        unw_word_t offset;
+        ret = unw_get_proc_name(&cursor, proc_name, 256, &offset);
+        if (ret != 0)
+            return ABT_ERR_OTHER;
+
+        /* Print function stack. */
+        fprintf(fp, "#%d %p in %s () <+%d> (%s = %p)\n", level,
+                (void *)((uintptr_t)ip), proc_name, (int)offset,
+                unw_regname(UNW_REG_SP), (void *)((uintptr_t)sp));
+    }
+    return ABT_SUCCESS;
+}
+
+static void ythread_unwind_stack(void *arg)
+{
+    struct unwind_stack_t *p_arg = (struct unwind_stack_t *)arg;
+    if (ythread_unwind_stack_impl(p_arg->fp) != ABT_SUCCESS) {
+        fprintf(p_arg->fp, "libunwind error\n");
+    }
+}
+
+#endif /* ABT_CONFIG_ENABLE_STACK_UNWIND */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -57,6 +57,7 @@ basic/ext_thread
 basic/ext_thread2
 basic/timer
 basic/info_print
+basic/info_print_stack
 basic/info_stackdump
 basic/info_stackdump2
 basic/error

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	ext_thread2 \
 	timer \
 	info_print \
+	info_print_stack \
 	info_stackdump \
 	info_stackdump2 \
 	error
@@ -137,6 +138,7 @@ ext_thread_SOURCES = ext_thread.c
 ext_thread2_SOURCES = ext_thread2.c
 timer_SOURCES = timer.c
 info_print_SOURCES = info_print.c
+info_print_stack_SOURCES = info_print_stack.c
 info_stackdump_SOURCES = info_stackdump.c
 info_stackdump2_SOURCES = info_stackdump2.c
 error_SOURCES = error.c
@@ -200,6 +202,7 @@ testing:
 	./ext_thread2
 	./timer
 	./info_print
+	./info_print_stack
 	./info_stackdump
 	./info_stackdump2
 	./error

--- a/test/basic/info_print_stack.c
+++ b/test/basic/info_print_stack.c
@@ -1,0 +1,178 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_THREADS 10
+
+volatile int g_go = 0;
+
+typedef struct thread_arg {
+    int id;
+    int level;
+    void *stack;
+} thread_arg_t;
+
+void user_thread_func_lv4(int level)
+{
+    while (g_go == 0) {
+        int ret = ABT_thread_yield();
+        ATS_ERROR(ret, "ABT_thread_yield");
+    }
+}
+
+void user_thread_func_lv3(int level)
+{
+    if (level == 0) {
+        while (g_go == 0) {
+            int ret = ABT_thread_yield();
+            ATS_ERROR(ret, "ABT_thread_yield");
+        }
+    } else {
+        user_thread_func_lv4(level - 1);
+    }
+    user_thread_func_lv4(level - 1);
+}
+
+void user_thread_func_lv2(int level)
+{
+    if (level == 0) {
+        while (g_go == 0) {
+            int ret = ABT_thread_yield();
+            ATS_ERROR(ret, "ABT_thread_yield");
+        }
+    } else {
+        user_thread_func_lv3(level - 1);
+    }
+    user_thread_func_lv3(level - 1);
+}
+
+void user_thread_func(void *arg)
+{
+    thread_arg_t *t_arg = (thread_arg_t *)arg;
+    int level = t_arg->level;
+    if (level == 0) {
+        while (g_go == 0) {
+            int ret = ABT_thread_yield();
+            ATS_ERROR(ret, "ABT_thread_yield");
+        }
+    } else {
+        user_thread_func_lv2(level - 1);
+    }
+    user_thread_func_lv2(level - 1);
+}
+
+static inline void create_thread(ABT_pool pool, ABT_thread *threads,
+                                 thread_arg_t *args, int i)
+{
+    int ret;
+    args[i].id = i;
+    args[i].level = i % 4;
+    args[i].stack = NULL;
+    if (i % 3 == 0) {
+        ret = ABT_thread_create(pool, user_thread_func, (void *)&args[i],
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    } else if (i % 3 == 1) {
+        ABT_thread_attr attr;
+        ret = ABT_thread_attr_create(&attr);
+        ATS_ERROR(ret, "ABT_thread_attr_create");
+        ret = ABT_thread_attr_set_stacksize(attr, 32768);
+        ATS_ERROR(ret, "ABT_thread_attr_set_stacksize");
+        ret = ABT_thread_create(pool, user_thread_func, (void *)&args[i], attr,
+                                &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+        ret = ABT_thread_attr_free(&attr);
+        ATS_ERROR(ret, "ABT_thread_attr_free");
+    } else {
+        const size_t stacksize = 32768;
+        args[i].stack = malloc(stacksize);
+        ABT_thread_attr attr;
+        ret = ABT_thread_attr_create(&attr);
+        ATS_ERROR(ret, "ABT_thread_attr_create");
+        ret = ABT_thread_attr_set_stack(attr, args[i].stack, stacksize);
+        ATS_ERROR(ret, "ABT_thread_attr_set_stack");
+        ret = ABT_thread_create(pool, user_thread_func, (void *)&args[i], attr,
+                                &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+        ret = ABT_thread_attr_free(&attr);
+        ATS_ERROR(ret, "ABT_thread_attr_free");
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    int ret;
+    int num_threads = DEFAULT_NUM_THREADS;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+    }
+    ATS_init(argc, argv, 1);
+
+    ATS_printf(2, "# of ESs : 1\n");
+    ATS_printf(1, "# of ULTs: %d\n", num_threads);
+
+    ABT_xstream xstream;
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
+    thread_arg_t *args =
+        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_threads);
+
+    /* Create execution streams */
+    ret = ABT_xstream_self(&xstream);
+    ATS_ERROR(ret, "ABT_xstream_self");
+
+    /* Get the pools attached to an execution stream */
+    ABT_pool pool;
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    /* Create the first (num_threads - 4) threads, which will be executed. */
+    for (i = 0; i < num_threads - 4; i++)
+        create_thread(pool, threads, args, i);
+
+    /* Execute some of the threads. */
+    ret = ABT_thread_yield();
+    ATS_ERROR(ret, "ABT_thread_yield");
+
+    /* Create the last four threads, which are not executed. */
+    for (i = num_threads - 4; i < num_threads; i++)
+        create_thread(pool, threads, args, i);
+
+    /* Print unwinded stacks. */
+    for (i = 0; i < num_threads; i++) {
+        printf("threads[%d]:\n", i);
+        ret = ABT_info_print_thread_stack(stdout, threads[i]);
+        ATS_ERROR(ret, "ABT_info_print_thread_stack");
+        printf("\n");
+    }
+    g_go = 1;
+
+    /* Join and free ULTs */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    for (i = 0; i < num_threads; i++) {
+        if (args[i].stack)
+            free(args[i].stack);
+    }
+    free(threads);
+    free(args);
+
+    return ret;
+}


### PR DESCRIPTION
This PR implements a stack unwinding feature in Argobots. This PR should address #101 pointed out by @bfaccini .

## Why it is useful

This stack unwinding feature is for debugging. Specifically, this feature enables a user to dump thread information including ULTs in pools in a more user-friendly manner.

## How to use it

1. Configure Argobots with libunwind (I checked this with libunwind-1.4.0, but it should work with LLVM's libunwind).
```sh
./configure --with-libunwind=LIBUNWIND_INSTALL_PATH --enable-stack-unwind
```
2. Run `ABT_info_print_thread_stack_unwind()` or `ABT_info_trigger_print_all_thread_stacks()`
See https://github.com/shintaro-iwasaki/argobots/blob/supportlibunwind/test/basic/info_stack_unwind.c .

It will print the following (`ABT_info_trigger_print_all_thread_stacks()`), where `thread_func` is a user function. It will show the full stack trace if user functions are nested.
```
=== ULT (0x7f9d8888c780) ===
id        : 10
ctx       : 0x7f9d8888c7e0
  p_ctx    : 0x7f9d8888c4d0
  p_link   : (nil)
stack     : 0x7f9d88888780
stacksize : 16384
#0 0x7f9d8a2b1fc0 in ythread_unwind_stack () <+16> (RSP = 0x7f9d8888c500)
#1 0x7f9d8a2af0ed in ABT_thread_yield () <+189> (RSP = 0x7f9d8888c510)
#2 0x557292d28f8d in thread_func () <+189> (RSP = 0x7f9d8888c530)
#3 0x7f9d8a2b3ece in ABTD_ythread_func_wrapper () <+30> (RSP = 0x7f9d8888c770)
#4 0x7f9d8a2b4071 in make_fcontext () <+33> (RSP = 0x7f9d8888c780)
```

## Performance Impact
By default, this feature is disabled, so this PR does not degrade the performance.

**Enabling this feature degrades the performance on _a non-x86/64 machine_** because I implemented an optimized `peek_fcontext` assembly function only for x86/64. Precisely speaking, the performance is degraded if the underlying architecture is not (x86/64 + fcontext). If ucontext is chosen on x86/64 (= when you manually set `--disable-fcontext`), however, the performance is originally bad, so the overhead added by this feature is almost negligible.

### Q & A
Q: Can't it show code lines and/or values of arguments like GDB when a program is compiled with `-g`?
A: It is not possible with `libunwind`: it needs `dwarfdump` etc. This future work is of low priority. Please use GDB if needed (I guess, with GDB, one can check the stack trace by manually setting RSP and RIP).

Q: Why is a special optimization available only for x86/64?
A: It is because I did not implement `peek_fcontext` for other architectures. There is no fundamental technical difficulty (debugging is tedious, though), so I might support them in the future. Note that, apart from performance, this PR covers all the combinations of architectures and context types (ucontext/fcontext).
