### PR TITLE
error: directly return an error without jump

### DIFF
--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -234,7 +234,7 @@ ABTU_ret_err static int read_cpuset(pthread_t native_thread,
     }
     p_cpuset->num_cpuids = num_cpuids;
     ret = ABTU_malloc(sizeof(int) * num_cpuids, (void **)&p_cpuset->cpuids);
-    ABTI_CHECK_ERROR_RET(ret);
+    ABTI_CHECK_ERROR(ret);
     for (i = 0, j = 0; i < CPU_SETSIZE; i++) {
         if (CPU_ISSET(i, &cpuset))
             p_cpuset->cpuids[j++] = i;

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -25,7 +25,7 @@
  */
 int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_barrier *p_newbarrier;
 
     abt_errno = ABTU_malloc(sizeof(ABTI_barrier), (void **)&p_newbarrier);
@@ -38,25 +38,19 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
                             (void **)&p_newbarrier->waiters);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newbarrier);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
     abt_errno = ABTU_malloc(num_waiters * sizeof(ABT_unit_type),
                             (void **)&p_newbarrier->waiter_type);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newbarrier->waiters);
         ABTU_free(p_newbarrier);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
 
     /* Return value */
     *newbarrier = ABTI_barrier_get_handle(p_newbarrier);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -74,10 +68,8 @@ fn_fail:
  */
 int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
-
     ABTI_ASSERT(p_barrier->counter == 0);
 
     /* Only when num_waiters is different from p_barrier->num_waiters, we
@@ -87,6 +79,7 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
         p_barrier->num_waiters = num_waiters;
     } else if (num_waiters > p_barrier->num_waiters) {
         /* Free existing arrays and reallocate them */
+        int abt_errno;
         ABTI_ythread **new_waiters;
         ABT_unit_type *new_waiter_types;
         abt_errno = ABTU_malloc(num_waiters * sizeof(ABTI_ythread *),
@@ -96,7 +89,7 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
                                 (void **)&new_waiter_types);
         if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
             ABTU_free(new_waiters);
-            goto fn_fail;
+            ABTI_HANDLE_ERROR(abt_errno);
         }
         p_barrier->num_waiters = num_waiters;
         ABTU_free(p_barrier->waiters);
@@ -104,13 +97,7 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
         p_barrier->waiters = new_waiters;
         p_barrier->waiter_type = new_waiter_types;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("ABT_barrier_reinit", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -127,7 +114,6 @@ fn_fail:
  */
 int ABT_barrier_free(ABT_barrier *barrier)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_barrier h_barrier = *barrier;
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
@@ -145,13 +131,7 @@ int ABT_barrier_free(ABT_barrier *barrier)
 
     /* Return value */
     *barrier = ABT_BARRIER_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("ABT_barrier_free", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -167,7 +147,6 @@ fn_fail:
  */
 int ABT_barrier_wait(ABT_barrier barrier)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
@@ -244,13 +223,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
 
         ABTI_spinlock_release(&p_barrier->lock);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -268,16 +241,9 @@ fn_fail:
  */
 int ABT_barrier_get_num_waiters(ABT_barrier barrier, uint32_t *num_waiters)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
 
     *num_waiters = p_barrier->num_waiters;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("ABT_barrier_get_num_waiters", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/error.c
+++ b/src/error.c
@@ -80,18 +80,11 @@ int ABT_error_get_str(int err, char *str, size_t *len)
                                      "ABT_ERR_MISSING_JOIN",
                                      "ABT_ERR_FEATURE_NA" };
 
-    int abt_errno = ABT_SUCCESS;
     ABTI_CHECK_TRUE(err >= ABT_SUCCESS && err <= ABT_ERR_FEATURE_NA,
                     ABT_ERR_OTHER);
     if (str)
         strcpy(str, err_str[err]);
     if (len)
         *len = strlen(err_str[err]);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/global.c
+++ b/src/global.c
@@ -87,7 +87,7 @@ int ABT_init(int argc, char **argv)
     /* Create the primary ES */
     ABTI_xstream *p_local_xstream;
     abt_errno = ABTI_xstream_create_primary(&p_local_xstream);
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_xstream_create_primary");
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Init the ES local data */
     ABTI_local_set_xstream(p_local_xstream);
@@ -101,7 +101,7 @@ int ABT_init(int argc, char **argv)
     ABTD_atomic_relaxed_store_int(&p_main_ythread->thread.state,
                                   ABT_THREAD_STATE_RUNNING);
     p_main_ythread->thread.p_last_xstream = p_local_xstream;
-    ABTI_CHECK_ERROR_MSG(abt_errno, "ABTI_ythread_create_main");
+    ABTI_CHECK_ERROR(abt_errno);
     gp_ABTI_global->p_main_ythread = p_main_ythread;
     p_local_xstream->p_thread = &p_main_ythread->thread;
 

--- a/src/global.c
+++ b/src/global.c
@@ -5,6 +5,10 @@
 
 #include "abti.h"
 
+/* Must be in a critical section. */
+ABTU_ret_err static int init_library(void);
+ABTU_ret_err static int finailze_library(void);
+
 /** @defgroup ENV Init & Finalize
  * This group is for initialization and finalization of the Argobots
  * environment.
@@ -41,15 +45,74 @@ int ABT_init(int argc, char **argv)
 {
     ABTI_UNUSED(argc);
     ABTI_UNUSED(argv);
-    int abt_errno = ABT_SUCCESS;
-
-    /* First, take a global lock protecting the initialization/finalization
-     * process. Don't go to fn_exit before taking a lock */
+    /* Take a global lock protecting the initialization/finalization process. */
     ABTI_spinlock_acquire(&g_ABTI_init_lock);
+    int abt_errno = init_library();
+    /* Unlock a global lock */
+    ABTI_spinlock_release(&g_ABTI_init_lock);
+    ABTI_CHECK_ERROR(abt_errno);
+    return ABT_SUCCESS;
+}
 
+/**
+ * @ingroup ENV
+ * @brief   Terminate the Argobots execution environment.
+ *
+ * \c ABT_finalize() terminates the Argobots execution environment and
+ * deallocates memory internally used in Argobots. This function also contains
+ * deallocation of objects for the primary ES and the primary ULT.
+ *
+ * \c ABT_finalize() must be called by the primary ULT. Invoking the Argobots
+ * functions after \c ABT_finalize() is not allowed. To use the Argobots
+ * functions after calling \c ABT_finalize(), \c ABT_init() needs to be called
+ * again.
+ *
+ * @return Error code
+ * @retval ABT_SUCCESS on success
+ */
+int ABT_finalize(void)
+{
+    /* Take a global lock protecting the initialization/finalization process. */
+    ABTI_spinlock_acquire(&g_ABTI_init_lock);
+    int abt_errno = finailze_library();
+    /* Unlock a global lock */
+    ABTI_spinlock_release(&g_ABTI_init_lock);
+    ABTI_CHECK_ERROR(abt_errno);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup ENV
+ * @brief   Check whether \c ABT_init() has been called.
+ *
+ * \c ABT_initialized() returns \c ABT_SUCCESS if the Argobots execution
+ * environment has been initialized. Otherwise, it returns
+ * \c ABT_ERR_UNINITIALIZED.
+ *
+ * @return Error code
+ * @retval ABT_SUCCESS           if the environment has been initialized.
+ * @retval ABT_ERR_UNINITIALIZED if the environment has not been initialized.
+ */
+int ABT_initialized(void)
+{
+    if (ABTD_atomic_acquire_load_uint32(&g_ABTI_initialized) == 0) {
+        return ABT_ERR_UNINITIALIZED;
+    } else {
+        return ABT_SUCCESS;
+    }
+}
+
+/*****************************************************************************/
+/* Internal static functions                                                 */
+/*****************************************************************************/
+
+ABTU_ret_err static int init_library(void)
+{
+    int abt_errno;
     /* If Argobots has already been initialized, just return */
-    if (g_ABTI_num_inits++ > 0)
-        goto fn_exit;
+    if (g_ABTI_num_inits++ > 0) {
+        return ABT_SUCCESS;
+    }
 
     abt_errno = ABTU_malloc(sizeof(ABTI_global), (void **)&gp_ABTI_global);
     ABTI_CHECK_ERROR(abt_errno);
@@ -113,50 +176,19 @@ int ABT_init(int argc, char **argv)
         ABTI_info_print_config(stdout);
     }
     ABTD_atomic_release_store_uint32(&g_ABTI_initialized, 1);
-
-fn_exit:
-    /* Unlock a global lock */
-    ABTI_spinlock_release(&g_ABTI_init_lock);
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
-/**
- * @ingroup ENV
- * @brief   Terminate the Argobots execution environment.
- *
- * \c ABT_finalize() terminates the Argobots execution environment and
- * deallocates memory internally used in Argobots. This function also contains
- * deallocation of objects for the primary ES and the primary ULT.
- *
- * \c ABT_finalize() must be called by the primary ULT. Invoking the Argobots
- * functions after \c ABT_finalize() is not allowed. To use the Argobots
- * functions after calling \c ABT_finalize(), \c ABT_init() needs to be called
- * again.
- *
- * @return Error code
- * @retval ABT_SUCCESS on success
- */
-int ABT_finalize(void)
+ABTU_ret_err static int finailze_library(void)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
 
-    /* First, take a global lock protecting the initialization/finalization
-     * process. Don't go to fn_exit before taking a lock */
-    ABTI_spinlock_acquire(&g_ABTI_init_lock);
-
     /* If Argobots is not initialized, just return */
-    if (g_ABTI_num_inits == 0) {
-        abt_errno = ABT_ERR_UNINITIALIZED;
-        goto fn_exit;
-    }
+    ABTI_CHECK_TRUE(g_ABTI_num_inits > 0, ABT_ERR_UNINITIALIZED);
     /* If Argobots is still referenced by others, just return */
-    if (--g_ABTI_num_inits != 0)
-        goto fn_exit;
+    if (--g_ABTI_num_inits != 0) {
+        return ABT_SUCCESS;
+    }
 
     ABTI_xstream *p_local_xstream = ABTI_local_get_xstream_or_null(p_local);
     /* If called by an external thread, return an error. */
@@ -219,36 +251,5 @@ int ABT_finalize(void)
     ABTU_free(gp_ABTI_global);
     gp_ABTI_global = NULL;
     ABTD_atomic_release_store_uint32(&g_ABTI_initialized, 0);
-
-fn_exit:
-    /* Unlock a global lock */
-    ABTI_spinlock_release(&g_ABTI_init_lock);
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
-}
-
-/**
- * @ingroup ENV
- * @brief   Check whether \c ABT_init() has been called.
- *
- * \c ABT_initialized() returns \c ABT_SUCCESS if the Argobots execution
- * environment has been initialized. Otherwise, it returns
- * \c ABT_ERR_UNINITIALIZED.
- *
- * @return Error code
- * @retval ABT_SUCCESS           if the environment has been initialized.
- * @retval ABT_ERR_UNINITIALIZED if the environment has not been initialized.
- */
-int ABT_initialized(void)
-{
-    int abt_errno = ABT_SUCCESS;
-
-    if (ABTD_atomic_acquire_load_uint32(&g_ABTI_initialized) == 0) {
-        abt_errno = ABT_ERR_UNINITIALIZED;
-    }
-
-    return abt_errno;
+    return ABT_SUCCESS;
 }

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -71,7 +71,7 @@ ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond, ABTI_mutex *p_mutex)
     if (!p_ythread) {
         /* external thread or non-yieldable thread */
         int abt_errno = ABTU_calloc(1, sizeof(ABTI_thread), (void **)&p_thread);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_thread->type = ABTI_THREAD_TYPE_EXT;
         /* use state for synchronization */
         ABTD_atomic_relaxed_store_int(&p_thread->state,

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -91,15 +91,6 @@
         }                                                                      \
     } while (0)
 
