### PR TITLE
test/basic/thread_attr: increase the stack size

### DIFF
--- a/test/basic/thread_attr.c
+++ b/test/basic/thread_attr.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     /* ULT attribute */
     ret = ABT_thread_attr_create(&attr);
     ATS_ERROR(ret, "ABT_thread_attr_create");
-    ABT_thread_attr_set_stacksize(attr, 8192);
+    ABT_thread_attr_set_stacksize(attr, 262144);
 
     /* Create threads */
     for (i = 0; i < num_xstreams; i++) {


### PR DESCRIPTION
It seems that 8 KB ULT stack used in `test/basic/thread_attr.c` is too little on some platforms.  As far as I checked, 32-bit CentOS + clang 3.4.2 + some debugging options can sometimes cause SEGV because of stack overflow when `ABT_thread_get_attr()` is called in a ULT if (seemingly) the underlying execution stream has not executed `posix_memalign()` before and thus `posix_memalign()` internally called by `ABT_thread_get_attr()` takes a slow and deep execution path. I checked the function stack and `$esp`.

In any case, this SEGV is annoying and should be fixed.  This patch increases the size to 262144.

Note that the stack canary (#293) could not detect this issue since SEGV occurred first.  We need a page protection mechanism for debugging (though it is complicated and potentially heavier).
