### PR TITLE
info: improve API

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1786,9 +1786,29 @@ DOT_CLEANUP            = YES
 # Custom style
 #---------------------------------------------------------------------------
 
+ALIASES += DOC_V10="<b>[Argobots 1.0]</b>"
+
+ALIASES += DOC_V11="<b>[Argobots 1.1]</b>"
+
+ALIASES += DOC_V1X="<b>[Argobots 1.x]</b>"
+
+ALIASES += DOC_V20="<b>[Argobots 2.0]</b>"
+
+ALIASES += changev11="<dl class=\"section attention\"><dt>Changes from Argobots 1.0 to Argobots 1.1</dt><dd>"
+
+ALIASES += changev20="<dl class=\"section note\"><dt>Changes from Argobots 1.x to Argobots 2.0 (planned)</dt><dd>"
+
 ALIASES += contexts="\par Execution context"
 
+ALIASES += endchangev11="</dd></dl>"
+
+ALIASES += endchangev20="</dd></dl>"
+
+ALIASES += endrationale="</dd></dl>"
+
 ALIASES += errors="\par Errors"
+
+ALIASES += rationale="<dl class=\"section user\"><dt>Rationale</dt><dd>"
 
 ALIASES += undefined="\par Undefined behavior"
 
@@ -1796,9 +1816,15 @@ ALIASES += undefined="\par Undefined behavior"
 # Execution context
 #---------------------------------------------------------------------------
 
+ALIASES += DOC_CONTEXT_ANY="This routine can be called in any execution context. Argobots does not need to be initialized."
+
+ALIASES += DOC_CONTEXT_CTXSWITCH="This routine may perform context switching for the calling ULT."
+
 ALIASES += DOC_CONTEXT_INIT="This routine can be called in any execution context. Argobots must be initialized."
 
 ALIASES += DOC_CONTEXT_NOCTXSWITCH="This routine does not perform context switching the calling ULT unless any user-defined function that is involved in this routine performs context switching."
+
+ALIASES += DOC_CONTEXT_NOTE_SIGNAL_SAFE="This routine is signal-safe.  Note that it is the user's responsibility to call this function properly by, for example, loading the Argobots library and/or resolving the symbol of this routine in a signal handler."
 
 ALIASES += DOC_CONTEXT_TOOL_CALLBACK{1}="This routine can be called only in a callback function \1."
 
@@ -1808,6 +1834,18 @@ ALIASES += DOC_CONTEXT_TOOL_CALLBACK{1}="This routine can be called only in a ca
 
 ALIASES += DOC_DESC_ATOMICITY_TOOL_CALLBACK_REGISTRATION="A combination of a callback function, an event mask its argument for a tool interface is updated atomically."
 
+ALIASES += DOC_DESC_V10_ACCEPT_TASK{1}="\DOC_V10 The user cannot pass a tasklet handle as \1.\n \DOC_V11 This routine accepts a tasklet handle as \1.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general.  Argobots 1.1 has introduced this change since this change does not break the compatibility of API and ABI of Argobots 1.0. @endrationale"
+
+ALIASES += DOC_DESC_V10_ACCEPT_THREAD{1}="\DOC_V10 The user cannot pass a ULT handle as \1.\n \DOC_V11 This routine accepts a ULT handle as \1.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general.  Argobots 1.1 has introduced this change since this change does not break the compatibility of API and ABI of Argobots 1.0. @endrationale"
+
+ALIASES += DOC_DESC_V1X_PRINT_HANDLE_INFO{3}="\DOC_V1X This routine returns \3 when \1 is \2.\n \DOC_V20 This routine prints that \1 is an invalid handle when \1 is \2.\n @rationale The information routines primarily for debugging and diagnosis should avoid returning an error as much as possible. @endrationale"
+
+ALIASES += DOC_DESC_V1X_PRINT_HANDLE_INFO{4}="\DOC_V1X This routine returns \4 when \1 is \2 or \3.\n \DOC_V20 This routine prints that \1 is an invalid handle when \1 is \2 or \3.\n @rationale The information routines primarily for debugging and diagnosis should avoid returning an error as much as possible. @endrationale"
+
+ALIASES += DOC_DESC_V1X_PRINT_RUNTIME_INFO="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED when Argobots is not initialized.\n \DOC_V20 This routine prints the queried information and returns \c ABT_SUCCESS when Argobots is not initialized.\n @rationale The information routines primarily for debugging and diagnosis should avoid returning an error as much as possible. @endrationale"
+
+ALIASES += DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized.\n \DOC_V20 This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized and the queried information cannot be retrieved when Argobots is not initialized.\n @rationale Retrieving static configurations before initializing Argobots is helpful to check if the loaded Argobots implements necessary features. @endrationale"
+
 #---------------------------------------------------------------------------
 # Error
 #---------------------------------------------------------------------------