-#define ABTI_CHECK_ERROR_MSG(abt_errno, msg)                                   \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
-            HANDLE_ERROR(msg);                                                 \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
 #define ABTI_CHECK_ERROR_RET(abt_errno)                                        \
     do {                                                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -21,291 +21,6 @@
         ((void)sizeof(char[2 * !!(cond)-1]));                                  \
     } while (0)
 
-#define ABTI_SETUP_WITH_INIT_CHECK()                                           \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(gp_ABTI_global == NULL)) {                           \
-            abt_errno = ABT_ERR_UNINITIALIZED;                                 \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_XSTREAM(pp_local_xstream)                             \
-    do {                                                                       \
-        ABTI_xstream *p_local_xstream_tmp =                                    \
-            ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
-        if (ABTI_IS_EXT_THREAD_ENABLED &&                                      \
-            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
-            abt_errno = ABT_ERR_INV_XSTREAM;                                   \
-            goto fn_fail;                                                      \
-        }                                                                      \
-        ABTI_xstream **pp_local_xstream_tmp = (pp_local_xstream);              \
-        if (pp_local_xstream_tmp) {                                            \
-            *pp_local_xstream_tmp = p_local_xstream_tmp;                       \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_YTHREAD(pp_local_xstream, pp_ythread)                 \
-    do {                                                                       \
-        ABTI_xstream *p_local_xstream_tmp =                                    \
-            ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTI_IS_EXT_THREAD_ENABLED &&       \
-            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
-            abt_errno = ABT_ERR_INV_XSTREAM;                                   \
-            goto fn_fail;                                                      \
-        }                                                                      \
-        ABTI_xstream **pp_local_xstream_tmp = (pp_local_xstream);              \
-        if (pp_local_xstream_tmp) {                                            \
-            *pp_local_xstream_tmp = p_local_xstream_tmp;                       \
-        }                                                                      \
-        ABTI_thread *p_thread_tmp = p_local_xstream_tmp->p_thread;             \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(                                                     \
-                !(p_thread_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {         \
-            abt_errno = ABT_ERR_INV_THREAD;                                    \
-            goto fn_fail;                                                      \
-        }                                                                      \
-        ABTI_ythread **pp_ythread_tmp = (pp_ythread);                          \
-        if (pp_ythread_tmp) {                                                  \
-            *pp_ythread_tmp = ABTI_thread_get_ythread(p_thread_tmp);           \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(pp_local_xstream)             \
-    do {                                                                       \
-        ABTI_SETUP_WITH_INIT_CHECK();                                          \
-        ABTI_SETUP_LOCAL_XSTREAM(pp_local_xstream);                            \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(pp_local_xstream, pp_ythread) \
-    do {                                                                       \
-        ABTI_SETUP_WITH_INIT_CHECK();                                          \
-        ABTI_SETUP_LOCAL_YTHREAD(pp_local_xstream, pp_ythread);                \
-    } while (0)
-
-#define ABTI_CHECK_ERROR(abt_errno)                                            \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_ERROR_RET(abt_errno)                                        \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {                         \
-            return abt_errno;                                                  \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_TRUE(cond, val)                                             \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
-            abt_errno = (val);                                                 \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_TRUE_RET(cond, val)                                         \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
-            return (val);                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_YIELDABLE(p_thread, pp_ythread, err)                        \
-    do {                                                                       \
-        ABTI_thread *p_tmp = (p_thread);                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(!(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {      \
-            abt_errno = (err);                                                 \
-            goto fn_fail;                                                      \
-        }                                                                      \
-        *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
-    } while (0)
-
-#define ABTI_CHECK_YIELDABLE_RET(p_thread, pp_ythread, err)                    \
-    do {                                                                       \
-        ABTI_thread *p_tmp = (p_thread);                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(!(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {      \
-            return (err);                                                      \
-        }                                                                      \
-        *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
-    } while (0)
-
-#define ABTI_CHECK_TRUE_MSG(cond, val, msg)                                    \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
-            abt_errno = (val);                                                 \
-            HANDLE_ERROR(msg);                                                 \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                         \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_xstream *)NULL)) {                        \
-            abt_errno = ABT_ERR_INV_XSTREAM;                                   \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_POOL_PTR(p)                                            \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_pool *)NULL)) {                           \
-            abt_errno = ABT_ERR_INV_POOL;                                      \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_SCHED_PTR(p)                                           \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_sched *)NULL)) {                          \
-            abt_errno = ABT_ERR_INV_SCHED;                                     \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
-            abt_errno = ABT_ERR_INV_THREAD;                                    \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_YTHREAD_PTR(p)                                         \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_ythread *)NULL)) {                        \
-            abt_errno = ABT_ERR_INV_THREAD;                                    \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                     \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_thread_attr *)NULL)) {                    \
-            abt_errno = ABT_ERR_INV_THREAD_ATTR;                               \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
-            abt_errno = ABT_ERR_INV_TASK;                                      \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_KEY_PTR(p)                                             \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_key *)NULL)) {                            \
-            abt_errno = ABT_ERR_INV_KEY;                                       \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_MUTEX_PTR(p)                                           \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_mutex *)NULL)) {                          \
-            abt_errno = ABT_ERR_INV_MUTEX;                                     \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                      \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_mutex_attr *)NULL)) {                     \
-            abt_errno = ABT_ERR_INV_MUTEX_ATTR;                                \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_COND_PTR(p)                                            \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_cond *)NULL)) {                           \
-            abt_errno = ABT_ERR_INV_COND;                                      \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                          \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_rwlock *)NULL)) {                         \
-            abt_errno = ABT_ERR_INV_RWLOCK;                                    \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_FUTURE_PTR(p)                                          \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_future *)NULL)) {                         \
-            abt_errno = ABT_ERR_INV_FUTURE;                                    \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                        \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_eventual *)NULL)) {                       \
-            abt_errno = ABT_ERR_INV_EVENTUAL;                                  \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_BARRIER_PTR(p)                                         \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_barrier *)NULL)) {                        \
-            abt_errno = ABT_ERR_INV_BARRIER;                                   \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)                                 \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_xstream_barrier *)NULL)) {                \
-            abt_errno = ABT_ERR_INV_BARRIER;                                   \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_TIMER_PTR(p)                                           \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_timer *)NULL)) {                          \
-            abt_errno = ABT_ERR_INV_TIMER;                                     \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
-#define ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p)                                    \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(p == (ABTI_tool_context *)NULL)) {                   \
-            abt_errno = ABT_ERR_INV_TOOL_CONTEXT;                              \
-            goto fn_fail;                                                      \
-        }                                                                      \
-    } while (0)
-
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
 #define ABTI_IS_PRINT_ABT_ERRNO_ENABLED 1
 #else
@@ -341,10 +56,273 @@
         }                                                                      \
     } while (0)
 
