### PR TITLE
mutex: mutex without Argobots initialization 

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1072,6 +1072,95 @@ typedef enum ABT_sync_event_type            ABT_sync_event_type;
 #endif
 
 /**
+ * @ingroup MUTEX
+ * @brief   A struct that can be converted to ABT_mutex.
+ * @hideinitializer
+ *
+ * \c ABT_mutex_memory is a struct to statically allocate and initialize
+ * \c ABT_mutex.  \c ABT_mutex_memory can be statically initialized by
+ * \c ABT_MUTEX_MEMORY_INITIALIZER and \c ABT_RECURSIVE_MUTEX_INITIALIZER and
+ * can be converted to \c ABT_mutex by \c ABT_MUTEX_MEMORY_GET_HANDLE().
+ *
+ * \c dummy may not be accessed by a user.
+ */
+typedef struct {
+    int dummy[16];
+} ABT_mutex_memory;
+
+/**
+ * @ingroup MUTEX
+ * @brief   Initialize \c ABT_mutex_memory.
+ *
+ * \c ABT_MUTEX_INITIALIZER() statically initializes \c ABT_mutex_memory.  The
+ * created mutex is not recursive.
+
+ * The following shows how to use \c ABT_MUTEX_INITIALIZER.
+ * @code{.c}
+ * ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+ *
+ * void thread(void *)
+ * {
+ *     ABT_mutex mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+ *     ABT_mutex_lock(mutex);
+ *     ABT_mutex_unlock(mutex);
+ * }
+ * @endcode
+ *
+ * \c ABT_mutex obtained by \c ABT_MUTEX_MEMORY_GET_HANDLE() may not be freed by
+ * \c ABT_mutex_free().  The lifetime of \c ABT_mutex obtained by
+ * \c ABT_MUTEX_MEMORY_GET_HANDLE() is the same as that of \c ABT_mutex_memory.
+ *
+ * \c ABT_mutex_memory associated with the mutex that is in use may not be
+ * initialized.
+ */
+#define ABT_MUTEX_INITIALIZER                                                  \
+    { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }
+
+/**
+ * @ingroup MUTEX
+ * @brief   Initialize \c ABT_mutex_memory with a recursive property.
+ *
+ * \c ABT_RECURSIVE_MUTEX_INITIALIZER statically initializes
+ * \c ABT_mutex_memory.  The created mutex is recursive.
+ *
+ * The following shows how to use \c ABT_RECURSIVE_MUTEX_INITIALIZER.
+ * @code{.c}
+ * ABT_mutex_memory rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+ *
+ * void thread(void *)
+ * {
+ *     ABT_mutex rec_mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&rec_mutex_mem);
+ *     // rec_mutex is recursive.
+ *     ABT_mutex_lock(rec_mutex);
+ *     ABT_mutex_lock(rec_mutex);
+ *     ABT_mutex_unlock(rec_mutex);
+ *     ABT_mutex_unlock(rec_mutex);
+ * }
+ * @endcode
+ *
+ * \c ABT_mutex_memory associated with the mutex that is in use may not be
+ * initialized.
+ */
+#define ABT_RECURSIVE_MUTEX_INITIALIZER                                        \
+    { { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }
+
+/**
+ * @ingroup MUTEX
+ * @brief   Obtain \c ABT_mutex from \c ABT_mutex_memory.
+ *
+ * \c ABT_MUTEX_MEMORY_GET_HANDLE() takes the pointer \c p_mutex_memory, which
+ * points to \c ABT_mutex_memory, and returns \c ABT_mutex that internally uses
+ * \c p_mutex_memory to store the data.  If the memory pointed to by
+ * \c p_mutex_memory is not properly initialized, it returns a corrupted mutex.
+ *
+ * \c ABT_mutex obtained by \c ABT_MUTEX_MEMORY_GET_HANDLE() may not be freed by
+ * \c ABT_mutex_free().  The lifetime of \c ABT_mutex obtained by
+ * \c ABT_MUTEX_MEMORY_GET_HANDLE() is the same as that of \c ABT_mutex_memory.
+ */
+#define ABT_MUTEX_MEMORY_GET_HANDLE(p_mutex_memory)                            \
+    ((ABT_mutex)p_mutex_memory)
+
+/**
  * @ingroup SCHED_CONFIG
  * @brief   A struct that sets and gets a scheduler configuration.
  */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -94,10 +94,8 @@ enum ABTI_sched_used {
      ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK |                                 \
      ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK)
 
-enum ABTI_mutex_attr_val {
-    ABTI_MUTEX_ATTR_NONE = 0,
-    ABTI_MUTEX_ATTR_RECURSIVE = 1 << 0
-};
+#define ABTI_MUTEX_ATTR_NONE 0
+#define ABTI_MUTEX_ATTR_RECURSIVE 1
 
 /* Macro functions */
 #define ABTI_UNUSED(a) (void)(a)
@@ -163,14 +161,14 @@ struct ABTI_waitlist {
 };
 
 struct ABTI_mutex_attr {
-    uint32_t attrs;          /* bit-or'ed attributes */
-    uint32_t nesting_cnt;    /* nesting count */
-    ABTI_thread_id owner_id; /* owner's ID */
+    int attrs; /* bit-or'ed attributes */
 };
 
 struct ABTI_mutex {
-    ABTI_spinlock lock;   /* lock */
-    ABTI_mutex_attr attr; /* attributes */
+    int attrs;               /* attributes copied from ABTI_mutex_attr. */
+    ABTI_spinlock lock;      /* lock */
+    int nesting_cnt;         /* nesting count (if recursive) */
+    ABTI_thread_id owner_id; /* owner's ID (if recursive) */
 #ifndef ABT_CONFIG_USE_SIMPLE_MUTEX
     ABTI_spinlock waiter_lock; /* lock */
     ABTI_waitlist waitlist;    /* waiting list */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -94,7 +94,9 @@ enum ABTI_sched_used {
      ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK |                                 \
      ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK)
 
+/* ABTI_MUTEX_ATTR_NONE must be 0. See ABT_MUTEX_INITIALIZER. */
 #define ABTI_MUTEX_ATTR_NONE 0
+/* ABTI_MUTEX_ATTR_RECURSIVE must be 1. See ABT_RECURSIVE_MUTEX_INITIALIZER. */
 #define ABTI_MUTEX_ATTR_RECURSIVE 1
 
 /* Macro functions */
@@ -165,7 +167,9 @@ struct ABTI_mutex_attr {
 };
 
 struct ABTI_mutex {
-    int attrs;               /* attributes copied from ABTI_mutex_attr. */
+    int attrs;               /* attributes copied from ABTI_mutex_attr.  Check
+                              * ABT_(RECURSIVE_)MUTEX_INITIALIZER to see how
+                              * this variable can be  initialized. */
     ABTI_spinlock lock;      /* lock */
     int nesting_cnt;         /* nesting count (if recursive) */
     ABTI_thread_id owner_id; /* owner's ID (if recursive) */

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -168,15 +168,12 @@ int ABT_mutex_free(ABT_mutex *mutex)
  * unlocked as many times as the level of ownership.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
  * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] mutex  mutex handle
  * @return Error code
@@ -205,15 +202,12 @@ int ABT_mutex_lock(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
  * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] mutex  mutex handle
  * @return Error code
@@ -242,15 +236,12 @@ int ABT_mutex_lock_low(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{\c mutex is locked and
  * therefore the caller fails to take a lock}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] mutex  mutex handle
  * @return Error code
@@ -280,15 +271,12 @@ int ABT_mutex_lock_high(ABT_mutex mutex)
  * routine never fails if \c mutex is not locked.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS_LOCK_ACQUIRED{\c mutex}
  * \DOC_ERROR_SUCCESS_LOCK_FAILED{\c mutex}
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] mutex  mutex handle
  * @return Error code
@@ -324,14 +312,11 @@ int ABT_mutex_trylock(ABT_mutex mutex)
  * be cautious when using this routine.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] mutex  mutex handle
  * @return Error code
