### PR TITLE
pool: improve API

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1856,6 +1856,8 @@ ALIASES += DOC_DESC_V10_ACCEPT_TASK{1}="\DOC_V10 The user cannot pass a tasklet 
 
 ALIASES += DOC_DESC_V10_ACCEPT_THREAD{1}="\DOC_V10 The user cannot pass a ULT handle as \1.\n \DOC_V11 This routine accepts a ULT handle as \1.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general.  Argobots 1.1 has introduced this change since this change does not break the compatibility of API and ABI of Argobots 1.0. @endrationale"
 
+ALIASES += DOC_DESC_V10_ACCESS_VIOLATION="\DOC_V10 If a pool access violation happens regarding an access type of a pool, an error is returned.\n \DOC_V11 If a pool access violation happens regarding an access type of a pool, the results are undefined.\n @rationale The implementation of Argobots 1.0 does not strictly check this error, so some user programs work without any problem if it is no simultaneously accessed, although it is a user error.  Such an error is often not recoverable, for example, when an execution stream pushes a ULT to a pool that cannot be accessed by this execution stream.  Correctly implementing the access violation check could break the actual API compatibility.  From Argobots 1.1, it is the user's responsibility to manage access to pools. @endrationale"
+
 ALIASES += DOC_DESC_V10_ALWAYS_SCHED_TYPE_ULT="\DOC_V10 If \c ABT_SCHED_TYPE_TASK is set, the created scheduler runs on a tasklet.\n \DOC_V11 All schedulers run on ULTs.\n @rationale A scheduler that cannot yield is almost useless; such a scheduler is highly restrictive while it provides tiny performance benefits.  Argobots 1.1 always creates a ULT-based scheduler regardless of \c ABT_sched_type. @endrationale"
 
 ALIASES += DOC_DESC_V10_BARRIER_NUM_WAITERS{1}="\DOC_V10 This routine accepts zero as \c num_waiters.\n \DOC_V11 This routine returns \c ABT_ERR_INV_ARG if \c num_waiters is zero. @rationale A barrier with \c num_waiters = 0 is useless and should be prohibited.  Even with Argobots 1.0, calling \c ABT_barrier_wait() for a barrier with \c num_waiters = 0 is not allowed. @endrationale"
@@ -1866,6 +1868,12 @@ ALIASES += DOC_DESC_V10_EVENTUAL_UPDATE_READY_BUFFER{1}="\DOC_V10 This routine u
 
 ALIASES += DOC_DESC_V10_FUTURE_COMPARTMENT_ORDER="\DOC_V10 The order of elements of \c arg passed to \c cb_func() is the same order as the \c ABT_future_set() calls are terminated.\n \DOC_V11 The order of elements of \c arg passed to \c cb_func() is undefined. @rationale This specification in Argobots 1.0 is unclear and unreasonable because the exact timing of termination of \c ABT_future_set() is not observable if \c ABT_future_set() is called concurrently. @endrationale"
 
+ALIASES += DOC_DESC_V10_NOEXT{1}="\DOC_V10 If an external thread calls this routine, \1 is returned.\n \DOC_V11 An external thread may call this routine.\n @rationale Argobots 1.0 narrows the type of the caller without any reason.  Argobots 1.1 fixes it. @endrationale"
+
+ALIASES += DOC_DESC_V10_POOL_NOACCESS="\DOC_V10 The Argobots runtime respects an access type of a pool and returns an error if possible if a pool access violation happens regarding an access type of a pool.\n \DOC_V11 The Argobots runtime does not check an access type of a pool.  If a pool access violation happens regarding an access type of a pool, the results are undefined.\n @rationale This access type was used for access violation error check.  This check will be removed in Argobots 1.1 since correctly implementing the access violation check could break the actual API compatibility.  From Argobots 1.1, it is the user's responsibility to manage access to pools. @endrationale"
+
+ALIASES += DOC_DESC_V10_POOL_NOTASK="\DOC_V10 A type of \c ABT_unit is \c ABT_UNIT_TYPE_TASK if an encapsulated work unit is a tasklet. Such a unit is created by \c u_create_from_task(). \n \DOC_V11 A type of any \c ABT_unit is \c ABT_UNIT_TYPE_THERAD.  Accordingly, \c u_create_from_thread() is called to create \c ABT_unit for both ULTs and tasklets. \n @rationale In Argobots 1.0, the user needs to use a map (e.g., a hash table) to check if a type of a given \c ABT_unit is either \c ABT_UNIT_TYPE_THREAD or \c ABT_UNIT_TYPE_TASK, which makes the implementation of a user-defined pool extremely tedious.  Argobots 1.1 marks these functions as unused to ease the implementation. @endrationale"
+
 ALIASES += DOC_DESC_V10_REJECT_MUTEX_ATTR_NULL{1}="\DOC_V10 This routine returns \c ABT_ERR_INV_MUTEX_ATTR if \1 is \c ABT_MUTEX_ATTR_NULL.\n \DOC_V11 This routine uses the default mutex attributes if \1 is \c ABT_MUTEX_ATTR_NULL. @rationale Most of the Argobots routines use the default attributes if the given configuration or attributes are NULL.  This routine should also follow this basic rule. @endrationale"
 
 ALIASES += DOC_DESC_V1X_ERROR_CODE_CHANGE{3}="\DOC_V1X \1 is returned if \3.\n \DOC_V20 \2 is returned if \3.\n @rationale Argobots 2.0 changes the error code for consistent behavior with the other Argobots routines. @endrationale"
@@ -1875,6 +1883,8 @@ ALIASES += DOC_DESC_V1X_NOEXT{1}="\DOC_V1X If an external thread calls this rout
 ALIASES += DOC_DESC_V1X_NOTASK{1}="\DOC_V1X If a tasklet calls this routine, \1 is returned.\n \DOC_V20 A tasklet may call this routine.\n @rationale Argobots 2.0 integrates a ULT and a tasklet into a single thread concept to make the API more general. @endrationale"
 
 ALIASES += DOC_DESC_V1X_NULL_PTR{2}="\DOC_V1X If \1 is \c NULL, \2 is returned.\n \DOC_V20 If \1 is \c NULL, the results are undefined.\n @rationale Argobots 2.0 will not check NULL pointers. @endrationale"
+
+ALIASES += DOC_DESC_V1X_P_POP_WAIT="\DOC_V1X \c ABT_pool_def does not define \c p_pop_wait. \n \DOC_V20 \c ABT_pool_def defines \c p_pop_wait. \n @rationale To maintain the ABI compatibility, \c p_pop_wait is excluded from \c ABT_pool_def. @endrationale"
 
 ALIASES += DOC_DESC_V1X_PREMATURE_SCHED_USED_CHECK{2}="\DOC_V1X \2 is returned if this routine finds \1 is already used.\n \DOC_V20 The results are undefined if \1 is already used.\n @rationale The current mechanism that checks if a scheduler is used is premature since this is not maintained atomically.  From Argobots 2.0, it becomes the user's responsibility to guarantee that \1 is not used. @endrationale"
 
@@ -1950,7 +1960,13 @@ ALIASES += DOC_ERROR_INV_MUTEX_HANDLE{1}="If \1 is \c ABT_MUTEX_NULL, \c ABT_ERR
 
 ALIASES += DOC_ERROR_INV_MUTEX_PTR{1}="If \1 points to \c ABT_MUTEX_NULL, \c ABT_ERR_INV_MUTEX is returned.\n"
 
+ALIASES += DOC_ERROR_INV_POOL_ACCESS{1}="If \1 is not a valid pool access type, \c ABT_ERR_INV_POOL_ACCESS is returned.\n"
+
 ALIASES += DOC_ERROR_INV_POOL_HANDLE{1}="If \1 is \c ABT_POOL_NULL, \c ABT_ERR_INV_POOL is returned.\n"
+
+ALIASES += DOC_ERROR_INV_POOL_KIND{1}="If \1 is not a valid pool kind, \c ABT_ERR_INV_POOL_KIND is returned.\n"
+
+ALIASES += DOC_ERROR_INV_POOL_PTR{1}="If \1 points to \c ABT_POOL_NULL, \c ABT_ERR_INV_POOL is returned.\n"
 
 ALIASES += DOC_ERROR_INV_RWLOCK_HANDLE{1}="If \1 is \c ABT_RWLOCK_NULL, \c ABT_ERR_INV_RWLOCK is returned.\n"
 
@@ -1977,6 +1993,8 @@ ALIASES += DOC_ERROR_INV_THREAD_NY{1}="If \1 is a tasklet, \c ABT_ERR_INV_THREAD
 ALIASES += DOC_ERROR_INV_TIMER_HANDLE{1}="If \1 is \c ABT_TIMER_NULL, \c ABT_ERR_INV_TIMER is returned.\n"
 
 ALIASES += DOC_ERROR_INV_TIMER_PTR{1}="If \1 points to \c ABT_TIMER_NULL, \c ABT_ERR_INV_TIMER is returned.\n"
