### PR TITLE
error: do not update a variable on failure

### DIFF
--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -42,7 +42,6 @@ fn_exit:
     return abt_errno;
 
 fn_fail:
-    *newpool = ABT_POOL_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -75,7 +74,6 @@ fn_exit:
 
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    *newpool = ABT_POOL_NULL;
     goto fn_exit;
 }
 
@@ -204,20 +202,17 @@ fn_fail:
 int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_unit unit;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    unit = ABTI_pool_pop(p_pool);
+    *p_unit = ABTI_pool_pop(p_pool);
 
 fn_exit:
-    *p_unit = unit;
     return abt_errno;
 
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    unit = ABT_UNIT_NULL;
     goto fn_exit;
 }
 
@@ -244,40 +239,34 @@ fn_fail:
 int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_unit unit;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    unit = ABTI_pool_pop_wait(p_pool, time_secs);
+    *p_unit = ABTI_pool_pop_wait(p_pool, time_secs);
 
 fn_exit:
-    *p_unit = unit;
     return abt_errno;
 
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    unit = ABT_UNIT_NULL;
     goto fn_exit;
 }
 
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_unit unit;
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    unit = ABTI_pool_pop_timedwait(p_pool, abstime_secs);
+    *p_unit = ABTI_pool_pop_timedwait(p_pool, abstime_secs);
 
 fn_exit:
-    *p_unit = unit;
     return abt_errno;
 
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    unit = ABT_UNIT_NULL;
     goto fn_exit;
 }
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -59,7 +59,6 @@ fn_exit:
     return abt_errno;
 
 fn_fail:
-    *newsched = ABT_SCHED_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -111,7 +110,6 @@ fn_exit:
 
 fn_fail:
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    *newsched = ABT_SCHED_NULL;
     goto fn_exit;
 }
 
@@ -291,9 +289,6 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
     int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
