### PR TITLE
sync: ULTs should not yield if there is no contention

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1820,6 +1820,8 @@ ALIASES += DOC_CONTEXT_ANY="This routine can be called in any execution context.
 
 ALIASES += DOC_CONTEXT_CTXSWITCH="This routine may perform context switching for the calling ULT."
 
+ALIASES += DOC_CONTEXT_CTXSWITCH_CONDITIONAL{1}="This routine may perform context switching for the calling ULT if \1.  Otherwise, this routine does not context switch the calling ULT unless any user-defined function that is involved in this routine performs context switching."
+
 ALIASES += DOC_CONTEXT_FINALIZE="This routine must be called by the same caller of \c ABT_init() at the same nesting level."
 
 ALIASES += DOC_CONTEXT_INIT="This routine can be called in any execution context. Argobots must be initialized."

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -170,8 +170,10 @@ int ABT_barrier_free(ABT_barrier *barrier)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{the
+ * caller is not the last waiter that waits on \c barrier}\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{the caller is
+ * not the last waiter that waits on \c barrier}
  *
  * @errors
  * \DOC_ERROR_SUCCESS

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -142,8 +142,10 @@ int ABT_eventual_free(ABT_eventual *eventual)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{
+ * \c eventual is not ready}\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c eventual is
+ *                                                               not ready}
  *
  * @errors
  * \DOC_ERROR_SUCCESS

