### PR TITLE
sched: improve API

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1842,15 +1842,21 @@ ALIASES += DOC_DESC_ATOMICITY_EVENTUAL_READINESS="The readiness of an eventual i
 
 ALIASES += DOC_DESC_ATOMICITY_FUTURE_READINESS="The readiness of a future is managed atomically."
 
+ALIASES += DOC_DESC_ATOMICITY_SCHED_REQUEST="Management of requests for schedulers is performed atomically."
+
 ALIASES += DOC_DESC_ATOMICITY_TOOL_CALLBACK_REGISTRATION="A combination of a callback function, an event mask its argument for a tool interface is updated atomically."
 
 ALIASES += DOC_DESC_ATOMICITY_WORK_UNIT_KEY="Work-unit-specific values associated with a work-unit-specific data key are read and updated atomically."
+
+ALIASES += DOC_DESC_SCHED_AUTOMATIC{1}="If \1 is not configured to be automatically freed, it is the user's responsibility to free \1 after its use unless \c newsched is associated with the main scheduler of the primary execution stream.  If \1 is configured to be automatically freed, \1 is automatically freed when a work unit associated with \1 is freed.  If the user never associates \1 with a work unit (e.g., by \c ABT_pool_add_sched() or \c ABT_xstream_set_main_sched()), it is the user's responsibility to free \1."
 
 ALIASES += DOC_DESC_TIMER_RESOLUTION="The resolution of elapsed time depends on the clock resolution by the system."
 
 ALIASES += DOC_DESC_V10_ACCEPT_TASK{1}="\DOC_V10 The user cannot pass a tasklet handle as \1.\n \DOC_V11 This routine accepts a tasklet handle as \1.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general.  Argobots 1.1 has introduced this change since this change does not break the compatibility of API and ABI of Argobots 1.0. @endrationale"
 
 ALIASES += DOC_DESC_V10_ACCEPT_THREAD{1}="\DOC_V10 The user cannot pass a ULT handle as \1.\n \DOC_V11 This routine accepts a ULT handle as \1.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general.  Argobots 1.1 has introduced this change since this change does not break the compatibility of API and ABI of Argobots 1.0. @endrationale"
+
+ALIASES += DOC_DESC_V10_ALWAYS_SCHED_TYPE_ULT="\DOC_V10 If \c ABT_SCHED_TYPE_TASK is set, the created scheduler runs on a tasklet.\n \DOC_V11 All schedulers run on ULTs.\n @rationale A scheduler that cannot yield is almost useless; such a scheduler is highly restrictive while it provides tiny performance benefits.  Argobots 1.1 always creates a ULT-based scheduler regardless of \c ABT_sched_type. @endrationale"
 
 ALIASES += DOC_DESC_V10_BARRIER_NUM_WAITERS{1}="\DOC_V10 This routine accepts zero as \c num_waiters.\n \DOC_V11 This routine returns \c ABT_ERR_INV_ARG if \c num_waiters is zero. @rationale A barrier with \c num_waiters = 0 is useless and should be prohibited.  Even with Argobots 1.0, calling \c ABT_barrier_wait() for a barrier with \c num_waiters = 0 is not allowed. @endrationale"
 
@@ -1868,6 +1874,10 @@ ALIASES += DOC_DESC_V1X_NOEXT{1}="\DOC_V1X If an external thread calls this rout
 
 ALIASES += DOC_DESC_V1X_NOTASK{1}="\DOC_V1X If a tasklet calls this routine, \1 is returned.\n \DOC_V20 A tasklet may call this routine.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general. @endrationale"
 
+ALIASES += DOC_DESC_V1X_NULL_PTR{2}="\DOC_V1X If \1 is \c NULL, \2 is returned.\n \DOC_V20 If \1 is \c NULL, the results are undefined.\n @rationale Argobots 2.0 will not check NULL pointers. @endrationale"
+
+ALIASES += DOC_DESC_V1X_PREMATURE_SCHED_USED_CHECK{2}="\DOC_V1X \2 is returned if this routine finds \1 is already used.\n \DOC_V20 The results are undefined if \1 is already used.\n @rationale The current mechanism that checks if a scheduler is used is premature since this is not maintained atomically.  From Argobots 2.0, it becomes the user's responsibility to guarantee that \1 is not used. @endrationale"
+
 ALIASES += DOC_DESC_V1X_PREMATURE_WAITER_CHECK{2}="\DOC_V1X \2 is returned if this routine finds a waiter on \1.\n \DOC_V20 The results are undefined if a waiter is blocked on \1.\n @rationale Check this is premature considering the asynchronous nature of \1.  From Argobots 2.0, it becomes the user's responsibility to guarantee that there is no waiter on \1. @endrationale"
 
 ALIASES += DOC_DESC_V1X_PRINT_HANDLE_INFO{3}="\DOC_V1X This routine returns \3 when \1 is \2.\n \DOC_V20 This routine prints that \1 is an invalid handle when \1 is \2.\n @rationale The information routines primarily for debugging and diagnosis should avoid returning an error as much as possible. @endrationale"
@@ -1879,6 +1889,8 @@ ALIASES += DOC_DESC_V1X_PRINT_RUNTIME_INFO="\DOC_V1X This routine returns \c ABT
 ALIASES += DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized.\n \DOC_V20 This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized and the queried information cannot be retrieved when Argobots is not initialized.\n @rationale Retrieving static configurations before initializing Argobots is helpful to check if the loaded Argobots implements necessary features. @endrationale"
 
 ALIASES += DOC_DESC_V1X_RETURN_UNINITIALIZED="\DOC_V1X This routine returns \c ABT_ERR_UNINITIALIZED if Argobots is not initialized.\n \DOC_V20 The results are undefined if Argobots is not initialized.\n @rationale From Argobots 2.0, all the Argobots routines that are not explicitly noted do not check if Argobots is initialized.  This omission can reduce the branches that are mostly unnecessary. @endrationale"
+
+ALIASES += DOC_DESC_V1X_SCHED_GET_POOLS_IDX{4}="\DOC_V1X If the summation of \1 and \2 is larger than the number of pools associated with \3, this routine returns \c ABT_ERR_SCHED.\n \DOC_V20 This routine does not update elements of \4 if corresponding pool elements specified by \1 and \2 are out of range.\n @rationale The restriction is unnecessary and thus this behavior is deprecated. @endrationale"
 
 ALIASES += DOC_DESC_V1X_SET_VALUE_ON_ERROR{2}="\DOC_V1X \1 is set to \2 if an error occurs.\n \DOC_V20 \1 is not updated if an error occurs.\n @rationale To ensure the atomicity of the API, Argobots 2.0 guarantees that the routine has no effect if the routine returns an error (as possible).  Argobots 2.0 does not update a returned value when the routine throws an error. @endrationale"
 
