### PR TITLE
improve support for functions under uninitialized Argobots

### DIFF
--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -55,7 +55,7 @@ void ABTD_env_init(ABTI_global *p_global)
     } else {
         /* By default, we use the CPU affinity */
         p_global->set_affinity = ABT_TRUE;
-        ABTD_affinity_init(env);
+        ABTD_affinity_init(p_global, env);
     }
 
 #ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
@@ -216,7 +216,7 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* Check if the requested allocation method is really possible. */
     if (lp_alloc != ABTI_MEM_LP_MALLOC) {
-        p_global->mem_lp_alloc = ABTI_mem_check_lp_alloc(lp_alloc);
+        p_global->mem_lp_alloc = ABTI_mem_check_lp_alloc(p_global, lp_alloc);
     } else {
         p_global->mem_lp_alloc = lp_alloc;
     }

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -20,6 +20,7 @@ noinst_HEADERS = \
 	include/abti_error.h \
 	include/abti_eventual.h \
 	include/abti_future.h \
+	include/abti_global.h \
 	include/abti_key.h \
 	include/abti_local.h \
 	include/abti_log.h \

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -55,8 +55,8 @@ void ABTD_xstream_context_print(ABTD_xstream_context *p_ctx, FILE *p_os,
                                 int indent);
 
 /* ES Affinity */
-void ABTD_affinity_init(const char *affinity_str);
-void ABTD_affinity_finalize(void);
+void ABTD_affinity_init(ABTI_global *p_global, const char *affinity_str);
+void ABTD_affinity_finalize(ABTI_global *p_global);
 ABTU_ret_err int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,
                                            int max_cpuids, int *cpuids,
                                            int *p_num_cpuids);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -480,14 +480,17 @@ extern ABTI_local_func gp_ABTI_local_func;
 extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 
 /* Execution Stream (ES) */
-ABTU_ret_err int ABTI_xstream_create_primary(ABTI_xstream **pp_xstream);
-void ABTI_xstream_start_primary(ABTI_xstream **pp_local_xstream,
+ABTU_ret_err int ABTI_xstream_create_primary(ABTI_global *p_global,
+                                             ABTI_xstream **pp_xstream);
+void ABTI_xstream_start_primary(ABTI_global *p_global,
+                                ABTI_xstream **pp_local_xstream,
                                 ABTI_xstream *p_xstream,
                                 ABTI_ythread *p_ythread);
-void ABTI_xstream_free(ABTI_local *p_local, ABTI_xstream *p_xstream,
-                       ABT_bool force_free);
+void ABTI_xstream_free(ABTI_global *p_global, ABTI_local *p_local,
+                       ABTI_xstream *p_xstream, ABT_bool force_free);
 void ABTI_xstream_schedule(void *p_arg);
-void ABTI_xstream_run_unit(ABTI_xstream **pp_local_xstream, ABT_unit unit,
+void ABTI_xstream_run_unit(ABTI_global *p_global,
+                           ABTI_xstream **pp_local_xstream, ABT_unit unit,
                            ABTI_pool *p_pool);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
@@ -504,8 +507,8 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
                                          ABT_pool *pools,
                                          ABTI_sched_config *p_config,
                                          ABTI_sched **pp_newsched);
-void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
-                     ABT_bool force_free);
+void ABTI_sched_free(ABTI_global *p_global, ABTI_local *p_local,
+                     ABTI_sched *p_sched, ABT_bool force_free);
 ABTU_ret_err int ABTI_sched_get_migration_pool(ABTI_sched *, ABTI_pool *,
                                                ABTI_pool **);
 ABT_bool ABTI_sched_has_to_stop(ABTI_local **pp_local, ABTI_sched *p_sched);
@@ -537,35 +540,43 @@ void ABTI_pool_reset_id(void);
 void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 
 /* Threads */
-ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_local *p_local,
+ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_global *p_global,
+                                          ABTI_local *p_local,
                                           ABTI_thread *p_thread,
                                           ABTI_thread_mig_data **pp_mig_data);
 void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
                         void (*thread_func)(void *), void *arg,
                         ABTI_thread *p_thread);
 void ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
-void ABTI_thread_free(ABTI_local *p_local, ABTI_thread *p_thread);
+void ABTI_thread_free(ABTI_global *p_global, ABTI_local *p_local,
+                      ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 void ABTI_thread_reset_id(void);
 ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);
 
 /* Yieldable threads */