+
+ALIASES += DOC_ERROR_INV_UNIT_HANDLE{1}="If \1 is \c ABT_UNIT_NULL, \c ABT_ERR_INV_UNIT is returned.\n"
 
 ALIASES += DOC_ERROR_INV_XSTREAM_BARRIER_HANDLE{1}="If \1 is \c ABT_XSTREAM_BARRIER_NULL, \c ABT_ERR_INV_XSTREAM_BARRIER is returned.\n"
 
@@ -2011,6 +2029,8 @@ ALIASES += DOC_ERROR_TASK{1}="If the caller is a tasklet, \1 is returned.\n"
 ALIASES += DOC_ERROR_UNINITIALIZED="If the Argobots runtime is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
 
 ALIASES += DOC_ERROR_UNINITIALIZED_INFO_QUERY="If the queried information requires initialized Argobots while Argobots is not initialized, \c ABT_ERR_UNINITIALIZED is returned.\n"
+
+ALIASES += DOC_ERROR_USR_POOL_INIT{1}="If \1 does not return \c ABT_SUCCESS, the error returned by \1 is returned.\n"
 
 ALIASES += DOC_ERROR_USR_SCHED_INIT{1}="If \1 does not return \c ABT_SUCCESS, the error returned by \1 is returned.\n"
 
@@ -2064,6 +2084,8 @@ ALIASES += DOC_UNDEFINED_NULL_PTR_CONDITIONAL{2}="If \2 and \1 is \c NULL, the r
 
 ALIASES += DOC_UNDEFINED_NULL_PTR{1}="If \1 is \c NULL, the results are undefined.\n"
 
+ALIASES += DOC_UNDEFINED_POOL_FREE{1}="If \1 is not empty, the results are undefined.\n If any work unit is still associated with \1, the results are undefined.\n"
+
 ALIASES += DOC_UNDEFINED_SCHED_CONFIG_CREATE_UNFORMATTED="If the \a (2n+1)th element of the given variadic arguments is neither \c ABT_sched_config_var_end nor a variable of type \c ABT_sched_config_var, the results are undefined.\n If the \a (2n+2)th element of the given variadic arguments is not a variable of a type specified by \c type of the \a (2n+1)th element of type \c ABT_sched_config_var, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_SCHED_USED{1}="If \1 is being used, the results are undefined."
@@ -2081,5 +2103,9 @@ ALIASES += DOC_UNDEFINED_TOOL_QUERY{2}="If \1 is a tool context that is not pass
 ALIASES += DOC_UNDEFINED_UNINIT="If Argobots is not initialized, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_WAITER{1}="If any waiter is blocked on \1, the results are undefined.\n"
