### PR TITLE
self: give new names to functions that target underlying ULTs or ESs

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1870,6 +1870,8 @@ ALIASES += DOC_DESC_ATOMICITY_XSTREAM_REQUEST="Requests for execution streams ar
 
 ALIASES += DOC_DESC_ATOMICITY_XSTREAM_STATE="Management of states of execution streams is performed atomically."
 
+ALIASES += DOC_DESC_REPLACEMENT{1}="This routine will be replaced by \1 in the future."
+
 ALIASES += DOC_DESC_SCHED_AUTOMATIC{1}="If \1 is not configured to be automatically freed, it is the user's responsibility to free \1 after its use unless \c newsched is associated with the main scheduler of the primary execution stream.  If \1 is configured to be automatically freed, \1 is automatically freed when a work unit associated with \1 is freed.  If the user never associates \1 with a work unit (e.g., by \c ABT_pool_add_sched() or \c ABT_xstream_set_main_sched()), it is the user's responsibility to free \1."
 
 ALIASES += DOC_DESC_TIMER_RESOLUTION="The resolution of elapsed time depends on the clock resolution by the system."

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1897,7 +1897,9 @@ int ABT_self_is_primary(ABT_bool *is_primary) ABT_API_PUBLIC;
 int ABT_self_on_primary_xstream(ABT_bool *on_primary) ABT_API_PUBLIC;
 int ABT_self_is_unnamed(ABT_bool *is_unnamed) ABT_API_PUBLIC;
 int ABT_self_get_last_pool_id(int *pool_id) ABT_API_PUBLIC;
+int ABT_self_yield(void) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
+int ABT_self_exit(void) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;
 int ABT_self_get_arg(void **arg) ABT_API_PUBLIC;
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1884,6 +1884,14 @@ int ABT_task_get_arg(ABT_task task, void **arg) ABT_API_PUBLIC;
 #define ABT_task_get_specific     ABT_thread_get_specific
 
 /* Self */
+int ABT_self_get_xstream(ABT_xstream *xstream) ABT_API_PUBLIC;
+int ABT_self_get_xstream_rank(int *rank) ABT_API_PUBLIC;
+int ABT_self_get_thread(ABT_thread *thread) ABT_API_PUBLIC;
+int ABT_self_get_thread_id(ABT_unit_id *id) ABT_API_PUBLIC;
+int ABT_self_set_specific(ABT_key key, void *value) ABT_API_PUBLIC;
+int ABT_self_get_specific(ABT_key key, void **value) ABT_API_PUBLIC;
+#define ABT_self_get_task       ABT_self_get_thread
+#define ABT_self_get_task_id    ABT_self_get_thread_id
 int ABT_self_get_type(ABT_unit_type *type) ABT_API_PUBLIC;
 int ABT_self_is_primary(ABT_bool *is_primary) ABT_API_PUBLIC;
 int ABT_self_on_primary_xstream(ABT_bool *on_primary) ABT_API_PUBLIC;

--- a/src/key.c
+++ b/src/key.c
@@ -128,6 +128,9 @@ int ABT_key_free(ABT_key *key)
  *
  * \DOC_DESC_ATOMICITY_WORK_UNIT_KEY
  *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_set_specific()}
+ *
  * @changev20
  * \DOC_DESC_V1X_RETURN_UNINITIALIZED
  * @endchangev20
@@ -178,6 +181,9 @@ int ABT_key_set(ABT_key key, void *value)
  * to \c NULL.
  *
  * \DOC_DESC_ATOMICITY_WORK_UNIT_KEY
+ *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_specific()}
  *
  * @changev20
  * \DOC_DESC_V1X_RETURN_UNINITIALIZED