-ABTU_ret_err int ABTI_ythread_create_root(ABTI_local *p_local,
+ABTU_ret_err int ABTI_ythread_create_root(ABTI_global *p_global,
+                                          ABTI_local *p_local,
                                           ABTI_xstream *p_xstream,
                                           ABTI_ythread **pp_root_ythread);
-ABTU_ret_err int ABTI_ythread_create_primary(ABTI_local *p_local,
+ABTU_ret_err int ABTI_ythread_create_primary(ABTI_global *p_global,
+                                             ABTI_local *p_local,
                                              ABTI_xstream *p_xstream,
                                              ABTI_ythread **p_ythread);
-ABTU_ret_err int ABTI_ythread_create_main_sched(ABTI_local *p_local,
+ABTU_ret_err int ABTI_ythread_create_main_sched(ABTI_global *p_global,
+                                                ABTI_local *p_local,
                                                 ABTI_xstream *p_xstream,
                                                 ABTI_sched *p_sched);
-ABTU_ret_err int ABTI_ythread_create_sched(ABTI_local *p_local,
+ABTU_ret_err int ABTI_ythread_create_sched(ABTI_global *p_global,
+                                           ABTI_local *p_local,
                                            ABTI_pool *p_pool,
                                            ABTI_sched *p_sched);
 ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
                                      ABTI_ythread *p_ythread);
-void ABTI_ythread_free_primary(ABTI_local *p_local, ABTI_ythread *p_ythread);
-void ABTI_ythread_free_root(ABTI_local *p_local, ABTI_ythread *p_ythread);
+void ABTI_ythread_free_primary(ABTI_global *p_global, ABTI_local *p_local,
+                               ABTI_ythread *p_ythread);
+void ABTI_ythread_free_root(ABTI_global *p_global, ABTI_local *p_local,
+                            ABTI_ythread *p_ythread);
 void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);
 void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
                           ABTI_ythread *p_ythread,
@@ -580,10 +591,11 @@ ABTI_thread_attr_dup(const ABTI_thread_attr *p_attr,
                      ABTI_thread_attr **pp_dup_attr) ABTU_ret_err;
 
 /* Key */
-void ABTI_ktable_free(ABTI_local *p_local, ABTI_ktable *p_ktable);
+void ABTI_ktable_free(ABTI_global *p_global, ABTI_local *p_local,
+                      ABTI_ktable *p_ktable);
 
 /* Information */
-void ABTI_info_print_config(FILE *fp);
+void ABTI_info_print_config(ABTI_global *p_global, FILE *fp);
 void ABTI_info_check_print_all_thread_stacks(void);
 
 #include "abti_timer.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -589,6 +589,7 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_timer.h"
 #include "abti_log.h"
 #include "abti_local.h"
+#include "abti_global.h"
 #include "abti_self.h"
 #include "abti_pool.h"
 #include "abti_sched.h"

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -56,12 +56,17 @@
         }                                                                      \
     } while (0)
 
-#define ABTI_SETUP_WITH_INIT_CHECK()                                           \
+#define ABTI_SETUP_GLOBAL(pp_global)                                           \
     do {                                                                       \
+        ABTI_global *p_global_tmp = ABTI_global_get_global_or_null();          \
         if (ABTI_IS_ERROR_CHECK_ENABLED &&                                     \
-            ABTU_unlikely(gp_ABTI_global == NULL)) {                           \
+            ABTU_unlikely(p_global_tmp == NULL)) {                             \
             HANDLE_ERROR_FUNC_WITH_CODE(ABT_ERR_UNINITIALIZED);                \
             return ABT_ERR_UNINITIALIZED;                                      \
+        }                                                                      \
+        ABTI_global **pp_global_tmp = (pp_global);                             \
+        if (pp_global_tmp) {                                                   \
+            *pp_global_tmp = p_global_tmp;                                     \
         }                                                                      \
     } while (0)
 
@@ -104,18 +109,6 @@
         if (pp_ythread_tmp) {                                                  \
             *pp_ythread_tmp = ABTI_thread_get_ythread(p_thread_tmp);           \
         }                                                                      \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(pp_local_xstream)             \
-    do {                                                                       \
-        ABTI_SETUP_WITH_INIT_CHECK();                                          \
-        ABTI_SETUP_LOCAL_XSTREAM(pp_local_xstream);                            \
-    } while (0)
-
-#define ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(pp_local_xstream, pp_ythread) \
-    do {                                                                       \
-        ABTI_SETUP_WITH_INIT_CHECK();                                          \
-        ABTI_SETUP_LOCAL_YTHREAD(pp_local_xstream, pp_ythread);                \
     } while (0)
 
 #define ABTI_HANDLE_ERROR(n)                                                   \

