### PR TITLE
self: improve API

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1822,7 +1822,11 @@ ALIASES += DOC_CONTEXT_CTXSWITCH="This routine may perform context switching for
 
 ALIASES += DOC_CONTEXT_INIT="This routine can be called in any execution context. Argobots must be initialized."
 
+ALIASES += DOC_CONTEXT_INIT_NOEXT="This routine can be called in either a ULT context or a tasklet context. Argobots must be initialized."
+
 ALIASES += DOC_CONTEXT_INIT_NOTASK="This routine can be called in either a ULT context or an external thread context. Argobots must be initialized."
+
+ALIASES += DOC_CONTEXT_INIT_YIELDABLE="This routine can be called in a ULT context. Argobots must be initialized."
 
 ALIASES += DOC_CONTEXT_NOCTXSWITCH="This routine does not perform context switching the calling ULT unless any user-defined function that is involved in this routine performs context switching."
 
@@ -1848,6 +1852,8 @@ ALIASES += DOC_DESC_V10_ACCEPT_THREAD{1}="\DOC_V10 The user cannot pass a ULT ha
 
 ALIASES += DOC_DESC_V10_BARRIER_NUM_WAITERS{1}="\DOC_V10 This routine accepts zero as \c num_waiters.\n \DOC_V11 This routine returns \c ABT_ERR_INV_ARG if \c num_waiters is zero. @rationale A barrier with \c num_waiters = 0 is useless and should be prohibited.  Even with Argobots 1.0, calling \c ABT_barrier_wait() for a barrier with \c num_waiters = 0 is not allowed. @endrationale"
 
+ALIASES += DOC_DESC_V10_ERROR_CODE_CHANGE{3}="\DOC_V10 \1 is returned if \3.\n \DOC_V11 \2 is returned if \3.\n @rationale Argobots 1.0 returned an error code which is obviously wrong.  Argobots 1.1 fixes the error code for consistent behavior with the other Argobots routines. @endrationale"
+
 ALIASES += DOC_DESC_V10_EVENTUAL_UPDATE_READY_BUFFER{1}="\DOC_V10 This routine updates the memory buffer of \1 and returns \c ABT_SUCCESS if \1 is ready.\n \DOC_V11 This routine returns \c ABT_ERR_EVENTUAL if \1 is ready.\n @rationale An update of the memory buffer when \1 is ready breaks the semantics of \c eventual.  Such an update should be prohibited. @endrationale"
 
 ALIASES += DOC_DESC_V10_FUTURE_COMPARTMENT_ORDER="\DOC_V10 The order of elements of \c arg passed to \c cb_func() is the same order as the \c ABT_future_set() calls are terminated.\n \DOC_V11 The order of elements of \c arg passed to \c cb_func() is undefined. @rationale This specification in Argobots 1.0 is unclear and unreasonable because the exact timing of termination of \c ABT_future_set() is not observable if \c ABT_future_set() is called concurrently. @endrationale"
@@ -1855,6 +1861,8 @@ ALIASES += DOC_DESC_V10_FUTURE_COMPARTMENT_ORDER="\DOC_V10 The order of elements
 ALIASES += DOC_DESC_V10_REJECT_MUTEX_ATTR_NULL{1}="\DOC_V10 This routine returns \c ABT_ERR_INV_MUTEX_ATTR if \1 is \c ABT_MUTEX_ATTR_NULL.\n \DOC_V11 This routine uses the default mutex attributes if \1 is \c ABT_MUTEX_ATTR_NULL. @rationale Most of the Argobots routines use the default attributes if the given configuration or attributes are NULL.  This routine should also follow this basic rule. @endrationale"
 
 ALIASES += DOC_DESC_V1X_ERROR_CODE_CHANGE{3}="\DOC_V1X \1 is returned if \3.\n \DOC_V20 \2 is returned if \3.\n @rationale Argobots 2.0 changes the error code for consistent behavior with the other Argobots routines. @endrationale"