+
+ALIASES += DOC_UNDEFINED_WORK_UNIT_NOT_ASSOCIATED{2}="If \1 is not associated with \2, the results are undefined.\n"
+
+ALIASES += DOC_UNDEFINED_WORK_UNIT_NOT_IN_POOL{2}="If \2 is not in \1, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_WORK_UNIT_RUNNING{1}="If \1 is running, the results are undefined.\n"

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -948,6 +948,7 @@ typedef struct {
      * caller of \c p_pop() is non-conforming.
      */
     ABT_pool_pop_fn           p_pop;
+#ifdef ABT_ENABLE_VER_20_API
     /**
      * @fn    ABT_unit (*p_pop_wait)(ABT_pool pool, double time_secs)
      * @brief Function that pops a work unit from a pool with wait.
@@ -968,6 +969,7 @@ typedef struct {
      * @endchangev20
      */
     ABT_pool_pop_wait_fn      p_pop_wait;
+#endif
     /**
      * @fn    ABT_unit (*p_pop_timedwait)(ABT_pool pool, double abstime_secs)
      * @brief Function that pops a work unit from a pool with wait.

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -186,17 +186,51 @@ enum ABT_sched_type {
     ABT_SCHED_TYPE_TASK
 };
 
+/**
+ * @ingroup POOL
+ * @brief   Predefined pool type.
+ *
+ * Predefined pools provide all the pool functions that are defined in
+ * \c ABT_pool_def unless otherwise noted.
+ */
 enum ABT_pool_kind {
-    ABT_POOL_FIFO,       /* FIFO pool */
-    ABT_POOL_FIFO_WAIT   /* FIFO pool with ability to wait for units */
+    /** FIFO pool. */
+    ABT_POOL_FIFO,
+    /**
+     * FIFO pool with a waiting ability.  If a caller's pop operation fails,
+     * either an execution stream running the caller or a calling external
+     * thread will suspend for a while.  This can reduce CPU utilization when
+     * a pool is empty, but it increases an overhead of each pool operation.
+     *
+     * If the user does not know how \c ABT_POOL_FIFO_WAIT works,
+     * \c ABT_POOL_FIFO is recommended. */
+    ABT_POOL_FIFO_WAIT
 };
 
+/**
+ * @ingroup POOL
+ * @brief   Pool access type.
+ */
 enum ABT_pool_access {
-    ABT_POOL_ACCESS_PRIV, /* Used by only one ES */
-    ABT_POOL_ACCESS_SPSC, /* Producers on ES1, consumers on ES2 */
-    ABT_POOL_ACCESS_MPSC, /* Producers on any ES, consumers on the same ES */
-    ABT_POOL_ACCESS_SPMC, /* Producers on the same ES, consumers on any ES */
-    ABT_POOL_ACCESS_MPMC  /* Producers on any ES, consumers on any ES */
+    /**
+     * The created pool may be pushed and popped by only one execution stream
+     * in the lifetime of the pool. */
+    ABT_POOL_ACCESS_PRIV,
+    /**
+     * The created pool may be pushed by only one execution stream and popped
+     * by only one execution stream in the lifetime of the pool.  The two
+     * execution streams can be different. */
+    ABT_POOL_ACCESS_SPSC,
+    /**
+     * The created pool may be popped by only one execution stream in the
+     * lifetime of the pool. */
+    ABT_POOL_ACCESS_MPSC,
+    /**
+     * The created pool may be pushed by only one execution stream in the
+     * lifetime of the pool. */
+    ABT_POOL_ACCESS_SPMC,
+    /** No restriction regarding a caller of pushing and popping operations. */
+    ABT_POOL_ACCESS_MPMC
 };
 
 enum ABT_unit_type {
@@ -736,29 +770,269 @@ typedef int           (*ABT_pool_free_fn)(ABT_pool);
 typedef int           (*ABT_pool_print_all_fn)(ABT_pool, void *arg,
                                                void (*)(void*, ABT_unit));
 
+/**
+ * @ingroup POOL
+ * @brief   A struct that defines a pool.
+ */
 typedef struct {
-    ABT_pool_access access; /* Access type */
-
-    /* Functions to manage units */
+    /**
+     * @brief Access type.
+     *
+     * This value is used to determine a value returned by
+     * \c ABT_pool_get_access().  The Argobots assumes all pools can be accessed
+     * by any ULT, tasklet, or external thread.  It is the user's responsibility
+     * to manage the access to pools.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOACCESS
+     * @endchangev11
+     */
+    ABT_pool_access access;
+    /**
+     * @brief Unused function
+     *
+     * This function is not used.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOTASK
+     * @endchangev11
+     */
     ABT_unit_get_type_fn           u_get_type;
+    /**
+     * @fn    ABT_thread (*u_get_thread)(ABT_unit unit)
+     * @brief Function that extracts an \c ABT_thread handle from an \c ABT_unit
+     *        handle.
+     *
+     * \c u_get_thread() returns a work unit handle from \c unit.  \c unit is
+     * not \c ABT_UNIT_NULL.
+     *
+     * \c u_get_thread() is not optional, so the user must implement this
+     * function.
+     *
+     * The caller of \c u_get_thread() is undefined, so a program that relies on
+     * the caller of \c u_get_thread() is non-conforming.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOTASK
+     * @endchangev11
+     */
     ABT_unit_get_thread_fn         u_get_thread;
+    /**
+     * @brief Unused function.
+     *
+     * This function is not used.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOTASK
+     * @endchangev11
+     */
     ABT_unit_get_task_fn           u_get_task;
+    /**
+     * @fn    ABT_bool (*u_is_in_pool)(ABT_unit unit)
+     * @brief Function that returns whether a work unit is in its associated
+     *        pool or not.
+     *
+     * \c u_is_in_pool() returns whether the work unit \c unit is in its
+     * associated pool or not.  If \c unit is in its pool, this function returns
+     * \c ABT_TRUE.  Otherwise, this function returns \c ABT_FALSE.  \c unit is
+     * not \c ABT_UNIT_NULL.
+     *
+     * \c u_is_in_pool() is optional, so the user may set \c u_is_in_pool to
+     * \c NULL.  The Argobots does not call \c u_is_in_pool() if it is not
+     * supported.
+     *
+     * The caller of \c u_is_in_pool() is undefined, so a program that relies on
+     * the caller of \c u_is_in_pool() is non-conforming.
+     */
     ABT_unit_is_in_pool_fn         u_is_in_pool;
+    /**
+     * @fn    ABT_unit (*u_create_from_thread)(ABT_thread thread)
+     * @brief Function that creates an \c ABT_unit handle that is associated
+     *        with an \c ABT_thread handle.
+     *
+     * \c u_create_from_thread() creates a user-defined \c ABT_unit handle that
+     * is associated with the work-unit \c thread and returns.  \c thread is
+     * neither \c ABT_THREAD_NULL nor \c ABT_TASK_NULL.
+     *
+     * \c u_create_from_thread() is not optional, so the user must implement
+     * this function.
+     *
+     * The caller of \c u_create_from_thread() is undefined, so a program that
+     * relies on the caller of \c u_create_from_thread() is non-conforming.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOTASK
+     * @endchangev11
+     */
     ABT_unit_create_from_thread_fn u_create_from_thread;
+    /**
+     * @brief Unused function.
+     *
+     * This function is not used.
+     *
+     * @changev11
+     * \DOC_DESC_V10_POOL_NOTASK
+     * @endchangev11
+     */
     ABT_unit_create_from_task_fn   u_create_from_task;
+    /**
+     * @fn    void (*u_free)(ABT_unit *unit)
+     * @brief Function that frees a work unit.
+     *
+     * \c u_free() frees the work unit \c unit that is created by
+     * \c u_create_from_thread().  Its associated entity (i.e., \c ABT_thread)
+     * is freed by the Argobots runtime.  \c unit is neither pointing to
+     * \c ABT_UNIT_NULL nor \c NULL.  The user may modify a value of \c unit.
+     *
+     * \c u_free() is not optional, so the user must implement this function.
+     *
+     * The caller of \c u_free() is undefined, so a program that relies on the
+     * caller of \c u_free() is non-conforming.
+     */
     ABT_unit_free_fn               u_free;
-
-    /* Functions to manage the pool */
+    /**
+     * @fn    int (*p_init)(ABT_pool pool, ABT_pool_config pool_config)
+     * @brief Function that frees a work unit.
+     *
+     * \c p_init() sets up the pool \c pool with the pool configuration
+     * \c pool_config.  If \c p_init() does not return \c ABT_SUCCESS, the
+     * pool creation fails.
+     *
+     * \c p_init() is optional, so the user may set \c p_init to \c NULL.
+     *
+     * The caller of \c p_init() is undefined, so a program that relies on the
+     * caller of \c p_init() is non-conforming.
+     */
     ABT_pool_init_fn          p_init;
+    /**
+     * @fn    size_t (*p_get_size)(ABT_pool pool)
+     * @brief Function that returns a work unit.
+     *
+     * \c p_get_size() returns the size of the pool \c pool.  The Argobots
+     * assumes that the size is the number of work units in \c pool.
+     *
+     * @note
+     * Specifically, the current Argobots treats a pool whose size is zero as an
+     * empty pool.
+     *
+     * \c u_free() is not optional, so the user must implement this function.
+     *
+     * The caller of \c p_get_size() is undefined, so a program that relies on
+     * the caller of \c p_get_size() is non-conforming.
+     */
     ABT_pool_get_size_fn      p_get_size;
+    /**
+     * @fn    void (*p_push)(ABT_pool pool, ABT_unit unit)
+     * @brief Function that pushes a work unit to a pool.
+     *
+     * \c p_push() pushes the work unit \c unit to the pool \c pool.  \c unit
+     * must be stored in \c pool and can be popped by its pop functions (e.g.,
+     * \c p_pop()) later.
+     *
+     * \c p_push() is not optional, so the user must implement this function.
+     *
+     * The caller of \c p_push() is undefined, so a program that relies on the
+     * caller of \c p_push() is non-conforming.
+     */
     ABT_pool_push_fn          p_push;
+    /**
+     * @fn    ABT_unit (*p_pop)(ABT_pool pool)
+     * @brief Function that pops a work unit from a pool.
+     *
+     * \c p_pop() pops a work unit from the pool \c pool and returns it.  If
+     * no work unit exists in \c pool, \c ABT_UNIT_NULL must be returned.
+     *
+     * \c p_pop() is not optional, so the user must implement this function.
+     *
+     * The caller of \c p_pop() is undefined, so a program that relies on the
+     * caller of \c p_pop() is non-conforming.
+     */
     ABT_pool_pop_fn           p_pop;
+    /**
+     * @fn    ABT_unit (*p_pop_wait)(ABT_pool pool, double time_secs)
+     * @brief Function that pops a work unit from a pool with wait.
+     *
+     * \c p_pop_wait() pops a work unit from the pool \c pool and returns it.
+     * If no work unit exists in \c pool, \c ABT_UNIT_NULL must be returned.
+     * \c time_secs hints at the duration in seconds that indicates how long the
+     * caller should wait on \c pool until a work unit is added to \c pool.
+     *
+     * \c p_pop_wait() is optional, so the user may set \c p_pop_wait to
+     * \c NULL.
+     *
+     * The caller of \c p_pop_wait() is undefined, so a program that relies on
+     * the caller of \c p_pop_wait() is non-conforming.
+     *
+     * @changev20
+     * \DOC_DESC_V1X_P_POP_WAIT
+     * @endchangev20
+     */
     ABT_pool_pop_wait_fn      p_pop_wait;
-    ABT_pool_pop_timedwait_fn p_pop_timedwait; /* Deprecated.  No built-in
-                                                * scheduler uses pop_timedwait().
-                                                * Use p_pop_wait() instead. */
+    /**
+     * @fn    ABT_unit (*p_pop_timedwait)(ABT_pool pool, double abstime_secs)
+     * @brief Function that pops a work unit from a pool with wait.
+     *
+     * \c p_pop_timedwait() pops a work unit from the pool \c pool and returns
+     * it.  If no work unit exists in \c pool, \c ABT_UNIT_NULL must be
+     * returned.  \c abstime_secs hints at the system time that indicates how
+     * long the caller should wait on \c pool until a work unit is added to
+     * \c pool.  The current system time is obtained via \c ABT_get_wtime().
+     *
+     * \c p_pop_timedwait() is optional, so the user may set \c p_pop_timedwait
+     * to \c NULL.
+     *
+     * The caller of \c p_pop_timedwait() is undefined, so a program that relies
+     * on the caller of \c p_pop_timedwait() is non-conforming.
+     *
+     * @changev20
+     * \DOC_V20 \c p_pop_timedwait() is deprecated.  The user should use
+     * \c p_pop_wait() instead.
+     * @endchangev20
+     */
+    ABT_pool_pop_timedwait_fn p_pop_timedwait;
+    /**
+     * @fn    int (*p_remove)(ABT_pool pool, ABT_unit unit)
+     * @brief Function that removes a work unit from a pool.
+     *
+     * \c p_remove() removes the work unit \c unit from the pool \c pool.  The
+     * caller of this function guarantees that \c unit exists in the pool.
+     * The return value of this function is ignored.
+     *
+     * \c p_remove() is optional, so the user may set \c p_remove to \c NULL.
+     *
+     * The caller of \c p_remove() is undefined, so a program that relies on
+     * the caller of \c p_remove() is non-conforming.
+     */
     ABT_pool_remove_fn        p_remove;
+    /**
+     * @fn    int (*p_free)(ABT_pool pool)
+     * @brief Function that frees a pool.
+     *
+     * \c p_free() frees the pool \c pool.  The return value of this function is
+     * ignored.
+     *
+     * \c p_free() is optional, so the user may set \c p_free to \c NULL.
+     *
+     * The caller of \c p_free() is undefined, so a program that relies on the
+     * caller of \c p_free() is non-conforming.
+     */
     ABT_pool_free_fn          p_free;
+    /**
+     * @fn    int (*p_print_all)(ABT_pool pool, void *arg,
+     *                           void (*print_f)(void *arg, ABT_unit unit))
+     * @brief Function that applies a function to all work units in a pool.
+     *
+     * \c p_print_all() applies \c print_f to all work units in the pool
+     * \c pool.  \c print_f() is called with the user-given argument \c arg and
+     * the work unit.  The caller guarantees that \c print_f() does not modify
+     * the state of \c pool and work units in \c pool.
+     *
+     * \c p_print_all() is optional, so the user may set \c p_print_all to
+     * \c NULL.
+     *
+     * The caller of \c p_print_all() is undefined, so a program that relies on
+     * the caller of \c p_print_all() is non-conforming.
+     */
     ABT_pool_print_all_fn     p_print_all;
 } ABT_pool_def;
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -308,12 +308,9 @@ struct ABTI_pool {
     uint64_t id;                      /* ID */
 
     /* Functions to manage units */
-    ABT_unit_get_type_fn u_get_type;
     ABT_unit_get_thread_fn u_get_thread;
-    ABT_unit_get_task_fn u_get_task;
     ABT_unit_is_in_pool_fn u_is_in_pool;
     ABT_unit_create_from_thread_fn u_create_from_thread;
-    ABT_unit_create_from_task_fn u_create_from_task;
     ABT_unit_free_fn u_free;
 
     /* Functions to manage the pool */
@@ -330,12 +327,9 @@ struct ABTI_pool {
 
 struct ABTI_pool_def {
     ABT_pool_access access;
-    ABT_unit_get_type_fn u_get_type;
     ABT_unit_get_thread_fn u_get_thread;
-    ABT_unit_get_task_fn u_get_task;
     ABT_unit_is_in_pool_fn u_is_in_pool;
     ABT_unit_create_from_thread_fn u_create_from_thread;
-    ABT_unit_create_from_task_fn u_create_from_task;
     ABT_unit_free_fn u_free;
     ABT_pool_init_fn p_init;
     ABT_pool_get_size_fn p_get_size;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -112,6 +112,7 @@ typedef enum ABTI_sched_used ABTI_sched_used;
 typedef void *ABTI_sched_id;       /* Scheduler id */
 typedef uintptr_t ABTI_sched_kind; /* Scheduler kind */
 typedef struct ABTI_pool ABTI_pool;
+typedef struct ABTI_pool_def ABTI_pool_def;
 typedef struct ABTI_thread ABTI_thread;
 typedef struct ABTI_thread_attr ABTI_thread_attr;
 typedef struct ABTI_ythread ABTI_ythread;
@@ -327,6 +328,26 @@ struct ABTI_pool {
     ABT_pool_print_all_fn p_print_all;
 };
 
+struct ABTI_pool_def {
+    ABT_pool_access access;
+    ABT_unit_get_type_fn u_get_type;
+    ABT_unit_get_thread_fn u_get_thread;
+    ABT_unit_get_task_fn u_get_task;
+    ABT_unit_is_in_pool_fn u_is_in_pool;
+    ABT_unit_create_from_thread_fn u_create_from_thread;
+    ABT_unit_create_from_task_fn u_create_from_task;
+    ABT_unit_free_fn u_free;
+    ABT_pool_init_fn p_init;
+    ABT_pool_get_size_fn p_get_size;
+    ABT_pool_push_fn p_push;
+    ABT_pool_pop_fn p_pop;
+    ABT_pool_pop_wait_fn p_pop_wait;
+    ABT_pool_pop_timedwait_fn p_pop_timedwait;
+    ABT_pool_remove_fn p_remove;
+    ABT_pool_free_fn p_free;
+    ABT_pool_print_all_fn p_print_all;
+};
+
 struct ABTI_thread {
     ABTI_thread *p_prev;
     ABTI_thread *p_next;
@@ -510,9 +531,9 @@ ABTU_ret_err int ABTI_pool_create_basic(ABT_pool_kind kind,
                                         ABTI_pool **pp_newpool);
 void ABTI_pool_free(ABTI_pool *p_pool);
 ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
-                                        ABT_pool_def *p_def);
+                                        ABTI_pool_def *p_def);
 ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
-                                             ABT_pool_def *p_def);
+                                             ABTI_pool_def *p_def);
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
 

--- a/src/info.c
+++ b/src/info.c
@@ -1133,22 +1133,22 @@ static void info_print_unit(void *arg, ABT_unit unit)
     FILE *fp = p_arg->fp;
     ABT_pool pool = p_arg->pool;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-    ABT_unit_type type = p_pool->u_get_type(unit);
+    ABT_thread thread = p_pool->u_get_thread(unit);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
 
-    if (type == ABT_UNIT_TYPE_THREAD) {
+    if (!p_thread) {
+        fprintf(fp, "=== unknown (%p) ===\n", (void *)unit);
+    } else if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
         fprintf(fp, "=== ULT (%p) ===\n", (void *)unit);
-        ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_ythread *p_ythread = ABTI_ythread_get_ptr(thread);
+        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
         ABT_unit_id thread_id = ABTI_thread_get_id(&p_ythread->thread);
         fprintf(fp,
                 "id        : %" PRIu64 "\n"
                 "ctx       : %p\n",
                 (uint64_t)thread_id, (void *)&p_ythread->ctx);
         ABTI_ythread_print_stack(p_ythread, fp);
-    } else if (type == ABT_UNIT_TYPE_TASK) {
-        fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);
     } else {
-        fprintf(fp, "=== unknown (%p) ===\n", (void *)unit);
+        fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);
     }
 }
 

