### PR TITLE
maint: fix ABI string

### DIFF
--- a/maint/version.m4
+++ b/maint/version.m4
@@ -21,6 +21,6 @@ m4_define([ABT_RELEASE_DATE_m4],[unreleased development copy])dnl
 #     4. If any interfaces have been removed since the last public
 #     release, then set age to 0.
 
-m4_define([libabt_so_version_m4],[0:0:0])dnl
+m4_define([libabt_so_version_m4],[1:0:0])dnl
 
 [#] end of __file__


### PR DESCRIPTION
This PR fixes the ABI string, which has not been updated in the release 1.0 by mistake.
 