### PR TITLE
improve ABT_info functions

### DIFF
--- a/src/arch/abtd_stream.c
+++ b/src/arch/abtd_stream.c
@@ -108,3 +108,29 @@ void ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx)
 {
     p_ctx->native_thread = pthread_self();
 }
+
+void ABTD_xstream_context_print(ABTD_xstream_context *p_ctx, FILE *p_os,
+                                int indent)
+{
+    if (p_ctx == NULL) {
+        fprintf(p_os, "%*s== NULL XSTREAM CONTEXT ==\n", indent, "");
+    } else {
+        const char *state;
+        if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_RUNNING) {
+            state = "RUNNING";
+        } else if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_WAITING) {
+            state = "WAITING";
+        } else if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN) {
+            state = "REQ_JOIN";
+        } else if (p_ctx->state == ABTD_XSTREAM_CONTEXT_STATE_REQ_TERMINATE) {
+            state = "REQ_TERMINATE";
+        } else {
+            state = "UNKNOWN";
+        }
+        fprintf(p_os,
+                "%*s== XSTREAM CONTEXT (%p) ==\n"
+                "%*sstate : %s\n",
+                indent, "", (void *)p_ctx, indent, "", state);
+    }
+    fflush(p_os);
+}

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -222,6 +222,10 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC,
     /* Whether the tool interface is enabled or not */
     ABT_INFO_QUERY_KIND_ENABLED_TOOL,