+
+ALIASES += DOC_DESC_V1X_NOEXT{1}="\DOC_V1X If an external thread calls this routine, \1 is returned.\n \DOC_V20 An external thread may call this routine.\n @rationale Argobots 2.0 allows an external thread as much as possible unless it is semantically wrong. @endrationale"
 
 ALIASES += DOC_DESC_V1X_NOTASK{1}="\DOC_V1X If a tasklet calls this routine, \1 is returned.\n \DOC_V20 A tasklet may call this routine.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general. @endrationale"
 
@@ -1867,6 +1875,8 @@ ALIASES += DOC_DESC_V1X_PRINT_HANDLE_INFO{4}="\DOC_V1X This routine returns \4 w
 ALIASES += DOC_DESC_V1X_PRINT_RUNTIME_INFO="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED when Argobots is not initialized.\n \DOC_V20 This routine prints the queried information and returns \c ABT_SUCCESS when Argobots is not initialized.\n @rationale The information routines primarily for debugging and diagnosis should avoid returning an error as much as possible. @endrationale"
 
 ALIASES += DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized.\n \DOC_V20 This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized and the queried information cannot be retrieved when Argobots is not initialized.\n @rationale Retrieving static configurations before initializing Argobots is helpful to check if the loaded Argobots implements necessary features. @endrationale"
+
+ALIASES += DOC_DESC_V1X_RETURN_UNINITIALIZED="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized.\n \DOC_V20 The results are undefined if Argobots is not initialized.\n @rationale From Argobots 2.0, all the Argobots routines that are not explicitly noted do not check if Argobots is initialized.  This omission can reduce the branches that are mostly unnecessary. @endrationale"
 
 ALIASES += DOC_DESC_V1X_SET_VALUE_ON_ERROR{2}="\DOC_V1X \1 is set to \2 if an error occurs.\n \DOC_V20 \1 is not updated if an error occurs.\n @rationale To ensure the atomicity of the API, Argobots 2.0 guarantees that the routine has no effect if the routine returns an error (as possible).  Argobots 2.0 does not update a returned value when the routine throws an error. @endrationale"
 
@@ -1932,6 +1942,10 @@ ALIASES += DOC_ERROR_INV_THREAD_ATTR_HANDLE{1}="If \1 is \c ABT_THREAD_ATTR_NULL
 
 ALIASES += DOC_ERROR_INV_THREAD_HANDLE{1}="If \1 is \c ABT_THREAD_NULL or \c ABT_TASK_NULL, \c ABT_ERR_INV_THREAD is returned.\n"
 
+ALIASES += DOC_ERROR_INV_THREAD_NY="If the caller is a tasklet, \c ABT_ERR_INV_THREAD is returned.\n"
+
+ALIASES += DOC_ERROR_INV_THREAD_NY{1}="If \1 is a tasklet, \c ABT_ERR_INV_THREAD is returned.\n"
+
 ALIASES += DOC_ERROR_INV_TIMER_HANDLE{1}="If \1 is \c ABT_TIMER_NULL, \c ABT_ERR_INV_TIMER is returned.\n"
 
 ALIASES += DOC_ERROR_INV_TIMER_PTR{1}="If \1 points to \c ABT_TIMER_NULL, \c ABT_ERR_INV_TIMER is returned.\n"
@@ -1939,6 +1953,8 @@ ALIASES += DOC_ERROR_INV_TIMER_PTR{1}="If \1 points to \c ABT_TIMER_NULL, \c ABT
 ALIASES += DOC_ERROR_INV_XSTREAM_BARRIER_HANDLE{1}="If \1 is \c ABT_XSTREAM_BARRIER_NULL, \c ABT_ERR_INV_XSTREAM_BARRIER is returned.\n"
 
 ALIASES += DOC_ERROR_INV_XSTREAM_BARRIER_PTR{1}="If \1 points to \c ABT_XSTREAM_BARRIER_NULL, \c ABT_ERR_INV_XSTREAM_BARRIER is returned.\n"