--- a/src/info.c
+++ b/src/info.c
@@ -1160,12 +1160,10 @@ ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
         fflush(fp);
         return ABT_SUCCESS;
     }
+    ABTI_CHECK_TRUE(p_pool->p_print_all, ABT_ERR_POOL);
 
     ABT_pool pool = ABTI_pool_get_handle(p_pool);
 
-    if (!p_pool->p_print_all) {
-        return ABT_ERR_POOL;
-    }
     fprintf(fp, "== pool (%p) ==\n", (void *)p_pool);
     struct info_print_unit_arg_t arg;
     arg.fp = fp;

--- a/src/log.c
+++ b/src/log.c
@@ -79,37 +79,18 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
+    if (unit == ABT_UNIT_NULL)
+        return;
 
-    ABTI_ythread *p_ythread = NULL;
-    ABTI_thread *p_task = NULL;
-    switch (p_pool->u_get_type(unit)) {
-        case ABT_UNIT_TYPE_THREAD:
-            p_ythread = ABTI_ythread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_ythread->thread.p_last_xstream) {
-                LOG_DEBUG("[U%" PRIu64 ":E%d] pushed to P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread),
-                          p_ythread->thread.p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[U%" PRIu64 "] pushed to P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread), p_pool->id);
-            }
-            break;
-
-        case ABT_UNIT_TYPE_TASK:
-            p_task = ABTI_thread_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->p_last_xstream) {
-                LOG_DEBUG("[T%" PRIu64 ":E%d] pushed to P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task),
-                          p_task->p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[T%" PRIu64 "] pushed to P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task), p_pool->id);
-            }
-            break;
-
-        default:
-            ABTI_ASSERT(0);
-            ABTU_unreachable();
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
+    if (p_thread->p_last_xstream) {
+        LOG_DEBUG("[%c%" PRIu64 ":E%d] pushed to P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
+                  p_pool->id);
+    } else {
+        LOG_DEBUG("[%c%" PRIu64 "] pushed to P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_pool->id);
     }
 }
 
@@ -117,37 +98,18 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 {
     if (gp_ABTI_global->use_logging == ABT_FALSE)
         return;
+    if (unit == ABT_UNIT_NULL)
+        return;
 
-    ABTI_ythread *p_ythread = NULL;
-    ABTI_thread *p_task = NULL;
-    switch (p_pool->u_get_type(unit)) {
-        case ABT_UNIT_TYPE_THREAD:
-            p_ythread = ABTI_ythread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_ythread->thread.p_last_xstream) {
-                LOG_DEBUG("[U%" PRIu64 ":E%d] removed from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread),
-                          p_ythread->thread.p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[U%" PRIu64 "] removed from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread), p_pool->id);
-            }
-            break;
-
-        case ABT_UNIT_TYPE_TASK:
-            p_task = ABTI_thread_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->p_last_xstream) {
-                LOG_DEBUG("[T%" PRIu64 ":E%d] removed from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task),
-                          p_task->p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[T%" PRIu64 "] removed from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task), p_pool->id);
-            }
-            break;
-
-        default:
-            ABTI_ASSERT(0);
-            ABTU_unreachable();
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
+    if (p_thread->p_last_xstream) {
+        LOG_DEBUG("[%c%" PRIu64 ":E%d] removed from P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
+                  p_pool->id);
+    } else {
+        LOG_DEBUG("[%c%" PRIu64 "] removed from P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_pool->id);
     }
 }
 
@@ -158,38 +120,15 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
     if (unit == ABT_UNIT_NULL)
         return;
 
