### PR TITLE
mutex: add new functions to get a recursive property of a mutex

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1755,6 +1755,7 @@ int ABT_mutex_unlock(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_unlock_se(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_unlock_de(ABT_mutex mutex) ABT_API_PUBLIC;
 int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result) ABT_API_PUBLIC;
+int ABT_mutex_get_attr(ABT_mutex mutex, ABT_mutex_attr *attr) ABT_API_PUBLIC;
 
 /* Mutex Attributes */
 int ABT_mutex_attr_create(ABT_mutex_attr *newattr) ABT_API_PUBLIC;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1760,6 +1760,7 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result) ABT_AP
 int ABT_mutex_attr_create(ABT_mutex_attr *newattr) ABT_API_PUBLIC;
 int ABT_mutex_attr_free(ABT_mutex_attr *attr) ABT_API_PUBLIC;
 int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive) ABT_API_PUBLIC;
+int ABT_mutex_attr_get_recursive(ABT_mutex_attr attr, ABT_bool *recursive) ABT_API_PUBLIC;
 
 /* Condition variable */
 int ABT_cond_create(ABT_cond *newcond) ABT_API_PUBLIC;

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -501,3 +501,48 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
     *result = (p_mutex1 == p_mutex2) ? ABT_TRUE : ABT_FALSE;
     return ABT_SUCCESS;
 }
+
+/**
+ * @ingroup MUTEX
+ * @brief   Get attributes of a mutex.
+ *
+ * \c ABT_mutex_get_attr() returns a newly created attribute object that is
+ * copied from the attributes of the mutex \c mutex through \c attr.  Attribute
+ * values of \c attr may be different from those used on the creation of
+ * \c mutex.  Since this routine allocates a mutex attribute object, it is the
+ * user's responsibility to free \c attr after its use.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
+ * \DOC_ERROR_RESOURCE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c attr}
+ *
+ * @param[in]  mutex  mutex handle
+ * @param[out] attr   mutex attribute handle
+ * @return Error code
+ */
+int ABT_mutex_get_attr(ABT_mutex mutex, ABT_mutex_attr *attr)
+{
+    ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
+    ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
+
+    ABTI_mutex_attr *p_newattr;
+    int abt_errno = ABTU_malloc(sizeof(ABTI_mutex_attr), (void **)&p_newattr);
+    ABTI_CHECK_ERROR(abt_errno);
+
+    /* Copy values.  Nesting count must be initialized. */
+    p_newattr->attrs = p_mutex->attr.attrs;
+    p_newattr->nesting_cnt = 0;
+    p_newattr->owner_id = 0;
+
+    /* Return value */
+    *attr = ABTI_mutex_attr_get_handle(p_newattr);
+    return ABT_SUCCESS;
+}

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -126,3 +126,42 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
     }
     return ABT_SUCCESS;
 }
+
+/**
+ * @ingroup MUTEX_ATTR
+ * @brief   Get a recursive property in a mutex attribute.
+ *
+ * \c ABT_mutex_attr_get_recursive() retrieves the recursive property (i.e.,
+ * whether the mutex can be locked multiple times by the same owner or not) in
+ * the mutex attribute \c attr.  If \c attr is configured to be recursive,
+ * \c recursive is set to \c ABT_TRUE.  Otherwise, \c recursive is set to
+ * \c ABT_FALSE.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_MUTEX_ATTR_HANDLE{\c attr}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c recursive}
+ *
+ * @param[in] attr       mutex attribute handle
+ * @param[in] recursive  flag for a recursive locking support
+ * @return Error code
+ */
+int ABT_mutex_attr_get_recursive(ABT_mutex_attr attr, ABT_bool *recursive)
+{
+    ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(attr);
+    ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
+
+    /* Get the value */
+    if (p_attr->attrs & ABTI_MUTEX_ATTR_RECURSIVE) {
+        *recursive = ABT_TRUE;
+    } else {
+        *recursive = ABT_FALSE;
+    }
+    return ABT_SUCCESS;
+}

--- a/test/basic/mutex.c
+++ b/test/basic/mutex.c
@@ -101,6 +101,19 @@ int main(int argc, char *argv[])
     ret = ABT_mutex_create(&mutex);
     ATS_ERROR(ret, "ABT_mutex_create");
 
+    /* The default mutex must not be recursive. */
+    ABT_mutex_attr mutex_attr;
+    ret = ABT_mutex_get_attr(mutex, &mutex_attr);
+    ATS_ERROR(ret, "ABT_mutex_get_attr");
+
+    ABT_bool is_recursive = ABT_TRUE;
+    ret = ABT_mutex_attr_get_recursive(mutex_attr, &is_recursive);
+    ATS_ERROR(ret, "ABT_mutex_attr_get_recursive");
+    assert(is_recursive == ABT_FALSE);
+
+    ret = ABT_mutex_attr_free(&mutex_attr);
+    ATS_ERROR(ret, "ABT_mutex_attr_free");
+
     /* Create ULTs */
     for (i = 0; i < num_xstreams; i++) {
         for (j = 0; j < num_threads; j++) {

--- a/test/basic/mutex_recursive.c
+++ b/test/basic/mutex_recursive.c
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
     ABT_pool *pools;
     ABT_thread **threads;
     thread_arg_t **args;
+    ABT_bool is_recursive;
 
     int i, j;
     int ret, expected;
@@ -81,8 +82,26 @@ int main(int argc, char *argv[])
     ret = ABT_mutex_attr_set_recursive(mattr, ABT_TRUE);
     ATS_ERROR(ret, "ABT_mutex_attr_set_recurvise");
 
+    /* Really recursive? */
+    is_recursive = ABT_FALSE;
+    ret = ABT_mutex_attr_get_recursive(mattr, &is_recursive);
+    ATS_ERROR(ret, "ABT_mutex_attr_get_recursive");
+    assert(is_recursive == ABT_TRUE);
+
     ret = ABT_mutex_create_with_attr(mattr, &g_mutex);
     ATS_ERROR(ret, "ABT_mutex_create_with_attr");
+
+    ret = ABT_mutex_attr_free(&mattr);
+    ATS_ERROR(ret, "ABT_mutex_attr_free");
+
+    /* The created mutex must be recursive.  Check it. */
+    ret = ABT_mutex_get_attr(g_mutex, &mattr);
+    ATS_ERROR(ret, "ABT_mutex_get_attr");
+
+    is_recursive = ABT_FALSE;
+    ret = ABT_mutex_attr_get_recursive(mattr, &is_recursive);
+    ATS_ERROR(ret, "ABT_mutex_attr_get_recursive");
+    assert(is_recursive == ABT_TRUE);
 
     ret = ABT_mutex_attr_free(&mattr);
     ATS_ERROR(ret, "ABT_mutex_attr_free");


### PR DESCRIPTION
This PR adds two new functions, `ABT_mutex_get_attr()` and `ABT_mutex_attr_get_recursive()`, which are useful to get a recursive property of a mutex.

They are implemented for completeness of the API, but these functions are useful for debugging too.
