### PR TITLE
util: introduce basic math functions

### DIFF
--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -116,8 +116,8 @@ void ABTD_env_init(ABTI_global *p_global)
     }
     /* Stack size must be a multiple of cacheline size. */
     p_global->thread_stacksize =
-        (p_global->thread_stacksize + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
-        (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+        ABTU_roundup_size(p_global->thread_stacksize,
+                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
     /* Default stack size for scheduler */
     env = getenv("ABT_SCHED_STACKSIZE");
@@ -221,21 +221,17 @@ void ABTD_env_init(ABTI_global *p_global)
     if (env != NULL) {
         p_global->mem_max_stacks = (uint32_t)atol(env);
     } else {
-        if (p_global->thread_stacksize * ABTD_MEM_MAX_NUM_STACKS >
-            ABTD_MEM_MAX_TOTAL_STACK_SIZE) {
-            /* Each execution stream caches too many stacks in total. Let's
-             * reduce the max # of stacks. */
-            p_global->mem_max_stacks =
-                ABTD_MEM_MAX_TOTAL_STACK_SIZE / p_global->thread_stacksize;
-        } else {
-            p_global->mem_max_stacks = ABTD_MEM_MAX_NUM_STACKS;
-        }
+        /* Each execution stream caches too many stacks in total. Let's
+         * reduce the max # of stacks. */
+        p_global->mem_max_stacks =
+            ABTU_min_uint32(ABTD_MEM_MAX_TOTAL_STACK_SIZE /
+                                p_global->thread_stacksize,
+                            ABTD_MEM_MAX_NUM_STACKS);
     }
     /* The value must be a multiple of ABT_MEM_POOL_MAX_LOCAL_BUCKETS. */
     p_global->mem_max_stacks =
-        ((p_global->mem_max_stacks + ABT_MEM_POOL_MAX_LOCAL_BUCKETS - 1) /
-         ABT_MEM_POOL_MAX_LOCAL_BUCKETS) *
-        ABT_MEM_POOL_MAX_LOCAL_BUCKETS;
+        ABTU_roundup_uint32(p_global->mem_max_stacks,
+                            ABT_MEM_POOL_MAX_LOCAL_BUCKETS);
 
     /* Maximum number of descriptors that each ES can keep during execution */
     env = getenv("ABT_MEM_MAX_NUM_DESCS");
@@ -248,9 +244,8 @@ void ABTD_env_init(ABTI_global *p_global)
     }
     /* The value must be a multiple of ABT_MEM_POOL_MAX_LOCAL_BUCKETS. */
     p_global->mem_max_descs =
-        ((p_global->mem_max_descs + ABT_MEM_POOL_MAX_LOCAL_BUCKETS - 1) /
-         ABT_MEM_POOL_MAX_LOCAL_BUCKETS) *
-        ABT_MEM_POOL_MAX_LOCAL_BUCKETS;
+        ABTU_roundup_uint32(p_global->mem_max_descs,
+                            ABT_MEM_POOL_MAX_LOCAL_BUCKETS);
 
     /* How to allocate large pages.  The default is to use mmap() for huge
      * pages and then to fall back to allocate regular pages using mmap() when

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -74,9 +74,9 @@ ABTU_ret_err static inline int ABTI_ktable_create(ABTI_local *p_local,
     /* max alignment must be a power of 2. */
     ABTI_STATIC_ASSERT((ABTU_MAX_ALIGNMENT & (ABTU_MAX_ALIGNMENT - 1)) == 0);
     size_t ktable_size =
-        (offsetof(ABTI_ktable, p_elems) +
-         sizeof(ABTD_atomic_ptr) * key_table_size + ABTU_MAX_ALIGNMENT - 1) &
-        (~(ABTU_MAX_ALIGNMENT - 1));
+        ABTU_roundup_size(offsetof(ABTI_ktable, p_elems) +
+                              sizeof(ABTD_atomic_ptr) * key_table_size,
+                          ABTU_MAX_ALIGNMENT);
     /* Since only one ES can access the memory pool on creation, this uses an
      * unsafe memory pool without taking a lock. */
     if (ABTU_likely(ktable_size <= ABTI_KTABLE_DESC_SIZE)) {

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -12,8 +12,7 @@
  * used to determine whether the descriptor is allocated externally (i.e.,
  * malloc()) or taken from a memory pool. */
 #define ABTI_MEM_POOL_DESC_ELEM_SIZE                                           \
-    ((sizeof(ABTI_thread) + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &            \
-     (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)))
+    ABTU_roundup_size(sizeof(ABTI_thread), ABT_CONFIG_STATIC_CACHELINE_SIZE)
 
 enum {
     ABTI_MEM_LP_MALLOC = 0,
@@ -119,8 +118,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack_impl(
 {
     /* stacksize must be a multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE. */
     size_t alloc_stacksize =
-        (stacksize + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
-        (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+        ABTU_roundup_size(stacksize, ABT_CONFIG_STATIC_CACHELINE_SIZE);
     char *p_stack;
     int abt_errno =
         ABTU_malloc(alloc_stacksize + sizeof(ABTI_ythread), (void **)&p_stack);

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -11,6 +11,97 @@
 #include <assert.h>
 #include "abt_config.h"
 
+/* Basic math functions */
+static inline int ABTU_max_int(int a, int b)
+{
+    return a > b ? a : b;
+}
+
+static inline int32_t ABTU_max_int32(int32_t a, int32_t b)
+{
+    return a > b ? a : b;
+}
+
+static inline uint32_t ABTU_max_uint32(uint32_t a, uint32_t b)
+{
+    return a > b ? a : b;
+}
+
+static inline int64_t ABTU_max_int64(int64_t a, int64_t b)
+{
+    return a > b ? a : b;
+}
+
+static inline uint64_t ABTU_max_uint64(uint64_t a, uint64_t b)
+{
+    return a > b ? a : b;
+}
+
+static inline size_t ABTU_max_size(size_t a, size_t b)
+{
+    return a > b ? a : b;
+}
+
+static inline int ABTU_min_int(int a, int b)
+{
+    return a < b ? a : b;
+}
+
+static inline int32_t ABTU_min_int32(int32_t a, int32_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline uint32_t ABTU_min_uint32(uint32_t a, uint32_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline int64_t ABTU_min_int64(int64_t a, int64_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline uint64_t ABTU_min_uint64(uint64_t a, uint64_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline size_t ABTU_min_size(size_t a, size_t b)
+{
+    return a < b ? a : b;
+}
+
+static inline uint32_t ABTU_roundup_uint32(uint32_t val, uint32_t multiple)
+{
+    if ((multiple & (multiple - 1)) == 0) {
+        /* If multiple is a power of two. */
+        return (val + multiple - 1) & (~(multiple - 1));
+    } else {
+        return ((val + multiple - 1) / multiple) * multiple;
+    }
+}
+
+static inline uint64_t ABTU_roundup_uint64(uint64_t val, uint64_t multiple)
+{
+    if ((multiple & (multiple - 1)) == 0) {
+        /* If multiple is a power of two. */
+        return (val + multiple - 1) & (~(multiple - 1));
+    } else {
+        return ((val + multiple - 1) / multiple) * multiple;
+    }
+}
+
+static inline size_t ABTU_roundup_size(size_t val, size_t multiple)
+{
+    if ((multiple & (multiple - 1)) == 0) {
+        /* If multiple is a power of two. */
+        return (val + multiple - 1) & (~(multiple - 1));
+    } else {
+        return ((val + multiple - 1) / multiple) * multiple;
+    }
+}
+
 /* Utility feature */
 
 #ifdef HAVE___BUILTIN_EXPECT

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -132,9 +132,7 @@ static inline size_t ABTU_roundup_size(size_t val, size_t multiple)
 #define ABTU_alignof(type) 16 /* 16 bytes would be a good guess. */
 #endif
 #define ABTU_MAX_ALIGNMENT                                                     \
-    (ABTU_alignof(long double) > ABTU_alignof(long long)                       \
-         ? ABTU_alignof(long double)                                           \
-         : ABTU_alignof(long long))
+    ABTU_max_size(ABTU_alignof(long double), ABTU_alignof(long long))
 
 #ifdef HAVE_FUNC_ATTRIBUTE_WARN_UNUSED_RESULT
 #define ABTU_ret_err __attribute__((warn_unused_result))
@@ -222,8 +220,7 @@ ABTU_ret_err static inline int ABTU_malloc(size_t size, void **p_ptr)
     /* Round up to the smallest multiple of ABT_CONFIG_STATIC_CACHELINE_SIZE
      * which is greater than or equal to size in order to avoid any
      * false-sharing. */
-    size = (size + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
-           (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+    size = ABTU_roundup_size(size, ABT_CONFIG_STATIC_CACHELINE_SIZE);
     return ABTU_memalign(ABT_CONFIG_STATIC_CACHELINE_SIZE, size, p_ptr);
 }
 
@@ -248,7 +245,7 @@ ABTU_ret_err static inline int ABTU_realloc(size_t old_size, size_t new_size,
     if (ABTI_IS_ERROR_CHECK_ENABLED && ret != ABT_SUCCESS) {
         return ABT_ERR_MEM;
     }
-    memcpy(new_ptr, old_ptr, (old_size < new_size) ? old_size : new_size);
+    memcpy(new_ptr, old_ptr, ABTU_min_size(old_size, new_size));
     ABTU_free(old_ptr);
     *p_ptr = new_ptr;
     return ABT_SUCCESS;

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -47,9 +47,9 @@ void ABTI_mem_init(ABTI_global *p_global)
     size_t thread_stacksize = p_global->thread_stacksize;
     ABTI_ASSERT((thread_stacksize & (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) ==
                 0);
-    size_t stacksize = (thread_stacksize + sizeof(ABTI_ythread) +
-                        ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
-                       (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
+    size_t stacksize =
+        ABTU_roundup_size(thread_stacksize + sizeof(ABTI_ythread),
+                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
     if ((stacksize & (2 * ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0) {
         /* Avoid a multiple of 2 * cacheline size to avoid cache bank conflict.
          */

--- a/src/stream.c
+++ b/src/stream.c
@@ -570,7 +570,7 @@ int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     ABTI_sched *p_sched = p_xstream->p_main_sched;
-    max_pools = p_sched->num_pools > max_pools ? max_pools : p_sched->num_pools;
+    max_pools = ABTU_min_int(p_sched->num_pools, max_pools);
     memcpy(pools, p_sched->pools, sizeof(ABT_pool) * max_pools);
     return ABT_SUCCESS;
 }
@@ -839,7 +839,7 @@ int ABT_xstream_get_affinity(ABT_xstream xstream, int cpuset_size, int *cpuset,
     ABTI_CHECK_ERROR(abt_errno);
 
     int i, n;
-    n = affinity.num_cpuids > cpuset_size ? cpuset_size : affinity.num_cpuids;
+    n = ABTU_min_int(affinity.num_cpuids, cpuset_size);
     *num_cpus = n;
     for (i = 0; i < n; i++) {
         cpuset[i] = affinity.cpuids[i];


### PR DESCRIPTION
It is sometimes hard to understand the intension of the code without math functions.  Basic math functions improve readability.
```c
// min
if (p_global->thread_stacksize * ABTD_MEM_MAX_NUM_STACKS
    > ABTD_MEM_MAX_TOTAL_STACK_SIZE) {
    mem_max_stacks = ABTD_MEM_MAX_TOTAL_STACK_SIZE / p_global->thread_stacksize;
} else {
    mem_max_stacks = ABTD_MEM_MAX_NUM_STACKS;
}
// =>
mem_max_stacks = min(ABTD_MEM_MAX_TOTAL_STACK_SIZE / p_global->thread_stacksize,
                     ABTD_MEM_MAX_NUM_STACKS);

// roundup
size_t stacksize = (thread_stacksize + sizeof(ABTI_ythread)
                    + ABT_CONFIG_STATIC_CACHELINE_SIZE - 1) &
                    (~(ABT_CONFIG_STATIC_CACHELINE_SIZE - 1));
// =>
size_t stacksize = roundup(thread_stacksize + sizeof(ABTI_ythread),
                           ABT_CONFIG_STATIC_CACHELINE_SIZE);
```
Note that these functions are typed (i.e., not macros), so developers need to use, for example, `ABTU_max_int()` for `int`-type `max()`. This PR will neither degrade nor improve the performance of Argobots.