-
-    *stop = ABT_FALSE;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -377,15 +372,13 @@ fn_fail:
 int ABT_sched_get_size(ABT_sched sched, size_t *size)
 {
     int abt_errno = ABT_SUCCESS;
-    size_t pool_size = 0;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    pool_size = ABTI_sched_get_size(p_sched);
+    *size = ABTI_sched_get_size(p_sched);
 
 fn_exit:
-    *size = pool_size;
     return abt_errno;
 
 fn_fail:
@@ -420,15 +413,13 @@ size_t ABTI_sched_get_size(ABTI_sched *p_sched)
 int ABT_sched_get_total_size(ABT_sched sched, size_t *size)
 {
     int abt_errno = ABT_SUCCESS;
-    size_t pool_size = 0;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
-    pool_size = ABTI_sched_get_total_size(p_sched);
+    *size = ABTI_sched_get_total_size(p_sched);
 
 fn_exit:
-    *size = pool_size;
     return abt_errno;
 
 fn_fail:

--- a/src/stream.c
+++ b/src/stream.c
@@ -74,7 +74,6 @@ fn_exit:
     return abt_errno;
 
 fn_fail:
-    *newxstream = ABT_XSTREAM_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -177,7 +176,6 @@ fn_exit:
     return abt_errno;
 
 fn_fail:
-    *newxstream = ABT_XSTREAM_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }
@@ -383,7 +381,10 @@ fn_fail:
  *
  * \c ABT_xstream_self() returns the handle to ES object associated with
  * the caller work unit through \c xstream.
- * When an error occurs, \c xstream is set to \c ABT_XSTREAM_NULL.
+ *
+ * At present \c xstream is set to \c ABT_XSTREAM_NULL when an error occurs,
+ * but this behavior is deprecated.  The program should not rely on this
+ * behavior.
  *
  * @param[out] xstream  ES handle
  * @return Error code
@@ -394,16 +395,15 @@ fn_fail:
 int ABT_xstream_self(ABT_xstream *xstream)
 {
     int abt_errno = ABT_SUCCESS;
-    ABT_xstream ret = ABT_XSTREAM_NULL;
+    *xstream = ABT_XSTREAM_NULL;
 
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     /* Return value */
-    ret = ABTI_xstream_get_handle(p_local_xstream);
+    *xstream = ABTI_xstream_get_handle(p_local_xstream);
 
 fn_exit:
-    *xstream = ret;
     return abt_errno;
 
 fn_fail:
@@ -752,16 +752,14 @@ int ABT_xstream_equal(ABT_xstream xstream1, ABT_xstream xstream2,
 int ABT_xstream_get_num(int *num_xstreams)
 {
     int abt_errno = ABT_SUCCESS;
-    int ret = 0;
 
     /* In case that Argobots has not been initialized, return an error code
      * instead of making the call fail. */
     ABTI_SETUP_WITH_INIT_CHECK();
 
-    ret = gp_ABTI_global->num_xstreams;
+    *num_xstreams = gp_ABTI_global->num_xstreams;
 
 fn_exit:
-    *num_xstreams = ret;
     return abt_errno;
 
 fn_fail:

--- a/src/timer.c
+++ b/src/timer.c
@@ -53,7 +53,6 @@ fn_exit:
     return abt_errno;
 
 fn_fail:
-    *newtimer = ABT_TIMER_NULL;
     HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
     goto fn_exit;
 }

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -108,10 +108,10 @@ void *pthread_hello(void *arg)
     assert(ret == ABT_ERR_INV_XSTREAM && type == ABT_UNIT_TYPE_EXT);
 
     ret = ABT_self_is_primary(&flag);
-    assert(ret == ABT_ERR_INV_XSTREAM && flag == ABT_FALSE);
+    assert(ret == ABT_ERR_INV_XSTREAM);
 
     ret = ABT_self_on_primary_xstream(&flag);
-    assert(ret == ABT_ERR_INV_XSTREAM && flag == ABT_FALSE);
+    assert(ret == ABT_ERR_INV_XSTREAM);
 
     ATS_printf(1, "pthread: external thread\n");
 
@@ -145,10 +145,10 @@ int main(int argc, char *argv[])
     assert(ret == ABT_ERR_UNINITIALIZED && type == ABT_UNIT_TYPE_EXT);
 
     ret = ABT_self_is_primary(&flag);
-    assert(ret == ABT_ERR_UNINITIALIZED && flag == ABT_FALSE);
+    assert(ret == ABT_ERR_UNINITIALIZED);
 
     ret = ABT_self_on_primary_xstream(&flag);
-    assert(ret == ABT_ERR_UNINITIALIZED && flag == ABT_FALSE);
+    assert(ret == ABT_ERR_UNINITIALIZED);
 
     /* Initialize */
     ATS_read_args(argc, argv);


### PR DESCRIPTION
## Background

Some Argobots functions return errors for several reasons.  On failure, most Argobots function do not modify values including the Argobots' internal values and arguments given by the user.  This atomic behavior is reasonable: every function should either complete an operation or return an error without any side effect.

A few functions, however, update user-given arguments, which violates this policy and makes the behavior of Argobots functions inconsistent.  For example, `ABT_thread_create()` sets `*thread = ABT_THREAD_NULL` if it is called on any type of failure (e.g., memory allocation failure or calling `ABT_thread_create()` before `ABT_init()`) while `ABT_mutex_create()` does not (`*mutex` will not be modified).  Obviously, Argobots should not modify values on failure; otherwise, it should set `NULL` as `ABT_SUCCESS`.

## Solution

This PR removes side effects on failure so that all functions become atomic.  Unfortunately, it's not complete (e.g., `ABT_init()` might leak memory on failure), but this PR advances it.

Note that there are four functions that return an error code AND change user-given arguments in order to maintain the backward compatibility: `ABT_thread_self()`, `ABT_task_self()`, `ABT_xstream_self()`, `and ABT_self_get_type()`.

## Expected Impact

There is no visible performance impact, but some functions are rewritten not to modify values on failure (although this behavior is not mentioned in the document).  This change can cause a problem if the program relies on such behavior.  Please check a returned error code instead in order to check if there is an error.

If this change breaks the existing code significantly, please let us know so that we can fix it / revert this change.
