### PR TITLE
sched: initialize p_sched->p_data

### DIFF
--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -782,6 +782,7 @@ ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
     p_sched->num_pools = num_pools;
     p_sched->type = def->type;
     p_sched->p_ythread = NULL;
+    p_sched->data = NULL;
 
     p_sched->init = def->init;
     p_sched->run = def->run;


### PR DESCRIPTION
`ABT_sched`'s `p_data` is not initialized in `ABT_sched_create()`, so `ABT_sched_get_data()` returns an uninitialized value.  This behavior is not intuitive for most users.  Since scheduler creation is not performance critical, this PR initializes `p_data` to NULL on creation.