### PR TITLE
eventual: use ABT_bool for ABT_eventual_test()

### DIFF
--- a/src/eventual.c
+++ b/src/eventual.c
@@ -185,11 +185,11 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
  * @return Error code
  * @retval ABT_SUCCESS on success
  */
-int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready)
+int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready)
 {
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
-    int flag = ABT_FALSE;
+    ABT_bool flag = ABT_FALSE;
 
     ABTI_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready != ABT_FALSE) {

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -753,7 +753,7 @@ int ABT_rwlock_unlock(ABT_rwlock rwlock) ABT_API_PUBLIC;
 int ABT_eventual_create(int nbytes, ABT_eventual *neweventual) ABT_API_PUBLIC;
 int ABT_eventual_free(ABT_eventual *eventual) ABT_API_PUBLIC;
 int ABT_eventual_wait(ABT_eventual eventual, void **value) ABT_API_PUBLIC;
-int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready) ABT_API_PUBLIC;
+int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready) ABT_API_PUBLIC;
 int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes) ABT_API_PUBLIC;
 int ABT_eventual_reset(ABT_eventual eventual) ABT_API_PUBLIC;
 

--- a/test/basic/eventual_create.c
+++ b/test/basic/eventual_create.c
@@ -30,7 +30,8 @@ void fn1(void *args)
 void fn2(void *args)
 {
     ATS_UNUSED(args);
-    int i = 0, is_ready = 0;
+    int i = 0;
+    ABT_bool is_ready = 0;
     void *data;
     ATS_printf(1, "Thread 2 iteration %d waiting from eventual\n", i);
     ABT_eventual_test(myeventual, &data, &is_ready);


### PR DESCRIPTION
`ABT_bool` should be used for the `is_ready` argument of `ABT_eventual_test()`, which was `int`.  This PR fixes it.

```c
// Old definition
int ABT_eventual_test(ABT_eventual eventual, void **value, int *is_ready);

// New definition
// typedef int ABT_bool;
int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready);
```

Note that currently `ABT_bool` is `int`, so it does not cause any ABI compatibility issue.
