### PR TITLE
env: improve reading process of Argobots' environment variables

### DIFF
--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -13,7 +13,6 @@
 #define ABTD_SCHED_EVENT_FREQ 50
 #define ABTD_SCHED_SLEEP_NSEC 100
 
-#define ABTD_OS_PAGE_SIZE (4 * 1024)
 #define ABTD_HUGE_PAGE_SIZE (2 * 1024 * 1024)
 #define ABTD_MEM_PAGE_SIZE (2 * 1024 * 1024)
 #define ABTD_MEM_STACK_PAGE_SIZE (8 * 1024 * 1024)
@@ -171,16 +170,6 @@ void ABTD_env_init(ABTI_global *p_global)
         ABTI_ASSERT(p_global->mutex_max_wakeups >= 1);
     } else {
         p_global->mutex_max_wakeups = 1;
-    }
-
-    /* OS page size */
-    env = getenv("ABT_OS_PAGE_SIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_OS_PAGE_SIZE");
-    if (env != NULL) {
-        p_global->os_page_size = (uint32_t)atol(env);
-    } else {
-        p_global->os_page_size = ABTD_OS_PAGE_SIZE;
     }
 
     /* Huge page size */

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -20,228 +20,164 @@
 #define ABTD_MEM_MAX_TOTAL_STACK_SIZE (64 * 1024 * 1024)
 #define ABTD_MEM_MAX_NUM_DESCS 4096
 