+
+ALIASES += DOC_ERROR_INV_XSTREAM_EXT="If the caller is an external thread, \c ABT_ERR_INV_XSTREAM is returned.\n"
 
 ALIASES += DOC_ERROR_INV_XSTREAM_HANDLE{1}="If \1 is \c ABT_XSTREAM_NULL, \c ABT_ERR_INV_XSTREAM is returned.\n"
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -782,9 +782,9 @@ int ABT_task_self_id(ABT_unit_id *id) ABT_API_PUBLIC;
 
 /* Self */
 int ABT_self_get_type(ABT_unit_type *type) ABT_API_PUBLIC;
-int ABT_self_is_primary(ABT_bool *flag) ABT_API_PUBLIC;
-int ABT_self_on_primary_xstream(ABT_bool *flag) ABT_API_PUBLIC;
-int ABT_self_is_unnamed(ABT_bool *flag) ABT_API_PUBLIC;
+int ABT_self_is_primary(ABT_bool *is_primary) ABT_API_PUBLIC;
+int ABT_self_on_primary_xstream(ABT_bool *on_primary) ABT_API_PUBLIC;
+int ABT_self_is_unnamed(ABT_bool *is_unnamed) ABT_API_PUBLIC;
 int ABT_self_get_last_pool_id(int *pool_id) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -72,7 +72,7 @@ enum ABTI_sched_used {
 #define ABTI_THREAD_TYPE_EXT ((ABTI_thread_type)0)
 #define ABTI_THREAD_TYPE_THREAD ((ABTI_thread_type)(0x1 << 0))
 #define ABTI_THREAD_TYPE_ROOT ((ABTI_thread_type)(0x1 << 1))
-#define ABTI_THREAD_TYPE_MAIN ((ABTI_thread_type)(0x1 << 2))
+#define ABTI_THREAD_TYPE_PRIMARY ((ABTI_thread_type)(0x1 << 2))
 #define ABTI_THREAD_TYPE_MAIN_SCHED ((ABTI_thread_type)(0x1 << 3))
 #define ABTI_THREAD_TYPE_YIELDABLE ((ABTI_thread_type)(0x1 << 4))
 #define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 5))
@@ -177,16 +177,16 @@ struct ABTI_global {
         xstream_list_lock; /* Spinlock protecting ES list. Any read and
                             * write to this list requires a lock.*/
 
-    int num_cores;                /* Number of CPU cores */
-    ABT_bool set_affinity;        /* Whether CPU affinity is used */
-    ABT_bool use_logging;         /* Whether logging is used */
-    ABT_bool use_debug;           /* Whether debug output is used */
-    uint32_t key_table_size;      /* Default key table size */
-    size_t thread_stacksize;      /* Default stack size for ULT (in bytes) */
-    size_t sched_stacksize;       /* Default stack size for sched (in bytes) */
-    uint32_t sched_event_freq;    /* Default check frequency for sched */
-    uint64_t sched_sleep_nsec;    /* Default nanoseconds for scheduler sleep */
-    ABTI_ythread *p_main_ythread; /* ULT of the main function */
+    int num_cores;             /* Number of CPU cores */
+    ABT_bool set_affinity;     /* Whether CPU affinity is used */
+    ABT_bool use_logging;      /* Whether logging is used */
+    ABT_bool use_debug;        /* Whether debug output is used */
+    uint32_t key_table_size;   /* Default key table size */
+    size_t thread_stacksize;   /* Default stack size for ULT (in bytes) */
+    size_t sched_stacksize;    /* Default stack size for sched (in bytes) */
+    uint32_t sched_event_freq; /* Default check frequency for sched */
+    uint64_t sched_sleep_nsec; /* Default nanoseconds for scheduler sleep */
+    ABTI_ythread *p_primary_ythread; /* Primary ULT */
 
     uint32_t
         mutex_max_handovers;    /* Default max. # of local handovers (unused) */
@@ -522,9 +522,9 @@ ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
 ABTU_ret_err int ABTI_ythread_create_root(ABTI_local *p_local,
                                           ABTI_xstream *p_xstream,
                                           ABTI_ythread **pp_root_ythread);
-ABTU_ret_err int ABTI_ythread_create_main(ABTI_local *p_local,
-                                          ABTI_xstream *p_xstream,
-                                          ABTI_ythread **p_ythread);
+ABTU_ret_err int ABTI_ythread_create_primary(ABTI_local *p_local,
+                                             ABTI_xstream *p_xstream,
+                                             ABTI_ythread **p_ythread);
 ABTU_ret_err int ABTI_ythread_create_main_sched(ABTI_local *p_local,
                                                 ABTI_xstream *p_xstream,
                                                 ABTI_sched *p_sched);
@@ -533,7 +533,7 @@ ABTU_ret_err int ABTI_ythread_create_sched(ABTI_local *p_local,
                                            ABTI_sched *p_sched);
 ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
                                      ABTI_ythread *p_ythread);
-void ABTI_ythread_free_main(ABTI_local *p_local, ABTI_ythread *p_ythread);
+void ABTI_ythread_free_primary(ABTI_local *p_local, ABTI_ythread *p_ythread);
 void ABTI_ythread_free_root(ABTI_local *p_local, ABTI_ythread *p_ythread);
 void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);
 void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,

