### PR TITLE
fix signed/unsigned warning

### DIFF
--- a/examples/profiling/abtx_prof.h
+++ b/examples/profiling/abtx_prof.h
@@ -238,7 +238,7 @@ static inline uint64_t ABTXI_prof_get_cycles()
 #ifdef ABTXI_PROF_USE_CYCLES
 
 #define ABTXI_PROF_T int64_t
-#define ABTXI_PROF_T_INVALID 0xFFFFFFFFFFFFFFFF
+#define ABTXI_PROF_T_INVALID ((int64_t)0xFFFFFFFFFFFFFFFF)
 #define ABTXI_PROF_T_ZERO ((int64_t)0)
 #define ABTXI_prof_get_time() ABTXI_prof_get_cycles()
 #define ABTXI_PROF_T_STRING "HW cycles"
@@ -863,7 +863,7 @@ static char *ABTXI_prof_sprintf(ABTXI_prof_str_mem *p_str, size_t max_n,
     while (p_str->p_next) {
         p_str = p_str->p_next;
     }
-    if (p_str->len - p_str->cursor < max_n) {
+    if (p_str->len - p_str->cursor < (int)max_n) {
         int newlen = max_n > 4096 ? max_n : 4096;
         ABTXI_prof_str_mem *p_new = ABTXI_prof_str_mem_alloc(newlen);
         p_str->p_next = p_new;

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -183,7 +183,7 @@ typedef cpuset_t cpu_set_t;
 
 typedef struct {
     ABTD_affinity_cpuset initial_cpuset;
-    size_t num_cpusets;
+    uint32_t num_cpusets;
     ABTD_affinity_cpuset *cpusets;
 } global_affinity;
 
@@ -194,8 +194,9 @@ static inline int int_rem(int a, unsigned int b)
     /* Return x where a = n * b + x and 0 <= x < b */
     /* Because of ambiguity in the C specification, it uses a branch to check if
      * the result is positive. */
-    int ret = (a % b) + b;
-    return ret >= b ? (ret - b) : ret;
+    int int_b = b;
+    int ret = (a % int_b) + int_b;
+    return ret >= int_b ? (ret - int_b) : ret;
 }
 
 ABTU_ret_err static int get_num_cores(pthread_t native_thread, int *p_num_cores)
@@ -249,7 +250,7 @@ ABTU_ret_err static int apply_cpuset(pthread_t native_thread,
                                      const ABTD_affinity_cpuset *p_cpuset)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
-    size_t i;
+    uint32_t i;
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     for (i = 0; i < p_cpuset->num_cpuids; i++) {
@@ -268,7 +269,8 @@ void ABTD_affinity_init(const char *affinity_str)
     g_affinity.cpusets = NULL;
     g_affinity.initial_cpuset.cpuids = NULL;
     pthread_t self_native_thread = pthread_self();
-    int i, ret;
+    uint32_t i;
+    int ret;
     ret = get_num_cores(self_native_thread, &gp_ABTI_global->num_cores);
     if (ret != ABT_SUCCESS || gp_ABTI_global->num_cores == 0) {
         gp_ABTI_global->set_affinity = ABT_FALSE;
@@ -299,7 +301,7 @@ void ABTD_affinity_init(const char *affinity_str)
         ABTI_ASSERT(ret == ABT_SUCCESS);
         for (i = 0; i < p_list->num; i++) {
             const ABTD_affinity_id_list *p_id_list = p_list->p_id_lists[i];
-            int j, num_cpuids = 0, len_cpuids = 8;
+            uint32_t j, num_cpuids = 0, len_cpuids = 8;
             ret = ABTU_malloc(sizeof(int) * len_cpuids,
                               (void **)&g_affinity.cpusets[i].cpuids);
             ABTI_ASSERT(ret == ABT_SUCCESS);
@@ -313,7 +315,8 @@ void ABTD_affinity_init(const char *affinity_str)
                                       g_affinity.initial_cpuset.num_cpuids);
                 int cpuid = g_affinity.initial_cpuset.cpuids[cpuid_i];
                 /* If it is unique, add it.*/
-                int k, is_unique = 1;
+                uint32_t k;
+                int is_unique = 1;
                 for (k = 0; k < num_cpuids; k++) {
                     if (g_affinity.cpusets[i].cpuids[k] == cpuid) {
                         is_unique = 0;
@@ -373,7 +376,7 @@ void ABTD_affinity_finalize(void)
     }
     /* Free g_afinity. */
     ABTD_affinity_cpuset_destroy(&g_affinity.initial_cpuset);
-    int i;
+    uint32_t i;
     for (i = 0; i < g_affinity.num_cpusets; i++) {
         ABTD_affinity_cpuset_destroy(&g_affinity.cpusets[i]);
     }

--- a/src/arch/abtd_affinity_parser.c
+++ b/src/arch/abtd_affinity_parser.c
@@ -21,14 +21,14 @@ static void id_list_free(ABTD_affinity_id_list *p_id_list)
     ABTU_free(p_id_list);
 }
 
-static void id_list_add(ABTD_affinity_id_list *p_id_list, int id, int num,
+static void id_list_add(ABTD_affinity_id_list *p_id_list, int id, uint32_t num,
                         int stride)
 {
     /* Needs to add num ids. */
-    int i, ret;
-    ret = ABTU_realloc(sizeof(int) * p_id_list->num,
-                       sizeof(int) * (p_id_list->num + num),
-                       (void **)&p_id_list->ids);
+    uint32_t i;
+    int ret = ABTU_realloc(sizeof(int) * p_id_list->num,
+                           sizeof(int) * (p_id_list->num + num),
+                           (void **)&p_id_list->ids);
     ABTI_ASSERT(ret == ABT_SUCCESS);
     for (i = 0; i < num; i++) {
         p_id_list->ids[p_id_list->num + i] = id + stride * i;
@@ -48,7 +48,7 @@ static ABTD_affinity_list *list_create(void)
 static void list_free(ABTD_affinity_list *p_list)
 {
     if (p_list) {
-        int i;
+        uint32_t i;
         for (i = 0; i < p_list->num; i++)
             id_list_free(p_list->p_id_lists[i]);
         free(p_list->p_id_lists);
@@ -57,10 +57,11 @@ static void list_free(ABTD_affinity_list *p_list)
 }
 
 static void list_add(ABTD_affinity_list *p_list, ABTD_affinity_id_list *p_base,
-                     int num, int stride)
+                     uint32_t num, int stride)
 {
     /* Needs to add num id-lists. */
-    int i, j, ret;
+    uint32_t i, j;
+    int ret;
 
     ret = ABTU_realloc(sizeof(ABTD_affinity_id_list *) * p_list->num,
                        sizeof(ABTD_affinity_id_list *) * (p_list->num + num),
@@ -86,9 +87,10 @@ static inline int is_whitespace(char c)
 }
 
 /* Integer. */
-static int consume_int(const char *str, int *p_index, int *p_val)
+static int consume_int(const char *str, uint32_t *p_index, int *p_val)
 {
-    int index = *p_index, val = 0, val_sign = 1;
+    uint32_t index = *p_index;
+    int val = 0, val_sign = 1;
     char flag = 'n';
     while (1) {
         char c = *(str + index);
@@ -122,9 +124,10 @@ static int consume_int(const char *str, int *p_index, int *p_val)
 }
 
 /* Positive integer */
-static int consume_pint(const char *str, int *p_index, int *p_val)
+static int consume_pint(const char *str, uint32_t *p_index, int *p_val)
 {
-    int index = *p_index, val;
+    uint32_t index = *p_index;
+    int val;
     /* The value must be positive. */
     if (consume_int(str, &index, &val) && val > 0) {
         *p_index = index;
@@ -135,9 +138,9 @@ static int consume_pint(const char *str, int *p_index, int *p_val)
 }
 
 /* Symbol.  If succeeded, it returns a consumed characters. */
-static int consume_symbol(const char *str, int *p_index, char symbol)
+static int consume_symbol(const char *str, uint32_t *p_index, char symbol)
 {
-    int index = *p_index;
+    uint32_t index = *p_index;
     while (1) {
         char c = *(str + index);
         if (c == symbol) {
@@ -154,7 +157,7 @@ static int consume_symbol(const char *str, int *p_index, char symbol)
 }
 
 static ABTD_affinity_id_list *parse_es_id_list(const char *affinity_str,
-                                               int *p_index)
+                                               uint32_t *p_index)
 {
     ABTD_affinity_id_list *p_id_list = id_list_create();
     int val;
@@ -206,7 +209,7 @@ static ABTD_affinity_list *parse_list(const char *affinity_str)
 {
     if (!affinity_str)
         return NULL;
-    int index = 0;
+    uint32_t index = 0;
     ABTD_affinity_list *p_list = list_create();
     ABTD_affinity_id_list *p_id_list = NULL;
     while (1) {

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -241,7 +241,7 @@ static uint32_t roundup_pow2_uint32(uint32_t val)
      * 5 -> 8 */
     if (val == 0)
         return 0;
-    int i;
+    uint32_t i;
     for (i = 0; i < sizeof(uint32_t) * 8; i++) {
         if ((val - 1) >> i == 0)
             break;
@@ -254,7 +254,7 @@ static const char *get_abt_env(const char *env_suffix)
     /* Valid prefix is ABT_ and ABT_ENV_. ABT_ is prioritized. */
     char buffer[128];
     const char *prefixes[] = { "ABT_", "ABT_ENV_" };
-    int i;
+    uint32_t i;
     for (i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
         strcpy(buffer, prefixes[i]);
         strcpy(buffer + strlen(prefixes[i]), env_suffix);

--- a/src/error.c
+++ b/src/error.c
@@ -82,7 +82,7 @@ int ABT_error_get_str(int err, char *str, size_t *len)
                                      "ABT_ERR_INV_ARG" };
 
     ABTI_CHECK_TRUE(err >= ABT_SUCCESS &&
-                        err < sizeof(err_str) / sizeof(err_str[0]),
+                        err < (int)(sizeof(err_str) / sizeof(err_str[0])),
                     ABT_ERR_INV_ARG);
     /* This entry does not exist. */
     ABTI_CHECK_TRUE(err_str[err], ABT_ERR_INV_ARG);

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -65,11 +65,11 @@ void ABTD_affinity_cpuset_destroy(ABTD_affinity_cpuset *p_cpuset);
 
 /* ES Affinity Parser */
 typedef struct ABTD_affinity_id_list {
-    int num;
+    uint32_t num;
     int *ids; /* id here can be negative. */
 } ABTD_affinity_id_list;
 typedef struct ABTD_affinity_parser_list {
-    int num;
+    uint32_t num;
     ABTD_affinity_id_list **p_id_lists;
 } ABTD_affinity_list;
 ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -391,15 +391,15 @@ struct ABTI_eventual {
     ABTI_spinlock lock;
     ABT_bool ready;
     void *value;
-    int nbytes;
+    size_t nbytes;
     ABTI_thread *p_head; /* Head of waiters */
     ABTI_thread *p_tail; /* Tail of waiters */
 };
 
 struct ABTI_future {
     ABTI_spinlock lock;
-    ABTD_atomic_uint32 counter;
-    uint32_t compartments;
+    ABTD_atomic_size counter;
+    size_t compartments;
     void **array;
     void (*p_callback)(void **arg);
     ABTI_thread *p_head; /* Head of waiters */
@@ -407,8 +407,8 @@ struct ABTI_future {
 };
 
 struct ABTI_barrier {
-    uint32_t num_waiters;
-    volatile uint32_t counter;
+    size_t num_waiters;
+    volatile size_t counter;
     ABTI_ythread **waiters;
     ABT_unit_type *waiter_type;
     ABTI_spinlock lock;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -568,9 +568,9 @@ void ABTI_ktable_free(ABTI_local *p_local, ABTI_ktable *p_ktable);
 
 /* Mutex */
 void ABTI_mutex_wait(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
-                     int val);
+                     uint32_t val);
 void ABTI_mutex_wait_low(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
-                         int val);
+                         uint32_t val);
 void ABTI_mutex_wake_de(ABTI_local *p_local, ABTI_mutex *p_mutex);
 
 /* Information */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -262,7 +262,7 @@ struct ABTI_sched {
     ABT_sched_type type;        /* Can yield or not (ULT or task) */
     ABTD_atomic_uint32 request; /* Request */
     ABT_pool *pools;            /* Thread pools */
-    int num_pools;              /* Number of thread pools */
+    size_t num_pools;           /* Number of thread pools */
     ABTI_ythread *p_ythread;    /* Associated ULT */
     void *data;                 /* Data for a specific scheduler */
 

--- a/src/include/abti_ythread_htable.h
+++ b/src/include/abti_ythread_htable.h
@@ -53,7 +53,7 @@ struct ABTI_ythread_htable {
     ABTI_spinlock mutex; /* To protect table */
 #endif
     ABTD_atomic_uint32 num_elems;
-    uint32_t num_rows;
+    int num_rows;
     ABTI_ythread_queue *queue;
 
     ABTI_ythread_queue *h_list; /* list of non-empty high prio. queues */

--- a/src/info.c
+++ b/src/info.c
@@ -778,7 +778,8 @@ static void info_trigger_print_all_thread_stacks(
 
 ABTU_ret_err static int print_all_thread_stacks(FILE *fp)
 {
-    int i, abt_errno;
+    size_t i;
+    int abt_errno;
     struct info_pool_set_t pool_set;
 
     abt_errno = info_initialize_pool_set(&pool_set);
@@ -794,7 +795,7 @@ ABTU_ret_err static int print_all_thread_stacks(FILE *fp)
         for (i = 0; i < p_main_sched->num_pools; i++) {
             ABT_pool pool = p_main_sched->pools[i];
             ABTI_ASSERT(pool != ABT_POOL_NULL);
-            fprintf(fp, "  pools[%d] : %p\n", i,
+            fprintf(fp, "  pools[%zu] : %p\n", i,
                     (void *)ABTI_pool_get_ptr(pool));
             abt_errno = info_add_pool_set(pool, &pool_set);
             if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {

--- a/src/mem/mem_pool.c
+++ b/src/mem/mem_pool.c
@@ -75,10 +75,10 @@ mem_pool_return_partial_bucket(ABTI_mem_pool_global_pool *p_global_pool,
 }
 
 void ABTI_mem_pool_init_global_pool(
-    ABTI_mem_pool_global_pool *p_global_pool, int num_headers_per_bucket,
+    ABTI_mem_pool_global_pool *p_global_pool, size_t num_headers_per_bucket,
     size_t header_size, size_t header_offset, size_t page_size,
-    const ABTU_MEM_LARGEPAGE_TYPE *lp_type_requests, int num_lp_type_requests,
-    size_t alignment_hint)
+    const ABTU_MEM_LARGEPAGE_TYPE *lp_type_requests,
+    uint32_t num_lp_type_requests, size_t alignment_hint)
 {
     p_global_pool->num_headers_per_bucket = num_headers_per_bucket;
     ABTI_ASSERT(header_offset + sizeof(ABTI_mem_pool_header) <= header_size);
@@ -148,7 +148,7 @@ void ABTI_mem_pool_destroy_local_pool(ABTI_mem_pool_local_pool *p_local_pool)
         ABTI_mem_pool_return_bucket(p_local_pool->p_global_pool,
                                     p_local_pool->buckets[i]);
     }
-    const int num_headers_per_bucket = p_local_pool->num_headers_per_bucket;
+    const size_t num_headers_per_bucket = p_local_pool->num_headers_per_bucket;
     ABTI_mem_pool_header *cur_bucket = p_local_pool->buckets[bucket_index];
     if (cur_bucket->bucket_info.num_headers == num_headers_per_bucket) {
         /* The last bucket is also full. Return the last bucket as well. */

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -428,13 +428,13 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
 /*****************************************************************************/
 
 void ABTI_mutex_wait(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
-                     int val)
+                     uint32_t val)
 {
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_ythread_htable *p_htable = p_mutex->p_htable;
     ABTI_ythread *p_self = ABTI_thread_get_ythread(p_local_xstream->p_thread);
 
-    int rank = (int)p_local_xstream->rank;
+    int rank = p_local_xstream->rank;
     ABTI_ASSERT(rank < p_htable->num_rows);
     ABTI_ythread_queue *p_queue = &p_htable->queue[rank];
 
@@ -464,13 +464,13 @@ void ABTI_mutex_wait(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
 }
 
 void ABTI_mutex_wait_low(ABTI_xstream **pp_local_xstream, ABTI_mutex *p_mutex,
-                         int val)
+                         uint32_t val)
 {
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
     ABTI_ythread_htable *p_htable = p_mutex->p_htable;
     ABTI_ythread *p_self = ABTI_thread_get_ythread(p_local_xstream->p_thread);
 
-    int rank = (int)p_local_xstream->rank;
+    int rank = p_local_xstream->rank;
     ABTI_ASSERT(rank < p_htable->num_rows);
     ABTI_ythread_queue *p_queue = &p_htable->queue[rank];
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -166,7 +166,8 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
 {
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
-    ABTI_CHECK_TRUE((size_t)(idx + max_pools) <= p_sched->num_pools, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE((size_t)(idx + max_pools) <= p_sched->num_pools,
+                    ABT_ERR_SCHED);
 
     int p;
     for (p = idx; p < idx + max_pools; p++) {

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -166,7 +166,7 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
 {
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
-    ABTI_CHECK_TRUE(idx + max_pools <= p_sched->num_pools, ABT_ERR_SCHED);
+    ABTI_CHECK_TRUE((size_t)(idx + max_pools) <= p_sched->num_pools, ABT_ERR_SCHED);
 
     int p;
     for (p = idx; p < idx + max_pools; p++) {
@@ -306,8 +306,7 @@ int ABT_sched_get_size(ABT_sched sched, size_t *size)
 
 size_t ABTI_sched_get_size(ABTI_sched *p_sched)
 {
-    size_t pool_size = 0;
-    int p;
+    size_t pool_size = 0, p;
 
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
@@ -500,7 +499,7 @@ void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
     ABTI_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
     /* If sched is a default provided one, it should free its pool here.
      * Otherwise, freeing the pool is the user's responsibility. */
-    int p;
+    size_t p;
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
         int32_t num_scheds = ABTI_pool_release(p_pool);
@@ -585,8 +584,7 @@ ABTU_ret_err int ABTI_sched_get_migration_pool(ABTI_sched *p_sched,
 
 size_t ABTI_sched_get_total_size(ABTI_sched *p_sched)
 {
-    size_t pool_size = 0;
-    int p;
+    size_t pool_size = 0, p;
 
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
@@ -603,8 +601,7 @@ size_t ABTI_sched_get_total_size(ABTI_sched *p_sched)
  * between different schedulers associated with different ESs. */
 size_t ABTI_sched_get_effective_size(ABTI_local *p_local, ABTI_sched *p_sched)
 {
-    size_t pool_size = 0;
-    int p;
+    size_t pool_size = 0, p;
 
     for (p = 0; p < p_sched->num_pools; p++) {
         ABT_pool pool = p_sched->pools[p];
@@ -689,7 +686,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
                 "%*sused     : %s\n"
                 "%*sautomatic: %s\n"
                 "%*srequest  : 0x%x\n"
-                "%*snum_pools: %d\n"
+                "%*snum_pools: %zu\n"
                 "%*ssize     : %zu\n"
                 "%*stot_size : %zu\n"
                 "%*sdata     : %p\n",
@@ -705,7 +702,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
                 indent, "", ABTI_sched_get_total_size(p_sched), indent, "",
                 p_sched->data);
         if (print_sub == ABT_TRUE) {
-            int i;
+            size_t i;
             for (i = 0; i < p_sched->num_pools; i++) {
                 ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[i]);
                 ABTI_pool_print(p_pool, p_os, indent + 2);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1361,7 +1361,7 @@ xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     ABTI_ythread *p_ythread = NULL;
     ABTI_sched *p_main_sched;
     ABTI_pool *p_tar_pool = NULL;
-    int p;
+    size_t p;
 
     /* The main scheduler will to be a ULT, not a tasklet */
     p_sched->type = ABT_SCHED_TYPE_ULT;

--- a/test/basic/error.c
+++ b/test/basic/error.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
         { "ABT_ERR_INV_ARG", ABT_ERR_INV_ARG },
     };
 
-    for (i = 0; i < sizeof(error_pairs) / sizeof(error_pairs[0]); i++) {
+    for (i = 0; i < (int)(sizeof(error_pairs) / sizeof(error_pairs[0])); i++) {
         char str[256];
         ret = ABT_error_get_str(error_pairs[i].code, str, NULL);
         ATS_ERROR(ret, "ABT_error_get_str");

--- a/test/basic/sched_set_main.c
+++ b/test/basic/sched_set_main.c
@@ -78,9 +78,8 @@ static void thread_func(void *arg)
 
 int main(int argc, char *argv[])
 {
-    size_t i;
     int ret;
-    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int i, num_xstreams = DEFAULT_NUM_XSTREAMS;
     ABT_xstream *xstreams;
     ABT_pool *pools;
     ABT_thread *threads;
@@ -114,7 +113,7 @@ int main(int argc, char *argv[])
 
     /* Create ULTs */
     for (i = 1; i < num_xstreams; i++) {
-        ret = ABT_thread_create(pools[i], thread_func, (void *)i,
+        ret = ABT_thread_create(pools[i], thread_func, (void *)((uintptr_t)i),
                                 ABT_THREAD_ATTR_NULL, &threads[i]);
         ATS_ERROR(ret, "ABT_thread_create");
     }

--- a/test/benchmark/task_ops_all.c
+++ b/test/benchmark/task_ops_all.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     ABT_pool(*all_pools)[2];
     ABT_sched *scheds;
     ABT_thread *top_threads;
-    size_t i, t;
+    int i, t;
     uint64_t t_start;
 
     /* read command-line arguments */
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 
         /* warm-up */
         for (i = 0; i < num_xstreams; i++) {
-            ABT_thread_create(all_pools[i][0], test_fn, (void *)i,
+            ABT_thread_create(all_pools[i][0], test_fn, (void *)((uintptr_t)i),
                               ABT_THREAD_ATTR_NULL, &top_threads[i]);
         }
         for (i = 0; i < num_xstreams; i++) {
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
         /* measurement */
         t_start = ATS_get_cycles();
         for (i = 0; i < num_xstreams; i++) {
-            ABT_thread_create(all_pools[i][0], test_fn, (void *)i,
+            ABT_thread_create(all_pools[i][0], test_fn, (void *)((uintptr_t)i),
                               ABT_THREAD_ATTR_NULL, &top_threads[i]);
         }
         for (i = 0; i < num_xstreams; i++) {

--- a/test/benchmark/thread_ops_all.c
+++ b/test/benchmark/thread_ops_all.c
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
     ABT_pool(*all_pools)[2];
     ABT_sched *scheds;
     ABT_thread *top_threads;
-    size_t i, t;
+    int i, t;
     uint64_t t_start;
 
     /* read command-line arguments */
@@ -381,7 +381,7 @@ int main(int argc, char *argv[])
 
         /* warm-up */
         for (i = 0; i < num_xstreams; i++) {
-            ABT_thread_create(all_pools[i][0], test_fn, (void *)i,
+            ABT_thread_create(all_pools[i][0], test_fn, (void *)((uintptr_t)i),
                               ABT_THREAD_ATTR_NULL, &top_threads[i]);
         }
         for (i = 0; i < num_xstreams; i++) {
@@ -395,7 +395,7 @@ int main(int argc, char *argv[])
         t_start = ATS_get_cycles();
 #endif
         for (i = 0; i < num_xstreams; i++) {
-            ABT_thread_create(all_pools[i][0], test_fn, (void *)i,
+            ABT_thread_create(all_pools[i][0], test_fn, (void *)((uintptr_t)i),
                               ABT_THREAD_ATTR_NULL, &top_threads[i]);
         }
         for (i = 0; i < num_xstreams; i++) {


### PR DESCRIPTION
Some C compilers (e.g., `pgcc`) are based on C++ behavior, so they warn singed/unsigned comparison everywhere. This PR fixes this signed/unsigned comparison because 1.  this is very annoying and 2. signed/unsigned should be managed properly even if C allows mixing them.

Specifically, this PR explicitly casts arguments and changes types of variable to fix this warning. To check this warning with GCC/Clang, you need to explicitly pass `-Wsign-compare`.

This PR should not affect the performance of Argobots.
 