### PR TITLE
cond: using cond without Argobots initialization

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1818,6 +1818,8 @@ ALIASES += undefined="\par Undefined behavior"
 
 ALIASES += DOC_CONTEXT_ANY="This routine can be called in any execution context. Argobots does not need to be initialized."
 
+ALIASES += DOC_CONTEXT_ANY_NOTASK="This routine can be called in a ULT context and an external thread context. Argobots does not need to be initialized."
+
 ALIASES += DOC_CONTEXT_CTXSWITCH="This routine may switch the context of the calling ULT."
 
 ALIASES += DOC_CONTEXT_CTXSWITCH_CONDITIONAL{1}="This routine may switch the context of the calling ULT if \1.  Otherwise, this routine does not switch the context of the calling ULT unless any user-defined function that is involved in this routine switch the context of the calling ULT."

--- a/src/cond.c
+++ b/src/cond.c
@@ -130,8 +130,8 @@ int ABT_cond_free(ABT_cond *cond)
  * @endchangev20
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT_NOTASK \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_V1X \DOC_CONTEXT_ANY_NOTASK \DOC_CONTEXT_CTXSWITCH\n
+ * \DOC_V20 \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -140,7 +140,6 @@ int ABT_cond_free(ABT_cond *cond)
  * \DOC_V1X \DOC_ERROR_TASK{\c ABT_ERR_COND}
  *
  * @undefined
- * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_NOT_LOCKED{\c mutex}
  * \DOC_UNDEFINED_MUTEX_ILLEGAL_UNLOCK{\c mutex}
  * \DOC_UNDEFINED_COND_WAIT{\c cond, \c mutex}
@@ -206,7 +205,7 @@ int ABT_cond_wait(ABT_cond cond, ABT_mutex mutex)
  * occurs.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_CTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS_COND_SIGNALED
@@ -215,7 +214,6 @@ int ABT_cond_wait(ABT_cond cond, ABT_mutex mutex)
  * \DOC_ERROR_INV_MUTEX_HANDLE{\c mutex}
  *
  * @undefined
- * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_NULL_PTR{\c abstime}
  * \DOC_UNDEFINED_NOT_LOCKED{\c mutex}
  * \DOC_UNDEFINED_MUTEX_ILLEGAL_UNLOCK{\c mutex}
@@ -275,14 +273,11 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
  * effect if no waiter is currently blocked on \c cond.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_COND_HANDLE{\c cond}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] cond  condition variable handle
  * @return Error code
@@ -310,14 +305,11 @@ int ABT_cond_signal(ABT_cond cond)
  * on \c cond.
  *
  * @contexts
- * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ * \DOC_CONTEXT_ANY \DOC_CONTEXT_NOCTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_COND_HANDLE{\c cond}
- *
- * @undefined
- * \DOC_UNDEFINED_UNINIT
  *
  * @param[in] cond  condition variable handle
  * @return Error code