--- a/src/futures.c
+++ b/src/futures.c
@@ -145,8 +145,10 @@ int ABT_future_free(ABT_future *future)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{
+ * \c future is not ready}\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c future is
+ *                                                               not ready}
  *
  * @errors
  * \DOC_ERROR_SUCCESS

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -166,7 +166,8 @@ int ABT_mutex_free(ABT_mutex *mutex)
  * unlocked as many times as the level of ownership.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -202,7 +203,8 @@ int ABT_mutex_lock(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -238,7 +240,8 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -350,7 +353,8 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
  * be the same as that of the corresponding locking function.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                      \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -394,7 +398,8 @@ int ABT_mutex_unlock(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                      \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -438,7 +443,8 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                      \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -118,8 +118,10 @@ int ABT_rwlock_free(ABT_rwlock *rwlock)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{
+ * \c rwlock is locked by a writer}\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{
+ * \c rwlock is locked by a writer}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -177,8 +179,10 @@ int ABT_rwlock_rdlock(ABT_rwlock rwlock)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{
+ * \c rwlock is locked}\n
+ * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c rwlock is
+ *                                                               locked}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -228,7 +232,8 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
  * \c ABT_rwlock_unlock() unlocks the readers-writer lock \c rwlock.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                      \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -36,6 +36,7 @@ basic/sched_set_main
 basic/sched_stack
 basic/sched_config
 basic/sched_user_ws
+basic/sync_no_contention
 basic/main_sched
 basic/mutex
 basic/mutex_prio

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -41,6 +41,7 @@ TESTS = \
 	sched_stack \
 	sched_config \
 	sched_user_ws \
+	sync_no_contention \
 	main_sched \
 	mutex \
 	mutex_prio \
@@ -118,6 +119,7 @@ sched_set_main_SOURCES = sched_set_main.c
 sched_stack_SOURCES = sched_stack.c
 sched_config_SOURCES = sched_config.c
 sched_user_ws_SOURCES = sched_user_ws.c
+sync_no_contention_SOURCES = sync_no_contention.c
 main_sched_SOURCES = main_sched.c
 mutex_SOURCES = mutex.c
 mutex_prio_SOURCES = mutex_prio.c
@@ -183,6 +185,7 @@ testing:
 	./sched_stack
 	./sched_config
 	./sched_user_ws
+	./sync_no_contention
 	./main_sched
 	./mutex
 	./mutex_prio

--- a/test/basic/sync_no_contention.c
+++ b/test/basic/sync_no_contention.c
@@ -1,0 +1,297 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define NUM_REPETITIONS 1000
+
+int g_should_not_run_before_yield_flag = 0;
+void should_not_run_before_yield(void *arg)
+{
+    g_should_not_run_before_yield_flag++;
+}
+
+int g_set_barrier = 0;
+void set_barrier(void *arg)
+{
+    ABT_barrier barrier = (ABT_barrier)arg;
+    g_set_barrier = 1;
+    ABT_barrier_wait(barrier);
+}
+
+int main(int argc, char *argv[])
+{
+    int ret, i, j, lock_i, unlock_i;
+    ABT_thread evil_thread;
+    ABT_xstream xstream;
+    ABT_pool pool;
+
+    ATS_init(argc, argv, 1);
+
+    ret = ABT_xstream_self(&xstream);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    /* Case: barrier (num_waiters = 1) */
+    {
+        ABT_barrier barrier;
+
+        ret = ABT_barrier_create(1, &barrier);
+        ATS_ERROR(ret, "ABT_barrier_create");
+        ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                ABT_THREAD_ATTR_NULL, &evil_thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+
+        /* No yield is allowed. */
+        g_should_not_run_before_yield_flag = 0;
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            ret = ABT_barrier_wait(barrier);
+            ATS_ERROR(ret, "ABT_barrier_wait");
+        }
+        assert(g_should_not_run_before_yield_flag == 0);
+
+        ret = ABT_thread_free(&evil_thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_barrier_free(&barrier);
+        ATS_ERROR(ret, "ABT_barrier_free");
+    }
+
+    /* Case: barrier (num_waiters = 2) */
+    {
+        ABT_barrier barrier;
+        ABT_thread barrier_thread;
+
+        ret = ABT_barrier_create(2, &barrier);
+        ATS_ERROR(ret, "ABT_barrier_create");
+
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            ret = ABT_thread_create(pool, set_barrier, (void *)barrier,
+                                    ABT_THREAD_ATTR_NULL, &barrier_thread);
+            ATS_ERROR(ret, "ABT_thread_create");
+            g_set_barrier = 0;
+            while (g_set_barrier == 0) {
+                ret = ABT_thread_yield();
+                ATS_ERROR(ret, "ABT_thread_yield");
+            }
+            ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                    ABT_THREAD_ATTR_NULL, &evil_thread);
+            ATS_ERROR(ret, "ABT_thread_create");
+
+            /* No yield is allowed. */
+            g_should_not_run_before_yield_flag = 0;
+            ret = ABT_barrier_wait(barrier);
+            ATS_ERROR(ret, "ABT_barrier_wait");
+            assert(g_should_not_run_before_yield_flag == 0);
+
+            ret = ABT_thread_free(&barrier_thread);
+            ATS_ERROR(ret, "ABT_thread_free");
+            ret = ABT_thread_free(&evil_thread);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+
+        ret = ABT_barrier_free(&barrier);
+        ATS_ERROR(ret, "ABT_barrier_free");
+    }
+
+    /* Case: future */
+    {
+        ABT_future future;
+
+        ret = ABT_future_create(1, NULL, &future);
+        ATS_ERROR(ret, "ABT_future_create");
+        ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                ABT_THREAD_ATTR_NULL, &evil_thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+
+        /* No yield is allowed. */
+        g_should_not_run_before_yield_flag = 0;
+        ret = ABT_future_set(future, NULL);
+        ATS_ERROR(ret, "ABT_future_set");
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            ret = ABT_future_wait(future);
+            ATS_ERROR(ret, "ABT_future_wait");
+        }
+        assert(g_should_not_run_before_yield_flag == 0);
+
+        ret = ABT_thread_free(&evil_thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_future_free(&future);
+        ATS_ERROR(ret, "ABT_future_free");
+    }
+
+    /* Case: eventual */
+    {
+        ABT_eventual eventual;
+
+        ret = ABT_eventual_create(0, &eventual);
+        ATS_ERROR(ret, "ABT_eventual_create");
+        ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                ABT_THREAD_ATTR_NULL, &evil_thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+
+        /* No yield is allowed. */
+        g_should_not_run_before_yield_flag = 0;
+        ret = ABT_eventual_set(eventual, NULL, 0);
+        ATS_ERROR(ret, "ABT_eventual_set");
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            ret = ABT_eventual_wait(eventual, NULL);
+            ATS_ERROR(ret, "ABT_eventual_wait");
+        }
+        assert(g_should_not_run_before_yield_flag == 0);
+
+        ret = ABT_thread_free(&evil_thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_eventual_free(&eventual);
+        ATS_ERROR(ret, "ABT_eventual_free");
+    }
+
+    typedef int (*mutex_lock_f)(ABT_mutex);
+    typedef int (*mutex_unlock_f)(ABT_mutex);
+
+    mutex_lock_f mutex_lock_fs[] = { ABT_mutex_lock, ABT_mutex_lock_low,
+                                     ABT_mutex_lock_high, ABT_mutex_spinlock,
+                                     ABT_mutex_trylock };
+    mutex_unlock_f mutex_unlock_fs[] = { ABT_mutex_unlock, ABT_mutex_unlock_se,
+                                         ABT_mutex_unlock_de };
+
+    /* Case: mutex (non-recursive) */
+    for (lock_i = 0;
+         lock_i < (int)(sizeof(mutex_lock_fs) / sizeof(mutex_lock_fs[0]));
+         lock_i++) {
+        for (unlock_i = 0; unlock_i < (int)(sizeof(mutex_unlock_fs) /
+                                            sizeof(mutex_unlock_fs[0]));
+             unlock_i++) {
+            ABT_mutex mutex;
+
+            ret = ABT_mutex_create(&mutex);
+            ATS_ERROR(ret, "ABT_mutex_create");
+            ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                    ABT_THREAD_ATTR_NULL, &evil_thread);
+            ATS_ERROR(ret, "ABT_thread_create");
+
+            /* No yield is allowed. */
+            g_should_not_run_before_yield_flag = 0;
+            for (i = 0; i < NUM_REPETITIONS; i++) {
+                ret = mutex_lock_fs[lock_i](mutex);
+                ATS_ERROR(ret, "ABT_mutex_lock_xxx");
+                ret = mutex_unlock_fs[unlock_i](mutex);
+                ATS_ERROR(ret, "ABT_mutex_unlock_xxx");
+            }
+            assert(g_should_not_run_before_yield_flag == 0);
+
+            ret = ABT_thread_free(&evil_thread);
+            ATS_ERROR(ret, "ABT_thread_free");
+            ret = ABT_mutex_free(&mutex);
+            ATS_ERROR(ret, "ABT_mutex_free");
+        }
+    }
+
+    /* Case: mutex (recursive) */
+    for (lock_i = 0;
+         lock_i < (int)(sizeof(mutex_lock_fs) / sizeof(mutex_lock_fs[0]));
+         lock_i++) {
+        for (unlock_i = 0; unlock_i < (int)(sizeof(mutex_unlock_fs) /
+                                            sizeof(mutex_unlock_fs[0]));
+             unlock_i++) {
+            ABT_mutex mutex;
+            ABT_mutex_attr mutex_attr;
+
+            ret = ABT_mutex_attr_create(&mutex_attr);
+            ATS_ERROR(ret, "ABT_mutex_attr_create");
+            ret = ABT_mutex_attr_set_recursive(mutex_attr, ABT_TRUE);
+            ATS_ERROR(ret, "ABT_mutex_attr_set_recursive");
+            ret = ABT_mutex_create_with_attr(mutex_attr, &mutex);
+            ATS_ERROR(ret, "ABT_mutex_create_with_attr");
+            ret = ABT_mutex_attr_free(&mutex_attr);
+            ATS_ERROR(ret, "ABT_mutex_attr_free");
+            ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                    ABT_THREAD_ATTR_NULL, &evil_thread);
+            ATS_ERROR(ret, "ABT_thread_create");
+
+            /* No yield is allowed. */
+            g_should_not_run_before_yield_flag = 0;
+            for (i = 0; i < NUM_REPETITIONS; i++) {
+                /* This lock is recursive. */
+                for (j = 0; j < 10; j++) {
+                    ret = mutex_lock_fs[lock_i](mutex);
+                    ATS_ERROR(ret, "ABT_mutex_lock_xxx");
+                }
+                for (j = 0; j < 10; j++) {
+                    ret = mutex_unlock_fs[unlock_i](mutex);
+                    ATS_ERROR(ret, "ABT_mutex_unlock_xxx");
+                }
+            }
+            assert(g_should_not_run_before_yield_flag == 0);
+
+            ret = ABT_thread_free(&evil_thread);
+            ATS_ERROR(ret, "ABT_thread_free");
+            ret = ABT_mutex_free(&mutex);
+            ATS_ERROR(ret, "ABT_mutex_free");
+        }
+    }
+    /* Case: rwlock (readers' lock) */
+    {
+        ABT_rwlock rwlock;
+
+        ret = ABT_rwlock_create(&rwlock);
+        ATS_ERROR(ret, "ABT_rwlock_create");
+        ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                ABT_THREAD_ATTR_NULL, &evil_thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+
+        /* No yield is allowed. */
+        g_should_not_run_before_yield_flag = 0;
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            for (j = 0; j < 10; j++) {
+                ret = ABT_rwlock_rdlock(rwlock);
+                ATS_ERROR(ret, "ABT_rwlock_rdlock");
+            }
+            for (j = 0; j < 10; j++) {
+                ret = ABT_rwlock_unlock(rwlock);
+                ATS_ERROR(ret, "ABT_rwlock_unlock");
+            }
+        }
+        assert(g_should_not_run_before_yield_flag == 0);
+
+        ret = ABT_thread_free(&evil_thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_rwlock_free(&rwlock);
+        ATS_ERROR(ret, "ABT_rwlock_free");
+    }
+
+    /* Case: rwlock (writer's lock) */
+    {
+        ABT_rwlock rwlock;
+
+        ret = ABT_rwlock_create(&rwlock);
+        ATS_ERROR(ret, "ABT_rwlock_create");
+        ret = ABT_thread_create(pool, should_not_run_before_yield, NULL,
+                                ABT_THREAD_ATTR_NULL, &evil_thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+
+        /* No yield is allowed. */
+        g_should_not_run_before_yield_flag = 0;
+        for (i = 0; i < NUM_REPETITIONS; i++) {
+            ret = ABT_rwlock_wrlock(rwlock);
+            ATS_ERROR(ret, "ABT_rwlock_rdlock");
+            ret = ABT_rwlock_unlock(rwlock);
+            ATS_ERROR(ret, "ABT_rwlock_unlock");
+        }
+        assert(g_should_not_run_before_yield_flag == 0);
+
+        ret = ABT_thread_free(&evil_thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_rwlock_free(&rwlock);
+        ATS_ERROR(ret, "ABT_rwlock_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+    return ret;
+}


### PR DESCRIPTION
This PR addresses the issue #287 from both documentation and implementation perspectives.
A ULT may yield when it tries to take a lock but that lock is already locked by another work unit, but otherwise a ULT should not yield -- this behavior is natural and intuitive. Since some users rely on this behavior, we should clarify this behavior in the function description. This PR also adds a test to examine this behavior.

At this point, this patch itself does not change the existing Argobots implementation since it satisfies this behavior.