@@ -1895,6 +1907,8 @@ ALIASES += DOC_ERROR_FUTURE_NO_COMPARTMENT{1}="If the number of compartments of 
 ALIASES += DOC_ERROR_FUTURE_READY{1}="If \1 is ready, \c ABT_ERR_FUTURE is returned.\n"
 
 ALIASES += DOC_ERROR_INV_ARG_GREATER_THAN{2}="If \1 is larger than \2, \c ABT_ERR_INV_ARG is returned.\n"
+
+ALIASES += DOC_ERROR_INV_ARG_INV_SCHED_PREDEF{1}="If \1 is not a valid predefined scheduler type, \c ABT_ERR_INV_ARG is returned.\n"
 
 ALIASES += DOC_ERROR_INV_ARG_INV_TOOL_QUERY_KIND{2}="If \1 is not a valid tool query kind for \2, \c ABT_ERR_INV_ARG is returned.\n"
 
@@ -1942,6 +1956,8 @@ ALIASES += DOC_ERROR_INV_RWLOCK_PTR{1}="If \1 points to \c ABT_RWLOCK_NULL, \c A
 
 ALIASES += DOC_ERROR_INV_SCHED_HANDLE{1}="If \1 is \c ABT_SCHED_NULL, \c ABT_ERR_INV_SCHED is returned.\n"
 
+ALIASES += DOC_ERROR_INV_SCHED_PTR{1}="If \1 points to \c ABT_SCHED_NULL, \c ABT_ERR_INV_SCHED is returned.\n"
+
 ALIASES += DOC_ERROR_INV_TASK_HANDLE{1}="If \1 is \c ABT_THREAD_NULL or \c ABT_TASK_NULL, \c ABT_ERR_INV_TASK is returned.\n"
 
 ALIASES += DOC_ERROR_INV_THREAD_ATTR_HANDLE{1}="If \1 is \c ABT_THREAD_ATTR_NULL, \c ABT_ERR_INV_THREAD_ATTR is returned.\n"
@@ -1964,9 +1980,15 @@ ALIASES += DOC_ERROR_INV_XSTREAM_EXT="If the caller is an external thread, \c AB
 
 ALIASES += DOC_ERROR_INV_XSTREAM_HANDLE{1}="If \1 is \c ABT_XSTREAM_NULL, \c ABT_ERR_INV_XSTREAM is returned.\n"
 
+ALIASES += DOC_ERROR_NULL_PTR{2}="If \1 is \c NULL, \2 is returned.\n"
+
 ALIASES += DOC_ERROR_POOL_UNSUPPORTED_FEATURE{2}="If \1 does not support \2, \c ABT_ERR_POOL is returned.\n"
 
 ALIASES += DOC_ERROR_RESOURCE="If an error related to memory occurs, \c ABT_ERR_MEM is returned.\n If an error related to system calls occurs, \c ABT_ERR_SYS is returned.\n"
+
+ALIASES += DOC_ERROR_SCHED_GET_POOLS_IDX{3}="If the summation of \1 and \2 is larger than the number of pools associated with \3, \c ABT_ERR_SCHED is returned."
+
+ALIASES += DOC_ERROR_SCHED_USED{2}="If \1 is being used, \2 is returned.\n"
 
 ALIASES += DOC_ERROR_SUCCESS="If this routine succeeds, \c ABT_SUCCESS is returned.\n"
 
@@ -1984,6 +2006,8 @@ ALIASES += DOC_ERROR_UNINITIALIZED="If the Argobots runtime is not initialized, 
 
 ALIASES += DOC_ERROR_UNINITIALIZED_INFO_QUERY="If the queried information requires initialized Argobots while Argobots is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
 
+ALIASES += DOC_ERROR_USR_SCHED_INIT{1}="If the return value of \1 is not \c ABT_SUCCESS, the error returned by \1 is returned.\n"
+
 ALIASES += DOC_ERROR_WAITER{2}="If there is a waiter blocked on \1, \2 is returned."
 
 #---------------------------------------------------------------------------
@@ -1992,7 +2016,23 @@ ALIASES += DOC_ERROR_WAITER{2}="If there is a waiter blocked on \1, \2 is return
 
 ALIASES += DOC_NOTE_DEFAULT_MUTEX_ATTRIBUTE="To check the details of the default mutex attributes, please see \c ABT_mutex_attr_create()."
 
+ALIASES += DOC_NOTE_DEFAULT_POOL="To see the details of the default pool, please check \c ABT_pool_create()."
+
+ALIASES += DOC_NOTE_DEFAULT_POOL_CONFIG=""
+
+ALIASES += DOC_NOTE_DEFAULT_SCHED_CONFIG="To see the details of the default scheduler configuration, please check \c ABT_sched_config_create()."
+
+ALIASES += DOC_NOTE_EFFECT_ABT_FINALIZE="\c ABT_finalize() frees the primary execution stream, its main scheduler, and pools associated with the main scheduler."
+
 ALIASES += DOC_NOTE_INFO_PRINT="The information written by this routine is meant for debugging and diagnosis and can be changed because of an update of the internal implementation of Argobots.  A program that relies on the output of this routine is non-conforming."
+
+ALIASES += DOC_NOTE_NO_PADDING{2}="This routine does not pad \1 until a total \2 elements have been written to \1.  The remaining elements of \1 that are not written by this routine are unmodified."
+
+ALIASES += DOC_NOTE_POOL_SIZE="To see the details of the size of a pool, please check \c ABT_pool_get_size()."
+
+ALIASES += DOC_NOTE_POOL_TOTAL_SIZE="To see the details of the total size of a pool, please check \c ABT_pool_get_total_size()."
+
+ALIASES += DOC_NOTE_TIMING_REQUEST="The timing of the request fulfillment is undefined, so a program that relies on when the request is fulfilled is non-conforming."
 
 #---------------------------------------------------------------------------
 # Undefined behavior
@@ -2015,6 +2055,8 @@ ALIASES += DOC_UNDEFINED_NOT_LOCKED{1}="If \1 is not locked, the results are und
 ALIASES += DOC_UNDEFINED_NULL_PTR_CONDITIONAL{2}="If \2 and \1 is \c NULL, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_NULL_PTR{1}="If \1 is \c NULL, the results are undefined.\n"