--- a/src/cond.c
+++ b/src/cond.c
@@ -41,6 +41,9 @@ static inline double convert_timespec_to_sec(const struct timespec *p_ts);
  */
 int ABT_cond_create(ABT_cond *newcond)
 {
+    /* Check if the size of ABT_cond_memory is okay. */
+    ABTI_STATIC_ASSERT(sizeof(ABTI_cond) <= sizeof(ABT_cond_memory));
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newcond to NULL on error. */
     *newcond = ABT_COND_NULL;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1161,6 +1161,74 @@ typedef struct {
     ((ABT_mutex)p_mutex_memory)
 
 /**
+ * @ingroup COND
+ * @brief   A struct that can be converted to ABT_cond.
+ * @hideinitializer
+ *
+ * \c ABT_cond_memory is a struct to statically allocate and initialize
+ * \c ABT_cond.  \c ABT_cond_memory can be statically initialized by
+ * \c ABT_COND_MEMORY_INITIALIZER and converted to \c ABT_cond by
+ * \c ABT_COND_MEMORY_GET_HANDLE().
+ *
+ * \c dummy may not be accessed by a user.
+ */
+typedef struct {
+    int dummy[16];
+} ABT_cond_memory;
+
+/**
+ * @ingroup COND
+ * @brief   Initialize \c ABT_cond_memory.
+ *
+ * \c ABT_COND_INITIALIZER() statically initializes \c ABT_cond_memory.
+
+ * The following example shows how to use \c ABT_COND_INITIALIZER.
+ * @code{.c}
+ * ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+ * ABT_cond_memory cond_mem = ABT_COND_INITIALIZER;
+ *
+ * void thread(void *)
+ * {
+ *     ABT_mutex mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+ *     ABT_cond cond = ABT_COND_MEMORY_GET_HANDLE(&cond_mem);
+ *     ABT_mutex_lock(mutex);
+ *     if (...) {
+ *        ABT_cond_wait(cond, mutex);
+ *     } else {
+ *        ABT_cond_signal(cond);
+ *     }
+ *     ABT_mutex_unlock(mutex);
+ * }
+ * @endcode
+ *
+ * \c ABT_cond obtained by \c ABT_COND_MEMORY_GET_HANDLE() may not be freed by
+ * \c ABT_cond_free().  The lifetime of \c ABT_cond obtained by
+ * \c ABT_COND_MEMORY_GET_HANDLE() is the same as that of \c ABT_cond_memory.
+ *
+ * \c ABT_cond_memory associated with a condition variable that is in use may
+ * not be initialized.
+ */
+#define ABT_COND_INITIALIZER                                                   \
+    { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }
+
+/**
+ * @ingroup COND
+ * @brief   Obtain \c ABT_cond from \c ABT_cond_memory.
+ *
+ * \c ABT_COND_MEMORY_GET_HANDLE() takes the pointer \c p_cond_memory, which
+ * points to \c ABT_cond_memory, and returns \c ABT_cond that internally uses
+ * \c p_cond_memory to store the data.  If the memory pointed to by
+ * \c p_cond_memory is not properly initialized, it returns a corrupted
+ * condition variable.
+ *
+ * \c ABT_cond obtained by \c ABT_COND_MEMORY_GET_HANDLE() may not be freed by
+ * \c ABT_cond_free().  The lifetime of \c ABT_cond obtained by
+ * \c ABT_COND_MEMORY_GET_HANDLE() is the same as that of \c ABT_cond_memory.
+ */
+#define ABT_COND_MEMORY_GET_HANDLE(p_cond_memory)                              \
+    ((ABT_cond)p_cond_memory)
+
+/**
  * @ingroup SCHED_CONFIG
  * @brief   A struct that sets and gets a scheduler configuration.
  */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -47,6 +47,7 @@ basic/mutex_unlock_se
 basic/cond_test
 basic/cond_join
 basic/cond_signal_in_main
+basic/cond_static
 basic/cond_timedwait
 basic/future_create
 basic/rwlock_reader_incl

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -52,6 +52,7 @@ TESTS = \
 	cond_test \
 	cond_join \
 	cond_signal_in_main \
+	cond_static \
 	cond_timedwait \
 	rwlock_writer_excl \
 	rwlock_reader_writer_excl \
@@ -131,6 +132,7 @@ mutex_unlock_se_SOURCES = mutex_unlock_se.c
 cond_test_SOURCES = cond_test.c
 cond_join_SOURCES = cond_join.c
 cond_signal_in_main_SOURCES = cond_signal_in_main.c
+cond_static_SOURCES = cond_static.c
 cond_timedwait_SOURCES = cond_timedwait.c
 rwlock_writer_excl_SOURCES = rwlock_writer_excl.c
 rwlock_reader_writer_excl_SOURCES = rwlock_reader_writer_excl.c
@@ -198,6 +200,7 @@ testing:
 	./cond_test
 	./cond_join
 	./cond_signal_in_main
+	./cond_static
 	./cond_timedwait
 	./rwlock_writer_excl
 	./rwlock_reader_writer_excl

--- a/test/basic/cond_static.c
+++ b/test/basic/cond_static.c
@@ -1,0 +1,201 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define NUM_THREADS 4
+#define DEFAULT_NUM_ITER 100
+
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_cond_mem = ABT_COND_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    ABT_cond cond;
+    int counter;
+} mutex_cond_set;
+mutex_cond_set g_mutex_cond_sets[2];
+int g_iter = DEFAULT_NUM_ITER;
+
+void thread_func(void *arg)
+{
+    int i;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < 2; j++) {
+            int counter;
+            /* Check signal. */
+            ABT_mutex mutex1 = g_mutex_cond_sets[j].mutex;
+            ABT_cond cond1 = g_mutex_cond_sets[j].cond;
+            ABT_mutex_lock(mutex1);
+            counter = g_mutex_cond_sets[j].counter++;
+            if (counter % NUM_THREADS < NUM_THREADS / 2) {
+                ABT_cond_wait(cond1, mutex1);
+                assert(g_mutex_cond_sets[j].counter > counter + 1);
+            } else if (counter % NUM_THREADS < (NUM_THREADS / 2) * 2) {
+                ABT_cond_signal(cond1);
+            }
+            ABT_mutex_unlock(mutex1);
+
+            /* Check broadcast.  This works as a "barrier". */
+            ABT_mutex mutex2 = g_mutex_cond_sets[1 - j].mutex;
+            ABT_cond cond2 = g_mutex_cond_sets[1 - j].cond;
+            ABT_mutex_lock(mutex2);
+            counter = g_mutex_cond_sets[1 - j].counter++;
+            if (counter % NUM_THREADS < NUM_THREADS - 1) {
+                ABT_cond_wait(cond2, mutex2);
+                assert(g_mutex_cond_sets[1 - j].counter > counter + 1);
+            } else {
+                ABT_cond_broadcast(cond2);
+            }
+            ABT_mutex_unlock(mutex2);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret;
+    int expected = 0;
+    ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+    ABT_cond_memory cond_mem = ABT_COND_INITIALIZER;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+
+    /* Set up mutex and condition variable. */
+    g_mutex_cond_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_cond_sets[0].cond = ABT_COND_MEMORY_GET_HANDLE(&g_cond_mem);
+    g_mutex_cond_sets[0].counter = 0;
+    g_mutex_cond_sets[1].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+    g_mutex_cond_sets[1].cond = ABT_COND_MEMORY_GET_HANDLE(&cond_mem);
+    g_mutex_cond_sets[1].counter = 0;
+
+    /* Use mutex and cond before ABT_Init(). */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * NUM_THREADS);
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += 2 * NUM_THREADS * g_iter;
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, 1);
+
+    ATS_printf(1, "# of ULTs: %d\n", NUM_THREADS);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
+
+    /* Set up an execution stream */
+    ABT_xstream xstream;
+    ret = ABT_xstream_self(&xstream);
+    ATS_ERROR(ret, "ABT_xstream_self");
+
+    ABT_pool pool;
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    if (support_external_thread) {
+        /* Create ULTs and Pthreads */
+        pthread_t *pthreads = (pthread_t *)malloc(
+            sizeof(pthread_t) * (NUM_THREADS - NUM_THREADS / 2));
+        for (i = 0; i < NUM_THREADS / 2; i++) {
+            ret = ABT_thread_create(pool, thread_func, NULL,
+                                    ABT_THREAD_ATTR_NULL, &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        for (i = 0; i < NUM_THREADS - NUM_THREADS / 2; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        /* Join and free ULTs and Pthreads */
+        for (i = 0; i < NUM_THREADS / 2; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+        for (i = 0; i < NUM_THREADS - NUM_THREADS / 2; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+    } else {
+        /* Create ULTs */
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = ABT_thread_create(pool, thread_func, NULL,
+                                    ABT_THREAD_ATTR_NULL, &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        /* Join and free ULTs and Pthreads */
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+    }
+    expected += 2 * NUM_THREADS * g_iter;
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Use the mutex after finalization. */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * NUM_THREADS);
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += 2 * NUM_THREADS * g_iter;
+    }
+
+    /* Validation */
+    for (i = 0; i < 2; i++) {
+        assert(g_mutex_cond_sets[i].counter == expected);
+    }
+
+    free(threads);
+
+    return ret;
+}


### PR DESCRIPTION
## Pull Request Description

This patch does the same thing as #299 for a condition variable. This addresses #145.

This should be useful to translate programs that use `pthread_mutex_t` and `pthread_cond_t`. This PR does not change the logic of `ABTI_cond`, so it won't affect the performance of existing Argobots programs.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