--- a/src/include/abti_global.h
+++ b/src/include/abti_global.h
@@ -1,0 +1,25 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTI_GLOBAL_H_INCLUDED
+#define ABTI_GLOBAL_H_INCLUDED
+
+static inline ABTI_global *ABTI_global_get_global(void)
+{
+    ABTI_ASSERT(gp_ABTI_global);
+    return gp_ABTI_global;
+}
+
+static inline ABTI_global *ABTI_global_get_global_or_null(void)
+{
+    return gp_ABTI_global;
+}
+
+static inline void ABTI_global_set_global(ABTI_global *p_global)
+{
+    gp_ABTI_global = p_global;
+}
+
+#endif /* ABTI_GLOBAL_H_INCLUDED */

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -40,16 +40,17 @@ static inline ABT_sched ABTI_sched_get_handle(ABTI_sched *p_sched)
 
 /* Set `used` of p_sched to NOT_USED and free p_sched if its `automatic` is
  * ABT_TRUE, which means it is safe to free p_sched inside the runtime. */
-static inline void ABTI_sched_discard_and_free(ABTI_local *p_local,
+static inline void ABTI_sched_discard_and_free(ABTI_global *p_global,
+                                               ABTI_local *p_local,
                                                ABTI_sched *p_sched,
                                                ABT_bool force_free)
 {
     p_sched->used = ABTI_SCHED_NOT_USED;
     if (p_sched->automatic == ABT_TRUE || force_free) {
-        ABTI_sched_free(p_local, p_sched, force_free);
+        ABTI_sched_free(p_global, p_local, p_sched, force_free);
     } else {
         /* Threads should be discarded here. */
-        ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
+        ABTI_thread_free(p_global, p_local, &p_sched->p_ythread->thread);
         p_sched->p_ythread = NULL;
     }
 }

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -45,7 +45,8 @@ static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
     return ABTI_pool_get_ptr(pool);
 }
 