@@ -355,15 +340,14 @@ int ABT_mutex_spinlock(ABT_mutex mutex)
  * be the same as that of the corresponding locking function.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
- *                                                      \c mutex}
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                     \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
  *
  * @undefined
- * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_NOT_LOCKED{\c mutex}
  * \DOC_UNDEFINED_MUTEX_ILLEGAL_UNLOCK{\c mutex}
  *
@@ -400,15 +384,14 @@ int ABT_mutex_unlock(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
- *                                                      \c mutex}
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                     \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
  *
  * @undefined
- * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_NOT_LOCKED{\c mutex}
  * \DOC_UNDEFINED_MUTEX_ILLEGAL_UNLOCK{\c mutex}
  *
@@ -445,15 +428,14 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
  * non-conforming.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
- *                                                      \c mutex}
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH_CONDITIONAL{a waiter is waiting on
+ *                                                     \c mutex}
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
  *
  * @undefined
- * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_NOT_LOCKED{\c mutex}
  * \DOC_UNDEFINED_MUTEX_ILLEGAL_UNLOCK{\c mutex}
  *

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -105,9 +105,8 @@ int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
     ABTI_CHECK_ERROR(abt_errno);
 
     ABTI_mutex_init(p_newmutex);
-    if (p_attr) {
-        memcpy(&p_newmutex->attr, p_attr, sizeof(ABTI_mutex_attr));
-    }
+    if (p_attr)
+        p_newmutex->attrs = p_attr->attrs;
 
     /* Return value */
     *newmutex = ABTI_mutex_get_handle(p_newmutex);