--- a/src/self.c
+++ b/src/self.c
@@ -91,13 +91,14 @@ int ABT_self_get_type(ABT_unit_type *type)
  * @param[out] is_primary  result (\c ABT_TRUE: primary ULT, \c ABT_FALSE: not)
  * @return Error code
  */
-int ABT_self_is_primary(ABT_bool *flag)
+int ABT_self_is_primary(ABT_bool *is_primary)
 {
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     ABTI_thread *p_thread = p_local_xstream->p_thread;
-    *flag = (p_thread->type & ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
+    *is_primary =
+        (p_thread->type & ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
     return ABT_SUCCESS;
 }
 
@@ -136,14 +137,15 @@ int ABT_self_is_primary(ABT_bool *flag)
  *                                 \c ABT_FALSE: not)
  * @return Error code
  */
-int ABT_self_on_primary_xstream(ABT_bool *flag)
+int ABT_self_on_primary_xstream(ABT_bool *on_primary)
 {
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
     /* Return value */
-    *flag = (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) ? ABT_TRUE
-                                                                 : ABT_FALSE;
+    *on_primary = (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
+                      ? ABT_TRUE
+                      : ABT_FALSE;
     return ABT_SUCCESS;
 }
 
@@ -331,13 +333,13 @@ int ABT_self_get_arg(void **arg)
  * @param[out] is_unnamed  result (\c ABT_TRUE: unnamed, \c ABT_FALSE: not)
  * @return Error code
  */
-int ABT_self_is_unnamed(ABT_bool *flag)
+int ABT_self_is_unnamed(ABT_bool *is_unnamed)
 {
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
 
-    *flag = (p_local_xstream->p_thread->type & ABTI_THREAD_TYPE_NAMED)
-                ? ABT_FALSE
-                : ABT_TRUE;
+    *is_unnamed = (p_local_xstream->p_thread->type & ABTI_THREAD_TYPE_NAMED)
+                      ? ABT_FALSE
+                      : ABT_TRUE;
     return ABT_SUCCESS;
 }

--- a/src/self.c
+++ b/src/self.c
@@ -105,15 +105,17 @@ int ABT_self_is_primary(ABT_bool *is_primary)
     *is_primary = ABT_FALSE;
     ABTI_ythread *p_ythread;
     ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(NULL, &p_ythread);
-    *is_primary =
-        (p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN) ? ABT_TRUE : ABT_FALSE;
+    *is_primary = (p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY)
+                      ? ABT_TRUE
+                      : ABT_FALSE;
 #else
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream_or_null(ABTI_local_get_local());
     if (p_local_xstream) {
-        *is_primary = (p_local_xstream->p_thread->type & ABTI_THREAD_TYPE_MAIN)
-                          ? ABT_TRUE
-                          : ABT_FALSE;
+        *is_primary =
+            (p_local_xstream->p_thread->type & ABTI_THREAD_TYPE_PRIMARY)
+                ? ABT_TRUE
+                : ABT_FALSE;
     } else {
         *is_primary = ABT_FALSE;
     }

--- a/src/self.c
+++ b/src/self.c
@@ -11,25 +11,37 @@
 
 /**
  * @ingroup SELF
- * @brief   Return the type of calling work unit.
+ * @brief   Obtain a type of the caller.
  *
- * \c ABT_self_get_type() returns the type of calling work unit, e.g.,
- * \c ABT_UNIT_TYPE_THREAD for ULT and \c ABT_UNIT_TYPE_TASK for tasklet,
- * through \c type.
- * If this routine is called when Argobots has not been initialized,
- * \c ABT_ERR_UNINITIALIZED will be returned.
- * If this routine is called by an external thread, e.g., pthread,
- * \c ABT_ERR_INV_XSTREAM will be returned.
+ * \c ABT_self_get_type() returns a type of the calling work unit through
+ * \c type.  If the caller is a ULT, \c type is set to \c ABT_UNIT_TYPE_THREAD.
+ * If the caller is a tasklet, \c type is set to \c ABT_UNIT_TYPE_TASK.
+ * Otherwise (i.e., if the caller is an external thread), \c type is set to
+ * \c ABT_UNIT_TYPE_EXT.
  *
- * Now \c type will be set to \c ABT_UNIT_TYPE_EXT when it returns an
- * error, but this behavior is deprecated; the user should check the error code
- * to check if this routine is called by a thread not managed by Argobots.
+ * @changev20
+ * \DOC_DESC_V1X_NOEXT{\c ABT_ERR_INV_XSTREAM}
  *
- * @param[out] type  work unit type.
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c type, \c ABT_UNIT_TYPE_EXT}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ * \DOC_V1X \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c type}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] type  work unit type
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_get_type(ABT_unit_type *type)
 {
@@ -47,17 +59,37 @@ int ABT_self_get_type(ABT_unit_type *type)
  * @ingroup SELF
  * @brief   Check if the caller is the primary ULT.
  *
- * \c ABT_self_is_primary() confirms whether the caller is the primary ULT and
- * returns the result through \c flag.
- * If the caller is the primary ULT, \c flag is set to \c ABT_TRUE.
- * Otherwise, \c flag is set to \c ABT_FALSE.
+ * \c ABT_self_is_primary() checks whether the caller is the primary ULT and
+ * returns the result through \c is_primary.  If the caller is the primary ULT,
+ * \c is_primary is set to \c ABT_TRUE.  Otherwise, \c is_primary is set to
+ * \c ABT_FALSE.
  *
- * @param[out] flag    result (<tt>ABT_TRUE</tt>: primary ULT,
- *                     <tt>ABT_FALSE</tt>: not)
+ * @changev20
+ * \DOC_DESC_V1X_NOTASK{\c ABT_ERR_INV_THREAD}
+ *
+ * \DOC_DESC_V1X_NOEXT{\c ABT_ERR_INV_XSTREAM}
+ *
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c is_primary, \c ABT_FALSE}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ * \DOC_V1X \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_V1X \DOC_ERROR_INV_THREAD_NY
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c is_primary}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] is_primary  result (\c ABT_TRUE: primary ULT, \c ABT_FALSE: not)
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_is_primary(ABT_bool *flag)
 {
@@ -71,18 +103,38 @@ int ABT_self_is_primary(ABT_bool *flag)
 
 /**
  * @ingroup SELF
- * @brief   Check if the caller's ES is the primary ES.
+ * @brief   Check if the caller is running on the primary execution stream.
  *
- * \c ABT_self_on_primary_xstream() checks whether the caller work unit is
- * associated with the primary ES. If the caller is running on the primary ES,
- * \c flag is set to \c ABT_TRUE. Otherwise, \c flag is set to \c ABT_FALSE.
+ * \c ABT_self_on_primary_xstream() checks whether the caller is running on the
+ * primary execution stream and returns the result through \c on_primary.  If
+ * the caller is a work unit running on the primary execution stream,
+ * \c on_primary is set to \c ABT_TRUE.  Otherwise, \c on_primary is set to
+ * \c ABT_FALSE.
  *
- * @param[out] flag    result (<tt>ABT_TRUE</tt>: primary ES,
- *                     <tt>ABT_FALSE</tt>: not)
+ * @changev20
+ * \DOC_DESC_V1X_NOEXT{\c ABT_ERR_INV_XSTREAM}
+ *
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c on_primary, \c ABT_FALSE}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ * \DOC_V1X \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c on_primary}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] on_primary  result (\c ABT_TRUE: primary execution stream,
+ *                                 \c ABT_FALSE: not)
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_on_primary_xstream(ABT_bool *flag)
 {
@@ -97,21 +149,31 @@ int ABT_self_on_primary_xstream(ABT_bool *flag)
 
 /**
  * @ingroup SELF
- * @brief   Get the last pool's ID of calling work unit.
+ * @brief   Get ID of the last pool of the calling work unit.
  *
- * \c ABT_self_get_last_pool_id() returns the last pool's ID of caller work
- * unit.  If the work unit is not running, this routine returns the ID of the
- * pool where it is residing.  Otherwise, it returns the ID of the last pool
- * where the work unit was (i.e., the pool from which the work unit was
- * popped).
- * NOTE: If this routine is not called by Argobots work unit (ULT or tasklet),
- * \c pool_id will be set to \c -1.
+ * \c ABT_self_get_last_pool_id() returns the last pool's ID of the calling work
+ * unit through \c pool_id.
  *
- * @param[out] pool_id  pool id
- * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
+ * @changev20
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c pool_id, -1}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c pool_id}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] pool_id  pool ID
+ * @return  Error code
  */
 int ABT_self_get_last_pool_id(int *pool_id)
 {
@@ -131,21 +193,32 @@ int ABT_self_get_last_pool_id(int *pool_id)
 
 /**
  * @ingroup SELF
- * @brief   Suspend the current ULT.
+ * @brief   Suspend the calling ULT.
  *
- * \c ABT_self_suspend() suspends the execution of current ULT and switches
- * to the scheduler.  The caller ULT is not pushed to its associated pool and
- * its state becomes BLOCKED.  It can be awakened and be pushed back to the
- * pool when \c ABT_thread_resume() is called.
+ * \c ABT_self_suspend() suspends the execution of the calling ULT and switches
+ * to its parent ULT.  The caller ULT is not pushed to its associated pool and
+ * its state becomes blocked.  The suspended ULT can be awakened and pushed back
+ * to its associated pool when \c ABT_thread_resume() is called.
  *
- * This routine must be called by a ULT.  Otherwise, it returns
- * \c ABT_ERR_INV_THREAD without suspending the caller.
+ * @changev11
+ * \DOC_DESC_V10_ERROR_CODE_CHANGE{\c ABT_ERR_INV_THREAD,
+ *                                 \c ABT_ERR_INV_XSTREAM,
+ *                                 this routine is called by an external thread}
+ * @endchangev11
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_THREAD_NY
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{the caller}
  *
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
- * @retval ABT_ERR_INV_THREAD    called by a non-yieldable thread (tasklet)
  */
 int ABT_self_suspend(void)
 {
@@ -161,16 +234,32 @@ int ABT_self_suspend(void)
 
 /**
  * @ingroup SELF
- * @brief   Set the argument for the work unit function
+ * @brief   Set an argument for a work-unit function of the calling work unit
  *
- * \c ABT_self_set_arg() sets the argument for the caller's work unit
+ * \c ABT_self_set_arg() sets the argument \c arg for the caller's work unit
  * function.
  *
- * @param[in] arg  argument for the work unit function
+ * @note
+ * The newly set argument will be used if the caller is revived.
+ *
+ * @changev20
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ *
+ * @undefined
+ * \DOC_UNDEFINED_THREAD_UNSAFE{the caller}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[in] arg  argument a work-unit function of the calling work unit
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_set_arg(void *arg)
 {
@@ -183,19 +272,32 @@ int ABT_self_set_arg(void *arg)
 
 /**
  * @ingroup SELF
- * @brief   Retrieve the argument for the work unit function
+ * @brief   Retrieve an argument for a work unit function of the calling work
+ *          unit
  *
  * \c ABT_self_get_arg() returns the argument for the caller's work unit
- * function.  If the caller is a ULT, this routine returns the function argument
- * passed to \c ABT_thread_create() when the caller was created or set by \c
- * ABT_thread_set_arg().  On the other hand, if the caller is a tasklet, this
- * routine returns the function argument passed to \c ABT_task_create().
+ * function.
  *
- * @param[out] arg  argument for the work unit function
+ * @changev20
+ * \DOC_DESC_V1X_RETURN_UNINITIALIZED
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c arg, \c NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_V1X \DOC_ERROR_UNINITIALIZED
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c arg}
+ * \DOC_V20 \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] arg  argument for the caller's function
  * @return Error code
- * @retval ABT_SUCCESS on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_get_arg(void **arg)
 {
@@ -208,18 +310,26 @@ int ABT_self_get_arg(void **arg)
 
 /**
  * @ingroup SELF
- * @brief   Check if the running work unit is unnamed
+ * @brief   Check if the calling work unit is unnamed
  *
- * \c ABT_self_is_unnamed() returns whether the current work units is unnamed or
- * not.  If the caller is an external thread, it sets ABT_FALSE and returns
- * ABT_ERR_INV_XSTREAM.
+ * \c ABT_self_is_unnamed() checks if the current caller is unnamed and returns
+ * the result through \c is_unnamed.  \c is_unnamed is set to \c ABT_TRUE if the
+ * calling work unit is unnamed.  Otherwise, \c is_unnamed is set to \c
+ * ABT_FALSE.
  *
- * @param[out] flag  result (<tt>ABT_TRUE</tt> if unnamed)
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
  *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c is_unnamed}
+ *
+ * @param[out] is_unnamed  result (\c ABT_TRUE: unnamed, \c ABT_FALSE: not)
  * @return Error code
- * @retval ABT_SUCCESS           on success
- * @retval ABT_ERR_UNINITIALIZED Argobots has not been initialized
- * @retval ABT_ERR_INV_XSTREAM   called by an external thread
  */
 int ABT_self_is_unnamed(ABT_bool *flag)
 {

--- a/src/stream.c
+++ b/src/stream.c
@@ -877,7 +877,7 @@ void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
                                 ABTI_ythread *p_ythread)
 {
     /* p_ythread must be the main thread. */
-    ABTI_ASSERT(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN);
+    ABTI_ASSERT(p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY);
     /* The ES's state must be running here. */
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_xstream->state) ==
                 ABT_XSTREAM_STATE_RUNNING);
@@ -895,8 +895,8 @@ void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
     p_xstream->p_root_ythread->thread.p_last_xstream = p_xstream;
     ABTD_ythread_context_switch(&p_ythread->ctx,
                                 &p_xstream->p_root_ythread->ctx);
-    /* Come back to the main thread.  Now this thread is executed on top of the
-     * main scheduler, which is running on the root thread. */
+    /* Come back to the primary thread.  Now this thread is executed on top of
+     * the main scheduler, which is running on the root thread. */
     (*pp_local_xstream)->p_thread = &p_ythread->thread;
 }
 
@@ -1403,7 +1403,7 @@ xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
         }
     }
     if (p_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
-        ABTI_CHECK_TRUE(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN,
+        ABTI_CHECK_TRUE(p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY,
                         ABT_ERR_THREAD);
 
         /* Since the primary ES does not finish its execution until ABT_finalize

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -30,7 +30,11 @@ void task_hello(void *arg)
     assert(ret == ABT_SUCCESS && type == ABT_UNIT_TYPE_TASK);
 
     ret = ABT_self_is_primary(&flag);
+#ifdef ABT_ENABLE_VER_20_API
     assert(ret == ABT_SUCCESS && flag == ABT_FALSE);
+#else
+    assert(ret == ABT_ERR_INV_THREAD && flag == ABT_FALSE);
+#endif
 
     ret = ABT_self_on_primary_xstream(&flag);
     assert(ret == ABT_SUCCESS);
@@ -105,13 +109,25 @@ void *pthread_hello(void *arg)
     assert(ret == ABT_ERR_INV_XSTREAM && task == ABT_TASK_NULL);
 
     ret = ABT_self_get_type(&type);
+#ifdef ABT_ENABLE_VER_20_API
+    assert(ret == ABT_SUCCESS && type == ABT_UNIT_TYPE_EXT);
+#else
     assert(ret == ABT_ERR_INV_XSTREAM && type == ABT_UNIT_TYPE_EXT);
+#endif
 
     ret = ABT_self_is_primary(&flag);
-    assert(ret == ABT_ERR_INV_XSTREAM);
+#ifdef ABT_ENABLE_VER_20_API
+    assert(ret == ABT_SUCCESS && flag == ABT_FALSE);
+#else
+    assert(ret == ABT_ERR_INV_XSTREAM && flag == ABT_FALSE);
+#endif
 
     ret = ABT_self_on_primary_xstream(&flag);
-    assert(ret == ABT_ERR_INV_XSTREAM);
+#ifdef ABT_ENABLE_VER_20_API
+    assert(ret == ABT_SUCCESS && flag == ABT_FALSE);
+#else
+    assert(ret == ABT_ERR_INV_XSTREAM && flag == ABT_FALSE);
+#endif
 
     ATS_printf(1, "pthread: external thread\n");
 
@@ -131,6 +147,7 @@ int main(int argc, char *argv[])
     pthread_t pthread;
     int i, ret;
 
+#ifndef ABT_ENABLE_VER_20_API
     /* Self test: we should get ABT_ERR_UNITIALIZED */
     ret = ABT_xstream_self(&xstreams[0]);
     assert(ret == ABT_ERR_UNINITIALIZED && xstreams[0] == ABT_XSTREAM_NULL);
@@ -149,6 +166,7 @@ int main(int argc, char *argv[])
 
     ret = ABT_self_on_primary_xstream(&flag);
     assert(ret == ABT_ERR_UNINITIALIZED);
+#endif
 
     /* Initialize */
     ATS_read_args(argc, argv);


### PR DESCRIPTION
This PR improves the API and its explanation of `ABT_self_xxx()` functions for the upcoming Argobots 1.1.

This PR does not change the API of Argobots 1.0 except for the following "bug".

* `ABT_self_suspend()`: it returns `ABT_ERR_INV_XSTREAM` if it is called by an external thread.

  In Argobots 1.0, it returns `ABT_ERR_INV_THREAD` in such a case. I believe it is a bug, not an intended error code (for some particular reasons). Note that all the functions in Argobots return `ABT_ERR_INV_XSTREAM` when an external thread wrongly calls a routine.

Because Argobots-1.0 compatible error check is slightly heavier, some `ABT_self_xxx()` functions might be slightly slower (say, five cycles or so), but overall I don't think this change affect any program.

This PR also replaces "main ULT" with "primary ULT" since "primary ULT" is the correct term in Argobots.