-#define HANDLE_ERROR_FUNC_WITH_CODE_RET(n)                                     \
+#define ABTI_SETUP_WITH_INIT_CHECK()                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(gp_ABTI_global == NULL)) {                           \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_UNINITIALIZED);                \
+            return ABT_ERR_UNINITIALIZED;                                      \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_SETUP_LOCAL_XSTREAM(pp_local_xstream)                             \
+    do {                                                                       \
+        ABTI_xstream *p_local_xstream_tmp =                                    \
+            ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
+        if (ABTI_IS_EXT_THREAD_ENABLED &&                                      \
+            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_XSTREAM);                  \
+            return ABT_ERR_INV_XSTREAM;                                        \
+        }                                                                      \
+        ABTI_xstream **pp_local_xstream_tmp = (pp_local_xstream);              \
+        if (pp_local_xstream_tmp) {                                            \
+            *pp_local_xstream_tmp = p_local_xstream_tmp;                       \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_SETUP_LOCAL_YTHREAD(pp_local_xstream, pp_ythread)                 \
+    do {                                                                       \
+        ABTI_xstream *p_local_xstream_tmp =                                    \
+            ABTI_local_get_xstream_or_null(ABTI_local_get_local());            \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTI_IS_EXT_THREAD_ENABLED &&       \
+            ABTU_unlikely(p_local_xstream_tmp == NULL)) {                      \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_XSTREAM);                  \
+            return ABT_ERR_INV_XSTREAM;                                        \
+        }                                                                      \
+        ABTI_xstream **pp_local_xstream_tmp = (pp_local_xstream);              \
+        if (pp_local_xstream_tmp) {                                            \
+            *pp_local_xstream_tmp = p_local_xstream_tmp;                       \
+        }                                                                      \
+        ABTI_thread *p_thread_tmp = p_local_xstream_tmp->p_thread;             \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(                                                     \
+                !(p_thread_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {         \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_THREAD);                   \
+            return ABT_ERR_INV_THREAD;                                         \
+        }                                                                      \
+        ABTI_ythread **pp_ythread_tmp = (pp_ythread);                          \
+        if (pp_ythread_tmp) {                                                  \
+            *pp_ythread_tmp = ABTI_thread_get_ythread(p_thread_tmp);           \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(pp_local_xstream)             \
+    do {                                                                       \
+        ABTI_SETUP_WITH_INIT_CHECK();                                          \
+        ABTI_SETUP_LOCAL_XSTREAM(pp_local_xstream);                            \
+    } while (0)
+
+#define ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(pp_local_xstream, pp_ythread) \
+    do {                                                                       \
+        ABTI_SETUP_WITH_INIT_CHECK();                                          \
+        ABTI_SETUP_LOCAL_YTHREAD(pp_local_xstream, pp_ythread);                \
+    } while (0)
+
+#define ABTI_HANDLE_ERROR(n)                                                   \
     do {                                                                       \
         HANDLE_ERROR_FUNC_WITH_CODE(n);                                        \
         return n;                                                              \
+    } while (0)
+
+#define ABTI_CHECK_ERROR(abt_errno)                                            \
+    do {                                                                       \
+        int abt_errno_ = (abt_errno);                                          \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(abt_errno_ != ABT_SUCCESS)) {                        \
+            HANDLE_ERROR_FUNC_WITH_CODE(abt_errno_);                           \
+            return abt_errno_;                                                 \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_TRUE(cond, abt_errno)                                       \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
+            int abt_errno_ = (abt_errno);                                      \
+            HANDLE_ERROR_FUNC_WITH_CODE(abt_errno_);                           \
+            return abt_errno_;                                                 \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_YIELDABLE(p_thread, pp_ythread, abt_errno)                  \
+    do {                                                                       \
+        ABTI_thread *p_tmp = (p_thread);                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(!(p_tmp->type & ABTI_THREAD_TYPE_YIELDABLE))) {      \
+            int abt_errno_ = (abt_errno);                                      \
+            HANDLE_ERROR_FUNC_WITH_CODE(abt_errno_);                           \
+            return abt_errno_;                                                 \
+        }                                                                      \
+        *(pp_ythread) = ABTI_thread_get_ythread(p_tmp);                        \
+    } while (0)
+
+#define ABTI_CHECK_TRUE_MSG(cond, abt_errno, msg)                              \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
+            HANDLE_ERROR(msg);                                                 \
+            return (abt_errno);                                                \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_xstream *)NULL)) {                        \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_XSTREAM);                  \
+            return ABT_ERR_INV_XSTREAM;                                        \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_POOL_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_pool *)NULL)) {                           \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_POOL);                     \
+            return ABT_ERR_INV_POOL;                                           \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_SCHED_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_sched *)NULL)) {                          \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_SCHED);                    \
+            return ABT_ERR_INV_SCHED;                                          \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_THREAD);                   \
+            return ABT_ERR_INV_THREAD;                                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_YTHREAD_PTR(p)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_ythread *)NULL)) {                        \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_THREAD);                   \
+            return ABT_ERR_INV_THREAD;                                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_THREAD_ATTR_PTR(p)                                     \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread_attr *)NULL)) {                    \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_THREAD_ATTR);              \
+            return ABT_ERR_INV_THREAD_ATTR;                                    \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_TASK_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_thread *)NULL)) {                         \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_TASK);                     \
+            return ABT_ERR_INV_TASK;                                           \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_KEY_PTR(p)                                             \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_key *)NULL)) {                            \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_KEY);                      \
+            return ABT_ERR_INV_KEY;                                            \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_MUTEX_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_mutex *)NULL)) {                          \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_MUTEX);                    \
+            return ABT_ERR_INV_MUTEX;                                          \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p)                                      \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_mutex_attr *)NULL)) {                     \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_MUTEX_ATTR);               \
+            return ABT_ERR_INV_MUTEX_ATTR;                                     \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_COND_PTR(p)                                            \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_cond *)NULL)) {                           \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_COND);                     \
+            return ABT_ERR_INV_COND;                                           \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_RWLOCK_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_rwlock *)NULL)) {                         \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_RWLOCK);                   \
+            return ABT_ERR_INV_RWLOCK;                                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_FUTURE_PTR(p)                                          \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_future *)NULL)) {                         \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_FUTURE);                   \
+            return ABT_ERR_INV_FUTURE;                                         \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_EVENTUAL_PTR(p)                                        \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_eventual *)NULL)) {                       \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_EVENTUAL);                 \
+            return ABT_ERR_INV_EVENTUAL;                                       \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_BARRIER_PTR(p)                                         \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_barrier *)NULL)) {                        \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_BARRIER);                  \
+            return ABT_ERR_INV_BARRIER;                                        \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p)                                 \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_xstream_barrier *)NULL)) {                \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_XSTREAM_BARRIER);          \
+            return ABT_ERR_INV_XSTREAM_BARRIER;                                \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_TIMER_PTR(p)                                           \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_timer *)NULL)) {                          \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_TIMER);                    \
+            return ABT_ERR_INV_TIMER;                                          \
+        }                                                                      \
+    } while (0)
+
+#define ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p)                                    \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_tool_context *)NULL)) {                   \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_TOOL_CONTEXT);             \
+            return ABT_ERR_INV_TOOL_CONTEXT;                                   \
+        }                                                                      \
     } while (0)
 
 #endif /* ABTI_ERROR_H_INCLUDED */

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -144,14 +144,6 @@
         }                                                                      \
     } while (0)
 