-static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
+static inline void ABTI_xstream_terminate_thread(ABTI_global *p_global,
+                                                 ABTI_local *p_local,
                                                  ABTI_thread *p_thread)
 {
     LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n", ABTI_thread_get_id(p_thread),
@@ -53,7 +54,7 @@ static inline void ABTI_xstream_terminate_thread(ABTI_local *p_local,
     if (!(p_thread->type & ABTI_THREAD_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_thread->state,
                                       ABT_THREAD_STATE_TERMINATED);
-        ABTI_thread_free(p_local, p_thread);
+        ABTI_thread_free(p_global, p_local, p_thread);
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
          * because the ULT can be freed on a different ES.  In other words, we

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -51,11 +51,11 @@ ABTI_tool_context_get_handle(ABTI_tool_context *p_tctx)
 #define ABTI_TOOL_EVENT_TAG_DIRTY_BIT ((uint64_t)1 << (uint64_t)(64 - 1))
 
 static inline void
-ABTI_tool_event_thread_update_callback(ABT_tool_thread_callback_fn cb_func,
+ABTI_tool_event_thread_update_callback(ABTI_global *p_global,
+                                       ABT_tool_thread_callback_fn cb_func,
                                        uint64_t event_mask, void *user_arg)
 {
     /* The spinlock is needed to avoid data race between two writers. */
-    ABTI_global *p_global = gp_ABTI_global;
     ABTI_spinlock_acquire(&p_global->tool_writer_lock);
 
     /*

--- a/src/info.c
+++ b/src/info.c
@@ -201,13 +201,14 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
-    ABTI_SETUP_WITH_INIT_CHECK();
+    ABTI_SETUP_GLOBAL(NULL);
 #endif
     switch (query_kind) {
-        case ABT_INFO_QUERY_KIND_ENABLED_DEBUG:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((ABT_bool *)val) = gp_ABTI_global->use_debug;
-            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_DEBUG: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((ABT_bool *)val) = p_global->use_debug;
+        } break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO:
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
             *((ABT_bool *)val) = ABT_TRUE;
@@ -215,10 +216,11 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             *((ABT_bool *)val) = ABT_FALSE;
 #endif
             break;
-        case ABT_INFO_QUERY_KIND_ENABLED_LOG:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((ABT_bool *)val) = gp_ABTI_global->use_logging;
-            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_LOG: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((ABT_bool *)val) = p_global->use_logging;
+        } break;
         case ABT_INFO_QUERY_KIND_ENABLED_VALGRIND:
 #ifdef HAVE_VALGRIND_SUPPORT
             *((ABT_bool *)val) = ABT_TRUE;
@@ -285,34 +287,41 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             *((ABT_bool *)val) = ABT_FALSE;
 #endif
             break;
-        case ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((ABT_bool *)val) = gp_ABTI_global->print_config;
-            break;
-        case ABT_INFO_QUERY_KIND_ENABLED_AFFINITY:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((ABT_bool *)val) = gp_ABTI_global->set_affinity;
-            break;
-        case ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((unsigned int *)val) = gp_ABTI_global->max_xstreams;
-            break;
-        case ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((size_t *)val) = gp_ABTI_global->thread_stacksize;
-            break;
-        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((size_t *)val) = gp_ABTI_global->sched_stacksize;
-            break;
-        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((uint64_t *)val) = gp_ABTI_global->sched_event_freq;
-            break;
-        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC:
-            ABTI_SETUP_WITH_INIT_CHECK();
-            *((uint64_t *)val) = gp_ABTI_global->sched_sleep_nsec;
-            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((ABT_bool *)val) = p_global->print_config;
+        } break;
+        case ABT_INFO_QUERY_KIND_ENABLED_AFFINITY: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((ABT_bool *)val) = p_global->set_affinity;
+        } break;
+        case ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((unsigned int *)val) = p_global->max_xstreams;
+        } break;
+        case ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((size_t *)val) = p_global->thread_stacksize;
+        } break;
+        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((size_t *)val) = p_global->sched_stacksize;
+        } break;
+        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((uint64_t *)val) = p_global->sched_event_freq;
+        } break;
+        case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC: {
+            ABTI_global *p_global;
+            ABTI_SETUP_GLOBAL(&p_global);
+            *((uint64_t *)val) = p_global->sched_sleep_nsec;
+        } break;
         case ABT_INFO_QUERY_KIND_ENABLED_TOOL:
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
             *((ABT_bool *)val) = ABT_TRUE;
@@ -386,16 +395,19 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
  */
 int ABT_info_print_config(FILE *fp)
 {
+    ABTI_global *p_global;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
-    ABTI_SETUP_WITH_INIT_CHECK();
-#endif
-    if (!gp_ABTI_global) {
+    ABTI_SETUP_GLOBAL(&p_global);
+#else
+    p_global = ABTI_global_get_global_or_null();
+    if (!p_global) {
         fprintf(fp, "Argobots is not initialized.\n");
         fflush(fp);
         return ABT_SUCCESS;
     }
-    ABTI_info_print_config(fp);
+#endif
+    ABTI_info_print_config(p_global, fp);
     return ABT_SUCCESS;
 }
 
@@ -430,17 +442,18 @@ int ABT_info_print_config(FILE *fp)
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
+    ABTI_global *p_global;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
-    ABTI_SETUP_WITH_INIT_CHECK();
+    ABTI_SETUP_GLOBAL(&p_global);
 #else
-    if (!gp_ABTI_global) {
+    p_global = ABTI_global_get_global_or_null();
+    if (!p_global) {
         fprintf(fp, "Argobots is not initialized.\n");
         fflush(fp);
         return ABT_SUCCESS;
     }
 #endif
-    ABTI_global *p_global = gp_ABTI_global;
 
     ABTI_spinlock_acquire(&p_global->xstream_list_lock);
 
@@ -886,7 +899,8 @@ int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-ABTU_ret_err static int print_all_thread_stacks(FILE *fp);
+ABTU_ret_err static int print_all_thread_stacks(ABTI_global *p_global,
+                                                FILE *fp);
 
 #define PRINT_STACK_FLAG_UNSET 0
 #define PRINT_STACK_FLAG_INITIALIZE 1
@@ -911,16 +925,17 @@ void ABTI_info_check_print_all_thread_stacks(void)
     /* Wait for the other execution streams using a barrier mechanism. */
     int self_value = ABTD_atomic_fetch_add_int(&print_stack_barrier, 1);
     if (self_value == 0) {
+        ABTI_global *p_global = ABTI_global_get_global();
         /* This ES becomes the main ES. */
         double start_time = ABTI_get_wtime();
         ABT_bool force_print = ABT_FALSE;
 
         /* xstreams_lock is acquired to avoid dynamic ES creation while
          * printing data. */
-        ABTI_spinlock_acquire(&gp_ABTI_global->xstream_list_lock);
+        ABTI_spinlock_acquire(&p_global->xstream_list_lock);
         while (1) {
             if (ABTD_atomic_acquire_load_int(&print_stack_barrier) >=
-                gp_ABTI_global->num_xstreams) {
+                p_global->num_xstreams) {
                 break;
             }
             if (print_stack_timeout >= 0.0 &&
@@ -928,9 +943,9 @@ void ABTI_info_check_print_all_thread_stacks(void)
                 force_print = ABT_TRUE;
                 break;
             }
-            ABTI_spinlock_release(&gp_ABTI_global->xstream_list_lock);
+            ABTI_spinlock_release(&p_global->xstream_list_lock);
             ABTD_atomic_pause();
-            ABTI_spinlock_acquire(&gp_ABTI_global->xstream_list_lock);
+            ABTI_spinlock_acquire(&p_global->xstream_list_lock);
         }
         /* All the available ESs are (supposed to be) stopped. We *assume* that
          * no ES is calling and will call Argobots functions except this
@@ -941,14 +956,14 @@ void ABTI_info_check_print_all_thread_stacks(void)
                     "timeout (only %d ESs stop)\n",
                     ABTD_atomic_acquire_load_int(&print_stack_barrier));
         }
-        int abt_errno = print_all_thread_stacks(print_stack_fp);
+        int abt_errno = print_all_thread_stacks(p_global, print_stack_fp);
         if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
             fprintf(print_stack_fp, "ABT_info_trigger_print_all_thread_stacks: "
                                     "failed because of an internal error.\n");
         }
         fflush(print_stack_fp);
         /* Release the lock that protects ES data. */
-        ABTI_spinlock_release(&gp_ABTI_global->xstream_list_lock);
+        ABTI_spinlock_release(&p_global->xstream_list_lock);
         if (print_cb_func)
             print_cb_func(force_print, print_arg);
         /* Update print_stack_flag to 3. */
@@ -972,10 +987,8 @@ void ABTI_info_check_print_all_thread_stacks(void)
     }
 }
 
-void ABTI_info_print_config(FILE *fp)
+void ABTI_info_print_config(ABTI_global *p_global, FILE *fp)
 {
-    ABTI_global *p_global = gp_ABTI_global;
-
     fprintf(fp, "Argobots Configuration:\n");
     fprintf(fp, " - version: " ABT_VERSION "\n");
     fprintf(fp, " - # of cores: %d\n", p_global->num_cores);
@@ -1248,7 +1261,7 @@ static void info_trigger_print_all_thread_stacks(
     }
 }
 
-ABTU_ret_err static int print_all_thread_stacks(FILE *fp)
+ABTU_ret_err static int print_all_thread_stacks(ABTI_global *p_global, FILE *fp)
 {
     size_t i;
     int abt_errno;
@@ -1256,7 +1269,7 @@ ABTU_ret_err static int print_all_thread_stacks(FILE *fp)
 
     abt_errno = info_initialize_pool_set(&pool_set);
     ABTI_CHECK_ERROR(abt_errno);
-    ABTI_xstream *p_xstream = gp_ABTI_global->p_xstream_head;
+    ABTI_xstream *p_xstream = p_global->p_xstream_head;
     while (p_xstream) {
         ABTI_sched *p_main_sched = p_xstream->p_main_sched;
         fprintf(fp, "= xstream[%d] (%p) =\n", p_xstream->rank,

--- a/src/log.c
+++ b/src/log.c
@@ -11,7 +11,8 @@
 
 void ABTI_log_debug(FILE *fh, const char *format, ...)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE)
+    ABTI_global *p_global = ABTI_global_get_global_or_null();
+    if (!p_global || p_global->use_logging == ABT_FALSE)
         return;
     ABTI_local *p_local = ABTI_local_get_local_uninlined();
 
@@ -77,7 +78,8 @@ void ABTI_log_debug(FILE *fh, const char *format, ...)
 
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE)
+    ABTI_global *p_global = ABTI_global_get_global_or_null();
+    if (!p_global || p_global->use_logging == ABT_FALSE)
         return;
     if (unit == ABT_UNIT_NULL)
         return;
@@ -96,7 +98,8 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit)
 
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE)
+    ABTI_global *p_global = ABTI_global_get_global_or_null();
+    if (!p_global || p_global->use_logging == ABT_FALSE)
         return;
     if (unit == ABT_UNIT_NULL)
         return;
@@ -115,7 +118,8 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
 
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
 {
-    if (gp_ABTI_global->use_logging == ABT_FALSE)
+    ABTI_global *p_global = ABTI_global_get_global_or_null();
+    if (!p_global || p_global->use_logging == ABT_FALSE)
         return;
     if (unit == ABT_UNIT_NULL)
         return;

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -17,7 +17,7 @@ void ABTI_mem_init(ABTI_global *p_global)
 {
     int num_requested_types = 0;
     ABTU_MEM_LARGEPAGE_TYPE requested_types[3];
-    switch (gp_ABTI_global->mem_lp_alloc) {
+    switch (p_global->mem_lp_alloc) {
         case ABTI_MEM_LP_MMAP_RP:
             requested_types[num_requested_types++] = ABTU_MEM_LARGEPAGE_MMAP;
             requested_types[num_requested_types++] = ABTU_MEM_LARGEPAGE_MALLOC;
@@ -61,7 +61,7 @@ void ABTI_mem_init(ABTI_global *p_global)
                                    stacksize, thread_stacksize,
                                    p_global->mem_sp_size, requested_types,
                                    num_requested_types,
-                                   gp_ABTI_global->mem_page_size);
+                                   p_global->mem_page_size);
     /* The last four bytes will be used to store a mempool flag */
     ABTI_STATIC_ASSERT((ABTI_MEM_POOL_DESC_ELEM_SIZE &
                         (ABT_CONFIG_STATIC_CACHELINE_SIZE - 1)) == 0);
@@ -71,7 +71,7 @@ void ABTI_mem_init(ABTI_global *p_global)
                                    ABTI_MEM_POOL_DESC_ELEM_SIZE, 0,
                                    p_global->mem_page_size, requested_types,
                                    num_requested_types,
-                                   gp_ABTI_global->mem_page_size);
+                                   p_global->mem_page_size);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     ABTI_spinlock_clear(&p_global->mem_pool_stack_lock);
     ABTI_mem_pool_init_local_pool(&p_global->mem_pool_stack_ext,
@@ -82,12 +82,12 @@ void ABTI_mem_init(ABTI_global *p_global)
 #endif
 }
 
-void ABTI_mem_init_local(ABTI_xstream *p_local_xstream)
+void ABTI_mem_init_local(ABTI_global *p_global, ABTI_xstream *p_local_xstream)
 {
     ABTI_mem_pool_init_local_pool(&p_local_xstream->mem_pool_stack,
-                                  &gp_ABTI_global->mem_pool_stack);
+                                  &p_global->mem_pool_stack);
     ABTI_mem_pool_init_local_pool(&p_local_xstream->mem_pool_desc,
-                                  &gp_ABTI_global->mem_pool_desc);
+                                  &p_global->mem_pool_desc);
 }
 
 void ABTI_mem_finalize(ABTI_global *p_global)
@@ -106,10 +106,10 @@ void ABTI_mem_finalize_local(ABTI_xstream *p_local_xstream)
     ABTI_mem_pool_destroy_local_pool(&p_local_xstream->mem_pool_desc);
 }
 
-int ABTI_mem_check_lp_alloc(int lp_alloc)
+int ABTI_mem_check_lp_alloc(ABTI_global *p_global, int lp_alloc)
 {
-    size_t sp_size = gp_ABTI_global->mem_sp_size;
-    size_t pg_size = gp_ABTI_global->mem_page_size;
+    size_t sp_size = p_global->mem_sp_size;
+    size_t pg_size = p_global->mem_page_size;
     size_t alignment = ABT_CONFIG_STATIC_CACHELINE_SIZE;
     switch (lp_alloc) {
         case ABTI_MEM_LP_MMAP_RP:
@@ -136,7 +136,7 @@ int ABTI_mem_check_lp_alloc(int lp_alloc)
                 return ABTI_MEM_LP_MMAP_HP_THP;
             } else if (
                 ABTU_is_supported_largepage_type(pg_size,
-                                                 gp_ABTI_global->huge_page_size,
+                                                 p_global->huge_page_size,
                                                  ABTU_MEM_LARGEPAGE_MEMALIGN)) {
                 return ABTI_MEM_LP_THP;
             } else {
@@ -144,7 +144,7 @@ int ABTI_mem_check_lp_alloc(int lp_alloc)
             }
         case ABTI_MEM_LP_THP:
             if (ABTU_is_supported_largepage_type(pg_size,
-                                                 gp_ABTI_global->huge_page_size,
+                                                 p_global->huge_page_size,
                                                  ABTU_MEM_LARGEPAGE_MEMALIGN)) {
                 return ABTI_MEM_LP_THP;
             } else {
@@ -161,7 +161,7 @@ void ABTI_mem_init(ABTI_global *p_global)
 {
 }
 
-void ABTI_mem_init_local(ABTI_xstream *p_local_xstream)
+void ABTI_mem_init_local(ABTI_global *p_global, ABTI_xstream *p_local_xstream)
 {
 }
 

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -784,6 +784,9 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 {
     ABTI_local *p_local = ABTI_local_get_local();
 
+    ABTI_global *p_global;
+    ABTI_SETUP_GLOBAL(&p_global);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -800,7 +803,8 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     /* In both ABT_SCHED_TYPE_ULT and ABT_SCHED_TYPE_TASK cases, we use ULT-type
      * scheduler to reduce the code maintenance cost. */
 #endif
-    int abt_errno = ABTI_ythread_create_sched(p_local, p_pool, p_sched);
+    int abt_errno =
+        ABTI_ythread_create_sched(p_global, p_local, p_pool, p_sched);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -41,6 +41,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
     int abt_errno;
     int num_pools;
+    ABTI_global *p_global = ABTI_global_get_global();
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -53,11 +54,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
-    p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
+    p_data->sleep_time.tv_nsec = p_global->sched_sleep_nsec;
 #endif
 
     /* Set the default value by default. */
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    p_data->event_freq = p_global->sched_event_freq;
     if (p_config) {
         int event_freq;
         /* Set the variables from config */
@@ -91,6 +92,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream(ABTI_local_get_local());
     ABT_unit unit = ABT_UNIT_NULL;
@@ -114,7 +116,7 @@ static void sched_run(ABT_sched sched)
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[i]);
             ++pop_count;
             if ((unit = ABTI_pool_pop(p_pool)) != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
                 break;
             }
         }

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -38,6 +38,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
     int abt_errno;
     int num_pools;
+    ABTI_global *p_global = ABTI_global_get_global();
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -49,7 +50,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Set the default value by default. */
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    p_data->event_freq = p_global->sched_event_freq;
     if (p_config) {
         int event_freq;
         /* Set the variables from config */
@@ -83,6 +84,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream(ABTI_local_get_local());
     uint32_t work_count = 0;
@@ -111,7 +113,7 @@ static void sched_run(ABT_sched sched)
             /* Pop one work unit */
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
                 run_cnt_nowait++;
                 break;
             }
@@ -131,7 +133,7 @@ static void sched_run(ABT_sched sched)
                 unit = ABTI_pool_pop(p_pool);
             }
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(&p_local_xstream, unit,
+                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit,
                                       ABTI_pool_get_ptr(pools[0]));
                 break;
             }

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -40,6 +40,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
     int abt_errno;
     int num_pools;
+    ABTI_global *p_global = ABTI_global_get_global();
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -51,11 +52,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABTI_CHECK_ERROR(abt_errno);
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
-    p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
+    p_data->sleep_time.tv_nsec = p_global->sched_sleep_nsec;
 #endif
 
     /* Set the default value by default. */
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    p_data->event_freq = p_global->sched_event_freq;
     if (p_config) {
         int event_freq;
         /* Set the variables from config */
@@ -83,6 +84,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream(ABTI_local_get_local());
     uint32_t work_count = 0;
@@ -111,7 +113,7 @@ static void sched_run(ABT_sched sched)
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
                 break;
             }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -37,6 +37,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 {
     int abt_errno;
     int num_pools;
+    ABTI_global *p_global = ABTI_global_get_global();
 
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -48,11 +49,11 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
     ABTI_CHECK_ERROR(abt_errno);
 #ifdef ABT_CONFIG_USE_SCHED_SLEEP
     p_data->sleep_time.tv_sec = 0;
-    p_data->sleep_time.tv_nsec = gp_ABTI_global->sched_sleep_nsec;
+    p_data->sleep_time.tv_nsec = p_global->sched_sleep_nsec;
 #endif
 
     /* Set the default value by default. */
-    p_data->event_freq = gp_ABTI_global->sched_event_freq;
+    p_data->event_freq = p_global->sched_event_freq;
     if (p_config) {
         int event_freq;
         /* Set the variables from config */
@@ -80,6 +81,7 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 
 static void sched_run(ABT_sched sched)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream(ABTI_local_get_local());
     uint32_t work_count = 0;
@@ -106,7 +108,7 @@ static void sched_run(ABT_sched sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
         unit = ABTI_pool_pop(p_pool);
         if (unit != ABT_UNIT_NULL) {
-            ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);
+            ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
@@ -118,7 +120,7 @@ static void sched_run(ABT_sched sched)
             LOG_DEBUG_POOL_POP(p_pool, unit);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_unit_set_associated_pool(unit, p_pool);
-                ABTI_xstream_run_unit(&p_local_xstream, unit, p_pool);
+                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
                 CNT_INC(run_cnt);
             }
         }

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -238,6 +238,8 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
  */
 int ABT_sched_free(ABT_sched *sched)
 {
+    ABTI_global *p_global;
+    ABTI_SETUP_GLOBAL(&p_global);
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_sched *p_sched = ABTI_sched_get_ptr(*sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
@@ -246,7 +248,7 @@ int ABT_sched_free(ABT_sched *sched)
 #endif
 
     /* Free the scheduler */
-    ABTI_sched_free(p_local, p_sched, ABT_FALSE);
+    ABTI_sched_free(p_global, p_local, p_sched, ABT_FALSE);
 
     /* Return value */
     *sched = ABT_SCHED_NULL;
@@ -834,8 +836,8 @@ ABTU_ret_err int ABTI_sched_create_basic(ABT_sched_predef predef, int num_pools,
     return ABT_SUCCESS;
 }
 
-void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
-                     ABT_bool force_free)
+void ABTI_sched_free(ABTI_global *p_global, ABTI_local *p_local,
+                     ABTI_sched *p_sched, ABT_bool force_free)
 {
     ABTI_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
     /* Free the scheduler first. */
@@ -856,7 +858,7 @@ void ABTI_sched_free(ABTI_local *p_local, ABTI_sched *p_sched,
 
     /* Free the associated work unit */
     if (p_sched->p_ythread) {
-        ABTI_thread_free(p_local, &p_sched->p_ythread->thread);
+        ABTI_thread_free(p_global, p_local, &p_sched->p_ythread->thread);
     }
 
     LOG_DEBUG("[S%" PRIu64 "] freed\n", p_sched->id);

--- a/src/self.c
+++ b/src/self.c
@@ -48,8 +48,9 @@ int ABT_self_get_type(ABT_unit_type *type)
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* By default, type is ABT_UNIT_TYPE_EXT in Argobots 1.x */
     *type = ABT_UNIT_TYPE_EXT;
+    ABTI_SETUP_GLOBAL(NULL);
     ABTI_xstream *p_local_xstream;
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *type = ABTI_thread_type_get_type(p_local_xstream->p_thread->type);
 #else
     ABTI_xstream *p_local_xstream =
@@ -103,8 +104,9 @@ int ABT_self_is_primary(ABT_bool *is_primary)
 {
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *is_primary = ABT_FALSE;
+    ABTI_SETUP_GLOBAL(NULL);
     ABTI_ythread *p_ythread;
-    ABTI_SETUP_LOCAL_YTHREAD_WITH_INIT_CHECK(NULL, &p_ythread);
+    ABTI_SETUP_LOCAL_YTHREAD(NULL, &p_ythread);
     *is_primary = (p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY)
                       ? ABT_TRUE
                       : ABT_FALSE;
@@ -162,8 +164,9 @@ int ABT_self_on_primary_xstream(ABT_bool *on_primary)
 {
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *on_primary = ABT_FALSE;
+    ABTI_SETUP_GLOBAL(NULL);
     ABTI_xstream *p_local_xstream;
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *on_primary = (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY)
                       ? ABT_TRUE
                       : ABT_FALSE;
@@ -214,7 +217,8 @@ int ABT_self_get_last_pool_id(int *pool_id)
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *pool_id = -1;
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
+    ABTI_SETUP_GLOBAL(NULL);
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     ABTI_thread *p_self = p_local_xstream->p_thread;
     ABTI_ASSERT(p_self->p_pool);
     *pool_id = p_self->p_pool->id;
@@ -301,10 +305,9 @@ int ABT_self_set_arg(void *arg)
 {
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
-#else
-    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    ABTI_SETUP_GLOBAL(NULL);
 #endif
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
     p_local_xstream->p_thread->p_arg = arg;
     return ABT_SUCCESS;
@@ -344,10 +347,9 @@ int ABT_self_get_arg(void **arg)
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *arg = NULL;
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
-#else
-    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    ABTI_SETUP_GLOBAL(NULL);
 #endif
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
     *arg = p_local_xstream->p_thread->p_arg;
     return ABT_SUCCESS;

--- a/src/task.c
+++ b/src/task.c
@@ -243,7 +243,8 @@ int ABT_task_self(ABT_task *task)
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *task = ABT_TASK_NULL;
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
+    ABTI_SETUP_GLOBAL(NULL);
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     ABTI_CHECK_TRUE(!(p_local_xstream->p_thread->type &
                       ABTI_THREAD_TYPE_YIELDABLE),
                     ABT_ERR_INV_TASK);
@@ -287,7 +288,8 @@ int ABT_task_self_id(ABT_unit_id *id)
 {
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
-    ABTI_SETUP_LOCAL_XSTREAM_WITH_INIT_CHECK(&p_local_xstream);
+    ABTI_SETUP_GLOBAL(NULL);
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     ABTI_CHECK_TRUE(!(p_local_xstream->p_thread->type &
                       ABTI_THREAD_TYPE_YIELDABLE),
                     ABT_ERR_INV_TASK);

--- a/src/tool.c
+++ b/src/tool.c
@@ -86,9 +86,12 @@ int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
     ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
+    ABTI_global *p_global;
+    ABTI_SETUP_GLOBAL(&p_global);
+
     if (cb_func == NULL)
         event_mask = ABT_TOOL_EVENT_THREAD_NONE;
-    ABTI_tool_event_thread_update_callback(cb_func,
+    ABTI_tool_event_thread_update_callback(p_global, cb_func,
                                            event_mask &
                                                ABT_TOOL_EVENT_THREAD_ALL,
                                            user_arg);


### PR DESCRIPTION
## Pull Request Description

Some Argobots functions can be called without Argobots initialization; at least the description says so.  However, it is hard to guarantee such since its child function may access `gp_ABTI_global`, which is available only when Argobots is initialized.  Better support for functions under uninitialized Argobots is not only important to ensure the existing API but also useful to extend Argobots functionality (such as a static initializer of synchronization objects: #145).

This PR changes the current code so that internal functions that access `gp_ABTI_global` must take its as an argument. This change makes `gp_ABTI_global` dependency visible to top-level functions (e.g., public `ABT_xxx()` functions). This idea is similar to `p_local` and `p_local_xstream`.

This change should not have a positive performance impact, but I believe it is almost negligible (at most it increases a few more instructions to read a global variable and/or increases register pressure).

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