@@ -1816,7 +1854,33 @@ ALIASES += DOC_ERROR_FEATURE_NA{1}="If \1 is not supported, \c ABT_ERR_FEATURE_N
 
 ALIASES += DOC_ERROR_INV_ARG_INV_TOOL_QUERY_KIND{2}="If \1 is not a valid tool query kind for \2, \c ABT_ERR_INV_ARG is returned.\n"
 
+ALIASES += DOC_ERROR_INV_INFO_QUERY_KIND{1}="If \1 is not a valid info query kind, \c ABT_ERR_INV_QUERY_KIND is returned.\n"
+
+ALIASES += DOC_ERROR_INV_POOL_HANDLE{1}="If \1 is \c ABT_POOL_NULL, \c ABT_ERR_INV_POOL is returned.\n"
+
+ALIASES += DOC_ERROR_INV_SCHED_HANDLE{1}="If \1 is \c ABT_SCHED_NULL, \c ABT_ERR_INV_SCHED is returned.\n"
+
+ALIASES += DOC_ERROR_INV_TASK_HANDLE{1}="If \1 is \c ABT_THREAD_NULL or \c ABT_TASK_NULL, \c ABT_ERR_INV_TASK is returned.\n"
+
+ALIASES += DOC_ERROR_INV_THREAD_ATTR_HANDLE{1}="If \1 is \c ABT_THREAD_ATTR_NULL, \c ABT_ERR_INV_THREAD_ATTR is returned.\n"
+
+ALIASES += DOC_ERROR_INV_THREAD_HANDLE{1}="If \1 is \c ABT_THREAD_NULL or \c ABT_TASK_NULL, \c ABT_ERR_INV_THREAD is returned.\n"
+
+ALIASES += DOC_ERROR_INV_XSTREAM_HANDLE{1}="If \1 is \c ABT_XSTREAM_NULL, \c ABT_ERR_INV_XSTREAM is returned.\n"
+
+ALIASES += DOC_ERROR_POOL_UNSUPPORTED_FEATURE{2}="If \1 does not support \2, \c ABT_ERR_POOL is returned.\n"
+
 ALIASES += DOC_ERROR_SUCCESS="If this routine succeeds, \c ABT_SUCCESS is returned.\n"
+
+ALIASES += DOC_ERROR_UNINITIALIZED="If the Argobots runtime is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
+
+ALIASES += DOC_ERROR_UNINITIALIZED_INFO_QUERY="If the queried information requires initialized Argobots while Argobots is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
+
+#---------------------------------------------------------------------------
+# Note
+#---------------------------------------------------------------------------
+
+ALIASES += DOC_NOTE_INFO_PRINT="The information written by this routine is meant for debugging and diagnosis and can be changed because of an update of the internal implementation of Argobots.  A program that relies on the output of this routine is non-conforming."
 
 #---------------------------------------------------------------------------
 # Undefined behavior
@@ -1826,8 +1890,12 @@ ALIASES += DOC_UNDEFINED_CHANGE_STATE{1}="If the internal state of the Argobots 
 
 ALIASES += DOC_UNDEFINED_NULL_PTR{1}="If \1 is \c NULL, the results are undefined.\n"
 
+ALIASES += DOC_UNDEFINED_SYS_FILE{1}="If an error occurs regarding \1, the results are undefined.\n"
+
 ALIASES += DOC_UNDEFINED_TOOL_CALLBACK{1}="If the tool context passed to \1 is accessed after \1 finishes, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_TOOL_QUERY{2}="If \1 is a tool context that is not passed to the calling callback function, the results are undefined.\n If \1 and \2 are not the same pair passed to the calling callback function, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_UNINIT="If Argobots is not initialized, the results are undefined.\n"
+
+ALIASES += DOC_UNDEFINED_WORK_UNIT_RUNNING{1}="If \1 is running, the results are undefined.\n"

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,11 @@ AC_ARG_ENABLE([static-cacheline-size],
         <value>             - assume [value] bytes (e.g., <value> = 64)
 ],,[enable_static_cacheline_size=auto])
 