+    /* Whether fcontext is used for context switch or not */
+    ABT_INFO_QUERY_KIND_FCONTEXT,
+    /* Whether dynamic promotion is used for context switch or not */
+    ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION,
 };
 
 enum ABT_tool_query_kind {

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -51,6 +51,8 @@ void ABTD_xstream_context_free(ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_join(ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_revive(ABTD_xstream_context *p_ctx);
 void ABTD_xstream_context_set_self(ABTD_xstream_context *p_ctx);
+void ABTD_xstream_context_print(ABTD_xstream_context *p_ctx, FILE *p_os,
+                                int indent);
 
 /* ES Affinity */
 void ABTD_affinity_init(const char *affinity_str);

--- a/src/info.c
+++ b/src/info.c
@@ -115,10 +115,9 @@ static void info_trigger_print_all_thread_stacks(
  */
 int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
-    ABTI_SETUP_WITH_INIT_CHECK();
-
     switch (query_kind) {
         case ABT_INFO_QUERY_KIND_ENABLED_DEBUG:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((ABT_bool *)val) = gp_ABTI_global->use_debug;
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO:
@@ -129,6 +128,7 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_LOG:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((ABT_bool *)val) = gp_ABTI_global->use_logging;
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_VALGRIND:
@@ -197,24 +197,31 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((ABT_bool *)val) = gp_ABTI_global->print_config;
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_AFFINITY:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((ABT_bool *)val) = gp_ABTI_global->set_affinity;
             break;
         case ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((unsigned int *)val) = gp_ABTI_global->max_xstreams;
             break;
         case ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((size_t *)val) = gp_ABTI_global->thread_stacksize;
             break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((size_t *)val) = gp_ABTI_global->sched_stacksize;
             break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((uint64_t *)val) = gp_ABTI_global->sched_event_freq;
             break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC:
+            ABTI_SETUP_WITH_INIT_CHECK();
             *((uint64_t *)val) = gp_ABTI_global->sched_sleep_nsec;
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_TOOL:
@@ -240,13 +247,15 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
  *
  * @param[in] fp  output stream
  * @return Error code
- * @retval ABT_SUCCESS            on success
- * @retval ABT_ERR_UNINITIALIZED  Argobots has not been initialized
+ * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_config(FILE *fp)
 {
-    ABTI_SETUP_WITH_INIT_CHECK();
-
+    if (!gp_ABTI_global) {
+        fprintf(fp, "Argobots is not initialized.\n");
+        fflush(fp);
+        return ABT_SUCCESS;
+    }
     ABTI_info_print_config(fp);
     return ABT_SUCCESS;
 }
@@ -260,13 +269,15 @@ int ABT_info_print_config(FILE *fp)
  *
  * @param[in] fp  output stream
  * @return Error code
- * @retval ABT_SUCCESS            on success
- * @retval ABT_ERR_UNINITIALIZED  Argobots has not been initialized
+ * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
-    ABTI_SETUP_WITH_INIT_CHECK();
-
+    if (!gp_ABTI_global) {
+        fprintf(fp, "Argobots is not initialized.\n");
+        fflush(fp);
+        return ABT_SUCCESS;
+    }
     ABTI_global *p_global = gp_ABTI_global;
 
     ABTI_spinlock_acquire(&p_global->xstream_list_lock);

--- a/src/info.c
+++ b/src/info.c
@@ -620,9 +620,10 @@ void ABTI_info_print_config(FILE *fp)
     ABTI_global *p_global = gp_ABTI_global;
 
     fprintf(fp, "Argobots Configuration:\n");
+    fprintf(fp, " - version: " ABT_VERSION "\n");
     fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
-    fprintf(fp, " - cache line size: %u\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
-    fprintf(fp, " - huge page size: %zu\n", p_global->huge_page_size);
+    fprintf(fp, " - cache line size: %u B\n", ABT_CONFIG_STATIC_CACHELINE_SIZE);
+    fprintf(fp, " - huge page size: %zu B\n", p_global->huge_page_size);
     fprintf(fp, " - max. # of ESs: %d\n", p_global->max_xstreams);
     fprintf(fp, " - cur. # of ESs: %d\n", p_global->num_xstreams);
     fprintf(fp, " - ES affinity: %s\n",
@@ -631,14 +632,98 @@ void ABTI_info_print_config(FILE *fp)
             (p_global->use_logging == ABT_TRUE) ? "on" : "off");
     fprintf(fp, " - debug output: %s\n",
             (p_global->use_debug == ABT_TRUE) ? "on" : "off");
+    fprintf(fp, " - print errno: "
+#ifdef ABT_CONFIG_PRINT_ABT_ERRNO
+                "on"
+#else
+                "off"
+#endif
+                "\n");
+    fprintf(fp, " - valgrind support: "
+#ifdef HAVE_VALGRIND_SUPPORT
+                "yes"
+#else
+                "no"
+#endif
+                "\n");
+    fprintf(fp, " - thread cancellation: "
+#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+                "enabled"
+#else
+                "disabled"
+#endif
+                "\n");
+    fprintf(fp, " - task cancellation: "
+#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
+                "enabled"
+#else
+                "disabled"
+#endif
+                "\n");
+    fprintf(fp, " - thread migration: "
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+                "enabled"
+#else
+                "disabled"
+#endif
+                "\n");
+    fprintf(fp, " - external thread: "
+#ifndef ABT_CONFIG_DISABLE_EXT_THREAD
+                "enabled"
+#else
+                "disabled"
+#endif
+                "\n");
+    fprintf(fp, " - error check: "
+#ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
+                "enabled"
+#else
+                "disable"
+#endif
+                "\n");
+    fprintf(fp, " - tool interface: "
+#ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+                "yes"
+#else
+                "no"
+#endif
+                "\n");
+    fprintf(fp, " - context-switch: "
+#ifdef ABT_CONFIG_USE_FCONTEXT
+                "fcontext"
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION &&             \
+    defined(ABTD_FCONTEXT_PRESERVE_FPU)
+                " (dynamic-promotion)"
+#elif ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION &&           \
+    !defined(ABTD_FCONTEXT_PRESERVE_FPU)
+                " (dynamic-promotion, no FPU save)"
+#elif ABT_CONFIG_THREAD_TYPE != ABT_THREAD_TYPE_DYNAMIC_PROMOTION &&           \
+    !defined(ABTD_FCONTEXT_PRESERVE_FPU)
+                " (no FPU save)"
+#endif /* ABT_CONFIG_THREAD_TYPE, ABTD_FCONTEXT_PRESERVE_FPU */
+
+#else  /* ABT_CONFIG_USE_FCONTEXT */
+                "ucontext"
+#endif /* !ABT_CONFIG_USE_FCONTEXT */
+                "\n");
+
     fprintf(fp, " - key table entries: %" PRIu32 "\n",
             p_global->key_table_size);
-    fprintf(fp, " - ULT stack size: %zu KB\n",
+    fprintf(fp, " - default ULT stack size: %zu KB\n",
             p_global->thread_stacksize / 1024);
-    fprintf(fp, " - scheduler stack size: %zu KB\n",
+    fprintf(fp, " - default scheduler stack size: %zu KB\n",
             p_global->sched_stacksize / 1024);
-    fprintf(fp, " - scheduler event check frequency: %u\n",
+    fprintf(fp, " - default scheduler event check frequency: %u\n",
             p_global->sched_event_freq);
+    fprintf(fp, " - default scheduler sleep: "
+#ifdef ABT_CONFIG_USE_SCHED_SLEEP
+                "on"
+#else
+                "off"
+#endif
+                "\n");
+    fprintf(fp, " - default scheduler sleep duration : %" PRIu64 " [ns]\n",
+            p_global->sched_sleep_nsec);
 
     fprintf(fp, " - timer function: "
 #if defined(ABT_CONFIG_USE_CLOCK_GETTIME)
@@ -656,6 +741,7 @@ void ABTI_info_print_config(FILE *fp)
             p_global->mem_page_size / 1024);
     fprintf(fp, " - stack page size: %zu KB\n", p_global->mem_sp_size / 1024);
     fprintf(fp, " - max. # of stacks per ES: %u\n", p_global->mem_max_stacks);
+    fprintf(fp, " - max. # of descs per ES: %u\n", p_global->mem_max_descs);
     switch (p_global->mem_lp_alloc) {
         case ABTI_MEM_LP_MALLOC:
             fprintf(fp, " - large page allocation: malloc\n");

--- a/src/info.c
+++ b/src/info.c
@@ -152,10 +152,11 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             *((ABT_bool *)val) = ABT_FALSE;
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRESERVE_FPU:
-#ifdef ABTD_FCONTEXT_PRESERVE_FPU
-            *((ABT_bool *)val) = ABT_TRUE;
-#else
+#if !defined(ABTD_FCONTEXT_PRESERVE_FPU) && defined(ABT_CONFIG_USE_FCONTEXT)
             *((ABT_bool *)val) = ABT_FALSE;
+#else
+            /* If ucontext is used, FPU is preserved. */
+            *((ABT_bool *)val) = ABT_TRUE;
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL:

--- a/src/info.c
+++ b/src/info.c
@@ -593,6 +593,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
         ABTI_spinlock_release(&gp_ABTI_global->xstream_list_lock);
         if (print_cb_func)
             print_cb_func(force_print, print_arg);
+        fflush(print_stack_fp);
         /* Update print_stack_flag to 3. */
         ABTD_atomic_release_store_int(&print_stack_flag,
                                       PRINT_STACK_FLAG_FINALIZE);
@@ -745,6 +746,7 @@ ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
     arg.fp = fp;
     arg.pool = pool;
     p_pool->p_print_all(pool, &arg, info_print_unit);
+    fflush(fp);
     return ABT_SUCCESS;
 }
 

--- a/src/info.c
+++ b/src/info.c
@@ -105,6 +105,12 @@ static void info_trigger_print_all_thread_stacks(
  * - ABT_INFO_QUERY_KIND_ENABLED_TOOL
  *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
  *   set to \c *val if the tool is enabled.  Otherwise, ABT_FALSE is set.
+ * - ABT_INFO_QUERY_KIND_FCONTEXT
+ *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
+ *   set to \c *val if fcontext is used.  Otherwise, ABT_FALSE is set.
+ * - ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION
+ *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
+ *   set to \c *val if dynamic promotion is used.  Otherwise, ABT_FALSE is set.
  *
  * @param[in]  query_kind  query kind
  * @param[out] val         a pointer to a result
@@ -227,6 +233,20 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_TOOL:
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
+            *((ABT_bool *)val) = ABT_TRUE;
+#else
+            *((ABT_bool *)val) = ABT_FALSE;
+#endif
+            break;
+        case ABT_INFO_QUERY_KIND_FCONTEXT:
+#ifdef ABT_CONFIG_USE_FCONTEXT
+            *((ABT_bool *)val) = ABT_TRUE;
+#else
+            *((ABT_bool *)val) = ABT_FALSE;
+#endif
+            break;
+        case ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION:
+#if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION
             *((ABT_bool *)val) = ABT_TRUE;
 #else
             *((ABT_bool *)val) = ABT_FALSE;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -647,6 +647,8 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
             kind_str = "BASIC_WAIT";
         } else if (kind == sched_get_kind(ABTI_sched_get_prio_def())) {
             kind_str = "PRIO";
+        } else if (kind == sched_get_kind(ABTI_sched_get_randws_def())) {
+            kind_str = "RANDWS";
         } else {
             kind_str = "USER";
         }
@@ -690,6 +692,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
                 "%*snum_pools: %zu\n"
                 "%*ssize     : %zu\n"
                 "%*stot_size : %zu\n"
+                "%*sthread   : %p\n"
                 "%*sdata     : %p\n",
                 indent, "", (void *)p_sched,
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
@@ -701,7 +704,7 @@ void ABTI_sched_print(ABTI_sched *p_sched, FILE *p_os, int indent,
                 ABTD_atomic_acquire_load_uint32(&p_sched->request), indent, "",
                 p_sched->num_pools, indent, "", ABTI_sched_get_size(p_sched),
                 indent, "", ABTI_sched_get_total_size(p_sched), indent, "",
-                p_sched->data);
+                (void *)p_sched->p_ythread, indent, "", p_sched->data);
         if (print_sub == ABT_TRUE) {
             size_t i;
             for (i = 0; i < p_sched->num_pools; i++) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -1003,18 +1003,26 @@ void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
 
         fprintf(p_os,
                 "%*s== ES (%p) ==\n"
-                "%*srank      : %d\n"
-                "%*stype      : %s\n"
-                "%*sstate     : %s\n"
-                "%*smain_sched: %p\n",
+                "%*srank         : %d\n"
+                "%*stype         : %s\n"
+                "%*sstate        : %s\n"
+                "%*sroot_ythread : %p\n"
+                "%*sroot_pool    : %p\n"
+                "%*sthread       : %p\n"
+                "%*smain_sched   : %p\n",
                 indent, "", (void *)p_xstream, indent, "", p_xstream->rank,
                 indent, "", type, indent, "", state, indent, "",
+                (void *)p_xstream->p_root_ythread, indent, "",
+                (void *)p_xstream->p_root_pool, indent, "",
+                (void *)p_xstream->p_thread, indent, "",
                 (void *)p_xstream->p_main_sched);
 
         if (print_sub == ABT_TRUE) {
             ABTI_sched_print(p_xstream->p_main_sched, p_os,
                              indent + ABTI_INDENT, ABT_TRUE);
         }
+        fprintf(p_os, "%*sctx          :\n", indent, "");
+        ABTD_xstream_context_print(&p_xstream->ctx, p_os, indent + ABTI_INDENT);
     }
     fflush(p_os);
 }

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -133,4 +133,5 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
                 fprintf(p_os, "\n");
         }
     }
+    fflush(p_os);
 }

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -89,6 +89,8 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_ythread *p_ythread,
     size_t i, j, stacksize = p_ythread->stacksize;
     if (stacksize == 0 || p_stack == NULL) {
         /* Some threads do not have p_stack (e.g., the main thread) */
+        fprintf(p_os, "no stack\n");
+        fflush(0);
         return;
     }
 


### PR DESCRIPTION
This PR improves `ABT_info` functions:
1. Update the contents printed by info functions.
   - `ABT_info_print_all_xstreams()`, `ABT_info_print_xstream()`, `ABT_info_print_sched()`, `ABT_info_print_pool()`, and `ABT_info_print_thread()`.
2. Make some info  functions runnable before `ABT_init()`
   - `ABT_info_query_config()`, `ABT_info_print_config()`, and `ABT_info_print_all_xstreams()`
   - This is useful to check if the underlying Argobots supports necessary configure-time features before `ABT_init` (e.g., `support of external threads`).
3. Make some info functions accept NULL handles
   - For example, `ABT_info_print_thread()` prints `"THREAD NULL"` instead of returning an error when `ABT_THREAD_NULL` is passed.
4. Minor fixes and improvements
   - Fix the condition of FPU preservation.
   - Add a query kind to get implementation of user-level context-switches.
   - Add missing `fflush()`.

Strictly speaking, this PR breaks the existing API in terms of "error behavior" (e.g., whether it returns an error or not when `ABT_THREAD_NULL` is passed), though I do not think no program relies on this behavior. This PR widens the situation where these functions work without returning an error.