-    ABTI_ythread *p_ythread = NULL;
-    ABTI_thread *p_task = NULL;
-    switch (p_pool->u_get_type(unit)) {
-        case ABT_UNIT_TYPE_THREAD:
-            p_ythread = ABTI_ythread_get_ptr(p_pool->u_get_thread(unit));
-            if (p_ythread->thread.p_last_xstream) {
-                LOG_DEBUG("[U%" PRIu64 ":E%d] popped from "
-                          "P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread),
-                          p_ythread->thread.p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[U%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(&p_ythread->thread), p_pool->id);
-            }
-            break;
-
-        case ABT_UNIT_TYPE_TASK:
-            p_task = ABTI_thread_get_ptr(p_pool->u_get_task(unit));
-            if (p_task->p_last_xstream) {
-                LOG_DEBUG("[T%" PRIu64 ":E%d] popped from "
-                          "P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task),
-                          p_task->p_last_xstream->rank, p_pool->id);
-            } else {
-                LOG_DEBUG("[T%" PRIu64 "] popped from P%" PRIu64 "\n",
-                          ABTI_thread_get_id(p_task), p_pool->id);
-            }
-            break;
-
-        default:
-            ABTI_ASSERT(0);
-            ABTU_unreachable();
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
+    if (p_thread->p_last_xstream) {
+        LOG_DEBUG("[%c%" PRIu64 ":E%d] popped from P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_thread->p_last_xstream->rank,
+                  p_pool->id);
+    } else {
+        LOG_DEBUG("[%c%" PRIu64 "] popped from P%" PRIu64 "\n", unit_type,
+                  ABTI_thread_get_id(p_thread), p_pool->id);
     }
 }
 

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -45,7 +45,7 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 
 /* Obtain the FIFO pool definition according to the access type */
 ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
-                                        ABT_pool_def *p_def)
+                                        ABTI_pool_def *p_def)
 {
     /* Definitions according to the access type */
     /* FIXME: need better implementation, e.g., lock-free one */

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -22,12 +22,9 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
-static ABT_task unit_get_task(ABT_unit unit);
 static ABT_bool unit_is_in_pool(ABT_unit unit);
 static ABT_unit unit_create_from_thread(ABT_thread thread);
-static ABT_unit unit_create_from_task(ABT_task task);
 static void unit_free(ABT_unit *unit);
 
 struct data {
@@ -77,12 +74,9 @@ ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
     p_def->p_pop_wait = pool_pop_wait;
     p_def->p_pop_timedwait = pool_pop_timedwait;
     p_def->p_print_all = pool_print_all;
-    p_def->u_get_type = unit_get_type;
     p_def->u_get_thread = unit_get_thread;
-    p_def->u_get_task = unit_get_task;
     p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task = unit_create_from_task;
     p_def->u_free = unit_free;
 
     return ABT_SUCCESS;
@@ -432,35 +426,10 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 /* Unit functions */
 
-static ABT_unit_type unit_get_type(ABT_unit unit)
-{
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
-    return ABTI_thread_type_get_type(p_thread->type);
-}
-
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
-    ABT_thread h_thread;
-    ABTI_ythread *p_ythread =
-        ABTI_thread_get_ythread_or_null((ABTI_thread *)unit);
-    if (p_ythread) {
-        h_thread = ABTI_ythread_get_handle(p_ythread);
-    } else {
-        h_thread = ABT_THREAD_NULL;
-    }
-    return h_thread;
-}
-
-static ABT_task unit_get_task(ABT_unit unit)
-{
-    ABT_task h_task;
     ABTI_thread *p_thread = (ABTI_thread *)unit;
-    if (!(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE)) {
-        h_task = ABTI_thread_get_handle(p_thread);
-    } else {
-        h_task = ABT_TASK_NULL;
-    }
-    return h_task;
+    return ABTI_thread_get_handle(p_thread);
 }
 
 static ABT_bool unit_is_in_pool(ABT_unit unit)
@@ -472,23 +441,10 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_ythread *p_ythread = ABTI_ythread_get_ptr(thread);
-    ABTI_thread *p_thread = &p_ythread->thread;
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     p_thread->p_prev = NULL;
     p_thread->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-    ABTI_ASSERT(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE);
-
-    return (ABT_unit)p_thread;
-}
-
-static ABT_unit unit_create_from_task(ABT_task task)
-{
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(task);
-    p_thread->p_prev = NULL;
-    p_thread->p_next = NULL;
-    ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-    ABTI_ASSERT(!(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE));
 
     return (ABT_unit)p_thread;
 }

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -40,7 +40,7 @@ static inline data_t *pool_get_data_ptr(void *p_data)
 }
 
 ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
-                                             ABT_pool_def *p_def)
+                                             ABTI_pool_def *p_def)
 {
     p_def->access = access;
     p_def->p_init = pool_init;

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -17,12 +17,9 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
 static int pool_remove(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
-static ABT_unit_type unit_get_type(ABT_unit unit);
 static ABT_thread unit_get_thread(ABT_unit unit);
-static ABT_task unit_get_task(ABT_unit unit);
 static ABT_bool unit_is_in_pool(ABT_unit unit);
 static ABT_unit unit_create_from_thread(ABT_thread thread);
-static ABT_unit unit_create_from_task(ABT_task task);
 static void unit_free(ABT_unit *unit);
 
 struct data {
@@ -52,12 +49,9 @@ ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
     p_def->p_pop_timedwait = pool_pop_timedwait;
     p_def->p_remove = pool_remove;
     p_def->p_print_all = pool_print_all;
-    p_def->u_get_type = unit_get_type;
     p_def->u_get_thread = unit_get_thread;
-    p_def->u_get_task = unit_get_task;
     p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
-    p_def->u_create_from_task = unit_create_from_task;
     p_def->u_free = unit_free;
 
     return ABT_SUCCESS;
@@ -328,35 +322,10 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 /* Unit functions */
 
-static ABT_unit_type unit_get_type(ABT_unit unit)
-{
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
-    return ABTI_thread_type_get_type(p_thread->type);
-}
-
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
-    ABT_thread h_thread;
-    ABTI_ythread *p_ythread =
-        ABTI_thread_get_ythread_or_null((ABTI_thread *)unit);
-    if (p_ythread) {
-        h_thread = ABTI_ythread_get_handle(p_ythread);
-    } else {
-        h_thread = ABT_THREAD_NULL;
-    }
-    return h_thread;
-}
-
-static ABT_task unit_get_task(ABT_unit unit)
-{
-    ABT_task h_task;
     ABTI_thread *p_thread = (ABTI_thread *)unit;
-    if (!(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE)) {
-        h_task = ABTI_thread_get_handle(p_thread);
-    } else {
-        h_task = ABT_TASK_NULL;
-    }
-    return h_task;
+    return ABTI_thread_get_handle(p_thread);
 }
 
 static ABT_bool unit_is_in_pool(ABT_unit unit)
@@ -368,23 +337,10 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_ythread *p_ythread = ABTI_ythread_get_ptr(thread);
-    ABTI_thread *p_thread = &p_ythread->thread;
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     p_thread->p_prev = NULL;
     p_thread->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-    ABTI_ASSERT(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE);
-
-    return (ABT_unit)p_thread;
-}
-
-static ABT_unit unit_create_from_task(ABT_task task)
-{
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(task);
-    p_thread->p_prev = NULL;
-    p_thread->p_next = NULL;
-    ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-    ABTI_ASSERT(!(p_thread->type & ABTI_THREAD_TYPE_YIELDABLE));
 
     return (ABT_unit)p_thread;
 }

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -72,6 +72,10 @@ ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
 int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
                     ABT_pool *newpool)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x sets newpool to NULL on error. */
+    *newpool = ABT_POOL_NULL;
+#endif
     ABTI_pool *p_newpool;
     int abt_errno = pool_create(def, config, ABT_FALSE, &p_newpool);
     ABTI_CHECK_ERROR(abt_errno);