+
+ALIASES += DOC_UNDEFINED_SCHED_USED{1}="If \1 is being used, the results are undefined."
 
 ALIASES += DOC_UNDEFINED_SYS_FILE{1}="If an error occurs regarding \1, the results are undefined.\n"
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1914,6 +1914,8 @@ ALIASES += DOC_ERROR_INV_ARG_INV_TOOL_QUERY_KIND{2}="If \1 is not a valid tool q
 
 ALIASES += DOC_ERROR_INV_ARG_NEG{1}="If \1 is negative, \c ABT_ERR_INV_ARG is returned.\n"
 
+ALIASES += DOC_ERROR_INV_ARG_SCHED_CONFIG_TYPE="If a variable of type \c ABT_sched_config_var in the given list has an invalid \c type, \c ABT_ERR_INV_ARG is returned.\n"
+
 ALIASES += DOC_ERROR_INV_ARG_ZERO{1}="If \1 is zero, \c ABT_ERR_INV_ARG is returned.\n"
 
 ALIASES += DOC_ERROR_INV_BARRIER_HANDLE{1}="If \1 is \c ABT_BARRIER_NULL, \c ABT_ERR_INV_BARRIER is returned.\n"
@@ -1953,6 +1955,10 @@ ALIASES += DOC_ERROR_INV_POOL_HANDLE{1}="If \1 is \c ABT_POOL_NULL, \c ABT_ERR_I
 ALIASES += DOC_ERROR_INV_RWLOCK_HANDLE{1}="If \1 is \c ABT_RWLOCK_NULL, \c ABT_ERR_INV_RWLOCK is returned.\n"
 
 ALIASES += DOC_ERROR_INV_RWLOCK_PTR{1}="If \1 points to \c ABT_RWLOCK_NULL, \c ABT_ERR_INV_RWLOCK is returned.\n"
+
+ALIASES += DOC_ERROR_INV_SCHED_CONFIG_HANDLE{1}="If \1 is \c ABT_SCHED_CONFIG_NULL, \c ABT_ERR_INV_SCHED_CONFIG is returned.\n"
+
+ALIASES += DOC_ERROR_INV_SCHED_CONFIG_PTR{1}="If \1 points to \c ABT_SCHED_CONFIG_NULL, \c ABT_ERR_INV_SCHED_CONFIG is returned.\n"
 
 ALIASES += DOC_ERROR_INV_SCHED_HANDLE{1}="If \1 is \c ABT_SCHED_NULL, \c ABT_ERR_INV_SCHED is returned.\n"
 
@@ -2006,7 +2012,7 @@ ALIASES += DOC_ERROR_UNINITIALIZED="If the Argobots runtime is not initialized, 
 
 ALIASES += DOC_ERROR_UNINITIALIZED_INFO_QUERY="If the queried information requires initialized Argobots while Argobots is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
 
-ALIASES += DOC_ERROR_USR_SCHED_INIT{1}="If the return value of \1 is not \c ABT_SUCCESS, the error returned by \1 is returned.\n"
+ALIASES += DOC_ERROR_USR_SCHED_INIT{1}="If \1 does not return \c ABT_SUCCESS, the error returned by \1 is returned.\n"
 
 ALIASES += DOC_ERROR_WAITER{2}="If there is a waiter blocked on \1, \2 is returned."
 
@@ -2019,6 +2025,8 @@ ALIASES += DOC_NOTE_DEFAULT_MUTEX_ATTRIBUTE="To check the details of the default
 ALIASES += DOC_NOTE_DEFAULT_POOL="To see the details of the default pool, please check \c ABT_pool_create()."
 
 ALIASES += DOC_NOTE_DEFAULT_POOL_CONFIG=""
+
+ALIASES += DOC_NOTE_DEFAULT_SCHED_AUTOMATIC="To see the details of whether the scheduler is automatically freed or not, please check \c ABT_sched_create() and \c ABT_sched_create_basic()."
 
 ALIASES += DOC_NOTE_DEFAULT_SCHED_CONFIG="To see the details of the default scheduler configuration, please check \c ABT_sched_config_create()."
 
@@ -2055,6 +2063,8 @@ ALIASES += DOC_UNDEFINED_NOT_LOCKED{1}="If \1 is not locked, the results are und
 ALIASES += DOC_UNDEFINED_NULL_PTR_CONDITIONAL{2}="If \2 and \1 is \c NULL, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_NULL_PTR{1}="If \1 is \c NULL, the results are undefined.\n"
+
+ALIASES += DOC_UNDEFINED_SCHED_CONFIG_CREATE_UNFORMATTED="If the \a (2n+1)th element of the given variadic arguments is neither \c ABT_sched_config_var_end nor a variable of type \c ABT_sched_config_var, the results are undefined.\n If the \a (2n+2)th element of the given variadic arguments is not a variable of a type specified by \c type of the \a (2n+1)th element of type \c ABT_sched_config_var, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_SCHED_USED{1}="If \1 is being used, the results are undefined."
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -537,26 +537,73 @@ typedef enum ABT_sync_event_type            ABT_sync_event_type;
 #endif
 #define ABT_TASK_NULL ABT_THREAD_NULL
 
-/* Scheduler config */
+/**
+ * @ingroup SCHED_CONFIG
+ * @brief   A struct that sets and gets a scheduler configuration.
+ */
 typedef enum {
-    ABT_SCHED_CONFIG_INT    = 0, /* Parameter of type int */
-    ABT_SCHED_CONFIG_DOUBLE = 1, /* Parameter of type double */
-    ABT_SCHED_CONFIG_PTR    = 2, /* Parameter of type pointer */
+    /** Parameter of type int */
+    ABT_SCHED_CONFIG_INT    = 0,
+    /** Parameter of type double */
+    ABT_SCHED_CONFIG_DOUBLE = 1,
+    /** Parameter of type pointer */
+    ABT_SCHED_CONFIG_PTR    = 2,
 } ABT_sched_config_type;
 
+/**
+ * @ingroup SCHED_CONFIG
+ * @brief   A struct that sets and gets a scheduler configuration.
+ */
 typedef struct {
-  int idx;
-  ABT_sched_config_type type;
+    /** An index of the configuration variable.  It must be non-negative. */
+    int idx;
+    /** Type of the configuration variable. */
+    ABT_sched_config_type type;
 } ABT_sched_config_var;
 
+/**
+ * @ingroup SCHED_CONFIG
+ * @var     ABT_sched_config_var_end
+ * @brief   Predefined ABT_sched_config_var to mark the last parameter.
+ * @hideinitializer
+ *
+ * Check ABT_sched_config_create() for details.  The user may not change its
+ * variables.
+ */
 extern ABT_sched_config_var ABT_sched_config_var_end ABT_API_PUBLIC;