-#define ABTI_CHECK_TRUE_MSG_RET(cond, val, msg)                                \
-    do {                                                                       \
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!(cond))) {           \
-            HANDLE_ERROR(msg);                                                 \
-            return (val);                                                      \
-        }                                                                      \
-    } while (0)
-
 #define ABTI_CHECK_NULL_XSTREAM_PTR(p)                                         \
     do {                                                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -83,7 +83,7 @@ ABTU_ret_err static inline int ABTI_ktable_create(ABTI_local *p_local,
         /* Use memory pool. */
         void *p_mem;
         int abt_errno = ABTI_mem_alloc_desc(p_local, &p_mem);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
         p_ktable =
             (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
@@ -97,7 +97,7 @@ ABTU_ret_err static inline int ABTI_ktable_create(ABTI_local *p_local,
         void *p_mem;
         int abt_errno =
             ABTU_malloc(ktable_size + sizeof(ABTI_ktable_mem_header), &p_mem);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
         p_ktable =
             (ABTI_ktable *)(((char *)p_mem) + sizeof(ABTI_ktable_mem_header));
@@ -132,7 +132,7 @@ ABTU_ret_err static inline int ABTI_ktable_alloc_elem(ABTI_local *p_local,
         /* Use memory pool. */
         void *p_mem;
         int abt_errno = ABTI_mem_alloc_desc(p_local, &p_mem);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
         p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
         p_header->is_from_mempool = ABT_TRUE;
@@ -147,7 +147,7 @@ ABTU_ret_err static inline int ABTI_ktable_alloc_elem(ABTI_local *p_local,
         void *p_mem;
         int abt_errno =
             ABTU_malloc(size + sizeof(ABTI_ktable_mem_header), &p_mem);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTI_ktable_mem_header *p_header = (ABTI_ktable_mem_header *)p_mem;
         p_header->p_next = (ABTI_ktable_mem_header *)p_ktable->p_used_mem;
         p_header->is_from_mempool = ABT_FALSE;
@@ -234,7 +234,7 @@ ABTU_ret_err static inline int ABTI_ktable_set(ABTI_local *p_local,
                                               ABTI_KTABLE_LOCKED)) {
                 /* The lock was acquired, so let's allocate this table. */
                 abt_errno = ABTI_ktable_create(p_local, &p_ktable);
-                ABTI_CHECK_ERROR_RET(abt_errno);
+                ABTI_CHECK_ERROR(abt_errno);
 
                 /* Write down the value.  The lock is released here. */
                 ABTD_atomic_release_store_ptr(pp_ktable, p_ktable);
@@ -258,7 +258,7 @@ ABTU_ret_err static inline int ABTI_ktable_set(ABTI_local *p_local,
         }
     }
     abt_errno = ABTI_ktable_set_impl(p_local, p_ktable, p_key, value, ABT_TRUE);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
 
@@ -271,12 +271,12 @@ ABTU_ret_err static inline int ABTI_ktable_set_unsafe(ABTI_local *p_local,
     ABTI_ktable *p_ktable = *pp_ktable;
     if (!p_ktable) {
         abt_errno = ABTI_ktable_create(p_local, &p_ktable);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         *pp_ktable = p_ktable;
     }
     abt_errno =
         ABTI_ktable_set_impl(p_local, p_ktable, p_key, value, ABT_FALSE);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -36,7 +36,7 @@ ABTI_mem_alloc_nythread_malloc(ABTI_thread **pp_thread)
     ABTI_thread *p_thread;
     int abt_errno =
         ABTU_malloc(ABTI_MEM_POOL_DESC_ELEM_SIZE, (void **)&p_thread);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     p_thread->type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC;
     *pp_thread = p_thread;
     return ABT_SUCCESS;
@@ -55,7 +55,7 @@ ABTI_mem_alloc_nythread_mempool(ABTI_local *p_local, ABTI_thread **pp_thread)
     ABTI_thread *p_thread;
     int abt_errno = ABTI_mem_pool_alloc(&p_local_xstream->mem_pool_desc,
                                         (void **)&p_thread);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     p_thread->type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC;
     *pp_thread = p_thread;
     return ABT_SUCCESS;
@@ -106,7 +106,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
     ABTI_ASSERT((stacksize & (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0);
     void *p_ythread;
     int abt_errno = ABTI_mem_pool_alloc(p_mem_pool_stack, &p_ythread);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     *pp_stack = (void *)(((char *)p_ythread) - stacksize);
     *pp_ythread = (ABTI_ythread *)p_ythread;
@@ -124,7 +124,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack_impl(
     char *p_stack;
     int abt_errno =
         ABTU_malloc(alloc_stacksize + sizeof(ABTI_ythread), (void **)&p_stack);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     *pp_stack = (void *)p_stack;
     *pp_ythread = (ABTI_ythread *)(p_stack + alloc_stacksize);
@@ -143,19 +143,19 @@ ABTI_mem_alloc_ythread_default(ABTI_local *p_local, ABTI_ythread **pp_ythread)
         int abt_errno =
             ABTI_mem_alloc_ythread_malloc_desc_stack_impl(stacksize, &p_ythread,
                                                           &p_stack);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
     } else {
 #ifdef ABT_CONFIG_USE_MEM_POOL
         int abt_errno = ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
             &p_local_xstream->mem_pool_stack, stacksize, &p_ythread, &p_stack);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
 #else
         int abt_errno =
             ABTI_mem_alloc_ythread_malloc_desc_stack_impl(stacksize, &p_ythread,
                                                           &p_stack);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
 #endif
     }
@@ -180,12 +180,12 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
         int abt_errno =
             ABTI_mem_alloc_ythread_malloc_desc_stack_impl(stacksize, &p_ythread,
                                                           &p_stack);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
     } else {
         int abt_errno = ABTI_mem_alloc_ythread_mempool_desc_stack_impl(
             &p_local_xstream->mem_pool_stack, stacksize, &p_ythread, &p_stack);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
     }
     /* Copy members of p_attr. */
@@ -207,7 +207,7 @@ ABTI_mem_alloc_ythread_malloc_desc_stack(ABTI_thread_attr *p_attr,
     int abt_errno =
         ABTI_mem_alloc_ythread_malloc_desc_stack_impl(stacksize, &p_ythread,
                                                       &p_stack);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Copy members of p_attr. */
     p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
@@ -227,11 +227,11 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc(
         ABTI_STATIC_ASSERT(offsetof(ABTI_ythread, thread) == 0);
         int abt_errno =
             ABTI_mem_alloc_nythread(p_local, (ABTI_thread **)&p_ythread);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
     } else {
         /* Do not allocate stack, but Valgrind registration is preferred. */
         int abt_errno = ABTU_malloc(sizeof(ABTI_ythread), (void **)&p_ythread);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC;
     }
     /* Copy members of p_attr. */
@@ -306,7 +306,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_desc(ABTI_local *p_local,
     if (ABTI_IS_EXT_THREAD_ENABLED && p_local_xstream == NULL) {
         /* For external threads */
         int abt_errno = ABTU_malloc(ABTI_MEM_POOL_DESC_SIZE, &p_desc);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         *(uint32_t *)(((char *)p_desc) + ABTI_MEM_POOL_DESC_SIZE) = 1;
         *pp_desc = p_desc;
         return ABT_SUCCESS;
@@ -314,7 +314,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_desc(ABTI_local *p_local,
         /* Find the page that has an empty block */
         int abt_errno =
             ABTI_mem_pool_alloc(&p_local_xstream->mem_pool_desc, &p_desc);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         /* To distinguish it from a malloc'ed case, assign non-NULL value. */
         *(uint32_t *)(((char *)p_desc) + ABTI_MEM_POOL_DESC_SIZE) = 0;
         *pp_desc = p_desc;

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -45,7 +45,7 @@ ABTU_ret_err static inline int ABTI_mutex_init(ABTI_mutex *p_mutex)
 #ifndef ABT_CONFIG_USE_SIMPLE_MUTEX
     int abt_errno = ABTI_ythread_htable_create(gp_ABTI_global->max_xstreams,
                                                &p_mutex->p_htable);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     p_mutex->p_handover = NULL;
     p_mutex->p_giver = NULL;
 #endif

--- a/src/info.c
+++ b/src/info.c
@@ -115,7 +115,6 @@ static void info_trigger_print_all_thread_stacks(
  */
 int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_SETUP_WITH_INIT_CHECK();
 
     switch (query_kind) {
@@ -226,17 +225,10 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         default:
-            abt_errno = ABT_ERR_INV_QUERY_KIND;
-            ABTI_CHECK_ERROR(abt_errno);
+            ABTI_HANDLE_ERROR(ABT_ERR_INV_QUERY_KIND);
             break;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -253,17 +245,10 @@ fn_fail:
  */
 int ABT_info_print_config(FILE *fp)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_SETUP_WITH_INIT_CHECK();
 
     ABTI_info_print_config(fp);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -280,7 +265,6 @@ fn_fail:
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_SETUP_WITH_INIT_CHECK();
 
     ABTI_global *p_global = gp_ABTI_global;
@@ -298,13 +282,7 @@ int ABT_info_print_all_xstreams(FILE *fp)
     ABTI_spinlock_release(&p_global->xstream_list_lock);
 
     fflush(fp);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -321,18 +299,11 @@ fn_fail:
  */
 int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     ABTI_xstream_print(p_xstream, fp, 0, ABT_FALSE);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -349,18 +320,11 @@ fn_fail:
  */
 int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     ABTI_sched_print(p_sched, fp, 0, ABT_TRUE);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -377,18 +341,11 @@ fn_fail:
  */
 int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     ABTI_pool_print(p_pool, fp, 0);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -405,18 +362,11 @@ fn_fail:
  */
 int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
     ABTI_thread_print(p_thread, fp, 0);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -434,18 +384,11 @@ fn_fail:
  */
 int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     ABTI_thread_attr_print(p_attr, fp, 0);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 #ifdef ABT_CONFIG_USE_DOXYGEN
@@ -478,20 +421,13 @@ int ABT_info_print_task(FILE *fp, ABT_task task);
  */
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_ythread *p_ythread;
     ABTI_CHECK_YIELDABLE(p_thread, &p_ythread, ABT_ERR_INV_THREAD);
 
     ABTI_ythread_print_stack(p_ythread, fp);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -509,19 +445,12 @@ fn_fail:
  */
 int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = info_print_thread_stacks_in_pool(fp, p_pool);
+    int abt_errno = info_print_thread_stacks_in_pool(fp, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -833,7 +762,7 @@ info_initialize_pool_set(struct info_pool_set_t *p_set)
     size_t default_len = 16;
     int abt_errno =
         ABTU_malloc(sizeof(ABT_pool) * default_len, (void **)&p_set->pools);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     p_set->num = 0;
     p_set->len = default_len;
     return ABT_SUCCESS;
@@ -858,7 +787,7 @@ ABTU_ret_err static inline int info_add_pool_set(ABT_pool pool,
         int abt_errno =
             ABTU_realloc(sizeof(ABT_pool) * p_set->len,
                          sizeof(ABT_pool) * new_len, (void **)&p_set->pools);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         p_set->len = new_len;
     }
     p_set->pools[p_set->num++] = pool;

--- a/src/key.c
+++ b/src/key.c
@@ -41,22 +41,15 @@ static ABTD_atomic_uint32 g_key_id =
  */
 int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_key *p_newkey;
-
-    abt_errno = ABTU_malloc(sizeof(ABTI_key), (void **)&p_newkey);
+    int abt_errno = ABTU_malloc(sizeof(ABTI_key), (void **)&p_newkey);
     ABTI_CHECK_ERROR(abt_errno);
+
     p_newkey->f_destructor = destructor;
     p_newkey->id = ABTD_atomic_fetch_add_uint32(&g_key_id, 1);
     /* Return value */
     *newkey = ABTI_key_get_handle(p_newkey);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -74,7 +67,6 @@ fn_fail:
  */
 int ABT_key_free(ABT_key *key)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_key h_key = *key;
     ABTI_key *p_key = ABTI_key_get_ptr(h_key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
@@ -82,13 +74,7 @@ int ABT_key_free(ABT_key *key)
 
     /* Return value */
     *key = ABT_KEY_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -106,8 +92,6 @@ fn_fail:
  */
 int ABT_key_set(ABT_key key, void *value)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
@@ -115,17 +99,11 @@ int ABT_key_set(ABT_key key, void *value)
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
     /* Obtain the key-value table pointer. */
-    abt_errno =
+    int abt_errno =
         ABTI_ktable_set(ABTI_xstream_get_local(p_local_xstream),
                         &p_local_xstream->p_thread->p_keytable, p_key, value);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -146,8 +124,6 @@ fn_fail:
  */
 int ABT_key_get(ABT_key key, void **value)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
@@ -157,13 +133,7 @@ int ABT_key_get(ABT_key key, void **value)
 
     /* Obtain the key-value table pointer */
     *value = ABTI_ktable_get(&p_local_xstream->p_thread->p_keytable, p_key);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 void ABTI_ktable_free(ABTI_local *p_local, ABTI_ktable *p_ktable)

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -37,7 +37,7 @@ static inline void mutex_unlock_se(ABTI_local **pp_local, ABTI_mutex *p_mutex);
  */
 int ABT_mutex_create(ABT_mutex *newmutex)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_mutex *p_newmutex;
 
     abt_errno = ABTU_calloc(1, sizeof(ABTI_mutex), (void **)&p_newmutex);
@@ -45,18 +45,12 @@ int ABT_mutex_create(ABT_mutex *newmutex)
     abt_errno = ABTI_mutex_init(p_newmutex);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newmutex);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
 
     /* Return value */
     *newmutex = ABTI_mutex_get_handle(p_newmutex);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -77,7 +71,7 @@ fn_fail:
  */
 int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
     ABTI_mutex *p_newmutex;
@@ -87,19 +81,13 @@ int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
     abt_errno = ABTI_mutex_init(p_newmutex);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newmutex);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
     memcpy(&p_newmutex->attr, p_attr, sizeof(ABTI_mutex_attr));
 
     /* Return value */
     *newmutex = ABTI_mutex_get_handle(p_newmutex);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -119,7 +107,6 @@ fn_fail:
  */
 int ABT_mutex_free(ABT_mutex *mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_mutex h_mutex = *mutex;
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(h_mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
@@ -129,13 +116,7 @@ int ABT_mutex_free(ABT_mutex *mutex)
 
     /* Return value */
     *mutex = ABT_MUTEX_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -158,7 +139,6 @@ fn_fail:
  */
 int ABT_mutex_lock(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
@@ -182,13 +162,7 @@ int ABT_mutex_lock(ABT_mutex mutex)
         /* unknown attributes */
         ABTI_mutex_lock(&p_local, p_mutex);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -206,7 +180,6 @@ fn_fail:
  */
 int ABT_mutex_lock_low(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
@@ -230,13 +203,7 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
         /* unknown attributes */
         mutex_lock_low(&p_local, p_mutex);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 int ABT_mutex_lock_high(ABT_mutex mutex)
@@ -263,10 +230,10 @@ int ABT_mutex_lock_high(ABT_mutex mutex)
  */
 int ABT_mutex_trylock(ABT_mutex mutex)
 {
-    int abt_errno;
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
+    int abt_errno;
     if (p_mutex->attr.attrs == ABTI_MUTEX_ATTR_NONE) {
         /* default attributes */
         abt_errno = ABTI_mutex_trylock(p_mutex);
@@ -290,13 +257,8 @@ int ABT_mutex_trylock(ABT_mutex mutex)
         /* unknown attributes */
         abt_errno = ABTI_mutex_trylock(p_mutex);
     }
-
-fn_exit:
+    /* Trylock always needs to return an error code. */
     return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
 }
 
 /**
@@ -315,7 +277,6 @@ fn_fail:
  */
 int ABT_mutex_spinlock(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
@@ -339,13 +300,7 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
         /* unknown attributes */
         ABTI_mutex_spinlock(p_mutex);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -362,7 +317,6 @@ fn_fail:
  */
 int ABT_mutex_unlock(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
@@ -387,13 +341,7 @@ int ABT_mutex_unlock(ABT_mutex mutex)
         /* unknown attributes */
         ABTI_mutex_unlock(p_local, p_mutex);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -415,7 +363,6 @@ fn_fail:
  */
 int ABT_mutex_unlock_se(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
@@ -440,30 +387,17 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
         /* unknown attributes */
         mutex_unlock_se(&p_local, p_mutex);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 int ABT_mutex_unlock_de(ABT_mutex mutex)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 
     ABTI_mutex_unlock(p_local, p_mutex);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -25,10 +25,9 @@
  */
 int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_mutex_attr *p_newattr;
 
-    abt_errno = ABTU_malloc(sizeof(ABTI_mutex_attr), (void **)&p_newattr);
+    int abt_errno = ABTU_malloc(sizeof(ABTI_mutex_attr), (void **)&p_newattr);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Default values */
@@ -40,13 +39,7 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
 
     /* Return value */
     *newattr = ABTI_mutex_attr_get_handle(p_newattr);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -63,23 +56,15 @@ fn_fail:
  */
 int ABT_mutex_attr_free(ABT_mutex_attr *attr)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_mutex_attr h_attr = *attr;
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(h_attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
 
     /* Free the memory */
     ABTU_free(p_attr);
-
     /* Return value */
     *attr = ABT_MUTEX_ATTR_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -97,7 +82,6 @@ fn_fail:
  */
 int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
 
@@ -107,11 +91,5 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
     } else {
         p_attr->attrs &= ~ABTI_MUTEX_ATTR_RECURSIVE;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -73,7 +73,7 @@ static int pool_init(ABT_pool pool, ABT_pool_config config)
 
     data_t *p_data;
     abt_errno = ABTU_malloc(sizeof(data_t), (void **)&p_data);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     pthread_mutex_init(&p_data->mutex, NULL);
     pthread_cond_init(&p_data->cond, NULL);
@@ -276,10 +276,9 @@ static int pool_remove(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(p_pool->data);
     ABTI_thread *p_thread = (ABTI_thread *)unit;
 
-    ABTI_CHECK_TRUE_RET(p_data->num_threads != 0, ABT_ERR_POOL);
-    ABTI_CHECK_TRUE_RET(ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) ==
-                            1,
-                        ABT_ERR_POOL);
+    ABTI_CHECK_TRUE(p_data->num_threads != 0, ABT_ERR_POOL);
+    ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) == 1,
+                    ABT_ERR_POOL);
 
     pthread_mutex_lock(&p_data->mutex);
     if (p_data->num_threads == 1) {

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -31,19 +31,12 @@ ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
 int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
                     ABT_pool *newpool)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_newpool;
-
-    abt_errno = pool_create(def, config, ABT_FALSE, &p_newpool);
+    int abt_errno = pool_create(def, config, ABT_FALSE, &p_newpool);
     ABTI_CHECK_ERROR(abt_errno);
+
     *newpool = ABTI_pool_get_handle(p_newpool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -63,18 +56,12 @@ fn_fail:
 int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
                           ABT_bool automatic, ABT_pool *newpool)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_newpool;
-    abt_errno = ABTI_pool_create_basic(kind, access, automatic, &p_newpool);
+    int abt_errno = ABTI_pool_create_basic(kind, access, automatic, &p_newpool);
     ABTI_CHECK_ERROR(abt_errno);
+
     *newpool = ABTI_pool_get_handle(p_newpool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -87,8 +74,6 @@ fn_fail:
  */
 int ABT_pool_free(ABT_pool *pool)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABT_pool h_pool = *pool;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(h_pool);
 
@@ -97,13 +82,7 @@ int ABT_pool_free(ABT_pool *pool)
     ABTI_pool_free(p_pool);
 
     *pool = ABT_POOL_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -117,18 +96,11 @@ fn_fail:
  */
 int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *access = p_pool->access;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -146,19 +118,11 @@ fn_fail:
  */
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *size = ABTI_pool_get_total_size(p_pool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -175,19 +139,11 @@ fn_fail:
  */
 int ABT_pool_get_size(ABT_pool pool, size_t *size)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *size = ABTI_pool_get_size(p_pool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -201,19 +157,11 @@ fn_fail:
  */
 int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *p_unit = ABTI_pool_pop(p_pool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -238,36 +186,20 @@ fn_fail:
  */
 int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *p_unit = ABTI_pool_pop_wait(p_pool, time_secs);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *p_unit = ABTI_pool_pop_timedwait(p_pool, abstime_secs);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -281,8 +213,6 @@ fn_fail:
  */
 int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -290,13 +220,7 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 
     /* Save the producer ES information in the pool */
     ABTI_pool_push(p_pool, unit);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -310,20 +234,12 @@ fn_fail:
  */
 int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    abt_errno = ABTI_pool_remove(p_pool, unit);
+    int abt_errno = ABTI_pool_remove(p_pool, unit);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -348,22 +264,13 @@ fn_fail:
 int ABT_pool_print_all(ABT_pool pool, void *arg,
                        void (*print_fn)(void *, ABT_unit))
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     if (!p_pool->p_print_all) {
-        abt_errno = ABT_ERR_POOL;
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(ABT_ERR_POOL);
     }
-
     p_pool->p_print_all(pool, arg, print_fn);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -380,19 +287,11 @@ fn_fail:
  */
 int ABT_pool_set_data(ABT_pool pool, void *data)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     p_pool->data = data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -409,19 +308,11 @@ fn_fail:
  */
 int ABT_pool_get_data(ABT_pool pool, void **data)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *data = p_pool->data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -444,7 +335,6 @@ fn_fail:
  */
 int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -460,15 +350,9 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     /* In both ABT_SCHED_TYPE_ULT and ABT_SCHED_TYPE_TASK cases, we use ULT-type
      * scheduler to reduce the code maintenance cost.  ABT_SCHED_TYPE_TASK
      * should be removed in the future. */
-    abt_errno = ABTI_ythread_create_sched(p_local, p_pool, p_sched);
+    int abt_errno = ABTI_ythread_create_sched(p_local, p_pool, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -484,19 +368,11 @@ fn_fail:
  */
 int ABT_pool_get_id(ABT_pool pool, int *id)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     *id = (int)p_pool->id;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /*****************************************************************************/
@@ -522,10 +398,10 @@ ABTU_ret_err int ABTI_pool_create_basic(ABT_pool_kind kind,
             abt_errno = ABT_ERR_INV_POOL_KIND;
             break;
     }
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno = pool_create(&def, ABT_POOL_CONFIG_NULL, automatic, pp_newpool);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
 
@@ -604,7 +480,7 @@ ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
     int abt_errno;
     ABTI_pool *p_pool;
     abt_errno = ABTU_malloc(sizeof(ABTI_pool), (void **)&p_pool);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     p_pool->access = def->access;
     p_pool->automatic = automatic;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -46,7 +46,7 @@ static inline sched_data *sched_data_get_ptr(void *data)
 
 static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     int num_pools;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -68,7 +68,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
 
     /* Save the list of pools */
@@ -78,7 +78,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
         ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&p_data->pools);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
     memcpy(p_data->pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
@@ -89,13 +89,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     }
 
     p_sched->data = p_data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("basic: sched_init", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 static void sched_run(ABT_sched sched)

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -44,7 +44,7 @@ static inline sched_data *sched_data_get_ptr(void *data)
 
 static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     int num_pools;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -62,7 +62,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
 
     /* Save the list of pools */
@@ -72,7 +72,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
         ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&p_data->pools);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
     memcpy(p_data->pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
@@ -83,13 +83,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     }
 
     p_sched->data = p_data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("basic_wait: sched_init", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 static void sched_run(ABT_sched sched)

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -60,7 +60,7 @@ ABT_sched_config_var ABT_sched_config_automatic = { .idx = -3,
  */
 int ABT_sched_config_create(ABT_sched_config *config, ...)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_sched_config *p_config;
 
     char *buffer = NULL;
@@ -95,7 +95,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 ABTU_realloc(cur_buffer_size, buffer_size, (void **)&buffer);
             if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
                 ABTU_free(buffer);
-                goto fn_fail;
+                ABTI_HANDLE_ERROR(abt_errno);
             }
         }
         /* Copy the parameter index */
@@ -125,8 +125,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 ptr = (void *)&p;
                 break;
             default:
-                abt_errno = ABT_ERR_SCHED_CONFIG;
-                goto fn_fail;
+                ABTI_HANDLE_ERROR(ABT_ERR_SCHED_CONFIG);
         }
 
         memcpy(buffer + offset, ptr, size);
@@ -143,13 +142,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
 
     p_config = (ABTI_sched_config *)buffer;
     *config = ABTI_sched_config_get_handle(p_config);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -169,7 +162,7 @@ fn_fail:
  */
 int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     int v;
 
     /* We read all the variables and save the addresses */
@@ -188,13 +181,7 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
     ABTI_CHECK_ERROR(abt_errno);
 
     ABTU_free(variables);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -231,14 +218,14 @@ ABTU_ret_err int ABTI_sched_config_read_global(ABT_sched_config config,
 
     void **variables;
     abt_errno = ABTU_malloc(num_vars * sizeof(void *), (void **)&variables);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     variables[(ABT_sched_config_access.idx + 2) * (-1)] = &access_i;
     variables[(ABT_sched_config_automatic.idx + 2) * (-1)] = &automatic_i;
 
     abt_errno = ABTI_sched_config_read(config, 0, num_vars, variables);
     ABTU_free(variables);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     if (access_i != -1)
         *access = (ABT_pool_access)access_i;

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -38,7 +38,7 @@ static inline sched_data *sched_data_get_ptr(void *data)
 
 static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     int num_pools;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -59,7 +59,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
 
     /* Save the list of pools */
@@ -69,18 +69,12 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
         ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&p_data->pools);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_CHECK_ERROR(abt_errno);
     }
     memcpy(p_data->pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
     p_sched->data = p_data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("prio: sched_init", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 static void sched_run(ABT_sched sched)

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -35,7 +35,7 @@ ABT_sched_def *ABTI_sched_get_randws_def(void)
 
 static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     int num_pools;
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -56,7 +56,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
 
     /* Save the list of pools */
@@ -66,18 +66,12 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
         ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&p_data->pools);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_data);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
     memcpy(p_data->pools, p_sched->pools, sizeof(ABT_pool) * num_pools);
 
     p_sched->data = p_data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_WITH_CODE("randws: sched_init", abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 static void sched_run(ABT_sched sched)

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -41,26 +41,19 @@ static inline uint64_t sched_get_new_id(void);
 int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
                      ABT_sched_config config, ABT_sched *newsched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_sched;
-
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
+
     /* TODO: the default value of automatic is different from
      * ABT_sched_create_basic(). Make it consistent. */
     const ABT_bool def_automatic = ABT_FALSE;
-    abt_errno =
+    int abt_errno =
         sched_create(def, num_pools, pools, config, def_automatic, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
     *newsched = ABTI_sched_get_handle(p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -98,19 +91,12 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                            ABT_pool *pools, ABT_sched_config config,
                            ABT_sched *newsched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_newsched;
-    abt_errno =
+    int abt_errno =
         ABTI_sched_create_basic(predef, num_pools, pools, config, &p_newsched);
     ABTI_CHECK_ERROR(abt_errno);
     *newsched = ABTI_sched_get_handle(p_newsched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -129,24 +115,17 @@ fn_fail:
  */
 int ABT_sched_free(ABT_sched *sched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(*sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
-    ABTI_CHECK_TRUE_RET(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_SCHED);
 
     /* Free the scheduler */
     ABTI_sched_free(p_local, p_sched, ABT_FALSE);
 
     /* Return value */
     *sched = ABT_SCHED_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -164,19 +143,11 @@ fn_fail:
  */
 int ABT_sched_get_num_pools(ABT_sched sched, int *num_pools)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     *num_pools = p_sched->num_pools;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -193,24 +164,15 @@ fn_fail:
 int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
                         ABT_pool *pools)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
-
     ABTI_CHECK_TRUE(idx + max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
 
     int p;
     for (p = idx; p < idx + max_pools; p++) {
         pools[p - idx] = p_sched->pools[p];
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -225,19 +187,11 @@ fn_fail:
  */
 int ABT_sched_finish(ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     ABTI_sched_finish(p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -254,18 +208,11 @@ fn_fail:
  */
 int ABT_sched_exit(ABT_sched sched)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     ABTI_sched_exit(p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -287,19 +234,12 @@ fn_fail:
  */
 int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     *stop = ABTI_sched_has_to_stop(&p_local, p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -316,17 +256,11 @@ fn_fail:
  */
 int ABT_sched_set_data(ABT_sched sched, void *data)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+
     p_sched->data = data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -343,19 +277,11 @@ fn_fail:
  */
 int ABT_sched_get_data(ABT_sched sched, void **data)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     *data = p_sched->data;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -371,19 +297,11 @@ fn_fail:
  */
 int ABT_sched_get_size(ABT_sched sched, size_t *size)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     *size = ABTI_sched_get_size(p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 size_t ABTI_sched_get_size(ABTI_sched *p_sched)
@@ -412,19 +330,11 @@ size_t ABTI_sched_get_size(ABTI_sched *p_sched)
  */
 int ABT_sched_get_total_size(ABT_sched sched, size_t *size)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     *size = ABTI_sched_get_total_size(p_sched);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /*****************************************************************************/
@@ -451,7 +361,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     ABT_pool_kind kind = ABT_POOL_FIFO;
     ABT_bool automatic;
 
-    ABTI_CHECK_TRUE_RET(!pools || num_pools > 0, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE(!pools || num_pools > 0, ABT_ERR_SCHED);
 
     /* We set the access to the default one */
     access = ABT_POOL_ACCESS_MPSC;
@@ -460,7 +370,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     automatic = ABT_TRUE;
     /* We read the config and set the configured parameters */
     abt_errno = ABTI_sched_config_read_global(config, &access, &automatic);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* A pool array is provided, predef has to be compatible */
     if (pools != NULL) {
@@ -468,7 +378,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         ABT_pool *pool_list;
         abt_errno =
             ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&pool_list);
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
 
         int p;
         for (p = 0; p < num_pools; p++) {
@@ -476,7 +386,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                 ABTI_pool *p_newpool;
                 abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO, access,
                                                    ABT_TRUE, &p_newpool);
-                ABTI_CHECK_ERROR_RET(abt_errno);
+                ABTI_CHECK_ERROR(abt_errno);
                 pool_list[p] = ABTI_pool_get_handle(p_newpool);
             } else {
                 pool_list[p] = pools[p];
@@ -511,7 +421,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
                 break;
         }
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
         ABTU_free(pool_list);
     }
 
@@ -536,7 +446,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
-                ABTI_CHECK_ERROR_RET(abt_errno);
+                ABTI_CHECK_ERROR(abt_errno);
                 break;
         }
 
@@ -548,7 +458,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
             ABTI_pool *p_newpool;
             abt_errno =
                 ABTI_pool_create_basic(kind, access, ABT_TRUE, &p_newpool);
-            ABTI_CHECK_ERROR_RET(abt_errno);
+            ABTI_CHECK_ERROR(abt_errno);
             pool_list[p] = ABTI_pool_get_handle(p_newpool);
         }
 
@@ -579,7 +489,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
                 break;
         }
-        ABTI_CHECK_ERROR_RET(abt_errno);
+        ABTI_CHECK_ERROR(abt_errno);
     }
     return ABT_SUCCESS;
 }
@@ -829,7 +739,7 @@ ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
     int p, abt_errno;
 
     abt_errno = ABTU_malloc(sizeof(ABTI_sched), (void **)&p_sched);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     /* Copy of the contents of pools */
     ABT_pool *pool_list;

--- a/src/self.c
+++ b/src/self.c
@@ -33,7 +33,6 @@
  */
 int ABT_self_get_type(ABT_unit_type *type)
 {
-    int abt_errno = ABT_SUCCESS;
     *type = ABT_UNIT_TYPE_EXT;
 
     /* Deprecated: if Argobots has not been initialized, set type to
@@ -41,13 +40,7 @@ int ABT_self_get_type(ABT_unit_type *type)
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
     *type = ABTI_thread_type_get_type(p_local_xstream->p_thread->type);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -68,20 +61,12 @@ fn_fail:
  */
 int ABT_self_is_primary(ABT_bool *flag)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     ABTI_thread *p_thread = p_local_xstream->p_thread;
     *flag = (p_thread->type & ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -101,20 +86,13 @@ fn_fail:
  */
 int ABT_self_on_primary_xstream(ABT_bool *flag)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     /* Return value */
     *flag = (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) ? ABT_TRUE
                                                                  : ABT_FALSE;
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -137,8 +115,6 @@ fn_fail:
  */
 int ABT_self_get_last_pool_id(int *pool_id)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_SETUP_WITH_INIT_CHECK();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream_or_null(ABTI_local_get_local());
@@ -150,13 +126,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
         ABTI_ASSERT(p_self->p_pool);
         *pool_id = p_self->p_pool->id;
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -179,8 +149,6 @@ fn_fail:
  */
 int ABT_self_suspend(void)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_self;
     ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(&p_local_xstream, &p_self);
@@ -188,13 +156,7 @@ int ABT_self_suspend(void)
     ABTI_ythread_set_blocked(p_self);
     ABTI_ythread_suspend(&p_local_xstream, p_self, ABT_SYNC_EVENT_TYPE_USER,
                          NULL);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -212,19 +174,11 @@ fn_fail:
  */
 int ABT_self_set_arg(void *arg)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     p_local_xstream->p_thread->p_arg = arg;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -245,19 +199,11 @@ fn_fail:
  */
 int ABT_self_get_arg(void **arg)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     *arg = p_local_xstream->p_thread->p_arg;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -277,19 +223,11 @@ fn_fail:
  */
 int ABT_self_is_unnamed(ABT_bool *flag)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     *flag = (p_local_xstream->p_thread->type & ABTI_THREAD_TYPE_NAMED)
                 ? ABT_FALSE
                 : ABT_TRUE;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -27,7 +27,7 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
                                ABT_xstream_barrier *newbarrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABTI_xstream_barrier *p_newbarrier;
 
     abt_errno =
@@ -38,20 +38,14 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
     abt_errno = ABTD_xstream_barrier_init(num_waiters, &p_newbarrier->bar);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newbarrier);
-        goto fn_fail;
+        ABTI_HANDLE_ERROR(abt_errno);
     }
 
     /* Return value */
     *newbarrier = ABTI_xstream_barrier_get_handle(p_newbarrier);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -70,7 +64,6 @@ fn_fail:
 int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-    int abt_errno = ABT_SUCCESS;
     ABT_xstream_barrier h_barrier = *barrier;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
@@ -80,15 +73,9 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
 
     /* Return value */
     *barrier = ABT_XSTREAM_BARRIER_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -106,21 +93,14 @@ fn_fail:
 int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
 {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
-    int abt_errno = ABT_SUCCESS;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
     if (p_barrier->num_waiters > 1) {
         ABTD_xstream_barrier_wait(&p_barrier->bar);
     }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #endif
 }

--- a/src/task.c
+++ b/src/task.c
@@ -40,28 +40,20 @@ ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
 int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
                     ABT_task *newtask)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newtask;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     int refcount = (newtask != NULL) ? 1 : 0;
-    abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
-                            &p_newtask);
+    int abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
+                                &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
-    if (newtask) {
+    if (newtask)
         *newtask = ABTI_thread_get_handle(p_newtask);
-    }
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -98,7 +90,6 @@ fn_fail:
 int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
                                void *arg, ABT_task *newtask)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newtask;
 
@@ -108,20 +99,14 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     /* TODO: need to consider the access type of target pool */
     ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newtask != NULL) ? 1 : 0;
-    abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
-                            &p_newtask);
+    int abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
+                                &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
     if (newtask)
         *newtask = ABTI_thread_get_handle(p_newtask);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 #ifdef ABT_CONFIG_USE_DOXYGEN
@@ -211,7 +196,6 @@ int ABT_task_cancel(ABT_task task);
  */
 int ABT_task_self(ABT_task *task)
 {
-    int abt_errno = ABT_SUCCESS;
     *task = ABT_TASK_NULL;
 
     ABTI_xstream *p_local_xstream;
@@ -219,16 +203,11 @@ int ABT_task_self(ABT_task *task)
 
     ABTI_thread *p_thread = p_local_xstream->p_thread;
     if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
-        abt_errno = ABT_ERR_INV_THREAD;
+        return ABT_ERR_INV_THREAD;
     } else {
         *task = ABTI_thread_get_handle(p_thread);
     }
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -246,8 +225,6 @@ fn_fail:
  */
 int ABT_task_self_id(ABT_unit_id *id)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
@@ -255,13 +232,7 @@ int ABT_task_self_id(ABT_unit_id *id)
     ABTI_CHECK_TRUE(!(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE),
                     ABT_ERR_INV_THREAD);
     *id = ABTI_thread_get_id(p_thread);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 #ifdef ABT_CONFIG_USE_DOXYGEN
@@ -484,7 +455,7 @@ ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
 
     /* Allocate a task object */
     int abt_errno = ABTI_mem_alloc_nythread(p_local, &p_newtask);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     p_newtask->p_last_xstream = NULL;
     p_newtask->p_parent = NULL;

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -25,25 +25,15 @@
  */
 int ABT_thread_attr_create(ABT_thread_attr *newattr)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_newattr;
-
-    abt_errno = ABTU_malloc(sizeof(ABTI_thread_attr), (void **)&p_newattr);
+    int abt_errno = ABTU_malloc(sizeof(ABTI_thread_attr), (void **)&p_newattr);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Default values */
     ABTI_thread_attr_init(p_newattr, NULL, gp_ABTI_global->thread_stacksize,
                           ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK, ABT_TRUE);
-
-    /* Return value */
     *newattr = ABTI_thread_attr_get_handle(p_newattr);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -60,23 +50,14 @@ fn_fail:
  */
 int ABT_thread_attr_free(ABT_thread_attr *attr)
 {
-    int abt_errno = ABT_SUCCESS;
     ABT_thread_attr h_attr = *attr;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(h_attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     /* Free the memory */
     ABTU_free(p_attr);
-
-    /* Return value */
     *attr = ABT_THREAD_ATTR_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -103,15 +84,13 @@ fn_fail:
 int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
                               size_t stacksize)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     ABTI_thread_type new_thread_type;
     if (stackaddr != NULL) {
         if (((uintptr_t)stackaddr & 0x7) != 0) {
-            abt_errno = ABT_ERR_OTHER;
-            goto fn_fail;
+            ABTI_HANDLE_ERROR(ABT_ERR_OTHER);
         }
         new_thread_type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC;
     } else {
@@ -127,13 +106,7 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
 
     p_attr->p_stack = stackaddr;
     p_attr->stacksize = stacksize;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -155,19 +128,12 @@ fn_fail:
 int ABT_thread_attr_get_stack(ABT_thread_attr attr, void **stackaddr,
                               size_t *stacksize)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     *stackaddr = p_attr->p_stack;
     *stacksize = p_attr->stacksize;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -184,7 +150,6 @@ fn_fail:
  */
 int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
@@ -199,13 +164,7 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
     /* Unset the stack type and set new_thread_type. */
     p_attr->thread_type &= ~ABTI_THREAD_TYPES_MEM;
     p_attr->thread_type |= new_thread_type;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -222,18 +181,11 @@ fn_fail:
  */
 int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     *stacksize = p_attr->stacksize;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -255,22 +207,15 @@ int ABT_thread_attr_set_callback(ABT_thread_attr attr,
                                  void *cb_arg)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     /* Set the value */
     p_attr->f_cb = cb_func;
     p_attr->p_cb_arg = cb_arg;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -293,21 +238,14 @@ fn_fail:
 int ABT_thread_attr_set_migratable(ABT_thread_attr attr, ABT_bool flag)
 {
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
-    int abt_errno = ABT_SUCCESS;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
     /* Set the value */
     p_attr->migratable = flag;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #else
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #endif
 }
 
@@ -363,9 +301,9 @@ ABTU_ret_err int ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
                                       ABTI_thread_attr **pp_dup_attr)
 {
     ABTI_thread_attr *p_dup_attr;
-
     int abt_errno = ABTU_malloc(sizeof(ABTI_thread_attr), (void **)&p_dup_attr);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
+
     memcpy(p_dup_attr, p_attr, sizeof(ABTI_thread_attr));
     *pp_dup_attr = p_dup_attr;
     return ABT_SUCCESS;

--- a/src/timer.c
+++ b/src/timer.c
@@ -41,20 +41,12 @@ double ABT_get_wtime(void)
  */
 int ABT_timer_create(ABT_timer *newtimer)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_newtimer;
-
-    abt_errno = timer_alloc(&p_newtimer);
+    int abt_errno = timer_alloc(&p_newtimer);
     ABTI_CHECK_ERROR(abt_errno);
 
     *newtimer = ABTI_timer_get_handle(p_newtimer);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -74,25 +66,16 @@ fn_fail:
  */
 int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
     ABTI_timer *p_newtimer;
-
-    abt_errno = timer_alloc(&p_newtimer);
+    int abt_errno = timer_alloc(&p_newtimer);
     ABTI_CHECK_ERROR(abt_errno);
 
     memcpy(p_newtimer, p_timer, sizeof(ABTI_timer));
-
     *newtimer = ABTI_timer_get_handle(p_newtimer);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -111,7 +94,6 @@ fn_fail:
  */
 int ABT_timer_free(ABT_timer *timer)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(*timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
@@ -121,13 +103,7 @@ int ABT_timer_free(ABT_timer *timer)
      * Argobots initialization. */
     free(p_timer);
     *timer = ABT_TIMER_NULL;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -144,18 +120,11 @@ fn_fail:
  */
 int ABT_timer_start(ABT_timer timer)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
     ABTD_time_get(&p_timer->start);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -172,18 +141,11 @@ fn_fail:
  */
 int ABT_timer_stop(ABT_timer timer)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
     ABTD_time_get(&p_timer->end);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -202,23 +164,14 @@ fn_fail:
  */
 int ABT_timer_read(ABT_timer timer, double *secs)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
-    double start, end;
-
-    start = ABTD_time_read_sec(&p_timer->start);
-    end = ABTD_time_read_sec(&p_timer->end);
+    double start = ABTD_time_read_sec(&p_timer->start);
+    double end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -238,24 +191,15 @@ fn_fail:
  */
 int ABT_timer_stop_and_read(ABT_timer timer, double *secs)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
-    double start, end;
-
     ABTD_time_get(&p_timer->end);
-    start = ABTD_time_read_sec(&p_timer->start);
-    end = ABTD_time_read_sec(&p_timer->end);
+    double start = ABTD_time_read_sec(&p_timer->start);
+    double end = ABTD_time_read_sec(&p_timer->end);
 
     *secs = end - start;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -275,24 +219,15 @@ fn_fail:
  */
 int ABT_timer_stop_and_add(ABT_timer timer, double *secs)
 {
-    int abt_errno = ABT_SUCCESS;
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
-    double start, end;
-
     ABTD_time_get(&p_timer->end);
-    start = ABTD_time_read_sec(&p_timer->start);
-    end = ABTD_time_read_sec(&p_timer->end);
+    double start = ABTD_time_read_sec(&p_timer->start);
+    double end = ABTD_time_read_sec(&p_timer->end);
 
     *secs += (end - start);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /**
@@ -310,7 +245,7 @@ fn_fail:
  */
 int ABT_timer_get_overhead(double *overhead)
 {
-    int abt_errno = ABT_SUCCESS;
+    int abt_errno;
     ABT_timer h_timer;
     int i;
     const int iter = 5000;
@@ -330,13 +265,7 @@ int ABT_timer_get_overhead(double *overhead)
     ABTI_CHECK_ERROR(abt_errno);
 
     *overhead = sum / iter;
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /*****************************************************************************/
@@ -350,9 +279,8 @@ ABTU_ret_err static int timer_alloc(ABTI_timer **pp_newtimer)
      * malloc/free.  This is to allow ABT_timer to be used irrespective of
      * Argobots initialization. */
     ABTI_timer *p_newtimer = (ABTI_timer *)malloc(sizeof(ABTI_timer));
-    ABTI_CHECK_TRUE_RET(p_newtimer != NULL, ABT_ERR_MEM);
+    ABTI_CHECK_TRUE(p_newtimer != NULL, ABT_ERR_MEM);
 
     *pp_newtimer = p_newtimer;
-
     return ABT_SUCCESS;
 }

--- a/src/tool.c
+++ b/src/tool.c
@@ -46,7 +46,7 @@ int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
                                       void *user_arg)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
     if (cb_func == NULL)
         event_mask_thread = ABT_TOOL_EVENT_THREAD_NONE;
@@ -88,7 +88,7 @@ int ABT_tool_register_task_callback(ABT_tool_task_callback_fn cb_func,
                                     uint64_t event_mask_task, void *user_arg)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
     if (cb_func == NULL)
         event_mask_task = ABT_TOOL_EVENT_TASK_NONE;
@@ -196,21 +196,14 @@ int ABT_tool_query_thread(ABT_tool_context context, uint64_t event_thread,
                           ABT_tool_query_kind query_kind, void *val)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_tool_context *p_tctx = ABTI_tool_context_get_ptr(context);
     ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p_tctx);
-    abt_errno = tool_query(p_tctx, query_kind, val);
+
+    int abt_errno = tool_query(p_tctx, query_kind, val);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #endif
 }
 
@@ -233,21 +226,13 @@ int ABT_tool_query_task(ABT_tool_context context, uint64_t event_task,
                         ABT_tool_query_kind query_kind, void *val)
 {
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    HANDLE_ERROR_FUNC_WITH_CODE_RET(ABT_ERR_FEATURE_NA);
+    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_tool_context *p_tctx = ABTI_tool_context_get_ptr(context);
     ABTI_CHECK_NULL_TOOL_CONTEXT_PTR(p_tctx);
-    abt_errno = tool_query(p_tctx, query_kind, val);
+    int abt_errno = tool_query(p_tctx, query_kind, val);
     ABTI_CHECK_ERROR(abt_errno);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 #endif
 }
 
@@ -342,7 +327,7 @@ tool_query(ABTI_tool_context *p_tctx, ABT_tool_query_kind query_kind, void *val)
             }
             break;
         default:
-            return ABT_ERR_OTHER;
+            ABTI_HANDLE_ERROR(ABT_ERR_OTHER);
     }
     return ABT_SUCCESS;
 }

--- a/src/unit.c
+++ b/src/unit.c
@@ -26,19 +26,11 @@
  */
 int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
 {
-    int abt_errno = ABT_SUCCESS;
-
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     ABTI_unit_set_associated_pool(unit, p_pool);
-
-fn_exit:
-    return abt_errno;
-
-fn_fail:
-    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno);
-    goto fn_exit;
+    return ABT_SUCCESS;
 }
 
 /*****************************************************************************/

--- a/src/ythread_htable.c
+++ b/src/ythread_htable.c
@@ -16,7 +16,7 @@ ABTU_ret_err int ABTI_ythread_htable_create(uint32_t num_rows,
     size_t q_size = num_rows * sizeof(ABTI_ythread_queue);
 
     abt_errno = ABTU_malloc(sizeof(ABTI_ythread_htable), (void **)&p_htable);
-    ABTI_CHECK_ERROR_RET(abt_errno);
+    ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno = ABTU_memalign(64, q_size, (void **)&p_htable->queue);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {

--- a/test/basic/xstream_affinity.c
+++ b/test/basic/xstream_affinity.c
@@ -114,6 +114,15 @@ int main(int argc, char *argv[])
 
     ATS_printf(1, "# of ESs: %d\n", num_xstreams);
 
+    ABT_bool is_affinity_enabled = ABT_FALSE;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_AFFINITY,
+                                (void *)&is_affinity_enabled);
+    ATS_ERROR(ret, "ABT_info_query_config");
+    if (is_affinity_enabled == ABT_FALSE) {
+        /* This test should be skipped. */
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
     /* Check the affinity of the primary ES */
     ret = ABT_xstream_self(&primary_es);
     ATS_ERROR(ret, "ABT_xstream_self");


### PR DESCRIPTION
## Background

With `--enable-debug=err` etc, Argobots prints an error information to `stderr` on failure.  The line number information, however, is very useless.

For example, Argobots can output the following error.
```
[xstream.c:124] ABT_xstream_create_basic: 2
```
This line 124 points to `HANDLE_ERROR_FUNC_WITH_CODE()`.
```c
int ABT_xstream_create_basic(...)
{
    int abt_errno = ABT_SUCCESS;
    ABTI_xstream *p_newxstream;

    ABTI_sched *p_sched;
    abt_errno =
        ABTI_sched_create_basic(predef, num_pools, pools, config, &p_sched);
    ABTI_CHECK_ERROR(abt_errno);

    abt_errno =
        xstream_create(p_sched, ABTI_XSTREAM_TYPE_SECONDARY, -1, &p_newxstream);
    ABTI_CHECK_ERROR(abt_errno);

    abt_errno = xstream_start(p_newxstream);
    ABTI_CHECK_ERROR(abt_errno);

    *newxstream = ABTI_xstream_get_handle(p_newxstream);

fn_exit:
    return abt_errno;

fn_fail:
    HANDLE_ERROR_FUNC_WITH_CODE(abt_errno); // << HERE
    goto fn_exit;
}
```
This means that there's an error in `ABT_xstream_create_basic()`, but users and developers have no clue which function actually returns an error.  The error code of Argobots is not precise enough to diagnosis all the symptoms, so at least it should show a meaningful line number.

## Solution

This patch changes the current error handling mechanism to directly return an error code without `goto fn_fail;`.
```c
int ABT_xstream_create_basic(...)
{
    int abt_errno;
    ABTI_xstream *p_newxstream;

    ABTI_sched *p_sched;
    abt_errno =
        ABTI_sched_create_basic(predef, num_pools, pools, config, &p_sched);
    ABTI_CHECK_ERROR(abt_errno);

    abt_errno =
        xstream_create(p_sched, ABTI_XSTREAM_TYPE_SECONDARY, -1, &p_newxstream);
    ABTI_CHECK_ERROR(abt_errno);

    abt_errno = xstream_start(p_newxstream);
    ABTI_CHECK_ERROR(abt_errno);

    *newxstream = ABTI_xstream_get_handle(p_newxstream);
    return ABT_SUCCESS;
}
```
All the error will be directly returned to the user by `ABTI_CHECK_ERROR()`.  If enabled, this macro prints an error, so it will show exactly where the error happens.

This can also shorten functions: in total it reduces 1000+ lines.

## Expected Impact

There is no performance impact.  The printed information can be changed if you enable this debugging option.

