### PR TITLE
stream_barrier: add a fallback implementation of ABT_stream_barrier

### DIFF
--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -415,7 +415,13 @@ struct ABTI_barrier {
 
 struct ABTI_xstream_barrier {
     uint32_t num_waiters;
+#ifdef HAVE_PTHREAD_BARRIER_INIT
     ABTD_xstream_barrier bar;
+#else
+    ABTI_spinlock lock;
+    uint32_t counter;
+    ABTD_atomic_uint64 tag;
+#endif
 };
 
 struct ABTI_timer {

--- a/src/include/abti_stream_barrier.h
+++ b/src/include/abti_stream_barrier.h
@@ -6,7 +6,6 @@
 #ifndef ABTI_XSTREAM_BARRIER_H_INCLUDED
 #define ABTI_XSTREAM_BARRIER_H_INCLUDED
 
-#ifdef HAVE_PTHREAD_BARRIER_INIT
 static inline ABTI_xstream_barrier *
 ABTI_xstream_barrier_get_ptr(ABT_xstream_barrier barrier)
 {
@@ -38,6 +37,5 @@ ABTI_xstream_barrier_get_handle(ABTI_xstream_barrier *p_barrier)
     return (ABT_xstream_barrier)p_barrier;
 #endif
 }
-#endif
 
 #endif /* ABTI_XSTREAM_BARRIER_H_INCLUDED */

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -26,7 +26,6 @@
 int ABT_xstream_barrier_create(uint32_t num_waiters,
                                ABT_xstream_barrier *newbarrier)
 {
-#ifdef HAVE_PTHREAD_BARRIER_INIT
     int abt_errno;
     ABTI_xstream_barrier *p_newbarrier;
 
@@ -35,18 +34,21 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
     ABTI_CHECK_ERROR(abt_errno);
 
     p_newbarrier->num_waiters = num_waiters;
+#ifdef HAVE_PTHREAD_BARRIER_INIT
     abt_errno = ABTD_xstream_barrier_init(num_waiters, &p_newbarrier->bar);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         ABTU_free(p_newbarrier);
         ABTI_HANDLE_ERROR(abt_errno);
     }
+#else
+    ABTI_spinlock_clear(&p_newbarrier->lock);
+    p_newbarrier->counter = 0;
+    ABTD_atomic_relaxed_store_uint64(&p_newbarrier->tag, 0);
+#endif
 
     /* Return value */
     *newbarrier = ABTI_xstream_barrier_get_handle(p_newbarrier);
     return ABT_SUCCESS;
-#else
-    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
-#endif
 }
 
 /**
@@ -63,20 +65,18 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
  */
 int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
 {
-#ifdef HAVE_PTHREAD_BARRIER_INIT
     ABT_xstream_barrier h_barrier = *barrier;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
+#ifdef HAVE_PTHREAD_BARRIER_INIT
     ABTD_xstream_barrier_destroy(&p_barrier->bar);
+#endif
     ABTU_free(p_barrier);
 
     /* Return value */
     *barrier = ABT_XSTREAM_BARRIER_NULL;
     return ABT_SUCCESS;
-#else
-    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
-#endif
 }
 
 /**
@@ -92,15 +92,35 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
  */
 int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
 {
-#ifdef HAVE_PTHREAD_BARRIER_INIT
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 
     if (p_barrier->num_waiters > 1) {
+#ifdef HAVE_PTHREAD_BARRIER_INIT
         ABTD_xstream_barrier_wait(&p_barrier->bar);
+#else
+        /* The following implementation is a simple sense-reversal barrier
+         * implementation while it uses uint64_t instead of boolean to prevent
+         * a sense variable from wrapping around. */
+        ABTI_spinlock_acquire(&p_barrier->lock);
+        p_barrier->counter++;
+        if (p_barrier->counter == p_barrier->num_waiters) {
+            /* Wake up the other waiters. */
+            p_barrier->counter = 0;
+            /* Updating tag wakes up other waiters.  Note that this tag is
+             * sufficiently large, so it will not wrap around. */
+            uint64_t cur_tag = ABTD_atomic_relaxed_load_uint64(&p_barrier->tag);
+            uint64_t new_tag = (cur_tag + 1) & (UINT64_MAX >> 1);
+            ABTD_atomic_release_store_uint64(&p_barrier->tag, new_tag);
+            ABTI_spinlock_release(&p_barrier->lock);
+        } else {
+            /* Wait until the tag is updated by the last waiter */
+            uint64_t cur_tag = ABTD_atomic_relaxed_load_uint64(&p_barrier->tag);
+            ABTI_spinlock_release(&p_barrier->lock);
+            while (cur_tag == ABTD_atomic_acquire_load_uint64(&p_barrier->tag))
+                ABTD_atomic_pause();
+        }
+#endif
     }
     return ABT_SUCCESS;
-#else
-    ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
-#endif
 }


### PR DESCRIPTION
`ABT_stream_barrier` was unavailable if `pthread_barrier` is not supported. Although such a case should be extremely rare, we should provide the same functionality if it should happen.  This patch implements a simple sense-based barrier implementation (though it uses `uint64`-type tag instead of `bool`-type sense).  See https://en.wikipedia.org/wiki/Barrier_(computer_science) for details.

Note that `ABT_stream_barrier` uses `pthread_barrier` by default, so this PR will not affect execution on almost all platforms.