--- a/src/self.c
+++ b/src/self.c
@@ -11,6 +11,235 @@
 
 /**
  * @ingroup SELF
+ * @brief   Get an execution stream that is running the calling work unit.
+ *
+ * \c ABT_self_get_xstream() returns the handle of the execution stream that is
+ * running the calling work unit through \c xstream.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c xstream}
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] xstream  execution stream handle
+ * @return Error code
+ */
+int ABT_self_get_xstream(ABT_xstream *xstream)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+
+    /* Return value */
+    *xstream = ABTI_xstream_get_handle(p_local_xstream);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
+ * @brief   Return a rank of an execution stream that is running the calling
+ *          work unit.
+ *
+ * \c ABT_self_get_xstream_rank() returns the rank of the execution stream that
+ * is running the calling work unit through \c rank.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c rank}
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] rank  execution stream rank
+ * @return Error code
+ */
+int ABT_self_get_xstream_rank(int *rank)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    /* Return value */
+    *rank = (int)p_local_xstream->rank;
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
+ * @brief   Get the calling work unit.
+ *
+ * \c ABT_self_get_thread() returns the handle of the calling work unit through
+ * \c thread.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c thread}
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] thread  work unit handle
+ * @return Error code
+ */
+int ABT_self_get_thread(ABT_thread *thread)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    *thread = ABTI_thread_get_handle(p_local_xstream->p_thread);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
+ * @brief   Get ID of the calling work unit.
+ *
+ * \c ABT_self_get_thread_id() returns the ID of the calling work unit through
+ * \c id.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c id}
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[out] id  ID of the calling work unit
+ * @return Error code
+ */
+int ABT_self_get_thread_id(ABT_unit_id *id)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    *id = ABTI_thread_get_id(p_local_xstream->p_thread);
+    return ABT_SUCCESS;
+}
+
+#ifdef ABT_CONFIG_USE_DOXYGEN
+/**
+ * @ingroup SELF
+ * @brief   Get the calling work unit.
+ *
+ * The functionality of this routine is the same as \c ABT_self_get_thread().
+ */
+int ABT_self_get_task(ABT_thread *thread);
+#endif
+
+#ifdef ABT_CONFIG_USE_DOXYGEN
+/**
+ * @ingroup SELF
+ * @brief   Get ID of the calling work unit.
+ *
+ * The functionality of this routine is the same as \c ABT_self_get_thread_id().
+ */
+int ABT_self_get_task_id(ABT_unit_id *id);
+#endif
+
+/**
+ * @ingroup SELF
+ * @brief   Associate a value with a work-unit-specific key in the calling work
+ *          unit.
+ *
+ * \c ABT_self_set_specific() associates a value \c value of the
+ * work-unit-specific data key \c key in the calling work unit. Different work
+ * units may bind different values to the same key.
+ *
+ * \DOC_DESC_ATOMICITY_WORK_UNIT_KEY
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_KEY_HANDLE{\c key}
+ * \DOC_ERROR_RESOURCE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[in] key    work-unit-specific data key handle
+ * @param[in] value  value associated with \c key
+ * @return Error code
+ */
+int ABT_self_set_specific(ABT_key key, void *value)
+{
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    ABTI_global *p_global;
+    ABTI_SETUP_GLOBAL(&p_global);
+
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+
+    /* Obtain the key-value table pointer. */
+    int abt_errno =
+        ABTI_ktable_set(p_global, ABTI_xstream_get_local(p_local_xstream),
+                        &p_local_xstream->p_thread->p_keytable, p_key, value);
+    ABTI_CHECK_ERROR(abt_errno);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
+ * @brief   Get a value associated with a key in the calling work unit.
+ *
+ * \c ABT_self_get_specific() returns the value in the caller associated with
+ * the work-unit-specific data key \c key in the calling work unit through
+ * \c value. If the caller has never set a value for the key, this routine sets
+ * \c value to \c NULL.
+ *
+ * \DOC_DESC_ATOMICITY_WORK_UNIT_KEY
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_NOEXT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_KEY_HANDLE{\c key}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_NULL_PTR{\c value}
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[in]  key    work-unit-specific data key handle
+ * @param[out] value  value associated with \c key
+ * @return Error code
+ */
+int ABT_self_get_specific(ABT_key key, void **value)
+{
+    ABTI_key *p_key = ABTI_key_get_ptr(key);
+    ABTI_CHECK_NULL_KEY_PTR(p_key);
+
+    /* We don't allow an external thread to call this routine. */
+    ABTI_xstream *p_local_xstream;
+    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+
+    /* Obtain the key-value table pointer */
+    *value = ABTI_ktable_get(&p_local_xstream->p_thread->p_keytable, p_key);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
  * @brief   Obtain a type of the caller.
  *
  * \c ABT_self_get_type() returns a type of the calling work unit through

--- a/src/self.c
+++ b/src/self.c
@@ -462,6 +462,38 @@ int ABT_self_get_last_pool_id(int *pool_id)
 
 /**
  * @ingroup SELF
+ * @brief   Yield the calling ULT to its parent ULT
+ *
+ * \c ABT_self_yield() yields the calling ULT and pushes the calling ULT to its
+ * associated pool.  Its parent ULT will be resumed.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_THREAD_NY
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{the caller}
+ *
+ * @return Error code
+ */
+int ABT_self_yield(void)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_ythread *p_ythread;
+    ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
+
+    ABTI_ythread_yield(&p_local_xstream, p_ythread, ABT_SYNC_EVENT_TYPE_USER,
+                       NULL);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
  * @brief   Suspend the calling ULT.
  *
  * \c ABT_self_suspend() suspends the execution of the calling ULT and switches
@@ -498,6 +530,38 @@ int ABT_self_suspend(void)
     ABTI_ythread_set_blocked(p_self);
     ABTI_ythread_suspend(&p_local_xstream, p_self, ABT_SYNC_EVENT_TYPE_USER,
                          NULL);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
+ * @brief   Terminate a calling ULT.
+ *
+ * \c ABT_self_exit() terminates the calling ULT.  This routine does not return
+ * if it succeeds.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_THREAD_NY
+ * \DOC_ERROR_INV_THREAD_PRIMARY_ULT{\c the caller}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @return Error code
+ */
+int ABT_self_exit(void)
+{
+    ABTI_xstream *p_local_xstream;
+    ABTI_ythread *p_ythread;
+    ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
+    ABTI_CHECK_TRUE(!(p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY),
+                    ABT_ERR_INV_THREAD);
+
+    ABTI_ythread_exit(p_local_xstream, p_ythread);
     return ABT_SUCCESS;
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -588,6 +588,9 @@ int ABT_xstream_cancel(ABT_xstream xstream)
  * \c ABT_xstream_self() returns the handle of the execution stream that is
  * running the calling work unit through \c xstream.
  *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_xstream()}
+ *
  * @changev20
  * \DOC_DESC_V1X_RETURN_UNINITIALIZED
  *
@@ -630,6 +633,9 @@ int ABT_xstream_self(ABT_xstream *xstream)
  *
  * \c ABT_xstream_self_rank() returns the rank of the execution stream that is
  * running the calling work unit through \c rank.
+ *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_xstream_rank()}
  *
  * @changev20
  * \DOC_DESC_V1X_RETURN_UNINITIALIZED

--- a/src/task.c
+++ b/src/task.c
@@ -213,6 +213,9 @@ int ABT_task_cancel(ABT_task task)
  * \c ABT_task_self() returns the handle of the calling work unit through
  * \c task.
  *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_thread()}