-  /* To mark the last parameter in ABT_sched_config_create */
+/**
+ * @ingroup SCHED_CONFIG
+ * @var     ABT_sched_basic_freq
+ * @brief   Predefined ABT_sched_config_var to configure the frequency for
+ *          checking events of the basic scheduler.
+ *
+ * Its type is int.  The user may not change its variables.
+ * @hideinitializer
+ */
 extern ABT_sched_config_var ABT_sched_basic_freq ABT_API_PUBLIC;
-  /* To configure the frequency for checking events of the basic scheduler */
+/**
+ * @ingroup SCHED_CONFIG
+ * @var     ABT_sched_config_access
+ * @brief   Unused predefined ABT_sched_config_var.
+ * @hideinitializer
+ *
+ * Its type is int.  Currently, this setting is ignored.  The user may not
+ * change its variables.
+ */
 extern ABT_sched_config_var ABT_sched_config_access ABT_API_PUBLIC;
-  /* To configure the access type of the pools created automatically */
+/**
+ * @ingroup SCHED_CONFIG
+ * @var     ABT_sched_config_automatic
+ * @brief   Predefined ABT_sched_config_var to configure whether the scheduler
+ *          is freed automatically or not.
+ *
+ * Its type is int.  If the value is non-zero, the scheduler is freed
+ * automatically after its associated objects are released.  If the value is
+ * zero, the scheduler is configured to be not freed automatically by the
+ * Argobots runtime.  The user may not change its variables.
+ * @hideinitializer
+ */
 extern ABT_sched_config_var ABT_sched_config_automatic ABT_API_PUBLIC;
-  /* To configure whether the scheduler is freed automatically or not */
 
 /* Scheduler Functions */
 typedef int      (*ABT_sched_init_fn)(ABT_sched, ABT_sched_config);

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -146,17 +146,44 @@ enum ABT_sched_state {
     ABT_SCHED_STATE_TERMINATED
 };
 
+/**
+ * @ingroup SCHED
+ * @brief   Predefined scheduler type.
+ *
+ * Relying on a specific scheduling order is not recommended since its
+ * implementation can be changed.  Users can create their own scheduler by using
+ * \c ABT_sched_create().
+ */
 enum ABT_sched_predef {
-    ABT_SCHED_DEFAULT,   /* Default scheduler */
-    ABT_SCHED_BASIC,     /* Basic scheduler */
-    ABT_SCHED_PRIO,      /* Priority scheduler */
-    ABT_SCHED_RANDWS,    /* Random work-stealing scheduler */
-    ABT_SCHED_BASIC_WAIT /* Basic scheduler with ability to wait for units */
+    /** Default scheduler.  \c ABT_SCHED_BASIC is used. */
+    ABT_SCHED_DEFAULT,
+    /** Basic scheduler. */
+    ABT_SCHED_BASIC,
+    /**
+     * Priority scheduler.  This scheduler type is not recommended because this
+     * scheduler does not work as the user expects. */
+    ABT_SCHED_PRIO,
+    /**
+     * Random work-stealing scheduler.  This scheduler type is not recommended
+     * because this scheduler does not work as the user expects. */
+    ABT_SCHED_RANDWS,
+    /** Basic scheduler with the ability to wait for work units. */
+    ABT_SCHED_BASIC_WAIT,
 };
 
+/**
+ * @ingroup SCHED
+ * @brief   Scheduler's work unit type.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ALWAYS_SCHED_TYPE_ULT
+ * @endchangev11
+ */
 enum ABT_sched_type {
-    ABT_SCHED_TYPE_ULT,  /* can yield */
-    ABT_SCHED_TYPE_TASK  /* cannot yield */
+    /** A ULT is used for the scheduler's underlying work unit. */
+    ABT_SCHED_TYPE_ULT,
+    /** Ignored.  A ULT is used for the scheduler's underlying work unit. */
+    ABT_SCHED_TYPE_TASK
 };
 
 enum ABT_pool_kind {
@@ -538,13 +565,108 @@ typedef int      (*ABT_sched_free_fn)(ABT_sched);
 /* To get a pool ready for receiving a migration */
 typedef ABT_pool (*ABT_sched_get_migr_pool_fn)(ABT_sched);
 
+/**
+ * @ingroup SCHED
+ * @brief   A struct that defines a scheduler.
+ */
 typedef struct {
-    ABT_sched_type type; /* ULT or tasklet */
-
-    /* Functions of the scheduler */
+    /**
+     * @brief Unused value.
+     *
+     * This value is ignored.  A created scheduler always uses a ULT as an
+     * underlying work unit.
+     */
+    ABT_sched_type type;
+    /**
+     * @fn    int (*init)(ABT_sched sched, ABT_sched_config config)
+     * @brief Function that initializes a scheduler.
+     *
+     * \c init() initializes the scheduler \c sched with the scheduler
+     * configuration \c config.  If \c init() does not return \c ABT_SUCCESS,
+     * the scheduler creation fails.
+     *
+     * \c init() is optional, so the user may set \c init to \c NULL.
+     *
+     * @note
+     * The caller of \c init() is undefined, so a program that relies on the
+     * caller of \c init() is non-conforming.
+     *
+     * \c init() is called only on creating a scheduler.  \c init() is not
+     * called when its associated work unit is revived.
+     */
     ABT_sched_init_fn          init;
+    /**
+     * @fn    void (*run)(ABT_sched sched)
+     * @brief Function that defines a kernel of a scheduler.
+     *
+     * \c run() runs the scheduler \c sched.  The user can freely design this
+     * function, Argobots assumes the following properties:
+     *
+     * - Scheduling loop:
+     *
+     *   \c run() pops units from pools associated with \c sched and run it.
+     *
+     *   \c sched can access pools that are not associated with \c sched.
+     *   However, the Argobots runtime assumes that a scheduler that does not
+     *   have units in its associated pools is idle and should yield to the
+     *   parent.
+     *
+     * - Periodic event check:
+     *
+     *   \c run() calls \c ABT_xstream_check_events() with \c sched
+     *   periodically.
+     *
+     *   The frequency is user-defined, but some Argobots routines such as
+     *   request handling rely on \c ABT_xstream_check_events().
+     *
+     * - Finish \c run() if necessary:
+     *
+     *   \c run() calls \c ABT_sched_has_to_stop() with \c sched periodically
+     *   and if it returns \c ABT_TRUE as \c stop, \c run() should return
+     *   immediately.
+     *
+     *   The frequency is user-defined, but some Argobots routines such as
+     *   request handling rely on the mechanism of \c ABT_sched_has_to_stop().
+     *
+     * The caller of \c run() is a work unit associated with \c sched.  If
+     * \c sched is the main scheduler, the underlying execution stream is
+     * unchanged in \c run().
+     *
+     * \c run() is not optional, so the user must implement this function.
+     */
     ABT_sched_run_fn           run;
+    /**
+     * @fn    int (*free)(ABT_sched sched)
+     * @brief Function that frees a scheduler.
+     *
+     * \c free() finalizes the scheduler \c sched with the scheduler.  The
+     * return value of \c free() is ignored.
+     *
+     * \c free() is optional, so the user may set \c free to \c NULL.
+     *
+     * \c free() is called only on freeing a scheduler.  \c free() is not called
+     * when its associated work unit is terminated.
+     *
+     * The caller of \c free() is undefined, so a program that relies on the
+     * caller of \c free() is non-conforming.
+     */
     ABT_sched_free_fn          free;
+    /**
+     * @fn    ABT_pool (*get_migr_pool)(ABT_sched sched)
+     * @brief Function that returns a pool for migration.
+     *
+     * \c get_migr_pool() returns a pool from pools associated with the
+     * scheduler \c sched as a work unit migration target.  If
+     * \c get_migr_pool() returns either \c ABT_POOL_NULL or a pool that is not
+     * associated with \c sched, the results are undefined.
+     *
+     * \c get_migr_pool() is optional, so the user may set \c get_migr_pool to
+     * \c NULL.  If \c get_migr_pool is \c NULL, the Argobots runtime chooses
+     * a proper pool that is associated with \c sched.
+     *
+     * The caller of \c get_migr_pool() is undefined, so a program that relies
+     * on the caller of \c get_migr_pool() is non-conforming.
+     */
     ABT_sched_get_migr_pool_fn get_migr_pool;
 } ABT_sched_def;
 

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -190,6 +190,15 @@
         }                                                                      \
     } while (0)
 