@@ -538,9 +537,7 @@ int ABT_mutex_get_attr(ABT_mutex mutex, ABT_mutex_attr *attr)
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Copy values.  Nesting count must be initialized. */
-    p_newattr->attrs = p_mutex->attr.attrs;
-    p_newattr->nesting_cnt = 0;
-    p_newattr->owner_id = 0;
+    p_newattr->attrs = p_mutex->attrs;
 
     /* Return value */
     *attr = ABTI_mutex_attr_get_handle(p_newattr);

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -38,6 +38,9 @@
  */
 int ABT_mutex_create(ABT_mutex *newmutex)
 {
+    /* Check if the size of ABT_mutex_memory is okay. */
+    ABTI_STATIC_ASSERT(sizeof(ABTI_mutex) <= sizeof(ABT_mutex_memory));
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newmutex to NULL on error. */
     *newmutex = ABT_MUTEX_NULL;

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -45,8 +45,6 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
 
     /* Default values */
     p_newattr->attrs = ABTI_MUTEX_ATTR_NONE;
-    p_newattr->nesting_cnt = 0;
-    p_newattr->owner_id = 0;
 
     /* Return value */
     *newattr = ABTI_mutex_attr_get_handle(p_newattr);

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -42,6 +42,7 @@ basic/mutex
 basic/mutex_prio
 basic/mutex_recursive
 basic/mutex_spinlock
+basic/mutex_static
 basic/mutex_unlock_se
 basic/cond_test
 basic/cond_join

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -47,6 +47,7 @@ TESTS = \
 	mutex_prio \
 	mutex_recursive \
 	mutex_spinlock \
+	mutex_static \
 	mutex_unlock_se \
 	cond_test \
 	cond_join \
@@ -125,6 +126,7 @@ mutex_SOURCES = mutex.c
 mutex_prio_SOURCES = mutex_prio.c
 mutex_recursive_SOURCES = mutex_recursive.c
 mutex_spinlock_SOURCES = mutex_spinlock.c
+mutex_static_SOURCES = mutex_static.c
 mutex_unlock_se_SOURCES = mutex_unlock_se.c
 cond_test_SOURCES = cond_test.c
 cond_join_SOURCES = cond_join.c
@@ -191,6 +193,7 @@ testing:
 	./mutex_prio
 	./mutex_recursive
 	./mutex_spinlock
+	./mutex_static
 	./mutex_unlock_se
 	./cond_test
 	./cond_join

--- a/test/basic/mutex_static.c
+++ b/test/basic/mutex_static.c
@@ -1,0 +1,242 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_PTHREADS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
+
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    int counter;
+    ABT_bool is_recursive;
+} mutex_set;
+mutex_set g_mutex_sets[4];
+int g_iter = DEFAULT_NUM_ITER;
+
+static int trylock(ABT_mutex mutex)
+{
+    while (ABT_mutex_trylock(mutex) != ABT_SUCCESS)
+        ;
+    return ABT_SUCCESS;
+}
+
+void thread_func(void *arg)
+{
+    int (*lock_fs[])(ABT_mutex) = { ABT_mutex_lock, ABT_mutex_lock_high,
+                                    ABT_mutex_lock_low, trylock,
+                                    ABT_mutex_spinlock };
+    int (*unlock_fs[])(ABT_mutex) = { ABT_mutex_unlock, ABT_mutex_unlock_se,
+                                      ABT_mutex_unlock_de };
+
+    int i;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < 4; j++) {
+            int k;
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++)
+                lock_fs[i % (sizeof(lock_fs) / sizeof(lock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+            g_mutex_sets[j].counter++;
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++)
+                unlock_fs[i % (sizeof(unlock_fs) / sizeof(unlock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j, ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_pthreads = DEFAULT_NUM_PTHREADS;
+    int num_threads = DEFAULT_NUM_THREADS;
+    int expected = 0;
+    ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+    ABT_mutex_memory rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+
+    /* Set up mutex. */
+    g_mutex_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_sets[0].counter = 0;
+    g_mutex_sets[0].is_recursive = ABT_FALSE;
+    g_mutex_sets[1].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_rec_mutex_mem);
+    g_mutex_sets[1].counter = 0;
+    g_mutex_sets[1].is_recursive = ABT_TRUE;
+    g_mutex_sets[2].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+    g_mutex_sets[2].counter = 0;
+    g_mutex_sets[2].is_recursive = ABT_FALSE;
+    g_mutex_sets[3].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&rec_mutex_mem);
+    g_mutex_sets[3].counter = 0;
+    g_mutex_sets[3].is_recursive = ABT_TRUE;
+
+    /* Use the mutex before ABT_Init(). */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += num_pthreads * g_iter;
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Check recursiveness of mutex. */
+    for (i = 0; i < 4; i++) {
+        ABT_mutex_attr mutex_attr;
+        ret = ABT_mutex_get_attr(g_mutex_sets[i].mutex, &mutex_attr);
+        ATS_ERROR(ret, "ABT_mutex_get_attr");
+        ABT_bool recursive;
+        ret = ABT_mutex_attr_get_recursive(mutex_attr, &recursive);
+        ATS_ERROR(ret, "ABT_mutex_attr_get_recursive");
+        assert(recursive == g_mutex_sets[i].is_recursive);
+        ret = ABT_mutex_attr_free(&mutex_attr);
+        ATS_ERROR(ret, "ABT_mutex_attr_free");
+    }
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_xstreams * num_threads);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create ULTs */
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            ret = ABT_thread_create(pools[i], thread_func, NULL,
+                                    ABT_THREAD_ATTR_NULL,
+                                    &threads[i * num_threads + j]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+    }
+    expected += num_xstreams * num_threads * g_iter;
+    /* Create Pthreads too. */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += num_pthreads * g_iter;
+    }
+
+    /* Join and free ULTs */
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            ret = ABT_thread_free(&threads[i * num_threads + j]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Use the mutex after finalization. */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += num_pthreads * g_iter;
+    }
+
+    /* Validation */
+    for (i = 0; i < 4; i++) {
+        assert(g_mutex_sets[i].counter == expected);
+    }
+
+    free(threads);
+    free(xstreams);
+    free(pools);
+
+    return ret;
+}