+ *
  * @changev20
  * \DOC_DESC_V1X_NOYIELDABLE{\c ABT_ERR_INV_TASK}
  *
@@ -260,6 +263,9 @@ int ABT_task_self(ABT_task *task)
  * @brief   Get ID of the calling work unit.
  *
  * \c ABT_task_self_id() returns the ID of the calling work unit through \c id.
+ *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_thread_id()}
  *
  * @changev20
  * \DOC_DESC_V1X_NOYIELDABLE{\c ABT_ERR_INV_TASK}

--- a/src/thread.c
+++ b/src/thread.c
@@ -586,6 +586,9 @@ int ABT_thread_join_many(int num_threads, ABT_thread *thread_list)
  * \c ABT_thread_exit() terminates the calling ULT.  This routine does not
  * return if it succeeds.
  *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_exit()}
+ *
  * @changev20
  * \DOC_DESC_V1X_RETURN_UNINITIALIZED
  * @endchangev20
@@ -1100,6 +1103,9 @@ int ABT_thread_yield_to(ABT_thread thread)
  *
  * \c ABT_thread_yield() yields the calling ULT and pushes the calling ULT to
  * its associated pool.  Its parent ULT will be resumed.
+ *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_yield()}
  *
  * @changev20
  * \DOC_DESC_V1X_YIELD_TASK

--- a/src/thread.c
+++ b/src/thread.c
@@ -674,6 +674,9 @@ int ABT_thread_cancel(ABT_thread thread)
  * \c ABT_thread_self() returns the handle of the calling work unit through
  * \c thread.
  *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_thread()}
+ *
  * @changev20
  * \DOC_DESC_V1X_NOTASK{\c ABT_ERR_INV_THREAD}
  *
@@ -721,6 +724,9 @@ int ABT_thread_self(ABT_thread *thread)
  *
  * \c ABT_thread_self_id() returns the ID of the calling work unit through
  * \c id.
+ *
+ * @note
+ * \DOC_DESC_REPLACEMENT{\c ABT_self_get_thread_id()}
  *
  * @changev20
  * \DOC_DESC_V1X_NOTASK{\c ABT_ERR_INV_THREAD}

--- a/src/thread.c
+++ b/src/thread.c
@@ -1019,13 +1019,12 @@ int ABT_thread_yield_to(ABT_thread thread)
     ABTI_ythread *p_cur_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     p_local_xstream = ABTI_local_get_xstream_or_null(ABTI_local_get_local());