+/* To avoid potential overflow, we intentionally use a smaller value than the
+ * real limit. */
+#define ABTD_ENV_INT_MAX ((int)(INT_MAX / 2))
+#define ABTD_ENV_UINT32_MAX ((int)(UINT32_MAX / 2))
+#define ABTD_ENV_UINT64_MAX ((int)(UINT64_MAX / 2))
+#define ABTD_ENV_SIZE_MAX ((int)(SIZE_MAX / 2))
+
+static uint32_t roundup_pow2_uint32(uint32_t val);
+static const char *get_abt_env(const char *env_suffix);
+static ABT_bool is_false(const char *str, ABT_bool include0);
+static ABT_bool is_true(const char *str, ABT_bool include1);
+static ABT_bool load_env_bool(const char *env_suffix, ABT_bool default_val);
+static int load_env_int(const char *env_suffix, int default_val, int min_val,
+                        int max_val);
+static uint32_t load_env_uint32(const char *env_suffix, uint32_t default_val,
+                                uint32_t min_val, uint32_t max_val);
+static uint64_t load_env_uint64(const char *env_suffix, uint64_t default_val,
+                                uint64_t min_val, uint64_t max_val);
+static size_t load_env_size(const char *env_suffix, size_t default_val,
+                            size_t min_val, size_t max_val);
+
 void ABTD_env_init(ABTI_global *p_global)
 {
-    char *env;
+    const char *env;
 
     /* Get the number of available cores in the system */
     p_global->num_cores = sysconf(_SC_NPROCESSORS_ONLN);
 
-    /* By default, we use the CPU affinity */
-    p_global->set_affinity = ABT_TRUE;
-    env = getenv("ABT_SET_AFFINITY");
-    if (env == NULL)
-        env = getenv("ABT_ENV_SET_AFFINITY");
-    if (env != NULL) {
-        if (strcasecmp(env, "n") == 0 || strcasecmp(env, "no") == 0) {
-            p_global->set_affinity = ABT_FALSE;
-        }
-    }
-    if (p_global->set_affinity == ABT_TRUE) {
+    /* ABT_SET_AFFINITY, ABT_ENV_SET_AFFINITY */
+    env = get_abt_env("SET_AFFINITY");
+    if (env != NULL && is_false(env, ABT_FALSE)) {
+        p_global->set_affinity = ABT_FALSE;
+    } else {
+        /* By default, we use the CPU affinity */
+        p_global->set_affinity = ABT_TRUE;
         ABTD_affinity_init(env);
     }
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
     /* If the debug log printing is set in configure, logging is turned on by
      * default. */
-    p_global->use_logging = ABT_TRUE;
-    p_global->use_debug = ABT_TRUE;
+    const ABT_bool default_use_logging = ABT_TRUE;
+    const ABT_bool default_use_debug = ABT_TRUE;
 #else
     /* Otherwise, logging is not turned on by default. */
-    p_global->use_logging = ABT_FALSE;
-    p_global->use_debug = ABT_FALSE;
+    const ABT_bool default_use_logging = ABT_FALSE;
+    const ABT_bool default_use_debug = ABT_FALSE;
 #endif
-    env = getenv("ABT_USE_LOG");
-    if (env == NULL)
-        env = getenv("ABT_ENV_USE_LOG");
-    if (env != NULL) {
-        if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
-            strcasecmp(env, "no") == 0) {
-            p_global->use_logging = ABT_FALSE;
-        } else {
-            p_global->use_logging = ABT_TRUE;
-        }
-    }
-    env = getenv("ABT_USE_DEBUG");
-    if (env == NULL)
-        env = getenv("ABT_ENV_USE_DEBUG");
-    if (env != NULL) {
-        if (strcmp(env, "0") == 0 || strcasecmp(env, "n") == 0 ||
-            strcasecmp(env, "no") == 0) {
-            p_global->use_debug = ABT_FALSE;
-        } else {
-            p_global->use_debug = ABT_TRUE;
-        }
-    }
+    /* ABT_USE_LOG, ABT_ENV_USE_LOG */
+    p_global->use_logging = load_env_bool("USE_LOG", default_use_logging);
 
-    /* Maximum size of the internal ES array */
-    env = getenv("ABT_MAX_NUM_XSTREAMS");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MAX_NUM_XSTREAMS");
-    if (env != NULL) {
-        p_global->max_xstreams = atoi(env);
-    } else {
-        p_global->max_xstreams = p_global->num_cores;
-    }
+    /* ABT_USE_DEBUG, ABT_ENV_USE_DEBUG */
+    p_global->use_debug = load_env_bool("USE_DEBUG", default_use_debug);
 
-    /* Default key table size */
-    env = getenv("ABT_KEY_TABLE_SIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_KEY_TABLE_SIZE");
-    if (env != NULL) {
-        p_global->key_table_size = (uint32_t)atoi(env);
-    } else {
-        p_global->key_table_size = ABTD_KEY_TABLE_DEFAULT_SIZE;
-    }
-    /* key_table_size must be a power of 2. */
-    {
-        int i;
-        for (i = 0; i < sizeof(size_t) * 8; i++) {
-            if ((p_global->key_table_size - 1) >> i == 0)
-                break;
-        }
-        p_global->key_table_size = ((uint32_t)1) << i;
-    }
+    /* ABT_MAX_NUM_XSTREAMS, ABT_ENV_MAX_NUM_XSTREAMS
+     * Maximum size of the internal ES array */
+    p_global->max_xstreams =
+        load_env_int("MAX_NUM_XSTREAMS", p_global->num_cores, 1,
+                     ABTD_ENV_INT_MAX);
 
-    /* Default stack size for ULT */
-    env = getenv("ABT_THREAD_STACKSIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_THREAD_STACKSIZE");
-    if (env != NULL) {
-        p_global->thread_stacksize = (size_t)atol(env);
-        ABTI_ASSERT(p_global->thread_stacksize >= 512);
-    } else {
-        p_global->thread_stacksize = ABTD_THREAD_DEFAULT_STACKSIZE;
-    }
-    /* Stack size must be a multiple of cacheline size. */
+    /* ABT_KEY_TABLE_SIZE, ABT_ENV_KEY_TABLE_SIZE
+     * Default key table size */
+    p_global->key_table_size = roundup_pow2_uint32(
+        load_env_uint32("KEY_TABLE_SIZE", ABTD_KEY_TABLE_DEFAULT_SIZE, 1,
+                        ABTD_ENV_UINT32_MAX));
+
+    /* ABT_THREAD_STACKSIZE, ABT_ENV_THREAD_STACKSIZE
+     * Default stack size for ULT */
     p_global->thread_stacksize =
-        ABTU_roundup_size(p_global->thread_stacksize,
+        ABTU_roundup_size(load_env_size("THREAD_STACKSIZE",
+                                        ABTD_THREAD_DEFAULT_STACKSIZE, 512,
+                                        ABTD_ENV_SIZE_MAX),
                           ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
-    /* Default stack size for scheduler */
-    env = getenv("ABT_SCHED_STACKSIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_SCHED_STACKSIZE");
-    if (env != NULL) {
-        p_global->sched_stacksize = (size_t)atol(env);
-        ABTI_ASSERT(p_global->sched_stacksize >= 512);
-    } else {
-        p_global->sched_stacksize = ABTD_SCHED_DEFAULT_STACKSIZE;
-    }
+    /* ABT_SCHED_STACKSIZE, ABT_ENV_SCHED_STACKSIZE
+     * Default stack size for scheduler */
+    p_global->sched_stacksize =
+        ABTU_roundup_size(load_env_size("SCHED_STACKSIZE",
+                                        ABTD_SCHED_DEFAULT_STACKSIZE, 512,
+                                        ABTD_ENV_SIZE_MAX),
+                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
-    /* Default frequency for event checking by the scheduler */
-    env = getenv("ABT_SCHED_EVENT_FREQ");
-    if (env == NULL)
-        env = getenv("ABT_ENV_SCHED_EVENT_FREQ");
-    if (env != NULL) {
-        p_global->sched_event_freq = (uint32_t)atol(env);
-        ABTI_ASSERT(p_global->sched_event_freq >= 1);
-    } else {
-        p_global->sched_event_freq = ABTD_SCHED_EVENT_FREQ;
-    }
+    /* ABT_SCHED_EVENT_FREQ, ABT_ENV_SCHED_EVENT_FREQ
+     * Default frequency for event checking by the scheduler */
+    p_global->sched_event_freq =
+        load_env_uint32("SCHED_EVENT_FREQ", ABTD_SCHED_EVENT_FREQ, 1,
+                        ABTD_ENV_UINT32_MAX);
 
-    /* Default nanoseconds for scheduler sleep */
-    env = getenv("ABT_SCHED_SLEEP_NSEC");
-    if (env == NULL)
-        env = getenv("ABT_ENV_SCHED_SLEEP_NSEC");
-    if (env != NULL) {
-        p_global->sched_sleep_nsec = atol(env);
-        ABTI_ASSERT(p_global->sched_sleep_nsec >= 0);
-    } else {
-        p_global->sched_sleep_nsec = ABTD_SCHED_SLEEP_NSEC;
-    }
+    /* ABT_SCHED_SLEEP_NSEC, ABT_ENV_SCHED_SLEEP_NSEC
+     * Default nanoseconds for scheduler sleep */
+    p_global->sched_sleep_nsec =
+        load_env_uint64("SCHED_SLEEP_NSEC", ABTD_SCHED_SLEEP_NSEC, 0,
+                        ABTD_ENV_UINT64_MAX);
 
-    /* Mutex attributes */
-    env = getenv("ABT_MUTEX_MAX_HANDOVERS");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MUTEX_MAX_HANDOVERS");
-    if (env != NULL) {
-        p_global->mutex_max_handovers = (uint32_t)atoi(env);
-        ABTI_ASSERT(p_global->mutex_max_handovers >= 1);
-    } else {
-        p_global->mutex_max_handovers = 64;
-    }
+    /* ABT_MUTEX_MAX_HANDOVERS, ABT_ENV_MUTEX_MAX_HANDOVERS
+     * Default maximum number of mutex handover */
+    p_global->mutex_max_handovers =
+        load_env_uint32("MUTEX_MAX_HANDOVERS", 64, 1, ABTD_ENV_UINT32_MAX);
 
-    env = getenv("ABT_MUTEX_MAX_WAKEUPS");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MUTEX_MAX_WAKEUPS");
-    if (env != NULL) {
-        p_global->mutex_max_wakeups = (uint32_t)atoi(env);
-        ABTI_ASSERT(p_global->mutex_max_wakeups >= 1);
-    } else {
-        p_global->mutex_max_wakeups = 1;
-    }
+    /* ABT_MUTEX_MAX_WAKEUPS, ABT_ENV_MUTEX_MAX_WAKEUPS
+     * Default maximum number of mutex wakeup operations */
+    p_global->mutex_max_wakeups =
+        load_env_uint32("MUTEX_MAX_WAKEUPS", 1, 1, ABTD_ENV_UINT32_MAX);
 
-    /* Huge page size */
-    env = getenv("ABT_HUGE_PAGE_SIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
-    if (env != NULL) {
-        p_global->huge_page_size = (size_t)atol(env);
-    } else {
-        p_global->huge_page_size = ABTD_HUGE_PAGE_SIZE;
-    }
+    /* ABT_HUGE_PAGE_SIZE, ABT_ENV_HUGE_PAGE_SIZE
+     * Huge page size */
+    p_global->huge_page_size =
+        load_env_size("HUGE_PAGE_SIZE", ABTD_HUGE_PAGE_SIZE, 4096,
+                      ABTD_ENV_SIZE_MAX);
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    /* Page size for memory allocation */
-    env = getenv("ABT_MEM_PAGE_SIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MEM_PAGE_SIZE");
-    if (env != NULL) {
-        p_global->mem_page_size = (size_t)atol(env);
-    } else {
-        p_global->mem_page_size = ABTD_MEM_PAGE_SIZE;
-    }
+    /* ABT_MEM_PAGE_SIZE, ABT_ENV_MEM_PAGE_SIZE
+     * Page size for memory allocation */
+    p_global->mem_page_size =
+        ABTU_roundup_size(load_env_size("MEM_PAGE_SIZE", ABTD_MEM_PAGE_SIZE,
+                                        4096, ABTD_ENV_SIZE_MAX),
+                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
-    /* Stack page size for memory allocation */
-    env = getenv("ABT_MEM_STACK_PAGE_SIZE");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MEM_STACK_PAGE_SIZE");
-    if (env != NULL) {
-        p_global->mem_sp_size = (size_t)atol(env);
-    } else {
-        p_global->mem_sp_size = ABTD_MEM_STACK_PAGE_SIZE;
-    }
+    /* ABT_MEM_STACK_PAGE_SIZE, ABT_ENV_MEM_STACK_PAGE_SIZE
+     * Stack page size for memory allocation */
+    p_global->mem_sp_size =
+        ABTU_roundup_size(load_env_size("MEM_STACK_PAGE_SIZE",
+                                        ABTD_MEM_STACK_PAGE_SIZE,
+                                        p_global->thread_stacksize * 4,
+                                        ABTD_ENV_SIZE_MAX),
+                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
-    /* Maximum number of stacks that each ES can keep during execution */
-    env = getenv("ABT_MEM_MAX_NUM_STACKS");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MEM_MAX_NUM_STACKS");
-    if (env != NULL) {
-        p_global->mem_max_stacks = (uint32_t)atol(env);
-    } else {
-        /* Each execution stream caches too many stacks in total. Let's
-         * reduce the max # of stacks. */
-        p_global->mem_max_stacks =
-            ABTU_min_uint32(ABTD_MEM_MAX_TOTAL_STACK_SIZE /
-                                p_global->thread_stacksize,
-                            ABTD_MEM_MAX_NUM_STACKS);
-    }
+    /* ABT_MEM_MAX_NUM_STACKS, ABT_ENV_MEM_MAX_NUM_STACKS
+     * Maximum number of stacks that each ES can keep during execution. */
+    /* If each execution stream caches too many stacks in total, let's reduce
+     * the max # of stacks. */
+    const uint32_t default_mem_max_stacks =
+        ABTU_min_uint32(ABTD_MEM_MAX_TOTAL_STACK_SIZE /
+                            p_global->thread_stacksize,
+                        ABTD_MEM_MAX_NUM_STACKS);
     /* The value must be a multiple of ABT_MEM_POOL_MAX_LOCAL_BUCKETS. */
     p_global->mem_max_stacks =
-        ABTU_roundup_uint32(p_global->mem_max_stacks,
+        ABTU_roundup_uint32(load_env_uint32("MEM_MAX_NUM_STACKS",
+                                            default_mem_max_stacks,
+                                            ABT_MEM_POOL_MAX_LOCAL_BUCKETS,
+                                            ABTD_ENV_UINT32_MAX),
                             ABT_MEM_POOL_MAX_LOCAL_BUCKETS);
 
-    /* Maximum number of descriptors that each ES can keep during execution */
-    env = getenv("ABT_MEM_MAX_NUM_DESCS");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MEM_MAX_NUM_DESCS");
-    if (env != NULL) {
-        p_global->mem_max_descs = (uint32_t)atol(env);
-    } else {
-        p_global->mem_max_descs = ABTD_MEM_MAX_NUM_DESCS;
-    }
+    /* ABT_MEM_MAX_NUM_DESCS, ABT_ENV_MEM_MAX_NUM_DESCS
+     * Maximum number of descriptors that each ES can keep during execution */
     /* The value must be a multiple of ABT_MEM_POOL_MAX_LOCAL_BUCKETS. */
     p_global->mem_max_descs =
-        ABTU_roundup_uint32(p_global->mem_max_descs,
+        ABTU_roundup_uint32(load_env_uint32("MEM_MAX_NUM_DESCS",
+                                            ABTD_MEM_MAX_NUM_DESCS,
+                                            ABT_MEM_POOL_MAX_LOCAL_BUCKETS,
+                                            ABTD_ENV_UINT32_MAX),
                             ABT_MEM_POOL_MAX_LOCAL_BUCKETS);
 
-    /* How to allocate large pages.  The default is to use mmap() for huge
+    /* ABT_MEM_LP_ALLOC, ABT_ENV_MEM_LP_ALLOC
+     * How to allocate large pages.  The default is to use mmap() for huge
      * pages and then to fall back to allocate regular pages using mmap() when
      * huge pages are run out of. */
-    env = getenv("ABT_MEM_LP_ALLOC");
-    if (env == NULL)
-        env = getenv("ABT_ENV_MEM_LP_ALLOC");
+    env = get_abt_env("MEM_LP_ALLOC");
 #if defined(HAVE_MAP_ANONYMOUS) || defined(HAVE_MAP_ANON)
 #if defined(__x86_64__)
     int lp_alloc = ABTI_MEM_LP_MMAP_HP_RP;
@@ -286,21 +222,153 @@ void ABTD_env_init(ABTI_global *p_global)
     }
 #endif
 
-    /* Whether to print the configuration on ABT_init() */
-    env = getenv("ABT_PRINT_CONFIG");
-    if (env == NULL)
-        env = getenv("ABT_ENV_PRINT_CONFIG");
-    if (env != NULL) {
-        if (strcmp(env, "1") == 0 || strcasecmp(env, "yes") == 0 ||
-            strcasecmp(env, "y") == 0) {
-            p_global->print_config = ABT_TRUE;
-        } else {
-            p_global->print_config = ABT_FALSE;
-        }
-    } else {
-        p_global->print_config = ABT_FALSE;
-    }
+    /* ABT_PRINT_CONFIG, ABT_ENV_PRINT_CONFIG
+     * Whether to print the configuration on ABT_init() */
+    p_global->print_config = load_env_bool("PRINT_CONFIG", ABT_FALSE);
 
     /* Init timer */
     ABTD_time_init();
+}
+
+/*****************************************************************************/
+/* Internal static functions                                                 */
+/*****************************************************************************/
+
+static uint32_t roundup_pow2_uint32(uint32_t val)
+{
+    /* 3 -> 4
+     * 4 -> 4
+     * 5 -> 8 */
+    if (val == 0)
+        return 0;
+    int i;
+    for (i = 0; i < sizeof(uint32_t) * 8; i++) {
+        if ((val - 1) >> i == 0)
+            break;
+    }
+    return ((uint32_t)1) << i;
+}
+
+static const char *get_abt_env(const char *env_suffix)
+{
+    /* Valid prefix is ABT_ and ABT_ENV_. ABT_ is prioritized. */
+    char buffer[128];
+    const char *prefixes[] = { "ABT_", "ABT_ENV_" };
+    int i;
+    for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+        strcpy(buffer, prefixes[i]);
+        strcpy(buffer + strlen(prefixes[i]), env_suffix);
+        const char *env = getenv(buffer);
+        if (env)
+            return env;
+    }
+    return NULL;
+}
+
+static ABT_bool is_false(const char *str, ABT_bool include0)
+{
+    if (include0 && strcmp(str, "0") == 0) {
+        return ABT_TRUE;
+    } else if (strcasecmp(str, "n") == 0 || strcasecmp(str, "no") == 0 ||
+               strcasecmp(str, "false") == 0 || strcasecmp(str, "off") == 0) {
+        return ABT_TRUE;
+    }
+    return ABT_FALSE;
+}
+
+static ABT_bool is_true(const char *str, ABT_bool include1)
+{
+    if (include1 && strcmp(str, "1") == 0) {
+        return ABT_TRUE;
+    } else if (strcasecmp(str, "y") == 0 || strcasecmp(str, "yes") == 0 ||
+               strcasecmp(str, "true") == 0 || strcasecmp(str, "on") == 0) {
+        return ABT_TRUE;
+    }
+    return ABT_FALSE;
+}
+
+static ABT_bool load_env_bool(const char *env_suffix, ABT_bool default_val)
+{
+    const char *env = get_abt_env(env_suffix);
+    if (!env) {
+        return default_val;
+    } else {
+        if (default_val) {
+            /* If env is not "false", return true */
+            return is_false(env, ABT_TRUE) ? ABT_FALSE : ABT_TRUE;
+        } else {
+            /* If env is not "true", return false */
+            return is_true(env, ABT_TRUE) ? ABT_TRUE : ABT_FALSE;
+        }
+    }
+}
+
+static int load_env_int(const char *env_suffix, int default_val, int min_val,
+                        int max_val)
+{
+    const char *env = get_abt_env(env_suffix);
+    if (!env) {
+        return ABTU_max_int(min_val, ABTU_min_int(max_val, default_val));
+    } else {
+        int val;
+        int abt_errno = ABTU_atoi(env, &val, NULL);
+        if (abt_errno != ABT_SUCCESS) {
+            return ABTU_max_int(min_val, ABTU_min_int(max_val, default_val));
+        } else {
+            return ABTU_max_int(min_val, ABTU_min_int(max_val, val));
+        }
+    }
+}
+
+static uint32_t load_env_uint32(const char *env_suffix, uint32_t default_val,
+                                uint32_t min_val, uint32_t max_val)
+{
+    const char *env = get_abt_env(env_suffix);
+    if (!env) {
+        return ABTU_max_uint32(min_val, ABTU_min_uint32(max_val, default_val));
+    } else {
+        uint32_t val;
+        int abt_errno = ABTU_atoui32(env, &val, NULL);
+        if (abt_errno != ABT_SUCCESS) {
+            return ABTU_max_uint32(min_val,
+                                   ABTU_min_uint32(max_val, default_val));
+        } else {
+            return ABTU_max_uint32(min_val, ABTU_min_uint32(max_val, val));
+        }
+    }
+}
+
+static uint64_t load_env_uint64(const char *env_suffix, uint64_t default_val,
+                                uint64_t min_val, uint64_t max_val)
+{
+    const char *env = get_abt_env(env_suffix);
+    if (!env) {
+        return ABTU_max_uint64(min_val, ABTU_min_uint64(max_val, default_val));
+    } else {
+        uint64_t val;
+        int abt_errno = ABTU_atoui64(env, &val, NULL);
+        if (abt_errno != ABT_SUCCESS) {
+            return ABTU_max_uint64(min_val,
+                                   ABTU_min_uint64(max_val, default_val));
+        } else {
+            return ABTU_max_uint64(min_val, ABTU_min_uint64(max_val, val));
+        }
+    }
+}
+
+static size_t load_env_size(const char *env_suffix, size_t default_val,
+                            size_t min_val, size_t max_val)
+{
+    const char *env = get_abt_env(env_suffix);
+    if (!env) {
+        return ABTU_max_size(min_val, ABTU_min_size(max_val, default_val));
+    } else {
+        size_t val;
+        int abt_errno = ABTU_atosz(env, &val, NULL);
+        if (abt_errno != ABT_SUCCESS) {
+            return ABTU_max_size(min_val, ABTU_min_size(max_val, default_val));
+        } else {
+            return ABTU_max_size(min_val, ABTU_min_size(max_val, val));
+        }
+    }
 }

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -89,18 +89,18 @@ void ABTD_env_init(ABTI_global *p_global)
     if (env == NULL)
         env = getenv("ABT_ENV_KEY_TABLE_SIZE");
     if (env != NULL) {
-        p_global->key_table_size = (int)atoi(env);
+        p_global->key_table_size = (uint32_t)atoi(env);
     } else {
         p_global->key_table_size = ABTD_KEY_TABLE_DEFAULT_SIZE;
     }
     /* key_table_size must be a power of 2. */
     {
         int i;
-        for (i = 0; i < sizeof(int) * 8; i++) {
+        for (i = 0; i < sizeof(size_t) * 8; i++) {
             if ((p_global->key_table_size - 1) >> i == 0)
                 break;
         }
-        p_global->key_table_size = 1 << i;
+        p_global->key_table_size = ((uint32_t)1) << i;
     }
 
     /* Default stack size for ULT */
@@ -177,7 +177,7 @@ void ABTD_env_init(ABTI_global *p_global)
     if (env == NULL)
         env = getenv("ABT_ENV_HUGE_PAGE_SIZE");
     if (env != NULL) {
-        p_global->huge_page_size = (uint32_t)atol(env);
+        p_global->huge_page_size = (size_t)atol(env);
     } else {
         p_global->huge_page_size = ABTD_HUGE_PAGE_SIZE;
     }
@@ -188,7 +188,7 @@ void ABTD_env_init(ABTI_global *p_global)
     if (env == NULL)
         env = getenv("ABT_ENV_MEM_PAGE_SIZE");
     if (env != NULL) {
-        p_global->mem_page_size = (uint32_t)atol(env);
+        p_global->mem_page_size = (size_t)atol(env);
     } else {
         p_global->mem_page_size = ABTD_MEM_PAGE_SIZE;
     }

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -178,19 +178,19 @@ struct ABTI_global {
     ABT_bool set_affinity;        /* Whether CPU affinity is used */
     ABT_bool use_logging;         /* Whether logging is used */
     ABT_bool use_debug;           /* Whether debug output is used */
-    int key_table_size;           /* Default key table size */
+    uint32_t key_table_size;      /* Default key table size */
     size_t thread_stacksize;      /* Default stack size for ULT (in bytes) */
     size_t sched_stacksize;       /* Default stack size for sched (in bytes) */
     uint32_t sched_event_freq;    /* Default check frequency for sched */
-    long sched_sleep_nsec;        /* Default nanoseconds for scheduler sleep */
+    uint64_t sched_sleep_nsec;    /* Default nanoseconds for scheduler sleep */
     ABTI_ythread *p_main_ythread; /* ULT of the main function */
 
     uint32_t mutex_max_handovers; /* Default max. # of local handovers */
     uint32_t mutex_max_wakeups;   /* Default max. # of wakeups */
-    uint32_t huge_page_size;      /* Huge page size */
+    size_t huge_page_size;        /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
-    uint32_t mem_page_size;  /* Page size for memory allocation */
-    uint32_t mem_sp_size;    /* Stack page size */
+    size_t mem_page_size;    /* Page size for memory allocation */
+    size_t mem_sp_size;      /* Stack page size */
     uint32_t mem_max_stacks; /* Max. # of stacks kept in each ES */
     uint32_t mem_max_descs;  /* Max. # of descriptors kept in each ES */
     int mem_lp_alloc;        /* How to allocate large pages */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -187,7 +187,6 @@ struct ABTI_global {
 
     uint32_t mutex_max_handovers; /* Default max. # of local handovers */
     uint32_t mutex_max_wakeups;   /* Default max. # of wakeups */
-    uint32_t os_page_size;        /* OS page size */
     uint32_t huge_page_size;      /* Huge page size */
 #ifdef ABT_CONFIG_USE_MEM_POOL
     uint32_t mem_page_size;  /* Page size for memory allocation */

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -68,7 +68,7 @@ ABTU_ret_err static inline int ABTI_ktable_create(ABTI_local *p_local,
                                                   ABTI_ktable **pp_ktable)
 {
     ABTI_ktable *p_ktable;
-    int key_table_size = gp_ABTI_global->key_table_size;
+    uint32_t key_table_size = gp_ABTI_global->key_table_size;
     /* size must be a power of 2. */
     ABTI_ASSERT((key_table_size & (key_table_size - 1)) == 0);
     /* max alignment must be a power of 2. */

--- a/src/include/abtu.h
+++ b/src/include/abtu.h
@@ -305,4 +305,13 @@ ABTU_alloc_largepage(size_t size, size_t alignment_hint,
                      void **p_ptr);
 void ABTU_free_largepage(void *ptr, size_t size, ABTU_MEM_LARGEPAGE_TYPE type);
 
+/* String-to-integer functions. */
+ABTU_ret_err int ABTU_atoi(const char *str, int *p_val, ABT_bool *p_overflow);
+ABTU_ret_err int ABTU_atoui32(const char *str, uint32_t *p_val,
+                              ABT_bool *p_overflow);
+ABTU_ret_err int ABTU_atoui64(const char *str, uint64_t *p_val,
+                              ABT_bool *p_overflow);
+ABTU_ret_err int ABTU_atosz(const char *str, size_t *p_val,
+                            ABT_bool *p_overflow);
+
 #endif /* ABTU_H_INCLUDED */

--- a/src/info.c
+++ b/src/info.c
@@ -593,7 +593,7 @@ void ABTI_info_print_config(FILE *fp)
     fprintf(fp, "Argobots Configuration:\n");
     fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
     fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
-    fprintf(fp, " - huge page size: %u\n", p_global->huge_page_size);
+    fprintf(fp, " - huge page size: %zu\n", p_global->huge_page_size);
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
     fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
     fprintf(fp, " - ES affinity: %s\n",
@@ -602,11 +602,12 @@ void ABTI_info_print_config(FILE *fp)
             (p_global->use_logging == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - debug output: %s\n",
             (p_global->use_debug == ABT_TRUE) ? "on" : "off");
-    fprintf(fp, " - key table entries: %d\n", p_global->key_table_size);
-    fprintf(fp, " - ULT stack size: %u KB\n",
-            (unsigned)(p_global->thread_stacksize / 1024));
-    fprintf(fp, " - scheduler stack size: %u KB\n",
-            (unsigned)(p_global->sched_stacksize / 1024));
+    fprintf(fp, " - key table entries: %" PRIu32 "\n",
+            p_global->key_table_size);
+    fprintf(fp, " - ULT stack size: %zu KB\n",
+            p_global->thread_stacksize / 1024);
+    fprintf(fp, " - scheduler stack size: %zu KB\n",
+            p_global->sched_stacksize / 1024);
     fprintf(fp, " - scheduler event check frequency: %u\n",
             p_global->sched_event_freq);
 
@@ -622,9 +623,9 @@ void ABTI_info_print_config(FILE *fp)
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
     fprintf(fp, "Memory Pool:\n");
-    fprintf(fp, " - page size for allocation: %u KB\n",
+    fprintf(fp, " - page size for allocation: %zu KB\n",
             p_global->mem_page_size / 1024);
-    fprintf(fp, " - stack page size: %u KB\n", p_global->mem_sp_size / 1024);
+    fprintf(fp, " - stack page size: %zu KB\n", p_global->mem_sp_size / 1024);
     fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
     switch (p_global->mem_lp_alloc) {
         case ABTI_MEM_LP_MALLOC:

--- a/src/info.c
+++ b/src/info.c
@@ -593,7 +593,6 @@ void ABTI_info_print_config(FILE *fp)
     fprintf(fp, "Argobots Configuration:\n");
     fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
     fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
-    fprintf(fp, " - OS page size: %u\n", p_global->os_page_size);
     fprintf(fp, " - huge page size: %u\n", p_global->huge_page_size);
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
     fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);

--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -4,4 +4,5 @@
 #
 
 abt_sources += \
+	util/atoi.c \
 	util/largepage.c

--- a/src/util/atoi.c
+++ b/src/util/atoi.c
@@ -1,0 +1,305 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+static ABTU_ret_err int atoi_impl(const char *str, ABT_bool *p_is_signed,
+                                  uint64_t *p_val, ABT_bool *p_overflow);
+
+ABTU_ret_err int ABTU_atoi(const char *str, int *p_val, ABT_bool *p_overflow)
+{
+    uint64_t val;
+    ABT_bool overflow, is_signed;
+    int abt_errno = atoi_impl(str, &is_signed, &val, &overflow);
+    ABTI_CHECK_ERROR(abt_errno);
+    if (is_signed) {
+        if (val > (uint64_t)(-(int64_t)INT_MIN)) {
+            /* Underflow. */
+            overflow = ABT_TRUE;
+            *p_val = INT_MIN;
+        } else {
+            *p_val = (int)(-(int64_t)val);
+        }
+    } else {
+        if (val > (uint64_t)INT_MAX) {
+            /* Overflow. */
+            overflow = ABT_TRUE;
+            *p_val = INT_MAX;
+        } else {
+            *p_val = (int)val;
+        }
+    }
+    if (p_overflow)
+        *p_overflow = overflow;
+    return abt_errno;
+}
+
+ABTU_ret_err int ABTU_atoui32(const char *str, uint32_t *p_val,
+                              ABT_bool *p_overflow)
+{
+    uint64_t val;
+    ABT_bool overflow, is_signed;
+    int abt_errno = atoi_impl(str, &is_signed, &val, &overflow);
+    ABTI_CHECK_ERROR(abt_errno);
+    if (is_signed) {
+        /* Underflow. */
+        if (val != 0)
+            overflow = ABT_TRUE;
+        *p_val = 0;
+    } else {
+        if (val > (uint64_t)UINT32_MAX) {
+            /* Overflow. */
+            overflow = ABT_TRUE;
+            *p_val = UINT32_MAX;
+        } else {
+            *p_val = (uint32_t)val;
+        }
+    }
+    if (p_overflow)
+        *p_overflow = overflow;
+    return abt_errno;
+}
+
+ABTU_ret_err int ABTU_atoui64(const char *str, uint64_t *p_val,
+                              ABT_bool *p_overflow)
+{
+    uint64_t val;
+    ABT_bool overflow, is_signed;
+    int abt_errno = atoi_impl(str, &is_signed, &val, &overflow);
+    ABTI_CHECK_ERROR(abt_errno);
+    if (is_signed) {
+        /* Underflow. */
+        if (val != 0)
+            overflow = ABT_TRUE;
+        *p_val = 0;
+    } else {
+        *p_val = val;
+    }
+    if (p_overflow)
+        *p_overflow = overflow;
+    return abt_errno;
+}
+
+ABTU_ret_err int ABTU_atosz(const char *str, size_t *p_val,
+                            ABT_bool *p_overflow)
+{
+    ABTI_STATIC_ASSERT(sizeof(size_t) == 4 || sizeof(size_t) == 8);
+    if (sizeof(size_t) == 4) {
+        uint32_t val;
+        ABT_bool overflow;
+        int abt_errno = ABTU_atoui32(str, &val, &overflow);
+        ABTI_CHECK_ERROR(abt_errno);
+        *p_val = (size_t)val;
+        if (p_overflow)
+            *p_overflow = overflow;
+        return abt_errno;
+    } else {
+        uint64_t val;
+        ABT_bool overflow;
+        int abt_errno = ABTU_atoui64(str, &val, &overflow);
+        ABTI_CHECK_ERROR(abt_errno);
+        *p_val = (size_t)val;
+        if (p_overflow)
+            *p_overflow = overflow;
+        return abt_errno;
+    }
+}
+
+/*****************************************************************************/
+/* Internal static functions                                                 */
+/*****************************************************************************/
+
+static ABTU_ret_err int atoi_impl(const char *str, ABT_bool *p_is_signed,
+                                  uint64_t *p_val, ABT_bool *p_overflow)
+{
+    uint64_t val = 0;
+    ABT_bool is_signed = ABT_FALSE, read_char = ABT_FALSE,
+             read_digit = ABT_FALSE;
+    while (1) {
+        if ((*str == '\n' || *str == '\t' || *str == ' ' || *str == '\r') &&
+            read_char == ABT_FALSE) {
+            /* Do nothing. */
+        } else if (*str == '+' && read_digit == ABT_FALSE) {
+            read_char = ABT_TRUE;
+        } else if (*str == '-' && read_digit == ABT_FALSE) {
+            /* Flip the digit. */
+            read_char = ABT_TRUE;
+            is_signed = is_signed ? ABT_FALSE : ABT_TRUE;
+        } else if ('0' <= *str && *str <= '9') {
+            read_char = ABT_TRUE;
+            read_digit = ABT_TRUE;
+            /* Will val overflow? */
+            if ((val > UINT64_MAX / 10) ||
+                (val * 10 > UINT64_MAX - (uint64_t)(*str - '0'))) {
+                /* Overflow. */
+                *p_overflow = ABT_TRUE;
+                *p_val = UINT64_MAX;
+                *p_is_signed = is_signed;
+                return ABT_SUCCESS;
+            }
+            val = val * 10 + (uint64_t)(*str - '0');
+            read_digit = ABT_TRUE;
+        } else {
+            /* Stop reading str. */
+            if (read_digit == ABT_FALSE) {
+                /* No integer. */
+                return ABT_ERR_INV_ARG;
+            }
+            *p_overflow = ABT_FALSE;
+            *p_val = val;
+            *p_is_signed = is_signed;
+            return ABT_SUCCESS;
+        }
+        str++;
+    }
+}
+
+#if 0
+
+void test_ABTU_atoi(const char *str, int err, int val, ABT_bool overflow)
+{
+    int ret_val;
+    ABT_bool ret_overflow;
+    int ret_err = ABTU_atoi(str, &ret_val, &ret_overflow);
+    assert(err == ret_err);
+    if (err == ABT_SUCCESS) {
+        assert(val == ret_val);
+        assert(overflow == ret_overflow);
+    }
+}
+
+void test_ABTU_atoui32(const char *str, int err, uint32_t val, ABT_bool overflow)
+{
+    uint32_t ret_val;
+    ABT_bool ret_overflow;
+    int ret_err = ABTU_atoui32(str, &ret_val, &ret_overflow);
+    assert(err == ret_err);
+    if (err == ABT_SUCCESS) {
+        assert(val == ret_val);
+        assert(overflow == ret_overflow);
+    }
+}
+
+void test_ABTU_atoui64(const char *str, int err, uint64_t val, ABT_bool overflow)
+{
+    uint64_t ret_val;
+    ABT_bool ret_overflow;
+    int ret_err = ABTU_atoui64(str, &ret_val, &ret_overflow);
+    assert(err == ret_err);
+    if (err == ABT_SUCCESS) {
+        assert(val == ret_val);
+        assert(overflow == ret_overflow);
+    }
+}
+
+void test_ABTU_atosz(const char *str, int err, size_t val, ABT_bool overflow)
+{
+    size_t ret_val;
+    ABT_bool ret_overflow;
+    int ret_err = ABTU_atosz(str, &ret_val, &ret_overflow);
+    assert(err == ret_err);
+    if (err == ABT_SUCCESS) {
+        assert(val == ret_val);
+        assert(overflow == ret_overflow);
+    }
+}
+
+int main()
+{
+    typedef struct {
+        const char *str;
+        int err;
+        int val;
+    } base_case_t;
+
+    /* Basic cases (no overflow). */
+    base_case_t cases[] = {
+        { "0", ABT_SUCCESS, 0 },
+        { "63", ABT_SUCCESS, 63 },
+        { "+14", ABT_SUCCESS, 14 },
+        { "+0", ABT_SUCCESS, 0 },
+        { "+-+-+---++0", ABT_SUCCESS, 0 },
+        { "+-+-+---+-+8800", ABT_SUCCESS, 8800 },
+        { "----1---", ABT_SUCCESS, 1 },
+        { "abc", ABT_ERR_INV_ARG, 0 },
+        { "13abc", ABT_SUCCESS, 13 },
+        { "000123456", ABT_SUCCESS, 123456 },
+        { "00000000", ABT_SUCCESS, 0 },
+        { "123x456", ABT_SUCCESS, 123 },
+        { "123+456", ABT_SUCCESS, 123 },
+        { "123 456", ABT_SUCCESS, 123 },
+        { "--12-3-45-6", ABT_SUCCESS, 12 },
+        { "", ABT_ERR_INV_ARG, 0 },
+        { "+", ABT_ERR_INV_ARG, 0 },
+        { "-", ABT_ERR_INV_ARG, 0 },
+        { "+ 2", ABT_ERR_INV_ARG, 0 },
+        { "    \n\t\r+-+-", ABT_ERR_INV_ARG, 0 },
+        { "    \n\t\r+-+-123", ABT_SUCCESS, 123 },
+    };
+
+    size_t i;
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        test_ABTU_atoi(cases[i].str, cases[i].err, cases[i].val, ABT_FALSE);
+        test_ABTU_atoui32(cases[i].str, cases[i].err, cases[i].val, ABT_FALSE);
+        test_ABTU_atoui64(cases[i].str, cases[i].err, cases[i].val, ABT_FALSE);
+        test_ABTU_atosz(cases[i].str, cases[i].err, cases[i].val, ABT_FALSE);
+    }
+
+    /* Check negative values. */
+    test_ABTU_atoi("-1", ABT_SUCCESS, -1, ABT_FALSE);
+    test_ABTU_atoi("-9990", ABT_SUCCESS, -9990, ABT_FALSE);
+    test_ABTU_atoi(" --+-1234a-", ABT_SUCCESS, -1234, ABT_FALSE);
+
+    /* Check overflow/underflow */
+    test_ABTU_atoi("2147483646", ABT_SUCCESS, 2147483646, ABT_FALSE);
+    test_ABTU_atoi("2147483647", ABT_SUCCESS, 2147483647, ABT_FALSE);
+    test_ABTU_atoi("2147483648", ABT_SUCCESS, 2147483647, ABT_TRUE);
+    test_ABTU_atoi("11112147483648", ABT_SUCCESS, 2147483647, ABT_TRUE);
+    test_ABTU_atoi("-2147483647", ABT_SUCCESS, -2147483647, ABT_FALSE);
+    test_ABTU_atoi("-2147483648", ABT_SUCCESS, -2147483648, ABT_FALSE);
+    test_ABTU_atoi("-2147483649", ABT_SUCCESS, -2147483648, ABT_TRUE);
+    test_ABTU_atoi("-11112147483648", ABT_SUCCESS, -2147483648, ABT_TRUE);
+
+    test_ABTU_atoui32("4294967294", ABT_SUCCESS, 4294967294, ABT_FALSE);
+    test_ABTU_atoui32("4294967295", ABT_SUCCESS, 4294967295, ABT_FALSE);
+    test_ABTU_atoui32("4294967296", ABT_SUCCESS, 4294967295, ABT_TRUE);
+    test_ABTU_atoui32("11114294967295", ABT_SUCCESS, 4294967295, ABT_TRUE);
+    test_ABTU_atoui32("-1", ABT_SUCCESS, 0, ABT_TRUE);
+    test_ABTU_atoui32("-2147483649", ABT_SUCCESS, 0, ABT_TRUE);
+
+    test_ABTU_atoui64("18446744073709551614", ABT_SUCCESS,
+                      18446744073709551614u, ABT_FALSE);
+    test_ABTU_atoui64("18446744073709551615", ABT_SUCCESS,
+                      18446744073709551615u, ABT_FALSE);
+    test_ABTU_atoui64("18446744073709551616", ABT_SUCCESS,
+                      18446744073709551615u, ABT_TRUE);
+    test_ABTU_atoui64("111118446744073709551615", ABT_SUCCESS,
+                      18446744073709551615u, ABT_TRUE);
+    test_ABTU_atoui64("-1", ABT_SUCCESS, 0, ABT_TRUE);
+    test_ABTU_atoui64("-18446744073709551616", ABT_SUCCESS, 0, ABT_TRUE);
+
+    if (sizeof(size_t) == 4) {
+        test_ABTU_atosz("4294967294", ABT_SUCCESS, 4294967294, ABT_FALSE);
+        test_ABTU_atosz("4294967295", ABT_SUCCESS, 4294967295, ABT_FALSE);
+        test_ABTU_atosz("4294967296", ABT_SUCCESS, 4294967295, ABT_TRUE);
+        test_ABTU_atosz("11114294967295", ABT_SUCCESS, 4294967295, ABT_TRUE);
+        test_ABTU_atosz("-1", ABT_SUCCESS, 0, ABT_TRUE);
+        test_ABTU_atosz("-2147483649", ABT_SUCCESS, 0, ABT_TRUE);
+    } else {
+        assert(sizeof(size_t) == 8);
+        test_ABTU_atosz("18446744073709551614", ABT_SUCCESS,
+                        18446744073709551614u, ABT_FALSE);
+        test_ABTU_atosz("18446744073709551615", ABT_SUCCESS,
+                        18446744073709551615u, ABT_FALSE);
+        test_ABTU_atosz("18446744073709551616", ABT_SUCCESS,
+                        18446744073709551615u, ABT_TRUE);
+        test_ABTU_atosz("111118446744073709551615", ABT_SUCCESS,
+                        18446744073709551615u, ABT_TRUE);
+        test_ABTU_atosz("-1", ABT_SUCCESS, 0, ABT_TRUE);
+        test_ABTU_atosz("-18446744073709551616", ABT_SUCCESS, 0, ABT_TRUE);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Problem

Argobots reads environment variables without checking if values are in an acceptable range.  
Although passing such a large value (e.g., 4GB for page size) is not practical,, some variable type are improper to read and store these values: `int` and `uint32_t` are used for data size. Values are read by 'atoi()' and `atol()`, so they might fail to read big unsigned values.

## What this PR does
This PR cleans up the code in `ABTD_env_init()`; it fixes type issues and uses new `atoi()` functions that can handle overflow.