@@ -140,6 +144,10 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
 int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
                           ABT_bool automatic, ABT_pool *newpool)
 {
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
+    /* Argobots 1.x sets newpool to NULL on error. */
+    *newpool = ABT_POOL_NULL;
+#endif
     ABTI_pool *p_newpool;
     int abt_errno = ABTI_pool_create_basic(kind, access, automatic, &p_newpool);
     ABTI_CHECK_ERROR(abt_errno);
@@ -761,7 +769,9 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
     /* Mark the scheduler as it is used in pool */
+#ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_INV_SCHED);
+#endif
     p_sched->used = ABTI_SCHED_IN_POOL;
 
 #ifndef ABT_CONFIG_ENABLE_VER_20_API

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -876,7 +876,9 @@ void ABTI_pool_free(ABTI_pool *p_pool)
 {
     LOG_DEBUG("[P%" PRIu64 "] freed\n", p_pool->id);
     ABT_pool h_pool = ABTI_pool_get_handle(p_pool);
-    p_pool->p_free(h_pool);
+    if (p_pool->p_free) {
+        p_pool->p_free(h_pool);
+    }
     ABTU_free(p_pool);
 }
 

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -14,19 +14,60 @@ ABTU_ret_err static int pool_create(ABT_pool_def *def, ABT_pool_config config,
 
 /**
  * @ingroup POOL
- * @brief   Create a new pool and return its handle through \c newpool.
+ * @brief   Create a new pool.
  *
- * This function creates a new pool, given by a definition (\c def) and a
- * configuration (\c config). The configuration can be \c ABT_SCHED_CONFIG_NULL
- * or obtained from a specific function of the pool defined by \c def. The
- * configuration will be passed as the parameter of the initialization function
- * of the pool.
+ * \c ABT_pool_create() creates a new pool, given by the pool definition
+ * (\c def) and a pool configuration (\c config), and returns its handle through
+ * \c newpool.  If \c p_init is not \c NULL, this routine calls \c p_init() with
+ * \c newpool as the first argument and \c config as the second argument.  This
+ * routine returns an error returned by \c p_init() if \c p_init() does not
+ * return \c ABT_SUCCESS.
  *
- * @param[in]  def     definition required for pool creation
- * @param[in]  config  specific config used during the pool creation
- * @param[out] newpool handle to a new pool
+ * The user can pass \c ABT_POOL_CONFIG_NULL as \c config.  The configuration is
+ * passed as the parameter of the initialization function of the pool.
+ *
+ * \c def must define all the non-optional functions.  See \c #ABT_pool_def for
+ * details.
+ *
+ * The caller of each pool function is undefined, so a program that relies on
+ * the caller of pool functions is non-conforming.
+ *
+ * @note
+ * Specifically, any explicit or implicit context-switching operation in a pool
+ * function may cause undefined behavior.
+ *
+ * This routine copies \c def and \c config, so the user can free \c def and
+ * \c config after this routine returns.
+ *
+ * The created pool is not automatically freed, so \c newpool must be freed by
+ * \c ABT_pool_free() after its use unless \c newpool is associated with the
+ * main scheduler of the primary execution stream.
+ *
+ * @note
+ * \DOC_NOTE_EFFECT_ABT_FINALIZE
+ *
+ * @changev20
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c newpool, \c ABT_POOL_NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_USR_POOL_INIT{\c p_init()}
+ * \DOC_ERROR_RESOURCE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c def}
+ * \DOC_UNDEFINED_NULL_PTR{any non-optional pool function of \c def}
+ * \DOC_UNDEFINED_NULL_PTR{\c newpool}
+ *
+ * @param[in]  def      pool definition required for pool creation
+ * @param[in]  config   pool configuration for pool creation
+ * @param[out] newpool  pool handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
                     ABT_pool *newpool)
@@ -41,17 +82,60 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
 
 /**
  * @ingroup POOL
- * @brief   Create a new pool from a predefined type and return its handle
- *          through \c newpool.
+ * @brief   Create a new pool from a predefined type.
  *
- * For more details see \c ABT_pool_create().
+ * \c ABT_pool_create_basic() creates a new pool, given by the pool type
+ * \c kind, the access type \c access, and the automatic flag \c automatic, and
+ * returns its handle through \c newpool.
  *
- * @param[in]  kind      name of the predefined pool
- * @param[in]  access    access type of the predefined pool
- * @param[in]  automatic ABT_TRUE if the pool should be automatically freed
- * @param[out] newpool   handle to a new pool
+ * \c kind specifies the implementation of \c newpool.  See \c #ABT_pool_kind
+ * for details of predefined pools.
+ *
+ * \c access hints at the usage of the created pool.  Argobots may choose an
+ * optimized implementation for a pool with a more restricted access type
+ * (\c #ABT_POOL_ACCESS_PRIV is the most strict access type).  See
+ * \c #ABT_pool_access for details.
+ *
+ * If \c automatic is \c ABT_FALSE, \c newpool is not automatically freed, so
+ * \c newpool must be freed by \c ABT_pool_free() after its use unless
+ * \c newpool is associated with the main scheduler of the primary execution
+ * stream.
+ *
+ * @note
+ * \DOC_NOTE_EFFECT_ABT_FINALIZE
+ *
+ * If \c automatic is \c ABT_TRUE, \c newpool is automatically freed when all
+ * the schedulers associated with \c newpool are freed.  If the user does not
+ * associate \c newpool with a scheduler, the user needs to manually free
+ * \c newpool regardless of \c automatic.
+ *
+ * @changev11
+ * \DOC_DESC_V10_POOL_NOACCESS
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c newpool, \c ABT_POOL_NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_KIND{\c kind}
+ * \DOC_ERROR_INV_POOL_ACCESS{\c access}
+ * \DOC_ERROR_RESOURCE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_BOOL{automatic}
+ * \DOC_UNDEFINED_NULL_PTR{\c newpool}
+ *
+ * @param[in]  kind       type of the predefined pool
+ * @param[in]  access     access type of the predefined pool
+ * @param[in]  automatic  \c ABT_TRUE if the pool should be automatically freed
+ * @param[out] newpool    pool handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
                           ABT_bool automatic, ABT_pool *newpool)
@@ -66,11 +150,32 @@ int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
 
 /**
  * @ingroup POOL
- * @brief   Free the given pool, and modify its value to ABT_POOL_NULL
+ * @brief   Free a pool.
  *
- * @param[inout] pool handle
+ * \c ABT_pool_free() frees the resource used for the pool \c pool and sets
+ * \c pool to \c ABT_POOL_NULL.  If \c pool is created by \c ABT_pool_create()
+ * and \c p_free is not \c NULL, this routine calls \c p_free() with \c pool as
+ * the argument.  The return value of \c p_free() is ignored.  Afterward, this
+ * routine deallocates the resource used for \c pool and sets \c pool to
+ * \c ABT_POOL_NULL.
+ *
+ * \c pool must be empty and no work unit may be associated with \c pool.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_PTR{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c pool}
+ * \DOC_UNDEFINED_POOL_FREE{\c pool}
+ * \DOC_UNDEFINED_THREAD_UNSAFE_FREE{\c pool}
+ *
+ * @param[in,out] pool  pool handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_free(ABT_pool *pool)
 {
@@ -87,12 +192,25 @@ int ABT_pool_free(ABT_pool *pool)
 
 /**
  * @ingroup POOL
- * @brief   Get the access type of target pool
+ * @brief   Get an access type of a pool.
  *
- * @param[in]  pool    handle to the pool
+ * \c ABT_pool_get_access() returns the access type of the pool \c pool through
+ * \c access.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c access}
+ *
+ * @param[in]  pool    pool handle
  * @param[out] access  access type
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 {
@@ -105,16 +223,41 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 
 /**
  * @ingroup POOL
- * @brief   Return the total size of a pool
+ * @brief   Get the total size of a pool.
  *
- * The returned size is the number of elements in the pool (provided by the
- * specific function in case of a user-defined pool), plus the number of
- * blocked ULTs and migrating ULTs.
+ * \c ABT_pool_get_total_size() returns the total size of the pool \c pool
+ * through \c size.
  *
- * @param[in] pool handle to the pool
- * @param[out] size size of the pool
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine sets \c size to the sum of a value returned by \c p_get_size()
+ *   called with \c pool as its argument and the number of blocking and
+ *   migrating work units that are associated with \c pool.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine sets \c size to the sum of the number of work units including
+ *   in \c pool and the number of blocking or migrating work units associated
+ *   with \c pool.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ * @endchangev11
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c size}
+ *
+ * @param[in]  pool  pool handle
+ * @param[out] size  total size of \c pool
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 {
@@ -127,15 +270,37 @@ int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 
 /**
  * @ingroup POOL
- * @brief   Return the size of a pool
+ * @brief   Get the size of a pool.
  *
- * The returned size is the number of elements in the pool (provided by the
- * specific function in case of a user-defined pool).
+ * \c ABT_pool_get_size() returns the size of the pool \c pool through \c size.
  *
- * @param[in] pool handle to the pool
- * @param[out] size size of the pool
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine sets \c size to a value returned by \c p_get_size() called
+ *   with \c pool as its argument.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine sets \c size to the number of work units in \c pool.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ * @endchangev11
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c size}
+ *
+ * @param[in]  pool  pool handle
+ * @param[out] size  size of \c pool
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_get_size(ABT_pool pool, size_t *size)
 {
@@ -148,12 +313,48 @@ int ABT_pool_get_size(ABT_pool pool, size_t *size)
 
 /**
  * @ingroup POOL
- * @brief   Pop a unit from the target pool
+ * @brief   Pop a work unit from a pool.
  *
- * @param[in] pool handle to the pool
- * @param[out] p_unit handle to the unit
+ * \c ABT_pool_pop() pops a work unit from the pool \c pool and sets it to
+ * \c p_unit.
+ *
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine sets \c p_unit to a value returned by \c p_pop() called with
+ *   \c pool as its argument.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine tries to pop a work unit from \c pool.  If this routine
+ *   successfully pops a work unit, this routine sets \c p_unit to the obtained
+ *   handle of \c ABT_unit.  Otherwise, this routine sets \c ABT_UNIT_NULL to
+ *   \c p_unit.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ *
+ * \DOC_DESC_V10_NOEXT{\c ABT_ERR_INV_XSTREAM}
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c p_unit, \c ABT_UNIT_NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c p_unit}
+ *
+ * @param[in]  pool    pool handle
+ * @param[out] p_unit  unit handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 {
@@ -166,23 +367,52 @@ int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 
 /**
  * @ingroup POOL
- * @brief   Pop a unit from the target pool with wait
+ * @brief   Pop a unit from a pool with wait.
  *
- * \c ABT_pool_pop_wait pops a unit from a pool \c pool if a unit is in a pool;
- * otherwise, it suspends an underlying execution stream and waits in a pool.
- * \c time_secs directs how long \c ABT_pool_pop_wait suspends the underlying
- * execution stream.  A work unit successfully popped from \c pool is returned
- * via \c p_unit.  If no work unit is available, it returns ABT_UNIT_NULL.
+ * \c ABT_pool_pop_wait() pops a work unit from the pool \c pool and sets it to
+ * \c p_unit.
  *
- * In most cases, \c ABT_pool_pop() is more efficient, but \c ABT_pool_pop_wait
- * is useful in cases where users want to make execution streams active only
- * when is available.
+ * - If \c pool is created by \c ABT_pool_create():
  *
- * @param[in]  pool       handle to the pool
- * @param[out] p_unit     handle to the unit
+ *   This routine sets \c p_unit to a value returned by \c p_pop_wait() called
+ *   with \c pool as its first argument and \c time_sec as the second argument.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine tries to pop a work unit from \c pool.  If \c pool is empty,
+ *   an underlying execution stream or an external thread that calls this
+ *   routine is blocked on \c pool for \c time_sec seconds.  If this routine
+ *   successfully pops a work unit, this routine sets \c p_unit to the obtained
+ *   handle of \c ABT_unit.  Otherwise, this routine sets \c p_unit to
+ *   \c ABT_UNIT_NULL.
+ *
+ * @note
+ * In most cases, \c ABT_pool_pop() is more efficient.  \c ABT_pool_pop_wait()
+ * would be useful in cases where the user wants to make execution streams sleep
+ * when \c pool is empty.
+ *
+ * @changev20
+ * \DOC_DESC_V1X_P_POP_WAIT
+ *
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c p_unit, \c ABT_UNIT_NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c p_pop_wait()}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c p_unit}
+ *
+ * @param[in]  pool       pool handle
+ * @param[out] p_unit     unit handle
  * @param[in]  time_secs  duration of waiting time (seconds)
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
 {
@@ -193,6 +423,62 @@ int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
     return ABT_SUCCESS;
 }
 
+/**
+ * @ingroup POOL
+ * @brief   Pop a unit from a pool with timed wait.
+ *
+ * \c ABT_pool_pop_timedwait() pops a work unit from the pool \c pool and sets
+ * it to \c p_unit.
+ *
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine sets \c p_unit to a value returned by \c p_pop_timedwait()
+ *   called with \c pool as its first argument and \c abstime_sec as the second
+ *   argument.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine tries to pop a work unit from \c pool.  If \c pool is empty,
+ *   an underlying execution stream or an external thread that calls this
+ *   routine is blocked on \c pool until the current time exceeds
+ *   \c abstime_secs.  If this routine successfully pops a work unit, this
+ *   routine sets \c p_unit to the obtained handle of \c ABT_unit.  Otherwise,
+ *   this routine sets \c ABT_UNIT_NULL to \c p_unit.
+ *
+ * @note
+ * \c abstime_secs can be calculated by adding an offset time to a value
+ * returned by \c ABT_get_wtime().
+ *
+ * This routine is deprecated.  The user should use \c ABT_pool_pop_wait()
+ * instead.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ *
+ * \DOC_DESC_V10_NOEXT{\c ABT_ERR_INV_XSTREAM}
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_SET_VALUE_ON_ERROR{\c p_unit, \c ABT_UNIT_NULL}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c p_pop_timedwait()}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c p_unit}
+ *
+ * @param[in]  pool          pool handle
+ * @param[out] p_unit        unit handle
+ * @param[in]  abstime_secs  absolute time for timeout
+ * @return Error code
+ */
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -204,12 +490,41 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 
 /**
  * @ingroup POOL
- * @brief   Push a unit to the target pool
+ * @brief   Push a unit to a pool
  *
- * @param[in] pool handle to the pool
- * @param[in] unit handle to the unit
+ * \c ABT_pool_push() pushes a work unit \c unit to the pool \c pool.
+ *
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine calls \c p_push() with \c pool as its first argument and
+ *   \c unit as the second argument.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine pushes a work unit \c unit to \c pool.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ *
+ * \DOC_DESC_V10_ERROR_CODE_CHANGE{\c ABT_ERR_UNIT, \c ABT_ERR_INV_UNIT,
+ *                                 \c unit is \c ABT_UNIT_NULL}
+ * @endchangev11
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_INV_UNIT_HANDLE{\c unit}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_WORK_UNIT_NOT_ASSOCIATED{\c unit, \c pool}
+ *
+ * @param[in] pool  pool handle
+ * @param[in] unit  unit handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 {
@@ -225,12 +540,43 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 
 /**
  * @ingroup POOL
- * @brief   Remove a specified unit from the target pool
+ * @brief   Remove a specified work unit from a pool
  *
- * @param[in] pool handle to the pool
- * @param[in] unit handle to the unit
+ * \c ABT_pool_remove() removes a work unit \c unit from the pool \c pool.
+ *
+ * - If \c pool is created by \c ABT_pool_create():
+ *
+ *   This routine calls \c p_remove() with \c pool as its first argument and
+ *   \c unit as the second argument.  The return value of \c p_remove() is
+ *   ignored.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine removes a work unit \c unit from the pool \c pool and returns
+ *   \c ABT_SUCCESS.
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ *
+ * \DOC_DESC_V10_NOEXT{\c ABT_ERR_INV_XSTREAM}
+ * @endchangev11
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_INV_UNIT_HANDLE{\c unit}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c p_remove()}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_WORK_UNIT_NOT_IN_POOL{\c pool, \c unit}
+ *
+ * @param[in] pool  pool handle
+ * @param[in] unit  unit handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
 {
@@ -244,22 +590,46 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
 
 /**
  * @ingroup POOL
- * @brief   Apply a print function to every unit in a pool using a user-defined
- *          function.
+ * @brief   Apply a print function to every work unit in a pool using a
+ *          user-defined function.
  *
- * This function applies \c print_fn to every unit in \c pool. As the name of
- * the argument implies, \c print_fn may not have any side effect;
- * \c ABT_pool_print_all() is for the purpose of debugging and profiling.  For
- * example, changing the state of \c ABT_unit in \c print_fn is forbidden.
+ * \c ABT_pool_print_all() calls \c print_fn() for every work unit in the pool
+ * \c pool.
  *
- * When \c pool does not support the print-all feature, ABT_ERR_POOL is
- * returned.
+ * - If \c pool is created by \c ABT_pool_create():
  *
- * @param[in] pool     handle to the pool
- * @param[in] arg      argument passed to \c print_fn
- * @param[in] print_fn user-defined print function
+ *   This routine calls \c p_pop_print() with \c pool as its first argument,
+ *   \c arg as the second argument, and \c print_fn as the third argument  The
+ *   return value of \c p_pop_print() is ignored.
+ *
+ * - If \c pool is created by \c ABT_pool_create_basic():
+ *
+ *   This routine calls \c print_fn() for every work unit in \c pool.
+ *   \c print_fn() is called with \c arg as its first argument and the handle of
+ *   the work unit as the second argument.
+ *
+ * @note
+ * As the name of the argument implies, \c print_fn() may not have any side
+ * effect; \c ABT_pool_print_all() is for debugging and profiling.  For example,
+ * changing the state of \c ABT_unit in \c print_fn() is forbidden.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c p_print_all()}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c print_fn}
+ * \DOC_UNDEFINED_CHANGE_STATE{\c print_fn()}
+ *
+ * @param[in] pool      pool handle
+ * @param[in] arg       argument passed to \c print_fn
+ * @param[in] print_fn  user-defined print function
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_print_all(ABT_pool pool, void *arg,
                        void (*print_fn)(void *, ABT_unit))
@@ -275,15 +645,25 @@ int ABT_pool_print_all(ABT_pool pool, void *arg,
 
 /**
  * @ingroup POOL
- * @brief   Set the specific data of the target user-defined pool
+ * @brief   Set user data in a pool.
  *
- * This function will be called by the user during the initialization of his
- * user-defined pool.
+ * \c ABT_pool_set_data() sets user data of the pool \c pool to \c data.  The
+ * old value is overwritten.
  *
- * @param[in] pool handle to the pool
- * @param[in] data specific data of the pool
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{\c pool}
+ *
+ * @param[in]  pool  pool handle
+ * @param[in]  data  user data in \c pool
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_set_data(ABT_pool pool, void *data)
 {
@@ -296,15 +676,27 @@ int ABT_pool_set_data(ABT_pool pool, void *data)
 
 /**
  * @ingroup POOL
- * @brief   Retrieve the specific data of the target user-defined pool
+ * @brief   Retrieve user data from a pool
  *
- * This function will be called by the user in a user-defined function of his
- * user-defined pool.
+ * \c ABT_pool_set_data() returns user data in the pool \c pool through \c data.
  *
- * @param[in] pool handle to the pool
- * @param[in] data specific data of the pool
+ * @note
+ * The specific data of the newly created pool is \c NULL.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c data}
+ *
+ * @param[in]  pool  pool handle
+ * @param[out] data  user data in \c pool
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_get_data(ABT_pool pool, void **data)
 {
@@ -317,21 +709,46 @@ int ABT_pool_get_data(ABT_pool pool, void **data)
 
 /**
  * @ingroup POOL
- * @brief   Push a scheduler to a pool
+ * @brief   Create a new work unit associated with a scheduler and push it to a
+ *          pool
  *
- * By pushing a scheduler, the user can change the running scheduler: when the
- * top scheduler (the running scheduler) will pick it from the pool and run it,
- * it will become the new scheduler. This new scheduler will be in charge until
- * it explicitly yields, except if ABT_sched_finish() or ABT_sched_exit() are
- * called.
+ * ABT_pool_add_sched() creates a work unit that works as a scheduler \c sched
+ * and pushes the newly created work unit to \c pool.  See \c ABT_pool_push()
+ * for the push operation.  The created work unit is automatically freed when it
+ * finishes its scheduling function.
  *
- * The scheduler should have been created by ABT_sched_create or
- * ABT_sched_create_basic.
+ * While the created work unit is using \c sched, the user may not free
+ * \c sched.  Associating \c sched with more than one work unit causes undefined
+ * behavior.
  *
- * @param[in] pool handle to the pool
- * @param[in] sched handle to the sched
+ * \c sched should have been created by \c ABT_sched_create() or
+ * \c ABT_sched_create_basic().
+ *
+ * @changev11
+ * \DOC_DESC_V10_ACCESS_VIOLATION
+ * @endchangev11
+ *
+ * @changev20
+ * \DOC_DESC_V1X_PREMATURE_SCHED_USED_CHECK{\c sched, \c ABT_ERR_INV_SCHED}
+ * @endchangev20
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_INV_SCHED_HANDLE{\c sched}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_V1X \DOC_ERROR_SCHED_USED{\c sched, \c ABT_ERR_INV_SCHED}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_V20 \DOC_UNDEFINED_SCHED_USED{\c sched}
+ *
+ * @param[in] pool   pool handle
+ * @param[in] sched  scheduler handle
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 {
@@ -358,14 +775,24 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 
 /**
  * @ingroup POOL
- * @brief   Get the ID of the target pool
+ * @brief   Get ID of a pool
  *
- * \c ABT_pool_get_id() returns the ID of \c pool.
+ * \c ABT_pool_get_id() returns the ID of the pool \c pool through \c id.
  *
- * @param[in]  pool  handle to the target pool
- * @param[out] id    pool id
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c id}
+ *
+ * @param[in]  pool  pool handle
+ * @param[out] id    pool ID
  * @return Error code
- * @retval ABT_SUCCESS on success
  */
 int ABT_pool_get_id(ABT_pool pool, int *id)
 {

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -79,12 +79,10 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     /* Copy def */
     ABTI_pool_def internal_def;
 
-    internal_def.u_get_type = def->u_get_type;
+    internal_def.access = def->access;
     internal_def.u_get_thread = def->u_get_thread;
-    internal_def.u_get_task = def->u_get_task;
     internal_def.u_is_in_pool = def->u_is_in_pool;
     internal_def.u_create_from_thread = def->u_create_from_thread;
-    internal_def.u_create_from_task = def->u_create_from_task;
     internal_def.u_free = def->u_free;
     internal_def.p_init = def->p_init;
     internal_def.p_get_size = def->p_get_size;
@@ -959,12 +957,9 @@ ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
     p_pool->data = NULL;
 
     /* Set up the pool functions from def */
-    p_pool->u_get_type = def->u_get_type;
     p_pool->u_get_thread = def->u_get_thread;
-    p_pool->u_get_task = def->u_get_task;
     p_pool->u_is_in_pool = def->u_is_in_pool;
     p_pool->u_create_from_thread = def->u_create_from_thread;
-    p_pool->u_create_from_task = def->u_create_from_task;
     p_pool->u_free = def->u_free;
     p_pool->p_init = def->p_init;
     p_pool->p_get_size = def->p_get_size;

--- a/src/stream.c
+++ b/src/stream.c
@@ -904,19 +904,16 @@ void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
 void ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
                            ABTI_pool *p_pool)
 {
-    ABT_unit_type type = p_pool->u_get_type(unit);
+    ABT_thread thread = p_pool->u_get_thread(unit);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
 
-    if (type == ABT_UNIT_TYPE_THREAD) {
-        ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_ythread *p_ythread = ABTI_ythread_get_ptr(thread);
-        /* Switch the context */
+    if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
+        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
+        /* Execute a ULT */
         xstream_schedule_ythread(pp_local_xstream, p_ythread);
     } else {
-        ABTI_ASSERT(type == ABT_UNIT_TYPE_TASK);
-        ABT_task task = p_pool->u_get_task(unit);
-        ABTI_thread *p_task = ABTI_thread_get_ptr(task);
-        /* Execute the task */
-        xstream_schedule_task(*pp_local_xstream, p_task);
+        /* Execute a tasklet */
+        xstream_schedule_task(*pp_local_xstream, p_thread);
     }
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -476,7 +476,7 @@ ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     thread_type |= ABTI_THREAD_TYPE_MIGRATABLE;
 #endif
     p_newtask->type |= thread_type;
-    p_newtask->unit = p_pool->u_create_from_task(h_newtask);
+    p_newtask->unit = p_pool->u_create_from_thread(h_newtask);
 
     ABTI_tool_event_thread_create(p_local, p_newtask,
                                   ABTI_local_get_xstream_or_null(p_local)

--- a/src/thread.c
+++ b/src/thread.c
@@ -654,6 +654,9 @@ int ABT_thread_yield_to(ABT_thread thread)
                         ABT_ERR_INV_THREAD,
                         "The target thread's pool is not the same as mine.");
 
+    ABTI_CHECK_TRUE(p_tar_ythread->thread.p_pool->u_is_in_pool, ABT_ERR_POOL);
+    ABTI_CHECK_TRUE(p_tar_ythread->thread.p_pool->p_remove, ABT_ERR_POOL);
+
     /* If the target thread is not in READY, we don't yield.  Note that ULT can
      * be regarded as 'ready' only if its state is READY and it has been
      * pushed into a pool. Since we set ULT's state to READY and then push it

--- a/src/thread.c
+++ b/src/thread.c
@@ -1342,13 +1342,8 @@ void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
         p_thread->p_pool = p_pool;
 
         /* Create a wrapper unit */
-        if (p_ythread) {
-            ABT_thread h_thread = ABTI_ythread_get_handle(p_ythread);
-            p_thread->unit = p_pool->u_create_from_thread(h_thread);
-        } else {
-            ABT_task task = ABTI_thread_get_handle(p_thread);
-            p_thread->unit = p_pool->u_create_from_task(task);
-        }
+        ABT_thread h_thread = ABTI_thread_get_handle(p_thread);
+        p_thread->unit = p_pool->u_create_from_thread(h_thread);
     }
 
     if (p_ythread) {

--- a/src/unit.c
+++ b/src/unit.c
@@ -39,17 +39,7 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
 
 void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
 {
-    ABT_unit_type type = p_pool->u_get_type(unit);
-
-    if (type == ABT_UNIT_TYPE_THREAD) {
-        ABT_thread thread = p_pool->u_get_thread(unit);
-        ABTI_ythread *p_thread = ABTI_ythread_get_ptr(thread);
-        p_thread->thread.p_pool = p_pool;
-
-    } else {
-        ABTI_ASSERT(type == ABT_UNIT_TYPE_TASK);
-        ABT_task task = p_pool->u_get_task(unit);
-        ABTI_thread *p_task = ABTI_thread_get_ptr(task);
-        p_task->p_pool = p_pool;
-    }
+    ABT_thread thread = p_pool->u_get_thread(unit);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    p_thread->p_pool = p_pool;
 }


### PR DESCRIPTION
This PR improves the API and its explanation of `ABT_pool_xxx()` functions for the upcoming Argobots 1.1.

The changes of this PR are relatively larger than the others, but this PR does not affect the behavior of a program (much) if a program does not use user-defined pools. In other words, unless your program uses `ABT_pool_create()` (*not `ABT_pool_create_basic()`*), these API changes are almost negligible.

### User-defined pools
- `ABT_pool_access`: the Argobots runtime uses access only to determine the pool implementation.

  It has been already removed by #239, but this change will be applied to Argobots 1.1. The user needs to be responsible for pool access management.
- `ABT_pool_def`: `u_get_type()`, `u_create_from_task()`, and `ABT_unit_get_task_fn` are unused. Instead, `u_create_from_thread()` is used for tasklets.

  All units including both ULTs and tasklets are created by `u_create_from_thread()`. This makes the implementation of the user-defined pool much easier since the user does not need to return a type of a work unit from `ABT_unit`, which requires a hash table.

### Others
- `ABT_pool_pop()`, `ABT_pool_pop_timedwait()`, and `ABT_pool_remove()`: calling these functions on an external thread is allowed.

  There is no reason to prohibit it. Argobots 1.1 allows it.

- `ABT_pool_push()`: `ABT_ERR_INV_UNIT` is returned instead of `ABT_ERR_UNIT` if `ABT_UNIT_NULL` is passed.

  This change makes a returned error more consistent.