+# --enable-ver20-api
+AC_ARG_ENABLE([ver20-api],
+    AS_HELP_STRING([--enable-ver20-api],
+                   [enable an experimental Argobots 2.0 API, which is disabled by default.]))
+
 # --with-lts
 AC_ARG_WITH([lts],
     AS_HELP_STRING([--with-lts=PATH],
@@ -531,6 +536,15 @@ AS_IF([test "x$enable_error_check" = "xno"],
      ABT_NULL="1"],
     [ABT_NULL="0"])
 AC_SUBST([ABT_NULL])
+
+
+AS_IF([test "x$enable_ver20_api" = "xyes"],
+    [AC_DEFINE(ABT_CONFIG_ENABLE_VER_20_API, 1,
+        [Define to enable Argobots 2.0 API])
+     ABT_ENABLE_VER_20_API="1"],
+    [ABT_ENABLE_VER_20_API="0"])
+AC_SUBST([ABT_ENABLE_VER_20_API])
+
 
 AS_IF([test "x$enable_error_check" = "xno" -o "x$enable_pool_producer_check" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_POOL_PRODUCER_CHECK, 1,

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -60,6 +60,12 @@ extern "C" {
 
 #define ABT_DEPRECATED @ABT_DEPRECATED@
 
+#define ABT_ENABLE_VER_20_API_VAL @ABT_ENABLE_VER_20_API@
+#undef ABT_ENABLE_VER_20_API
+#if ABT_ENABLE_VER_20_API_VAL
+#define ABT_ENABLE_VER_20_API 1
+#endif
+
 /* Error Classes */
 #define ABT_SUCCESS                 0  /* Successful return code */
 #define ABT_ERR_UNINITIALIZED       1  /* Uninitialized */

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -177,56 +177,61 @@ enum ABT_unit_type {
                              * thread. */
 };
 
+/**
+ * @ingroup INFO
+ * @brief   Query kind for \c ABT_info_query_config().
+ */
 enum ABT_info_query_kind {
-    /* Whether the debug mode is enabled or not */
+    /** Whether the debug mode is enabled or not */
     ABT_INFO_QUERY_KIND_ENABLED_DEBUG,
-    /* Whether Argobots prints an error number when an error happens or not */
+    /** Whether Argobots prints an error number when an error happens or not */
     ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO,
-    /* Whether Argobots prints a debug message or not */
+    /** Whether Argobots prints a debug message or not */
     ABT_INFO_QUERY_KIND_ENABLED_LOG,
-    /* Whether Argobots is configured to be Valgrind friendly */
+    /** Whether Argobots is configured to be Valgrind friendly */
     ABT_INFO_QUERY_KIND_ENABLED_VALGRIND,
-    /* Whether an error is checked or not */
+    /** Whether an error is checked or not */
     ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR,
-    /* Whether a pool access violation regarding producer is checked or not */
+    /** Whether a pool access violation regarding producer is checked or not */
     ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_PRODUCER,
-    /* Whether a pool access violation regarding consumer is checked or not */
+    /** Whether a pool access violation regarding consumer is checked or not */
     ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_CONSUMER,
-    /* Whether floating-point registers are saved on context switching or not */
+    /** Whether floating-point registers are saved on context switching or not
+     */
     ABT_INFO_QUERY_KIND_ENABLED_PRESERVE_FPU,
-    /* Whether the thread cancellation feature is supported or not */
+    /** Whether the thread cancellation feature is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL,
-    /* Whether the task cancellation feature is supported or not */
+    /** Whether the task cancellation feature is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_TASK_CANCEL,
-    /* Whether the thread and task migration feature is supported or not */
+    /** Whether the thread and task migration feature is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_MIGRATION,
-    /* Whether the stackable scheduler feature is supported or not */
+    /** Whether the stackable scheduler feature is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_STACKABLE_SCHED,
-    /* Whether the external thread feature is supported or not */
+    /** Whether the external thread feature is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
-    /* Whether a predefined scheduler sleeps or not */
+    /** Whether a predefined scheduler sleeps or not */
     ABT_INFO_QUERY_KIND_ENABLED_SCHED_SLEEP,
-    /* Whether the Argobots configuration is printed on ABT_init() or not */
+    /** Whether the Argobots configuration is printed on ABT_init() or not */
     ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG,
-    /* Whether the affinity setting is supported or not */
+    /** Whether the affinity setting is supported or not */
     ABT_INFO_QUERY_KIND_ENABLED_AFFINITY,
-    /* The maximum number of execution streams */
+    /** The maximum number of execution streams */
     ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS,
-    /* Default stack size of ULTs */
+    /** Default stack size of ULTs */
     ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE,
-    /* Default stack size of ULT-type schedulers */
+    /** Default stack size of ULT-type schedulers */
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE,
-    /* Default event-checking frequency of a predefined scheduler */
+    /** Default event-checking frequency of a predefined scheduler */
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ,
-    /* Default sleep time of a predefined scheduler */
+    /** Default sleep time of a predefined scheduler */
     ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC,
-    /* Whether the tool interface is enabled or not */
+    /** Whether the tool interface is enabled or not */
     ABT_INFO_QUERY_KIND_ENABLED_TOOL,
-    /* Whether fcontext is used for context switch or not */
+    /** Whether fcontext is used for context switch or not */
     ABT_INFO_QUERY_KIND_FCONTEXT,
-    /* Whether dynamic promotion is used for context switch or not */
+    /** Whether dynamic promotion is used for context switch or not */
     ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION,
-    /* Whether the stack unwinding feature is enabled or not */
+    /** Whether the stack unwinding feature is enabled or not */
     ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND,
 };
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -881,12 +881,12 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched) ABT_API_PUBLIC;
 int ABT_info_print_pool(FILE* fp, ABT_pool pool) ABT_API_PUBLIC;
 int ABT_info_print_thread(FILE* fp, ABT_thread thread) ABT_API_PUBLIC;
 int ABT_info_print_thread_attr(FILE* fp, ABT_thread_attr attr) ABT_API_PUBLIC;
+int ABT_info_print_task(FILE* fp, ABT_task task) ABT_API_PUBLIC;
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread) ABT_API_PUBLIC;
 int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool) ABT_API_PUBLIC;
 int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
                                              void (*cb_func)(ABT_bool, void *),
                                              void *arg) ABT_API_PUBLIC;