+#define ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p)                                    \
+    do {                                                                       \
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
+            ABTU_unlikely(p == (ABTI_sched_config *)NULL)) {                   \
+            HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_INV_SCHED_CONFIG);             \
+            return ABT_ERR_INV_SCHED_CONFIG;                                   \
+        }                                                                      \
+    } while (0)
+
 #define ABTI_CHECK_NULL_THREAD_PTR(p)                                          \
     do {                                                                       \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -347,9 +347,10 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_INV_SCHED);
     p_sched->used = ABTI_SCHED_IN_POOL;
 
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* In both ABT_SCHED_TYPE_ULT and ABT_SCHED_TYPE_TASK cases, we use ULT-type
-     * scheduler to reduce the code maintenance cost.  ABT_SCHED_TYPE_TASK
-     * should be removed in the future. */
+     * scheduler to reduce the code maintenance cost. */
+#endif
     int abt_errno = ABTI_ythread_create_sched(p_local, p_pool, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -27,9 +27,6 @@ typedef struct {
 #endif
 } sched_data;
 
-ABT_sched_config_var ABT_sched_basic_freq = { .idx = 0,
-                                              .type = ABT_SCHED_CONFIG_INT };
-
 ABT_sched_def *ABTI_sched_get_basic_def(void)
 {
     return &sched_basic_def;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -5,10 +5,6 @@
 
 #include "abti.h"
 
-/** @defgroup SCHED_BASIC Basic scheduler
- * This group is for the basic scheduler.
- */
-
 static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
 static int sched_free(ABT_sched);

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -47,24 +47,28 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
 
     /* Default settings */
     sched_data *p_data;
     abt_errno = ABTU_malloc(sizeof(sched_data), (void **)&p_data);
     ABTI_CHECK_ERROR(abt_errno);
 
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
     p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
 #endif
 
-    /* Set the variables from the config */
-    void *p_event_freq = &p_data->event_freq;
-    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
-    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
-        ABTU_free(p_data);
-        ABTI_CHECK_ERROR(abt_errno);
+    /* Set the default value by default. */
+    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    if (p_config) {
+        int event_freq;
+        /* Set the variables from config */
+        abt_errno = ABTI_sched_config_read(p_config, ABT_sched_basic_freq.idx,
+                                           &event_freq);
+        if (abt_errno == ABT_SUCCESS) {
+            p_data->event_freq = event_freq;
+        }
     }
 
     /* Save the list of pools */

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -11,7 +11,7 @@ static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_def = {
-    .type = ABT_SCHED_TYPE_TASK,
+    .type = ABT_SCHED_TYPE_ULT,
     .init = sched_init,
     .run = sched_run,
     .free = sched_free,

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -11,7 +11,7 @@ static int sched_free(ABT_sched);
 static void sched_sort_pools(int num_pools, ABT_pool *pools);
 
 static ABT_sched_def sched_basic_wait_def = {
-    .type = ABT_SCHED_TYPE_TASK,
+    .type = ABT_SCHED_TYPE_ULT,
     .init = sched_init,
     .run = sched_run,
     .free = sched_free,

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -24,10 +24,6 @@ typedef struct {
     ABT_pool *pools;
 } sched_data;
 
-ABT_sched_config_var ABT_sched_basic_wait_freq = { .idx = 0,
-                                                   .type =
-                                                       ABT_SCHED_CONFIG_INT };
-
 ABT_sched_def *ABTI_sched_get_basic_wait_def(void)
 {
     return &sched_basic_wait_def;

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -5,10 +5,6 @@
 
 #include "abti.h"
 
-/** @defgroup SCHED_BASIC_WAIT Basic waiting scheduler
- * This group is for the basic waiting scheduler.
- */
-
 static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
 static int sched_free(ABT_sched);

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -45,20 +45,23 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
 
     /* Default settings */
     sched_data *p_data;
     abt_errno = ABTU_malloc(sizeof(sched_data), (void **)&p_data);
     ABTI_CHECK_ERROR(abt_errno);
 
+    /* Set the default value by default. */
     p_data->event_freq = gp_ABTI_global->sched_event_freq;
-
-    /* Set the variables from the config */
-    void *p_event_freq = &p_data->event_freq;
-    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
-    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
-        ABTU_free(p_data);
-        ABTI_CHECK_ERROR(abt_errno);
+    if (p_config) {
+        int event_freq;
+        /* Set the variables from config */
+        abt_errno = ABTI_sched_config_read(p_config, ABT_sched_basic_freq.idx,
+                                           &event_freq);
+        if (abt_errno == ABT_SUCCESS) {
+            p_data->event_freq = event_freq;
+        }
     }
 
     /* Save the list of pools */

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -31,6 +31,9 @@ ABT_sched_config_var ABT_sched_config_automatic = { .idx = -3,
                                                     .type =
                                                         ABT_SCHED_CONFIG_INT };
 
+ABT_sched_config_var ABT_sched_basic_freq = { .idx = -4,
+                                              .type = ABT_SCHED_CONFIG_INT };
+
 /**
  * @ingroup SCHED_CONFIG
  * @brief   Create a new scheduler configuration.

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -43,23 +43,27 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
 
     /* Default settings */
     sched_data *p_data;
     abt_errno = ABTU_malloc(sizeof(sched_data), (void **)&p_data);
     ABTI_CHECK_ERROR(abt_errno);
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
     p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
 #endif
 
-    /* Set the variables from the config */
-    void *p_event_freq = &p_data->event_freq;
-    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
-    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
-        ABTU_free(p_data);
-        ABTI_CHECK_ERROR(abt_errno);
+    /* Set the default value by default. */
+    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    if (p_config) {
+        int event_freq;
+        /* Set the variables from config */
+        abt_errno = ABTI_sched_config_read(p_config, ABT_sched_basic_freq.idx,
+                                           &event_freq);
+        if (abt_errno == ABT_SUCCESS) {
+            p_data->event_freq = event_freq;
+        }
     }
 
     /* Save the list of pools */

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -11,7 +11,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config);
 static void sched_run(ABT_sched sched);
 static int sched_free(ABT_sched);
 
-static ABT_sched_def sched_prio_def = { .type = ABT_SCHED_TYPE_TASK,
+static ABT_sched_def sched_prio_def = { .type = ABT_SCHED_TYPE_ULT,
                                         .init = sched_init,
                                         .run = sched_run,
                                         .free = sched_free,

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -12,7 +12,7 @@ static void sched_run(ABT_sched sched);
 static int sched_free(ABT_sched);
 
 static ABT_sched_def sched_randws_def = {
-    .type = ABT_SCHED_TYPE_TASK,
+    .type = ABT_SCHED_TYPE_ULT,
     .init = sched_init,
     .run = sched_run,
     .free = sched_free,

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -40,23 +40,27 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
 
     /* Default settings */
     sched_data *p_data;
     abt_errno = ABTU_malloc(sizeof(sched_data), (void **)&p_data);
     ABTI_CHECK_ERROR(abt_errno);
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
     p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
 #endif
 
-    /* Set the variables from the config */
-    void *p_event_freq = &p_data->event_freq;
-    abt_errno = ABTI_sched_config_read(config, 1, 1, &p_event_freq);
-    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
-        ABTU_free(p_data);
-        ABTI_HANDLE_ERROR(abt_errno);
+    /* Set the default value by default. */
+    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    if (p_config) {
+        int event_freq;
+        /* Set the variables from config */
+        abt_errno = ABTI_sched_config_read(p_config, ABT_sched_basic_freq.idx,
+                                           &event_freq);
+        if (abt_errno == ABT_SUCCESS) {
+            p_data->event_freq = event_freq;
+        }
     }
 
     /* Save the list of pools */

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -667,27 +667,31 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     /* Always use MPMC pools */
     const ABT_pool_access def_access = ABT_POOL_ACCESS_MPMC;
 
-    ABTI_CHECK_TRUE(!pools || num_pools > 0, ABT_ERR_SCHED);
-
     /* A pool array is provided, predef has to be compatible */
     if (pools != NULL) {
         /* Copy of the contents of pools */
         ABT_pool *pool_list;
-        abt_errno =
-            ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&pool_list);
-        ABTI_CHECK_ERROR(abt_errno);
+        if (num_pools > 0) {
+            abt_errno =
+                ABTU_malloc(num_pools * sizeof(ABT_pool), (void **)&pool_list);
+            ABTI_CHECK_ERROR(abt_errno);
 
-        int p;
-        for (p = 0; p < num_pools; p++) {
-            if (pools[p] == ABT_POOL_NULL) {
-                ABTI_pool *p_newpool;
-                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO, def_access,
-                                                   ABT_TRUE, &p_newpool);
-                ABTI_CHECK_ERROR(abt_errno);
-                pool_list[p] = ABTI_pool_get_handle(p_newpool);
-            } else {
-                pool_list[p] = pools[p];
+            int p;
+            for (p = 0; p < num_pools; p++) {
+                if (pools[p] == ABT_POOL_NULL) {
+                    ABTI_pool *p_newpool;
+                    abt_errno =
+                        ABTI_pool_create_basic(ABT_POOL_FIFO, def_access,
+                                               ABT_TRUE, &p_newpool);
+                    ABTI_CHECK_ERROR(abt_errno);
+                    pool_list[p] = ABTI_pool_get_handle(p_newpool);
+                } else {
+                    pool_list[p] = pools[p];
+                }
             }
+        } else {
+            /* TODO: Check if it works. */
+            pool_list = NULL;
         }
 
         /* Creation of the scheduler */

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -96,7 +96,11 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
                      ABT_sched_config config, ABT_sched *newsched)
 {
     ABTI_sched *p_sched;
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    *newsched = ABT_SCHED_NULL;
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
+#endif
+    ABTI_CHECK_TRUE(num_pools >= 0, ABT_ERR_INV_ARG);
 
     /* TODO: the default value of automatic is different from
      * ABT_sched_create_basic(). Make it consistent. */
@@ -175,6 +179,12 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                            ABT_pool *pools, ABT_sched_config config,
                            ABT_sched *newsched)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    *newsched = ABT_SCHED_NULL;
+    ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
+#endif
+    ABTI_CHECK_TRUE(num_pools >= 0, ABT_ERR_INV_ARG);
+
     ABTI_sched *p_newsched;
     int abt_errno =
         ABTI_sched_create_basic(predef, num_pools, pools, config, &p_newsched);
@@ -229,7 +239,9 @@ int ABT_sched_free(ABT_sched *sched)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(*sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_SCHED);
+#endif
 
     /* Free the scheduler */
     ABTI_sched_free(p_local, p_sched, ABT_FALSE);
@@ -311,11 +323,19 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
 {
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+    ABTI_CHECK_TRUE(max_pools >= 0, ABT_ERR_INV_ARG);
+    ABTI_CHECK_TRUE(idx >= 0, ABT_ERR_INV_ARG);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_CHECK_TRUE((size_t)(idx + max_pools) <= p_sched->num_pools,
                     ABT_ERR_SCHED);
+#endif
 
-    int p;
-    for (p = idx; p < idx + max_pools; p++) {
+    size_t p;
+    for (p = idx; p < (size_t)idx + max_pools; p++) {
+        if (p >= p_sched->num_pools) {
+            /* Out of range. */
+            break;
+        }
         pools[p - idx] = p_sched->pools[p];
     }
     return ABT_SUCCESS;
@@ -436,9 +456,15 @@ int ABT_sched_exit(ABT_sched sched)
  */
 int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    *stop = ABT_FALSE;
+#endif
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    ABTI_CHECK_TRUE(p_local, ABT_ERR_INV_XSTREAM);
+#endif
 
     *stop = ABTI_sched_has_to_stop(&p_local, p_sched);
     return ABT_SUCCESS;
@@ -542,6 +568,10 @@ int ABT_sched_get_data(ABT_sched sched, void **data)
  */
 int ABT_sched_get_size(ABT_sched sched, size_t *size)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    *size = 0;
+#endif
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -586,6 +616,10 @@ int ABT_sched_get_size(ABT_sched sched, size_t *size)
  */
 int ABT_sched_get_total_size(ABT_sched sched, size_t *size)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    *size = 0;
+#endif
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -8,7 +8,7 @@
 ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
                                      ABT_pool *pools,
                                      ABTI_sched_config *p_config,
-                                     ABT_bool automatic,
+                                     ABT_bool def_automatic,
                                      ABTI_sched **pp_newsched);
 static inline ABTI_sched_kind sched_get_kind(ABT_sched_def *def);
 #ifdef ABT_CONFIG_USE_DEBUG_LOG
@@ -103,8 +103,7 @@ int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
 #endif
     ABTI_CHECK_TRUE(num_pools >= 0, ABT_ERR_INV_ARG);
 
-    /* TODO: the default value of automatic is different from
-     * ABT_sched_create_basic(). Make it consistent. */
+    /* The default automatic is different from ABT_sched_create_basic(). */
     const ABT_bool def_automatic = ABT_FALSE;
     ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
     int abt_errno =
@@ -664,25 +663,18 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     int abt_errno;
     ABT_pool_access access;
     ABT_pool_kind kind = ABT_POOL_FIFO;
-    ABT_bool automatic;
+    /* The default value is different from ABT_sched_create. */
+    const ABT_bool def_automatic = ABT_TRUE;
 
     ABTI_CHECK_TRUE(!pools || num_pools > 0, ABT_ERR_SCHED);
 
     /* We set the access to the default one */
     access = ABT_POOL_ACCESS_MPMC;
-    /* TODO: the default value is different from ABT_sched_create().
-     * Make it consistent. */
-    automatic = ABT_TRUE;
     /* We read the config and set the configured parameters */
     if (p_config) {
         abt_errno =
             ABTI_sched_config_read(p_config, ABT_sched_config_access.idx,
                                    &access);
-        /* No need to use this error code */
-        (void)abt_errno;
-        abt_errno =
-            ABTI_sched_config_read(p_config, ABT_sched_config_automatic.idx,
-                                   &automatic);
         /* No need to use this error code */
         (void)abt_errno;
     }
@@ -712,24 +704,24 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         switch (predef) {
             case ABT_SCHED_DEFAULT:
             case ABT_SCHED_BASIC:
-                abt_errno =
-                    sched_create(ABTI_sched_get_basic_def(), num_pools,
-                                 pool_list, NULL, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_basic_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             case ABT_SCHED_BASIC_WAIT:
-                abt_errno =
-                    sched_create(ABTI_sched_get_basic_wait_def(), num_pools,
-                                 pool_list, NULL, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_basic_wait_def(),
+                                         num_pools, pool_list, p_config,
+                                         def_automatic, pp_newsched);
                 break;
             case ABT_SCHED_PRIO:
-                abt_errno =
-                    sched_create(ABTI_sched_get_prio_def(), num_pools,
-                                 pool_list, NULL, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_prio_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             case ABT_SCHED_RANDWS:
-                abt_errno =
-                    sched_create(ABTI_sched_get_randws_def(), num_pools,
-                                 pool_list, NULL, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_randws_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
@@ -780,24 +772,24 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         switch (predef) {
             case ABT_SCHED_DEFAULT:
             case ABT_SCHED_BASIC:
-                abt_errno =
-                    sched_create(ABTI_sched_get_basic_def(), num_pools,
-                                 pool_list, p_config, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_basic_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             case ABT_SCHED_BASIC_WAIT:
-                abt_errno =
-                    sched_create(ABTI_sched_get_basic_wait_def(), num_pools,
-                                 pool_list, p_config, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_basic_wait_def(),
+                                         num_pools, pool_list, p_config,
+                                         def_automatic, pp_newsched);
                 break;
             case ABT_SCHED_PRIO:
-                abt_errno =
-                    sched_create(ABTI_sched_get_prio_def(), num_pools,
-                                 pool_list, p_config, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_prio_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             case ABT_SCHED_RANDWS:
-                abt_errno =
-                    sched_create(ABTI_sched_get_randws_def(), num_pools,
-                                 pool_list, p_config, automatic, pp_newsched);
+                abt_errno = sched_create(ABTI_sched_get_randws_def(), num_pools,
+                                         pool_list, p_config, def_automatic,
+                                         pp_newsched);
                 break;
             default:
                 abt_errno = ABT_ERR_INV_SCHED_PREDEF;
@@ -1021,7 +1013,7 @@ static inline ABTI_sched_kind sched_get_kind(ABT_sched_def *def)
 ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
                                      ABT_pool *pools,
                                      ABTI_sched_config *p_config,
-                                     ABT_bool automatic,
+                                     ABT_bool def_automatic,
                                      ABTI_sched **pp_newsched)
 {
     ABTI_sched *p_sched;
@@ -1029,6 +1021,18 @@ ABTU_ret_err static int sched_create(ABT_sched_def *def, int num_pools,
 
     abt_errno = ABTU_malloc(sizeof(ABTI_sched), (void **)&p_sched);
     ABTI_CHECK_ERROR(abt_errno);
+
+    /* We read the config and set the configured parameters */
+    ABT_bool automatic = def_automatic;
+    if (p_config) {
+        int automatic_val = 0;
+        abt_errno =
+            ABTI_sched_config_read(p_config, ABT_sched_config_automatic.idx,
+                                   &automatic_val);
+        if (abt_errno == ABT_SUCCESS) {
+            automatic = (automatic_val == 0) ? ABT_FALSE : ABT_TRUE;
+        }
+    }
 
     /* Copy of the contents of pools */
     ABT_pool *pool_list;

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -661,23 +661,13 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                                          ABTI_sched **pp_newsched)
 {
     int abt_errno;
-    ABT_pool_access access;
     ABT_pool_kind kind = ABT_POOL_FIFO;
     /* The default value is different from ABT_sched_create. */
     const ABT_bool def_automatic = ABT_TRUE;
+    /* Always use MPMC pools */
+    const ABT_pool_access def_access = ABT_POOL_ACCESS_MPMC;
 
     ABTI_CHECK_TRUE(!pools || num_pools > 0, ABT_ERR_SCHED);
-
-    /* We set the access to the default one */
-    access = ABT_POOL_ACCESS_MPMC;
-    /* We read the config and set the configured parameters */
-    if (p_config) {
-        abt_errno =
-            ABTI_sched_config_read(p_config, ABT_sched_config_access.idx,
-                                   &access);
-        /* No need to use this error code */
-        (void)abt_errno;
-    }
 
     /* A pool array is provided, predef has to be compatible */
     if (pools != NULL) {
@@ -691,7 +681,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         for (p = 0; p < num_pools; p++) {
             if (pools[p] == ABT_POOL_NULL) {
                 ABTI_pool *p_newpool;
-                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO, access,
+                abt_errno = ABTI_pool_create_basic(ABT_POOL_FIFO, def_access,
                                                    ABT_TRUE, &p_newpool);
                 ABTI_CHECK_ERROR(abt_errno);
                 pool_list[p] = ABTI_pool_get_handle(p_newpool);
@@ -763,7 +753,7 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
         for (p = 0; p < num_pools; p++) {
             ABTI_pool *p_newpool;
             abt_errno =
-                ABTI_pool_create_basic(kind, access, ABT_TRUE, &p_newpool);
+                ABTI_pool_create_basic(kind, def_access, ABT_TRUE, &p_newpool);
             ABTI_CHECK_ERROR(abt_errno);
             pool_list[p] = ABTI_pool_get_handle(p_newpool);
         }

--- a/src/stream.c
+++ b/src/stream.c
@@ -1354,8 +1354,6 @@ static void xstream_init_main_sched(ABTI_xstream *p_xstream,
                                     ABTI_sched *p_sched)
 {
     ABTI_ASSERT(p_xstream->p_main_sched == NULL);
-    /* The main scheduler will to be a ULT, not a tasklet */
-    p_sched->type = ABT_SCHED_TYPE_ULT;
     /* Set the scheduler as a main scheduler */
     p_sched->used = ABTI_SCHED_MAIN;
     /* Set the scheduler */
@@ -1370,9 +1368,6 @@ xstream_update_main_sched(ABTI_xstream **pp_local_xstream,
     ABTI_sched *p_main_sched;
     ABTI_pool *p_tar_pool = NULL;
     size_t p;
-
-    /* The main scheduler will to be a ULT, not a tasklet */
-    p_sched->type = ABT_SCHED_TYPE_ULT;
 
     /* Set the scheduler as a main scheduler */
     p_sched->used = ABTI_SCHED_MAIN;

--- a/src/stream.c
+++ b/src/stream.c
@@ -50,8 +50,8 @@ int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
     ABTI_xstream *p_newxstream;
 
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                            ABT_SCHED_CONFIG_NULL, &p_sched);
+        abt_errno =
+            ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
@@ -94,10 +94,11 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
 {
     int abt_errno;
     ABTI_xstream *p_newxstream;
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
 
     ABTI_sched *p_sched;
     abt_errno =
-        ABTI_sched_create_basic(predef, num_pools, pools, config, &p_sched);
+        ABTI_sched_create_basic(predef, num_pools, pools, p_config, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno =
@@ -135,8 +136,8 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
     ABTI_CHECK_TRUE(rank >= 0, ABT_ERR_INV_XSTREAM_RANK);
 
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                            ABT_SCHED_CONFIG_NULL, &p_sched);
+        abt_errno =
+            ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
@@ -478,8 +479,8 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 
     ABTI_sched *p_sched;
     if (sched == ABT_SCHED_NULL) {
-        abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                            ABT_SCHED_CONFIG_NULL, &p_sched);
+        abt_errno =
+            ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, NULL, &p_sched);
         ABTI_CHECK_ERROR(abt_errno);
     } else {
         p_sched = ABTI_sched_get_ptr(sched);
@@ -520,8 +521,8 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     ABTI_sched *p_sched;
-    abt_errno = ABTI_sched_create_basic(predef, num_pools, pools,
-                                        ABT_SCHED_CONFIG_NULL, &p_sched);
+    abt_errno =
+        ABTI_sched_create_basic(predef, num_pools, pools, NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno = xstream_update_main_sched(&p_local_xstream, p_xstream, p_sched);
@@ -859,8 +860,8 @@ ABTU_ret_err int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream)
     ABTI_sched *p_sched;
 
     /* For the primary ES, a default scheduler is created. */
-    abt_errno = ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL,
-                                        ABT_SCHED_CONFIG_NULL, &p_sched);
+    abt_errno =
+        ABTI_sched_create_basic(ABT_SCHED_DEFAULT, 0, NULL, NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
     abt_errno =

--- a/test/basic/sched_prio.c
+++ b/test/basic/sched_prio.c
@@ -137,6 +137,14 @@ static void create_scheds_and_xstreams(void)
 
         /* Create ES */
         if (i == 0) {
+            /* Move the primary ULT to the least priority pool so that it does
+             * not affect verify_exec_order(). */
+            ABT_thread self_thread;
+            ret = ABT_thread_self(&self_thread);
+            ATS_ERROR(ret, "ABT_thread_self");
+            ret = ABT_thread_set_associated_pool(self_thread,
+                                                 pools[0][num_pools[0] - 1]);
+            ATS_ERROR(ret, "ABT_thread_set_associated_pool");
             ret = ABT_xstream_self(&xstreams[i]);
             ATS_ERROR(ret, "ABT_xstream_self");
             ret = ABT_xstream_set_main_sched(xstreams[i], scheds[i]);


### PR DESCRIPTION
This PR improves the API and its explanation of `ABT_sched_xxx()` (including `ABT_sched_config_xxx()`) functions for the upcoming Argobots 1.1.

This PR does not change the API of Argobots 1.0 except for the following "behavior".

- `ABT_sched_type`: regardless of this value, the runtime will always create a ULT-type scheduler. A tasklet-type scheduler is too restrictive and the runtime cannot support it. Note that this change has been already adopted by #182.

- `ABT_sched_config_access`: regardless of this value, the runtime will always create a MPMC-type pool for a `ABT_POOL_NULL` pool. This is because non-MPMC pools are too restrictive (e.g., regarding a resume operation). The user can manually create such a pool by `ABT_pool_create_basic()`.

This PR also fixes some bugs (e.g.,  memory leak on an error path).