### PR DESCRIPTION
## Pull Request Description
Argobots assumes that the Argobots functionality is available only between `ABT_init()` and `ABT_finalize()`, so `ABT_mutex` can be created and used only when Argobots is initialized, but this makes it difficult to port existing Pthreads-based applications and runtimes if they do not have explicit initialization and finalization phases.  For example, some locks used in BOLT (Argobots-aware LLVM OpenMP) and Argobots-aware Open MPI can be called before `ABT_init()`, so currently those locks are implemented by combining `ABT_initialized()`, `ABT_thread_yield()`, and some atomic operations.  This is very cumbersome.

This PR provides a method to use an Argobots mutex even if Argobots is not initialized.  `ABT_mutex_memory` can be statically initialized.  Lock and unlock functions such as `ABT_mutex_lock()`, `ABT_mutex_unlock()`, and `ABT_mutex_trylock()` now work without Argobots initialization, so users can use those lock and unlock functions with `ABT_mutex` converted from `ABT_mutex_memory` before Argobots initialization.  If external threads are supported (this is enabled by default), such an `ABT_mutex` can always serialize concurrent accesses from external threads (=Pthreads) and ULTs.

```c
// ABT_RECURSIVE_MUTEX_INITIALIZER is also available.
ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
int g_protected_value = 0;
void inc_protected_value()
{
    ABT_mutex mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
    // inc_protected_value() can be used for Pthreads without ABT_init()
    // while it can be used for ULTs as well as Pthreads after ABT_init().
    ABT_mutex_lock(mutex);
    g_protected_value++;
    ABT_mutex_unlock(mutex);
}
````

This PR should not degrade the performance of the existing mutex implementation (~especially if `--enable-feature=no-ext-thread` is not explicitly set by users~  *[EDIT] there is no performance difference even if `--enable-feature=no-ext-thread` is set, but `ABT_mutex_xxx()` cannot be called without `ABT_init()` since the execution context is an external thread*).

This is not the main goal of this PR, but using `ABT_mutex_memory` is more lightweight than `ABT_mutex_create()`, so using this static initializer should be beneficial if applications create many `ABT_mutex`.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