-#define ABT_info_print_task ABT_info_print_thread
 
 /* Tool Functions */
 int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -10,7 +10,7 @@ static inline ABTI_thread *ABTI_thread_get_ptr(ABT_thread thread)
 {
 #ifndef ABT_CONFIG_DISABLE_ERROR_CHECK
     ABTI_thread *p_thread;
-    if (thread == ABT_THREAD_NULL) {
+    if (thread == ABT_THREAD_NULL || thread == ABT_TASK_NULL) {
         p_thread = NULL;
     } else {
         p_thread = (ABTI_thread *)thread;

--- a/src/info.c
+++ b/src/info.c
@@ -11,117 +11,185 @@ static void info_trigger_print_all_thread_stacks(
     FILE *fp, double timeout, void (*cb_func)(ABT_bool, void *), void *arg);
 
 /** @defgroup INFO  Information
- * This group is for getting diverse runtime information of Argobots.  The
- * routines in this group are meant for debugging and diagnosing Argobots.
+ * This group is for getting runtime information of Argobots.  The routines in
+ * this group are meant for debugging and diagnosing Argobots.
  */
 
 /**
  * @ingroup INFO
- * @brief   Get the configuration information associated with \c query_kind.
+ * @brief   Retrieve the configuration information.
  *
- * \c ABT_info_query_config() gets the configuration information associated with
- * the given \c query_kind and writes a value to \c val.
+ * \c ABT_info_query_config() returns the configuration information associated
+ * with the query kind \c query_kind through \c val.
  *
- * The behavior of \c ABT_info_query_config() depends on \c query_kind.
- * - ABT_INFO_QUERY_KIND_ENABLED_DEBUG
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the debug mode is enabled.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to print an error
- *   number when an error happens.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_LOG
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to print debug
- *   messages.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_VALGRIND
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to be Valgrind
- *   friendly.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_FALSE is
- *   set to \c *val if the Argobots library is configured to ignore some error
- *   checks.  Otherwise, ABT_TRUE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_PRODUCER
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_FALSE is
- *   set to \c *val if the Argobots library is configured to ignore an access
- *   violation error regarding pool producers.  Otherwise, ABT_TRUE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_CONSUMER
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_FALSE is
- *   set to \c *val if the Argobots library is configured to ignore an access
- *   violation error regarding pool consumers.  Otherwise, ABT_TRUE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_PRESERVE_FPU
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to save floating-point
- *   registers on user-level context switching.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the thread
- *   cancellation feature. Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_TASK_CANCEL
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the task
- *   cancellation feature. Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_MIGRATION
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the
- *   thread/task migration cancellation feature. Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_STACKABLE_SCHED
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the
- *   stackable scheduler feature is supported.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the
- *   external thread feature is supported.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_SCHED_SLEEP
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the sleep
- *   feature of predefined schedulers.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to print all the
- *   configuration settings on ABT_init().  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_AFFINITY
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the Argobots library is configured to enable the affinity
- *   setting.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS
- *   \c val must be a pointer to a variable of the type unsigned int.  The
- *   maximum number of execution streams that can be created in Argobots is set
- *   to \c *val.
- * - ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE
- *   \c val must be a pointer to a variable of the type size_t.  The default
- *   stack size of ULTs is set to \c *val.
- * - ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE
- *   \c val must be a pointer to a variable of the type size_t.  The default
- *   stack size of ULT-type schedulers is set to \c *val.
- * - ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ
- *   \c val must be a pointer to a variable of the type uint64_t.  The default
- *   event-checking frequency of predefined schedulers is set to \c *val.
- * - ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC
- *   \c val must be a pointer to a variable of the type uint64_t.  The default
- *   sleep time (nanoseconds) of predefined schedulers is set to \c *val.
- * - ABT_INFO_QUERY_KIND_ENABLED_TOOL
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the tool is enabled.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_FCONTEXT
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if fcontext is used.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if dynamic promotion is used.  Otherwise, ABT_FALSE is set.
- * - ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND
- *   \c val must be a pointer to a variable of the type ABT_bool.  ABT_TRUE is
- *   set to \c *val if the stack unwinding feature is enabled.  Otherwise,
- *   ABT_FALSE is set.
+ * The retrieved information is selected by \c query_kind.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_DEBUG
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the debug mode.
+ *   Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to print an error number when an
+ *   error occurs.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_LOG
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to print debug messages.
+ *   Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_VALGRIND
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to be Valgrind friendly.
+ *   Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_FALSE if Argobots is configured to ignore some error checks.
+ *   Otherwise, \c val is set to \c ABT_TRUE
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_PRODUCER
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_FALSE if Argobots is configured to ignore an access violation
+ *   error regarding pool producers.  Otherwise, \c val is set to \c ABT_TRUE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_CONSUMER
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_FALSE if Argobots is configured to ignore an access violation
+ *   error regarding pool consumers.  Otherwise, \c val is set to \c ABT_TRUE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_PRESERVE_FPU
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to save floating-point registers
+ *   on user-level context switching.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the thread cancellation
+ *   feature. Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_TASK_CANCEL
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the task cancellation
+ *   feature. Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_MIGRATION
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the thread/task
+ *   migration cancellation feature.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_STACKABLE_SCHED
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the stackable scheduler
+ *   feature is supported.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the external thread
+ *   feature is supported.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_SCHED_SLEEP
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the sleep feature of
+ *   predefined schedulers.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to print all the configuration
+ *   settings in \c ABT_init().  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_AFFINITY
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the affinity setting.
+ *   Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS
+ *
+ *   \c val must be a pointer to a variable of type \c unsigned \c int.  \c val
+ *   is set to the maximum number of execution streams that can be created by
+ *   Argobots.
+ *
+ * - \c ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE
+ *
+ *   \c val must be a pointer to a variable of type \c size_t.  \c val is set to
+ *   the default stack size of ULTs.
+ *
+ * - \c ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE
+ *
+ *   \c val must be a pointer to a variable of type \c size_t.  \c val is set to
+ *   the default stack size of ULT-type schedulers.
+ *
+ * - \c ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ
+ *
+ *   \c val must be a pointer to a variable of type \c uint64_t.  \c val is set
+ *   to the default event-checking frequency of predefined schedulers.
+ *
+ * - \c ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC
+ *
+ *   \c val must be a pointer to a variable of type \c uint64_t.  \c val is set
+ *   to the default sleep time of predefined schedulers in nanoseconds.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_TOOL
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the tool feature.
+ *   Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_FCONTEXT
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to use fcontext.  Otherwise,
+ *   \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the dynamic promotion
+ *   optimization.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable the stack unwinding
+ *   feature.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
+ * @changev20
+ * \DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_INFO_QUERY_KIND{\c query_kind}
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ * \DOC_V20 \DOC_ERROR_UNINITIALIZED_INFO_QUERY
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c val}
  *
  * @param[in]  query_kind  query kind
- * @param[out] val         a pointer to a result
+ * @param[out] val         result
  * @return Error code
- * @retval ABT_SUCCESS            on success
- * @retval ABT_ERR_INV_QUERY_KIND given query kind is invalid
- * @retval ABT_ERR_UNINITIALIZED  Argobots has not been initialized
  */
 int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
@@ -272,14 +340,32 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 
 /**
  * @ingroup INFO
- * @brief   Write the configuration information to the output stream.
+ * @brief   Print the runtime information of Argobots.
  *
- * \c ABT_info_print_config() writes the configuration information to the given
+ * \c ABT_info_print_config() writes the runtime information of Argobots to the
  * output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_RUNTIME_INFO
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp  output stream
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_config(FILE *fp)
 {
@@ -294,14 +380,32 @@ int ABT_info_print_config(FILE *fp)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of all created ESs to the output stream.
+ * @brief   Print the information of execution streams.
  *
- * \c ABT_info_print_all_xstreams() writes the information of all ESs to the
- * given output stream \c fp.
+ * \c ABT_info_print_all_xstreams() writes the information of all execution
+ * streams to the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_RUNTIME_INFO
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp  output stream
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
@@ -330,15 +434,33 @@ int ABT_info_print_all_xstreams(FILE *fp)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of the target ES to the output stream.
+ * @brief   Print the information of an execution stream.
  *
- * \c ABT_info_print_xstream() writes the information of the target ES
- * \c xstream to the given output stream \c fp.
+ * \c ABT_info_print_xstream() writes the information of the execution stream
+ * \c xstream to the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c xstream, \c ABT_XSTREAM_NULL,
+ *                                 \c ABT_ERR_INV_XSTREAM}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_XSTREAM_HANDLE{\c xstream}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp       output stream
- * @param[in] xstream  handle to the target ES
+ * @param[in] xstream  execution stream handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 {
@@ -349,15 +471,33 @@ int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of the target scheduler to the output stream.
+ * @brief   Print the information of a scheduler.
  *
- * \c ABT_info_print_sched() writes the information of the target scheduler
- * \c sched to the given output stream \c fp.
+ * \c ABT_info_print_sched() writes the information of the scheduler \c sched to
+ * the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c sched, \c ABT_SCHED_NULL,
+ *                                 \c ABT_ERR_INV_SCHED}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_SCHED_HANDLE{\c sched}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp     output stream
- * @param[in] sched  handle to the target scheduler
+ * @param[in] sched  scheduler handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 {
@@ -368,15 +508,33 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of the target pool to the output stream.
+ * @brief   Print the information of a pool.
  *
- * \c ABT_info_print_pool() writes the information of the target pool
- * \c pool to the given output stream \c fp.
+ * \c ABT_info_print_pool() writes the information of the pool \c pool to the
+ * output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c pool, \c ABT_POOL_NULL,
+ *                                 \c ABT_ERR_INV_POOL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp    output stream
- * @param[in] pool  handle to the target pool
+ * @param[in] pool  pool handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
@@ -387,15 +545,37 @@ int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of the target ULT to the output stream.
+ * @brief   Print the information of a work unit.
  *
- * \c ABT_info_print_thread() writes the information of the target ULT
- * \c thread to the given output stream \c fp.
+ * \c ABT_info_print_thread() writes the information of the work unit \c thread
+ * to the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCEPT_TASK{\c thread}
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c thread, \c ABT_THREAD_NULL,
+ *                                 \c ABT_TASK_NULL, \c ABT_ERR_INV_THREAD}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_THREAD_HANDLE{\c thread}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp      output stream
- * @param[in] thread  handle to the target ULT
+ * @param[in] thread  work unit handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
@@ -406,16 +586,33 @@ int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 
 /**
  * @ingroup INFO
- * @brief   Write the information of the target ULT attribute to the output
- * stream.
+ * @brief   Print the information of a ULT attribute.
  *
- * \c ABT_info_print_thread_attr() writes the information of the target ULT
- * attribute \c attr to the given output stream \c fp.
+ * \c ABT_info_print_thread_attr() writes the information of the ULT attribute
+ * \c attr to the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c attr, \c ABT_THREAD_ATTR_NULL,
+ *                                 \c ABT_ERR_INV_THREAD_ATTR}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_THREAD_ATTR_HANDLE{\c attr}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp    output stream
- * @param[in] attr  handle to the target ULT attribute
+ * @param[in] attr  ULT attribute handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
@@ -427,30 +624,76 @@ int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 #ifdef ABT_CONFIG_USE_DOXYGEN
 /**
  * @ingroup INFO
- * @brief   Write the information of the target tasklet to the output stream.
+ * @brief   Print the information of a work unit.
  *
- * \c ABT_info_print_task() writes the information of the target tasklet
- * \c task to the given output stream \c fp.
+ * \c ABT_info_print_task() writes the information of the work unit \c task to
+ * the output stream \c fp.  This routine is deprecated because this routine is
+ * the same as \c ABT_info_print_thread().
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCEPT_THREAD{\c task}
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c task, \c ABT_THREAD_NULL,
+ *                                 \c ABT_TASK_NULL, \c ABT_ERR_INV_TASK}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_TASK_HANDLE{\c task}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp    output stream
- * @param[in] task  handle to the target tasklet
+ * @param[in] task  work unit handle
  * @return Error code
- * @retval ABT_SUCCESS  on success
  */
 int ABT_info_print_task(FILE *fp, ABT_task task);
 #endif
 
 /**
  * @ingroup INFO
- * @brief   Dump the stack of the target thread to the output stream.
+ * @brief   Print stack of a work unit.
  *
- * \c ABT_info_print_thread_stack() dumps the call stack of \c thread
- * to the given output stream \c fp.
+ * \c ABT_info_print_thread_stack() prints the stack of the work unit \c thread
+ * to the output stream \c fp.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCEPT_TASK{\c thread}
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c thread, \c ABT_THREAD_NULL,
+ *                                 \c ABT_TASK_NULL, \c ABT_ERR_INV_THREAD}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_INV_THREAD_HANDLE{\c thread}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
+ * \DOC_UNDEFINED_WORK_UNIT_RUNNING{\c thread}
  *
  * @param[in] fp      output stream
- * @param[in] thread  handle to the target thread
+ * @param[in] thread  work unit handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 {
@@ -473,16 +716,35 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 
 /**
  * @ingroup INFO
- * @brief   Dump stack information of all the threads in the target pool.
+ * @brief   Print stacks of all work units in a pool.
  *
- * \c ABT_info_print_thread_stacks_in_pool() dumps call stacks of all threads
- * stored in \c pool.  This function returns \c ABT_ERR_POOL if \c pool does not
- * support \c p_print_all.
+ * \c ABT_info_print_thread_stacks_in_pool() prints stacks of all work units in
+ * the pool \c pool to the output stream \c fp.  \c pool must support
+ * \c p_print_all() to check all work units in the pool.
+ *
+ * @note
+ * \DOC_NOTE_INFO_PRINT
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PRINT_HANDLE_INFO{\c pool, \c ABT_POOL_NULL,
+ *                                 \c ABT_ERR_INV_POOL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c p_print_all()}
+ * \DOC_V1X \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
  *
  * @param[in] fp    output stream
- * @param[in] pool  handle to the target pool
+ * @param[in] pool  pool handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
 {
@@ -494,39 +756,62 @@ int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
 
 /**
  * @ingroup INFO
- * @brief   Dump stacks of threads in pools existing in Argobots.
+ * @brief   Print stacks of work units in pools associated with all the main
+ *          schedulers.
  *
- * \c ABT_info_trigger_print_all_thread_stacks() tries to dump call stacks of
- * all threads stored in pools in the Argobots runtime. This function itself
- * does not print stacks; it immediately returns after updating a flag. Stacks
- * are printed when all execution streams stop in \c ABT_xstream_check_events().
+ * \c ABT_info_trigger_print_all_thread_stacks() tries to print stacks of all
+ * threads stored in pools associated with all the main schedulers to the output
+ * stream \c fp.  This routine itself does not print stacks; it immediately
+ * returns after updating a flag.  Stacks are printed when all execution streams
+ * stop in \c ABT_xstream_check_events().
  *
- * If some execution streams do not stop within a certain time period, one of
- * the stopped execution streams starts to print stack information. In this
- * case, this function might not work correctly and at worst causes a crash.
- * This function does not work at all if no execution stream executes
- * \c ABT_xstream_check_events().
+ * If some execution streams do not stop within a certain time period specified
+ * by \c timeout in seconds where \c timeout is not negative, one of the
+ * execution streams that stop at \c ABT_xstream_check_events() starts to print
+ * the stack information.  In this case, this routine might not work correctly
+ * and at worst crashes a program.  This routine does not work at all if no
+ * execution stream executes \c ABT_xstream_check_events().
  *
- * \c cb_func is called after completing stack dump unless it is NULL. The first
- * argument is set to \c ABT_TRUE if not all the execution streams stop within
- * \c timeout. Otherwise, \c ABT_FALSE is set. The second argument is
- * user-defined data \c arg. Since \c cb_func is not called by a thread or an
- * execution stream, \c ABT_self_...() functions in \c cb_func return undefined
- * values. Neither signal-safety nor thread-safety is required for \c cb_func.
+ * The callback function \c cb_func() is called after completing printing stacks
+ * unless \c cb_func is \c NULL.  The first argument is set to \c ABT_TRUE if
+ * not all the execution streams stop within \c timeout.  Otherwise,
+ * \c ABT_FALSE is passed.  The second argument is the user-defined data \c arg
+ * passed to this routine.  The caller of \c cb_func() is undefined, so a
+ * program that relies on the caller of \c cb_func() is non-conforming.  Neither
+ * signal-safety nor thread-safety is required for \c cb_func().
  *
- * In Argobots, \c ABT_info_trigger_print_all_thread_stacks is exceptionally
- * signal-safe; it can be safely called in a signal handler.
+ * The following work units are not captured by this routine:
+ * - Work units that are suspending (e.g., by \c ABT_thread_suspend()).
+ * - Work units in pools that are not associated with main schedulers.
  *
- * The following threads are not captured in this function:
- * - threads that are suspending (e.g., by \c ABT_thread_suspend())
- * - threads in pools that are not associated with main schedulers
+ * Calling \c ABT_info_trigger_print_all_thread_stacks() multiple times updates
+ * old values.  The values are atomically updated.
+ *
+ * @note
+ * This routine prints the information in a best-effort basis.  Specifically,
+ * this routine does not return an error regarding \c fp to either the caller of
+ * this routine or \c cb_func().\n
+ * If the timeout mechanism is used, the program may crash, so this
+ * functionality should be used only for debugging and diagnosis.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH \DOC_CONTEXT_NOTE_SIGNAL_SAFE
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c fp}
+ * \DOC_UNDEFINED_NULL_PTR{\c cb_func}
+ * \DOC_UNDEFINED_SYS_FILE{\c fp}
+ * \DOC_UNDEFINED_CHANGE_STATE{\c cb_func()}
  *
  * @param[in] fp       output stream
- * @param[in] timeout  timeout (second). Disabled if the value is negative.
- * @param[in] cb_func  call-back function
- * @param[in] arg      an argument passed to \c cb_func
+ * @param[in] timeout  timeout in seconds
+ * @param[in] cb_func  callback function
+ * @param[in] arg      argument passed to \c cb_func()
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
                                              void (*cb_func)(ABT_bool, void *),

--- a/src/info.c
+++ b/src/info.c
@@ -654,7 +654,6 @@ int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
     return ABT_SUCCESS;
 }
 
-#ifdef ABT_CONFIG_USE_DOXYGEN
 /**
  * @ingroup INFO
  * @brief   Print the information of a work unit.
@@ -690,8 +689,16 @@ int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
  * @param[in] task  work unit handle
  * @return Error code
  */
-int ABT_info_print_task(FILE *fp, ABT_task task);
+int ABT_info_print_task(FILE *fp, ABT_task task)
+{
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(task);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_TASK_PTR(p_thread);
 #endif
+    ABTI_thread_print(p_thread, fp, 0);
+    return ABT_SUCCESS;
+}
 
 /**
  * @ingroup INFO

--- a/src/info.c
+++ b/src/info.c
@@ -193,6 +193,10 @@ static void info_trigger_print_all_thread_stacks(
  */
 int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x always requires an init check. */
+    ABTI_SETUP_WITH_INIT_CHECK();
+#endif
     switch (query_kind) {
         case ABT_INFO_QUERY_KIND_ENABLED_DEBUG:
             ABTI_SETUP_WITH_INIT_CHECK();
@@ -369,6 +373,10 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
  */
 int ABT_info_print_config(FILE *fp)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x always requires an init check. */
+    ABTI_SETUP_WITH_INIT_CHECK();
+#endif
     if (!gp_ABTI_global) {
         fprintf(fp, "Argobots is not initialized.\n");
         fflush(fp);
@@ -409,11 +417,16 @@ int ABT_info_print_config(FILE *fp)
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x always requires an init check. */
+    ABTI_SETUP_WITH_INIT_CHECK();
+#else
     if (!gp_ABTI_global) {
         fprintf(fp, "Argobots is not initialized.\n");
         fflush(fp);
         return ABT_SUCCESS;
     }
+#endif
     ABTI_global *p_global = gp_ABTI_global;
 
     ABTI_spinlock_acquire(&p_global->xstream_list_lock);
@@ -465,6 +478,10 @@ int ABT_info_print_all_xstreams(FILE *fp)
 int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 {
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
+#endif
     ABTI_xstream_print(p_xstream, fp, 0, ABT_FALSE);
     return ABT_SUCCESS;
 }
@@ -502,6 +519,10 @@ int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 {
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+#endif
     ABTI_sched_print(p_sched, fp, 0, ABT_TRUE);
     return ABT_SUCCESS;
 }
@@ -539,6 +560,10 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+#endif
     ABTI_pool_print(p_pool, fp, 0);
     return ABT_SUCCESS;
 }
@@ -580,6 +605,10 @@ int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+#endif
     ABTI_thread_print(p_thread, fp, 0);
     return ABT_SUCCESS;
 }
@@ -617,6 +646,10 @@ int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
+#endif
     ABTI_thread_attr_print(p_attr, fp, 0);
     return ABT_SUCCESS;
 }
@@ -698,6 +731,10 @@ int ABT_info_print_task(FILE *fp, ABT_task task);
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 {
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+#endif
     if (!p_thread) {
         fprintf(fp, "no stack\n");
         fflush(0);
@@ -749,6 +786,10 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x requires a NULL-handle check. */
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+#endif
     int abt_errno = info_print_thread_stacks_in_pool(fp, p_pool);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;


### PR DESCRIPTION
This PR updates the specification of the current info API for the upcoming Argobots 1.1.

Specifically, this PR restores the old error checks that existed in Argobots 1.0 for the backward compatibility. This PR itself does not hurt the performance. Unless the user program highly relies on the error code (not an error, an "error code"), this PR does not affect the behavior of the program.