-    if (ABTI_IS_ERROR_CHECK_ENABLED && ABTI_IS_EXT_THREAD_ENABLED &&
-        p_local_xstream == NULL) {
+    if (ABTI_IS_EXT_THREAD_ENABLED && p_local_xstream == NULL) {
         return ABT_SUCCESS;
     } else {
         p_cur_ythread =
             ABTI_thread_get_ythread_or_null(p_local_xstream->p_thread);
-        if (ABTI_IS_ERROR_CHECK_ENABLED && !p_cur_ythread)
+        if (!p_cur_ythread)
             return ABT_SUCCESS;
     }
 #else
@@ -1134,12 +1133,11 @@ int ABT_thread_yield(void)
     ABTI_ythread *p_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     p_local_xstream = ABTI_local_get_xstream_or_null(ABTI_local_get_local());
-    if (ABTI_IS_ERROR_CHECK_ENABLED && ABTI_IS_EXT_THREAD_ENABLED &&
-        ABTU_unlikely(p_local_xstream == NULL)) {
+    if (ABTI_IS_EXT_THREAD_ENABLED && ABTU_unlikely(p_local_xstream == NULL)) {
         return ABT_SUCCESS;
     } else {
         p_ythread = ABTI_thread_get_ythread_or_null(p_local_xstream->p_thread);
-        if (ABTI_IS_ERROR_CHECK_ENABLED && ABTU_unlikely(!p_ythread)) {
+        if (ABTU_unlikely(!p_ythread)) {
             return ABT_SUCCESS;
         }
     }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -56,6 +56,7 @@ basic/rwlock_writer_excl
 basic/eventual_create
 basic/eventual_test
 basic/barrier
+basic/self_rank_id
 basic/self_type
 basic/ext_thread
 basic/ext_thread2

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -12,6 +12,7 @@ basic/thread_revive
 basic/thread_attr
 basic/thread_attr2
 basic/thread_yield
+basic/thread_yield2
 basic/thread_yield_to
 basic/thread_self_suspend_resume
 basic/thread_get_last_xstream

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -14,6 +14,7 @@ basic/thread_attr2
 basic/thread_yield
 basic/thread_yield2
 basic/thread_yield_to
+basic/thread_exit
 basic/thread_self_suspend_resume
 basic/thread_get_last_xstream
 basic/thread_migrate

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
 	eventual_create \
 	eventual_test \
 	barrier \
+	self_rank_id \
 	self_type \
 	ext_thread \
 	ext_thread2 \
@@ -141,6 +142,7 @@ future_create_SOURCES = future_create.c
 eventual_create_SOURCES = eventual_create.c
 eventual_test_SOURCES = eventual_test.c
 barrier_SOURCES = barrier.c
+self_rank_id_SOURCES = self_rank_id.c
 self_type_SOURCES = self_type.c
 ext_thread_SOURCES = ext_thread.c
 ext_thread2_SOURCES = ext_thread2.c
@@ -209,6 +211,7 @@ testing:
 	./eventual_create
 	./eventual_test
 	./barrier
+	./self_rank_id
 	./self_type
 	./ext_thread
 	./ext_thread2

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -17,6 +17,7 @@ TESTS = \
 	thread_attr \
 	thread_attr2 \
 	thread_yield \
+	thread_yield2 \
 	thread_yield_to \
 	thread_self_suspend_resume \
 	thread_get_last_xstream \
@@ -98,6 +99,7 @@ thread_revive_SOURCES = thread_revive.c
 thread_attr_SOURCES = thread_attr.c
 thread_attr2_SOURCES = thread_attr2.c
 thread_yield_SOURCES = thread_yield.c
+thread_yield2_SOURCES = thread_yield2.c
 thread_yield_to_SOURCES = thread_yield_to.c
 thread_self_suspend_resume_SOURCES = thread_self_suspend_resume.c
 thread_get_last_xstream_SOURCES = thread_get_last_xstream.c
@@ -167,6 +169,7 @@ testing:
 	./thread_attr
 	./thread_attr2
 	./thread_yield
+	./thread_yield2
 	./thread_yield_to
 	./thread_self_suspend_resume
 	./thread_get_last_xstream

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -19,6 +19,7 @@ TESTS = \
 	thread_yield \
 	thread_yield2 \
 	thread_yield_to \
+	thread_exit \
 	thread_self_suspend_resume \
 	thread_get_last_xstream \
 	thread_migrate \
@@ -101,6 +102,7 @@ thread_attr2_SOURCES = thread_attr2.c
 thread_yield_SOURCES = thread_yield.c
 thread_yield2_SOURCES = thread_yield2.c
 thread_yield_to_SOURCES = thread_yield_to.c
+thread_exit_SOURCES = thread_exit.c
 thread_self_suspend_resume_SOURCES = thread_self_suspend_resume.c
 thread_get_last_xstream_SOURCES = thread_get_last_xstream.c
 thread_migrate_SOURCES = thread_migrate.c
@@ -171,6 +173,7 @@ testing:
 	./thread_yield
 	./thread_yield2
 	./thread_yield_to
+	./thread_exit
 	./thread_self_suspend_resume
 	./thread_get_last_xstream
 	./thread_migrate

--- a/test/basic/self_rank_id.c
+++ b/test/basic/self_rank_id.c
@@ -1,0 +1,273 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+ABT_bool g_is_check_error, g_support_external_thread;
+
+void task_hello(void *arg)
+{
+    int ret;
+    int rank1, rank2;
+    ABT_unit_id id1, id2;
+    ABT_thread thread;
+    ABT_xstream xstream;
+
+    ret = ABT_self_get_xstream(&xstream);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+
+    ret = ABT_xstream_get_rank(xstream, &rank1);
+    ATS_ERROR(ret, "ABT_xstream_get_rank");
+
+    ret = ABT_self_get_thread(&thread);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+
+    ret = ABT_thread_get_id(thread, &id1);
+    ATS_ERROR(ret, "ABT_thread_get_id");
+
+    /* Rank check */
+    ret = ABT_xstream_self_rank(&rank2);
+    ATS_ERROR(ret, "ABT_xstream_self_rank");
+    assert(rank1 == rank2);
+
+    ret = ABT_self_get_xstream_rank(&rank2);
+    ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+    assert(rank1 == rank2);
+
+    /* ID check */
+    ret = ABT_self_get_task_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_task_id");
+    assert(id1 == id2);
+
+    ret = ABT_self_get_thread_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_thread_id");
+    assert(id1 == id2);
+
+    ret = ABT_task_self_id(&id2);
+    ATS_ERROR(ret, "ABT_task_self_id");
+    assert(id1 == id2);
+
+#ifdef ABT_ENABLE_VER_20_API
+    ret = ABT_thread_self_id(&id2);
+    ATS_ERROR(ret, "ABT_thread_self_id");
+    assert(id1 == id2);
+#else
+    if (g_is_check_error) {
+        ret = ABT_thread_self_id(&id2);
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+}
+
+void thread_hello(void *arg)
+{
+    int ret;
+    int rank1, rank2;
+    ABT_unit_id id1, id2;
+    ABT_thread thread;
+    ABT_xstream xstream;
+
+    ret = ABT_self_get_xstream(&xstream);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+
+    ret = ABT_xstream_get_rank(xstream, &rank1);
+    ATS_ERROR(ret, "ABT_xstream_get_rank");
+
+    ret = ABT_self_get_thread(&thread);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+
+    ret = ABT_thread_get_id(thread, &id1);
+    ATS_ERROR(ret, "ABT_thread_get_id");
+
+    /* Rank check */
+    ret = ABT_xstream_self_rank(&rank2);
+    ATS_ERROR(ret, "ABT_xstream_self_rank");
+    assert(rank1 == rank2);
+
+    ret = ABT_self_get_xstream_rank(&rank2);
+    ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+    assert(rank1 == rank2);
+
+    /* ID check */
+    ret = ABT_self_get_task_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_task_id");
+    assert(id1 == id2);
+
+    ret = ABT_self_get_thread_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_thread_id");
+    assert(id1 == id2);
+
+    ret = ABT_thread_self_id(&id2);
+    ATS_ERROR(ret, "ABT_thread_self_id");
+    assert(id1 == id2);
+
+#ifdef ABT_ENABLE_VER_20_API
+    ret = ABT_task_self_id(&id2);
+    ATS_ERROR(ret, "ABT_task_self_id");
+    assert(id1 == id2);
+#else
+    if (g_is_check_error) {
+        ret = ABT_task_self_id(&id2);
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+
+    /* Even after yield, the ID should be the same. */
+    ret = ABT_thread_yield();
+    ATS_ERROR(ret, "ABT_thread_yield");
+
+    ret = ABT_self_get_task_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_task_id");
+    assert(id1 == id2);
+
+    ret = ABT_self_get_thread_id(&id2);
+    ATS_ERROR(ret, "ABT_self_get_thread_id");
+    assert(id1 == id2);
+
+    ret = ABT_thread_self_id(&id2);
+    ATS_ERROR(ret, "ABT_thread_self_id");
+    assert(id1 == id2);
+
+#ifdef ABT_ENABLE_VER_20_API
+    ret = ABT_task_self_id(&id2);
+    ATS_ERROR(ret, "ABT_task_self_id");
+    assert(id1 == id2);
+#else
+    if (g_is_check_error) {
+        ret = ABT_task_self_id(&id2);
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+}
+
+void *pthread_hello(void *arg)
+{
+    if (g_support_external_thread && g_is_check_error) {
+        int ret;
+        int rank;
+        ABT_thread_id id;
+        /* Rank check */
+        ret = ABT_xstream_self_rank(&rank);
+        assert(ret != ABT_SUCCESS);
+
+        ret = ABT_self_get_xstream_rank(&rank);
+        assert(ret != ABT_SUCCESS);
+
+        /* ID check */
+        ret = ABT_self_get_thread_id(&id);
+        assert(ret != ABT_SUCCESS);
+
+        ret = ABT_self_get_task_id(&id);
+        assert(ret != ABT_SUCCESS);
+
+        ret = ABT_thread_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+
+        ret = ABT_task_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+    }
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    ABT_xstream xstreams[2];
+    ABT_pool pools[2];
+    ABT_thread threads[2];
+    pthread_t pthread;
+    int i, ret;
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR,
+                                (void *)&g_is_check_error);
+    ATS_ERROR(ret, "ABT_info_query_config");
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&g_support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+
+#ifndef ABT_ENABLE_VER_20_API
+    /* Check error handling. */
+    if (g_is_check_error && g_support_external_thread) {
+        int rank;
+        ABT_thread_id id;
+        ret = ABT_xstream_self_rank(&rank);
+        assert(ret != ABT_SUCCESS);
+        ret = ABT_thread_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+        ret = ABT_task_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 2);
+
+    /* Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+
+    ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[1]);
+    ATS_ERROR(ret, "ABT_xstream_create");
+
+    /* Create ULTs */
+    for (i = 0; i < 2; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, &pools[i]);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+        ret = ABT_thread_create(pools[i], thread_hello, NULL,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+    /* Call it here. */
+    thread_hello(NULL);
+
+    /* Create a pthread */
+    ret = pthread_create(&pthread, NULL, pthread_hello, NULL);
+    assert(ret == 0);
+
+    /* Join and free ULTs */
+    for (i = 0; i < 2; i++) {
+        ret = ABT_thread_join(threads[i]);
+        ATS_ERROR(ret, "ABT_thread_join");
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+    ret = ABT_xstream_join(xstreams[1]);
+    ATS_ERROR(ret, "ABT_xstream_join");
+    ret = ABT_xstream_free(&xstreams[1]);
+    ATS_ERROR(ret, "ABT_xstream_free");
+    ret = pthread_join(pthread, NULL);
+    assert(ret == 0);
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+    ATS_ERROR(ret, "ATS_finalize");
+
+#ifndef ABT_ENABLE_VER_20_API
+    /* Check error handling. */
+    if (g_is_check_error && g_support_external_thread) {
+        int rank;
+        ABT_thread_id id;
+        ret = ABT_xstream_self_rank(&rank);
+        assert(ret != ABT_SUCCESS);
+        ret = ABT_thread_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+        ret = ABT_task_self_id(&id);
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+    return 0;
+}

--- a/test/basic/self_type.c
+++ b/test/basic/self_type.c
@@ -10,15 +10,19 @@
 
 void task_hello(void *arg)
 {
-    ABT_xstream xstream;
-    ABT_thread thread;
-    ABT_task task;
+    ABT_xstream xstream, xstream2;
+    ABT_thread thread, thread2;
+    ABT_task task, task2;
     ABT_unit_type type;
     ABT_bool flag;
     int ret;
 
     ret = ABT_xstream_self(&xstream);
     ATS_ERROR(ret, "ABT_stream_self");
+
+    ret = ABT_self_get_xstream(&xstream2);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+    assert(xstream == xstream2);
 
     ret = ABT_thread_self(&thread);
 #ifdef ABT_ENABLE_VER_20_API
@@ -27,8 +31,16 @@ void task_hello(void *arg)
     assert(ret == ABT_ERR_INV_THREAD && thread == ABT_THREAD_NULL);
 #endif
 
+    ret = ABT_self_get_thread(&thread2);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+
     ret = ABT_task_self(&task);
     ATS_ERROR(ret, "ABT_task_self");
+
+    ret = ABT_self_get_task(&task2);
+    ATS_ERROR(ret, "ABT_self_get_task");
+
+    assert(task == task2 && task == thread2);
 
     ret = ABT_self_get_type(&type);
     assert(ret == ABT_SUCCESS && type == ABT_UNIT_TYPE_TASK);
@@ -49,11 +61,11 @@ void task_hello(void *arg)
 
 void thread_hello(void *arg)
 {
-    ABT_xstream xstream;
+    ABT_xstream xstream, xstream2;
     ABT_pool pool;
-    ABT_thread thread;
+    ABT_thread thread, thread2;
     ABT_unit_id my_id;
-    ABT_task task;
+    ABT_task task, task2;
     ABT_unit_type type;
     ABT_bool flag;
     int ret;
@@ -61,8 +73,17 @@ void thread_hello(void *arg)
     ret = ABT_xstream_self(&xstream);
     ATS_ERROR(ret, "ABT_stream_self");
 
+    ret = ABT_self_get_xstream(&xstream2);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+    assert(xstream == xstream2);
+
     ret = ABT_thread_self(&thread);
     ATS_ERROR(ret, "ABT_thread_self");
+
+    ret = ABT_self_get_thread(&thread2);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+    assert(thread == thread2);
+
     ret = ABT_thread_get_id(thread, &my_id);
     ATS_ERROR(ret, "ABT_thread_get_id");
 
@@ -72,6 +93,10 @@ void thread_hello(void *arg)
 #else
     assert(ret == ABT_ERR_INV_TASK && task == ABT_TASK_NULL);
 #endif
+
+    ret = ABT_self_get_task(&task2);
+    ATS_ERROR(ret, "ABT_self_get_task");
+    assert(thread == task2);
 
     ret = ABT_self_get_type(&type);
     assert(ret == ABT_SUCCESS && type == ABT_UNIT_TYPE_THREAD);
@@ -114,6 +139,9 @@ void *pthread_hello(void *arg)
     assert(ret == ABT_ERR_INV_XSTREAM && xstream == ABT_XSTREAM_NULL);
 #endif
 
+    ret = ABT_self_get_xstream(&xstream);
+    assert(ret == ABT_ERR_INV_XSTREAM);
+
     ret = ABT_thread_self(&thread);
 #ifdef ABT_ENABLE_VER_20_API
     assert(ret == ABT_ERR_INV_XSTREAM);
@@ -121,12 +149,18 @@ void *pthread_hello(void *arg)
     assert(ret == ABT_ERR_INV_XSTREAM && thread == ABT_THREAD_NULL);
 #endif
 
+    ret = ABT_self_get_thread(&thread);
+    assert(ret == ABT_ERR_INV_XSTREAM);
+
     ret = ABT_task_self(&task);
 #ifdef ABT_ENABLE_VER_20_API
     assert(ret == ABT_ERR_INV_XSTREAM);
 #else
     assert(ret == ABT_ERR_INV_XSTREAM && task == ABT_TASK_NULL);
 #endif
+
+    ret = ABT_self_get_task(&task);
+    assert(ret == ABT_ERR_INV_XSTREAM);
 
     ret = ABT_self_get_type(&type);
 #ifdef ABT_ENABLE_VER_20_API
@@ -211,6 +245,21 @@ int main(int argc, char *argv[])
 #else
     assert(ret == ABT_ERR_INV_TASK && my_task == ABT_TASK_NULL);
 #endif
+
+    ABT_xstream xstream_tmp;
+    ret = ABT_self_get_xstream(&xstream_tmp);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+    assert(xstream_tmp == xstreams[0]);
+
+    ABT_thread thread_tmp;
+    ret = ABT_self_get_thread(&thread_tmp);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+    assert(thread_tmp == my_thread);
+
+    ABT_task task_tmp;
+    ret = ABT_self_get_task(&task_tmp);
+    ATS_ERROR(ret, "ABT_self_get_task");
+    assert(task_tmp == my_thread);
 
     ret = ABT_self_get_type(&type);
     assert(ret == ABT_SUCCESS && type == ABT_UNIT_TYPE_THREAD);

--- a/test/basic/thread_data.c
+++ b/test/basic/thread_data.c
@@ -22,32 +22,34 @@ static void tls_destructor(void *value)
     free(value);
 }
 
-static void thread_tls_test(void *arg)
+typedef int (*set_specific_func_t)(ABT_key, void *);
+typedef int (*get_specific_func_t)(ABT_key, void **);
+
+static void thread_tls_test_core(int my_id, set_specific_func_t set_specific_f,
+                                 get_specific_func_t get_specific_f,
+                                 int is_last)
 {
-    int my_id = (int)(intptr_t)arg;
     int i, ret;
     void *check;
     void *value[NUM_TLS];
 
-    ATS_printf(1, "[U%d] start\n", my_id);
-
     /* If we haven't set a value for a key, we should get NULL for the key. */
     for (i = 0; i < NUM_TLS; i++) {
-        ret = ABT_key_get(tls[i], &check);
-        ATS_ERROR(ret, "ABT_key_get");
+        ret = get_specific_f(tls[i], &check);
+        ATS_ERROR(ret, "get_specific_f");
         assert(check == NULL);
     }
 
     for (i = 0; i < NUM_TLS; i++) {
         value[i] = malloc(16);
         ATS_printf(1, "[U%d] malloc(%p)\n", my_id, value[i]);
-        ret = ABT_key_set(tls[i], value[i]);
-        ATS_ERROR(ret, "ABT_key_set");
+        ret = set_specific_f(tls[i], value[i]);
+        ATS_ERROR(ret, "set_specific_f");
     }
 
     for (i = 0; i < NUM_TLS; i++) {
-        ret = ABT_key_get(tls[i], &check);
-        ATS_ERROR(ret, "ABT_key_get");
+        ret = get_specific_f(tls[i], &check);
+        ATS_ERROR(ret, "get_specific_f");
         assert(value[i] == check);
     }
     ATS_printf(1, "[U%d] passed #1\n", my_id);
@@ -55,25 +57,45 @@ static void thread_tls_test(void *arg)
     ABT_thread_yield();
 
     for (i = 0; i < NUM_TLS; i++) {
-        ret = ABT_key_get(tls[i], &check);
-        ATS_ERROR(ret, "ABT_key_get");
+        ret = get_specific_f(tls[i], &check);
+        ATS_ERROR(ret, "get_specific_f");
         assert(value[i] == check);
     }
     ATS_printf(1, "[U%d] passed #2\n", my_id);
 
     ABT_thread_yield();
 
-    for (i = 2; i < NUM_TLS; i++) {
+    for (i = (is_last ? 2 : 0); i < NUM_TLS; i++) {
         ATS_printf(1, "[U%d] free(%p)\n", my_id, value[i]);
         free(value[i]);
-        ret = ABT_key_set(tls[i], NULL);
-        ATS_ERROR(ret, "ABT_key_set");
+        ret = set_specific_f(tls[i], NULL);
+        ATS_ERROR(ret, "set_specific_f");
 
-        ret = ABT_key_get(tls[i], &check);
-        ATS_ERROR(ret, "ABT_key_get");
+        ret = get_specific_f(tls[i], &check);
+        ATS_ERROR(ret, "get_specific_f");
         assert(check == NULL);
     }
     ATS_printf(1, "[U%d] passed #3\n", my_id);
+}
+
+static void thread_tls_test(void *arg)
+{
+    int my_id = (int)(intptr_t)arg;
+
+    ATS_printf(1, "[U%d] start\n", my_id);
+
+    set_specific_func_t set_specific_fs[2] = { ABT_key_set,
+                                               ABT_self_set_specific };
+    get_specific_func_t get_specific_fs[2] = { ABT_key_get,
+                                               ABT_self_get_specific };
+    int set_i, get_i;
+    for (set_i = 0; set_i < 2; set_i++) {
+        for (get_i = 0; get_i < 2; get_i++) {
+            int is_last = (set_i == 1 && get_i == 1);
+            thread_tls_test_core(my_id, set_specific_fs[set_i],
+                                 get_specific_fs[get_i], is_last);
+        }
+    }
 
     ATS_printf(1, "[U%d] end\n", my_id);
 }

--- a/test/basic/thread_exit.c
+++ b/test/basic/thread_exit.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define NUM_THREADS 100
+
+int g_count = 0;
+
+void thread_func(void *arg)
+{
+    g_count++;
+    if (arg == NULL) {
+        ABT_thread_exit();
+    } else {
+        ABT_self_exit();
+    }
+    assert(0);
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
+
+    /* Get the pool attached to the primary execution stream */
+    ABT_xstream xstream;
+    ret = ABT_self_get_xstream(&xstream);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+
+    ABT_pool pool;
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    /* Fork and join threads */
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
+    for (i = 0; i < NUM_THREADS; i++) {
+        void *arg = (i < NUM_THREADS / 2) ? NULL : ((void *)(intptr_t)1);
+        ret = ABT_thread_create(pool, thread_func, arg, ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+    for (i = 0; i < NUM_THREADS; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+    free(threads);
+
+    /* Finalize */
+    return ATS_finalize(0);
+}

--- a/test/basic/thread_yield2.c
+++ b/test/basic/thread_yield2.c
@@ -1,0 +1,148 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define NUM_THREADS 4
+
+ABT_bool g_is_check_error, g_support_external_thread;
+int g_count = 0;
+
+void thread_func(void *arg)
+{
+    int i, my_count, ret;
+
+    for (i = 0; i < 100; i++) {
+        my_count = g_count++;
+        ret = ABT_thread_yield();
+        ATS_ERROR(ret, "ABT_thread_yield");
+        /* After yield, all the other threads are scheduled, so g_count must be
+         * my_count + NUM_THREADS.
+         * Note that this does not hold for the last iteration because of the
+         * join optimization. */
+        if (i < 99)
+            assert(g_count == my_count + NUM_THREADS);
+
+        my_count = g_count++;
+        ret = ABT_self_yield();
+        ATS_ERROR(ret, "ABT_self_yield");
+        /* For the same reason, g_count must be my_count + NUM_THREADS. */
+        if (i < 99)
+            assert(g_count == my_count + NUM_THREADS);
+    }
+}
+
+void task_func(void *arg)
+{
+    int ret, my_count;
+
+    my_count = ++g_count;
+    /* Task cannot yield. */
+#ifndef ABT_ENABLE_VER_20_API
+    /* ABT_thread_yield() does nothing. */
+    ret = ABT_thread_yield();
+    ATS_ERROR(ret, "ABT_thread_yield");
+#else
+    /* ABT_thread_yield() returns an error. */
+    if (g_is_check_error) {
+        ret = ABT_thread_yield();
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+    if (g_is_check_error) {
+        ret = ABT_self_yield();
+        assert(ret != ABT_SUCCESS);
+    }
+    assert(my_count == g_count);
+}
+
+void *pthread_func(void *arg)
+{
+    int ret;
+#ifndef ABT_ENABLE_VER_20_API
+    /* ABT_thread_yield() does nothing. */
+    ret = ABT_thread_yield();
+    ATS_ERROR(ret, "ABT_thread_yield");
+#else
+    /* ABT_thread_yield() returns an error. */
+    if (g_is_check_error) {
+        ret = ABT_thread_yield();
+        assert(ret != ABT_SUCCESS);
+    }
+#endif
+    if (g_is_check_error) {
+        ret = ABT_self_yield();
+        assert(ret != ABT_SUCCESS);
+    }
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
+
+    /* Get the configuration. */
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR,
+                                (void *)&g_is_check_error);
+    ATS_ERROR(ret, "ABT_info_query_config");
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&g_support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+
+    /* Get the pool attached to the primary execution stream */
+    ABT_xstream xstream;
+    ret = ABT_self_get_xstream(&xstream);
+    ATS_ERROR(ret, "ABT_self_get_xstream");
+
+    ABT_pool pool;
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    /* Fork and join threads */
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
+    for (i = 0; i < NUM_THREADS; i++) {
+        ret = ABT_thread_create(pool, thread_func, NULL, ABT_THREAD_ATTR_NULL,
+                                &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+    for (i = 0; i < NUM_THREADS; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+    free(threads);
+
+    /* Fork and join tasks */
+    ABT_task *tasks = (ABT_task *)malloc(sizeof(ABT_task) * NUM_THREADS);
+    for (i = 0; i < NUM_THREADS; i++) {
+        ret = ABT_task_create(pool, task_func, NULL, &tasks[i]);
+        ATS_ERROR(ret, "ABT_task_create");
+    }
+    for (i = 0; i < NUM_THREADS; i++) {
+        ret = ABT_task_free(&tasks[i]);
+        ATS_ERROR(ret, "ABT_tasks_free");
+    }
+    free(tasks);
+
+    /* Fork and join a pthread */
+    if (g_support_external_thread) {
+        pthread_t pthread;
+        ret = pthread_create(&pthread, NULL, pthread_func, NULL);
+        assert(ret == 0);
+        ret = pthread_join(pthread, NULL);
+        assert(ret == 0);
+    }
+
+    /* Finalize */
+    return ATS_finalize(0);
+}


### PR DESCRIPTION
## Pull Request Description

Argobots functions that get, set, or manipulate underlying threads and execution streams should be named "ABT_self_xxx()", but some functions do not follow this rule.  To improve the name consistency, this PR creates functions that have the same functionality as the existing ones but are named properly:
```
 - ABT_xstream_self      -> ABT_self_get_xstream
 - ABT_xstream_self_rank -> ABT_self_get_xstream_rank
 - ABT_thread_self       -> ABT_self_get_thread
 - ABT_thread_self_id    -> ABT_self_get_thread_id
 - ABT_task_self         -> ABT_self_get_task
 - ABT_task_self_id      -> ABT_self_get_task_id
 - ABT_key_set           -> ABT_self_set_specific
 - ABT_key_get           -> ABT_self_get_specific
 - ABT_thread_yield      -> ABT_self_yield
 - ABT_thread_exit       -> ABT_self_exit
```

Note that this PR does not modify the existing functions, so the ABI/API compatibility will be kept.  There is no performance impact.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
