### PR TITLE
efficient synchronization of external threads using futex

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,14 @@ AC_ARG_ENABLE([stack-overflow-check],
         none|no
 ],,[enable_stack_overflow_check=no])
 
+# --enable-wait-policy
+AC_ARG_ENABLE([wait-policy],
+[  --enable-wait-policy@<:@=OPTS@:>@ set a wait policy of blocking operations
+        default|auto - choose the best policy, which is currently "passive".
+        active       - spin-wait on blocking.  It uses more CPU resources.
+        passive      - suspend CPU cores on blocking.  It increases latency.
+],,[enable_wait_policy=auto])
+
 # --disable-simple-mutex
 AC_ARG_ENABLE([simple-mutex],
     AS_HELP_STRING([--disable-simple-mutex], [use an experimental mutex implementation]),,
@@ -774,6 +782,10 @@ AS_IF([test "x$have_linux_futex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_LINUX_FUTEX, 1,
                  [Define to use Linux-type futex])])
 
+# --enable-wait-policy
+AS_IF([test "x$enable_wait_policy" = "xactive"],
+      [AC_DEFINE(ABT_CONFIG_ACTIVE_WAIT_POLICY, 1,
+                 [Define to enable the active wait policy])])
 
 # --disable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],

--- a/configure.ac
+++ b/configure.ac
@@ -875,6 +875,16 @@ AC_CHECK_LIB(pthread, pthread_join)
 # check pthread_barrier
 AC_CHECK_FUNCS(pthread_barrier_init)
 
+# check -lrt library
+AC_CHECK_LIB(rt, timer_create)
+if test "$ac_cv_lib_rt" = "yes" ; then
+    # -lrt is used for testing
+    abttest_timer_library="-lrt"
+else
+    abttest_timer_library=""
+fi
+AC_SUBST(abttest_timer_library)
+
 # check timer functions
 AC_CHECK_FUNCS(clock_gettime mach_absolute_time gettimeofday)
 if test "$ac_cv_func_clock_gettime" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -747,6 +747,34 @@ if test "$CC" != "xlc" -a "$CC" != "pgcc" -a "x$have_atomic_builtin" = "xyes" ; 
 fi
 
 
+# check if futex is available.  Note that futex() is basically Linux-specific.
+AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([
+ #include <unistd.h>
+ #include <linux/futex.h>
+ #include <syscall.h>
+ #include <assert.h>
+],[
+ // Maybe we should not include <futex.h> since it seems that it has some
+ // compatibility issues (see LLVM OpenMP).  We should use a constant value
+ // for futex_op if we found some compilation issues here.
+ int ret, futex_val = 0;
+ // The following does not sleep since futex_val is not 1.
+ ret = syscall(SYS_futex, &futex_val, FUTEX_WAIT_PRIVATE, 1, 0, 0, 0);
+ assert(ret == 0);
+ // The following does not wake up any since no thread is sleeping.
+ ret = syscall(SYS_futex, &futex_val, FUTEX_WAKE_PRIVATE, 1, 0, 0, 0);
+ // The return value is 0 since no thread was waken up.
+ assert(ret == 0);
+])],
+[have_linux_futex=yes],
+[have_linux_futex=no]
+)
+AS_IF([test "x$have_linux_futex" = "xyes"],
+      [AC_DEFINE(ABT_CONFIG_USE_LINUX_FUTEX, 1,
+                 [Define to use Linux-type futex])])
+
+
 # --disable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,

--- a/src/arch/Makefile.mk
+++ b/src/arch/Makefile.mk
@@ -7,6 +7,7 @@ abt_sources += \
 	arch/abtd_affinity.c \
 	arch/abtd_affinity_parser.c \
 	arch/abtd_env.c \
+	arch/abtd_futex.c \
 	arch/abtd_stream.c \
 	arch/abtd_time.c \
 	arch/abtd_ythread.c

--- a/src/arch/abtd_futex.c
+++ b/src/arch/abtd_futex.c
@@ -1,0 +1,167 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include "abti.h"
+
+#ifndef ABT_CONFIG_ACTIVE_WAIT_POLICY
+
+#ifdef ABT_CONFIG_USE_LINUX_FUTEX
+
+/* Use Linux futex. */
+#include <unistd.h>
+#include <linux/futex.h>
+#include <syscall.h>
+
+void ABTD_futex_wait_and_unlock(ABTD_futex_multiple *p_futex,
+                                ABTD_spinlock *p_lock)
+{
+    const int original_val = ABTD_atomic_relaxed_load_int(&p_futex->val);
+    ABTD_spinlock_release(p_lock);
+    do {
+        syscall(SYS_futex, &p_futex->val.val, FUTEX_WAIT_PRIVATE, original_val,
+                NULL, NULL, 0);
+    } while (ABTD_atomic_relaxed_load_int(&p_futex->val) == original_val);
+}
+
+void ABTD_futex_timedwait_and_unlock(ABTD_futex_multiple *p_futex,
+                                     ABTD_spinlock *p_lock,
+                                     double wait_time_sec)
+{
+    const int original_val = ABTD_atomic_relaxed_load_int(&p_futex->val);
+    ABTD_spinlock_release(p_lock);
+    struct timespec wait_time; /* This wait_time must be **relative**. */
+    wait_time.tv_sec = (time_t)wait_time_sec;
+    wait_time.tv_nsec =
+        (long)((wait_time_sec - (double)(time_t)wait_time_sec) * 1.0e9);
+    syscall(SYS_futex, &p_futex->val.val, FUTEX_WAIT_PRIVATE, original_val,
+            &wait_time, NULL, 0);
+}
+
+void ABTD_futex_broadcast(ABTD_futex_multiple *p_futex)
+{
+    int current_val = ABTD_atomic_relaxed_load_int(&p_futex->val);
+    ABTD_atomic_relaxed_store_int(&p_futex->val, current_val + 1);
+    syscall(SYS_futex, &p_futex->val.val, FUTEX_WAKE_PRIVATE, INT_MAX, NULL,
+            NULL, 0);
+}
+
+#else /* ABT_CONFIG_USE_LINUX_FUTEX */
+
+/* Use Pthreads. */
+#include <pthread.h>
+
+typedef struct pthread_sync {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    struct pthread_sync *p_next;
+    struct pthread_sync *p_prev;
+    ABTD_atomic_int val;
+} pthread_sync;
+
+#define PTHREAD_SYNC_STATIC_INITIALIZER                                        \
+    {                                                                          \
+        PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, NULL, NULL,       \
+            ABTD_ATOMIC_INT_STATIC_INITIALIZER(0),                             \
+    }
+
+void ABTD_futex_wait_and_unlock(ABTD_futex_multiple *p_futex,
+                                ABTD_spinlock *p_lock)
+{
+    pthread_sync sync_obj = PTHREAD_SYNC_STATIC_INITIALIZER;
+    pthread_mutex_lock(&sync_obj.mutex);
+    /* This p_next updates must be done "after" taking mutex but "before"
+     * releasing p_lock. */
+    pthread_sync *p_next = (pthread_sync *)p_futex->p_next;
+    if (p_next)
+        p_next->p_prev = &sync_obj;
+    sync_obj.p_next = p_next;
+    p_futex->p_next = (void *)&sync_obj;
+    ABTD_spinlock_release(p_lock);
+    while (ABTD_atomic_relaxed_load_int(&sync_obj.val) == 0) {
+        pthread_cond_wait(&sync_obj.cond, &sync_obj.mutex);
+    }
+    /* I cannot find whether a statically initialized mutex must be unlocked
+     * before it gets out of scope or not, but let's choose a safer way. */
+    pthread_mutex_unlock(&sync_obj.mutex);
+
+    /* Since now val is 1, there's no possibility that the signaler is still
+     * touching this sync_obj.  sync_obj can be safely released by exiting this
+     * function. */
+}
+
+void ABTD_futex_timedwait_and_unlock(ABTD_futex_multiple *p_futex,
+                                     ABTD_spinlock *p_lock,
+                                     double wait_time_sec)
+{
+    pthread_sync sync_obj = PTHREAD_SYNC_STATIC_INITIALIZER;
+
+    struct timespec wait_time; /* This time must be **relative**. */
+    clock_gettime(CLOCK_REALTIME, &wait_time);
+    wait_time.tv_sec += (time_t)wait_time_sec;
+    wait_time.tv_nsec +=
+        (long)((wait_time_sec - (double)(time_t)wait_time_sec) * 1.0e9);
+    if (wait_time.tv_nsec >= 1e9) {
+        wait_time.tv_sec += 1;
+        wait_time.tv_nsec -= 1e9;
+    }
+    pthread_mutex_lock(&sync_obj.mutex);
+    /* This p_next updates must be done "after" taking mutex but "before"
+     * releasing p_lock. */
+    pthread_sync *p_next = (pthread_sync *)p_futex->p_next;
+    if (p_next)
+        p_next->p_prev = &sync_obj;
+    sync_obj.p_next = p_next;
+    p_futex->p_next = (void *)&sync_obj;
+    ABTD_spinlock_release(p_lock);
+    pthread_cond_timedwait(&sync_obj.cond, &sync_obj.mutex, &wait_time);
+
+    /* I cannot find whether a statically initialized mutex must be unlocked
+     * before it gets out of scope or not, but let's choose a safer way. */
+    pthread_mutex_unlock(&sync_obj.mutex);
+
+    if (ABTD_atomic_acquire_load_int(&sync_obj.val) != 0) {
+        /* Since now val is 1, there's no possibility that the signaler is still
+         * touching sync_obj.  sync_obj can be safely released by exiting this
+         * function. */
+    } else {
+        /* Maybe this sync_obj is being touched by the signaler.  Take a lock
+         * and remove it from the list. */
+        ABTD_spinlock_acquire(p_lock);
+        /* Double check the value in a lock. */
+        if (ABTD_atomic_acquire_load_int(&sync_obj.val) == 0) {
+            /* timedout or spurious wakeup happens. Remove this sync_obj from
+             * p_futex carefully. */
+            if (p_futex->p_next == (void *)&sync_obj) {
+                p_futex->p_next = (void *)sync_obj.p_next;
+            } else {
+                ABTI_ASSERT(sync_obj.p_prev);
+                sync_obj.p_prev->p_next = sync_obj.p_next;
+                sync_obj.p_next->p_prev = sync_obj.p_prev;
+            }
+        }
+        ABTD_spinlock_release(p_lock);
+    }
+}
+
+void ABTD_futex_broadcast(ABTD_futex_multiple *p_futex)
+{
+    /* The caller must be holding a lock (p_lock above). */
+    pthread_sync *p_cur = (pthread_sync *)p_futex->p_next;
+    while (p_cur) {
+        pthread_sync *p_next = p_cur->p_next;
+        pthread_mutex_lock(&p_cur->mutex);
+        ABTD_atomic_relaxed_store_int(&p_cur->val, 1);
+        pthread_cond_broadcast(&p_cur->cond);
+        pthread_mutex_unlock(&p_cur->mutex);
+        /* After "val" is updated and the mutex is unlocked, that pthread_sync
+         * may not be touched. */
+        p_cur = p_next;
+    }
+    p_futex->p_next = NULL;
+}
+
+#endif /* !ABT_CONFIG_USE_LINUX_FUTEX */
+
+#endif /* !ABT_CONFIG_ACTIVE_WAIT_POLICY */

--- a/src/arch/abtd_ythread.c
+++ b/src/arch/abtd_ythread.c
@@ -38,62 +38,58 @@ static inline void ythread_terminate(ABTI_xstream *p_local_xstream,
     ABTD_ythread_context *p_ctx = &p_ythread->ctx;
     ABTD_ythread_context *p_link =
         ABTD_atomic_acquire_load_ythread_context_ptr(&p_ctx->p_link);
-    if (p_link) {
-        /* If p_link is set, it means that other ULT has called the join. */
-        ABTI_ythread *p_joiner = ABTI_ythread_context_get_ythread(p_link);
-        if (p_ythread->thread.p_last_xstream ==
-                p_joiner->thread.p_last_xstream &&
-            !(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED)) {
-            /* Only when the current ULT is on the same ES as p_joiner's,
-             * we can jump to the joiner ULT. */
-            ABTD_atomic_release_store_int(&p_ythread->thread.state,
-                                          ABT_THREAD_STATE_TERMINATED);
-            LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n",
-                      ABTI_thread_get_id(&p_ythread->thread),
-                      p_ythread->thread.p_last_xstream->rank);
-
-            /* Note that a parent ULT cannot be a joiner. */
-            ABTI_tool_event_ythread_resume(ABTI_xstream_get_local(
-                                               p_local_xstream),
-                                           p_joiner, &p_ythread->thread);
-            ABTI_ythread_finish_context_to_sibling(p_local_xstream, p_ythread,
-                                                   p_joiner);
-            return;
-        } else {
-            /* If the current ULT's associated ES is different from p_joiner's,
-             * we can't directly jump to p_joiner.  Instead, we wake up
-             * p_joiner here so that p_joiner's scheduler can resume it.
-             * Note that the main scheduler needs to jump back to the root
-             * scheduler, so the main scheduler needs to take this path. */
-            ABTI_ythread_set_ready(ABTI_xstream_get_local(p_local_xstream),
-                                   p_joiner);
-
-            /* We don't need to use the atomic OR operation here because the ULT
-             * will be terminated regardless of other requests. */
-            ABTD_atomic_release_store_uint32(&p_ythread->thread.request,
-                                             ABTI_THREAD_REQ_TERMINATE);
-        }
-    } else {
+    if (!p_link) {
         uint32_t req =
             ABTD_atomic_fetch_or_uint32(&p_ythread->thread.request,
                                         ABTI_THREAD_REQ_JOIN |
                                             ABTI_THREAD_REQ_TERMINATE);
-        if (req & ABTI_THREAD_REQ_JOIN) {
+        if (!(req & ABTI_THREAD_REQ_JOIN)) {
+            /* This case means there is no join request.  Let's go back to the
+             * parent ULT */
+            ABTI_ythread_finish_context_to_parent(p_local_xstream, p_ythread);
+            ABTU_unreachable();
+        } else {
             /* This case means there has been a join request and the joiner has
              * blocked.  We have to wake up the joiner ULT. */
             do {
                 p_link = ABTD_atomic_acquire_load_ythread_context_ptr(
                     &p_ctx->p_link);
             } while (!p_link);
-            ABTI_ythread_set_ready(ABTI_xstream_get_local(p_local_xstream),
-                                   ABTI_ythread_context_get_ythread(p_link));
         }
     }
-
-    /* No other ULT is waiting or blocked for this ULT. Since a context does not
-     * switch to another context when it finishes, we need to explicitly switch
-     * to the parent. */
+    /* Now p_link != NULL. */
+    ABTI_ythread *p_joiner = ABTI_ythread_context_get_ythread(p_link);
+    if (p_ythread->thread.p_last_xstream == p_joiner->thread.p_last_xstream &&
+        !(p_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED)) {
+        /* Only when the current ULT is on the same ES as p_joiner's,
+         * we can jump to the joiner ULT. */
+        ABTD_atomic_release_store_int(&p_ythread->thread.state,
+                                      ABT_THREAD_STATE_TERMINATED);
+        LOG_DEBUG("[U%" PRIu64 ":E%d] terminated\n",
+                  ABTI_thread_get_id(&p_ythread->thread),
+                  p_ythread->thread.p_last_xstream->rank);
+        /* Note that a parent ULT cannot be a joiner. */
+        ABTI_tool_event_ythread_resume(ABTI_xstream_get_local(p_local_xstream),
+                                       p_joiner, &p_ythread->thread);
+        ABTI_ythread_finish_context_to_sibling(p_local_xstream, p_ythread,
+                                               p_joiner);
+        ABTU_unreachable();
+    } else {
+        /* If the current ULT's associated ES is different from p_joiner's, we
+         * can't directly jump to p_joiner.  Instead, we wake up p_joiner here
+         * so that p_joiner's scheduler can resume it.  Note that the main
+         * scheduler needs to jump back to the root scheduler, so the main
+         * scheduler needs to take this path. */
+        ABTI_ythread_set_ready(ABTI_xstream_get_local(p_local_xstream),
+                               p_joiner);
+    }
+    /* We don't need to use the atomic OR operation here because the ULT
+     * will be terminated regardless of other requests. */
+    ABTD_atomic_release_store_uint32(&p_ythread->thread.request,
+                                     ABTI_THREAD_REQ_TERMINATE);
+    /* The waiter has been resumed.  Let's switch to the parent. */
     ABTI_ythread_finish_context_to_parent(p_local_xstream, p_ythread);
+    ABTU_unreachable();
 }
 
 #if ABT_CONFIG_THREAD_TYPE == ABT_THREAD_TYPE_DYNAMIC_PROMOTION

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -58,7 +58,7 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
     abt_errno = ABTU_malloc(sizeof(ABTI_barrier), (void **)&p_newbarrier);
     ABTI_CHECK_ERROR(abt_errno);
 
-    ABTI_spinlock_clear(&p_newbarrier->lock);
+    ABTD_spinlock_clear(&p_newbarrier->lock);
     p_newbarrier->num_waiters = arg_num_waiters;
     p_newbarrier->counter = 0;
     ABTI_waitlist_init(&p_newbarrier->waitlist);
@@ -145,7 +145,7 @@ int ABT_barrier_free(ABT_barrier *barrier)
     /* The lock needs to be acquired to safely free the barrier structure.
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
-    ABTI_spinlock_acquire(&p_barrier->lock);
+    ABTD_spinlock_acquire(&p_barrier->lock);
 
     /* p_barrier->counter must be checked after taking a lock. */
     ABTI_ASSERT(p_barrier->counter == 0);
@@ -202,7 +202,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
     }
 #endif
 
-    ABTI_spinlock_acquire(&p_barrier->lock);
+    ABTD_spinlock_acquire(&p_barrier->lock);
 
     ABTI_ASSERT(p_barrier->counter < p_barrier->num_waiters);
     p_barrier->counter++;
@@ -217,7 +217,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
         ABTI_waitlist_broadcast(p_local, &p_barrier->waitlist);
         /* Reset counter */
         p_barrier->counter = 0;
-        ABTI_spinlock_release(&p_barrier->lock);
+        ABTD_spinlock_release(&p_barrier->lock);
     }
     return ABT_SUCCESS;
 }

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -210,7 +210,7 @@ int ABT_barrier_wait(ABT_barrier barrier)
     /* If we do not have all the waiters yet */
     if (p_barrier->counter < p_barrier->num_waiters) {
         ABTI_waitlist_wait_and_unlock(&p_local, &p_barrier->waitlist,
-                                      &p_barrier->lock, ABT_FALSE,
+                                      &p_barrier->lock,
                                       ABT_SYNC_EVENT_TYPE_BARRIER,
                                       (void *)p_barrier);
     } else {

--- a/src/cond.c
+++ b/src/cond.c
@@ -254,8 +254,7 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     ABTI_mutex_unlock(p_local, p_mutex);
     ABT_bool is_timedout =
         ABTI_waitlist_wait_timedout_and_unlock(&p_local, &p_cond->waitlist,
-                                               &p_cond->lock, ABT_FALSE,
-                                               tar_time,
+                                               &p_cond->lock, tar_time,
                                                ABT_SYNC_EVENT_TYPE_COND,
                                                (void *)p_cond);
     /* Lock the mutex again */

--- a/src/cond.c
+++ b/src/cond.c
@@ -239,13 +239,13 @@ int ABT_cond_timedwait(ABT_cond cond, ABT_mutex mutex,
     thread.type = ABTI_THREAD_TYPE_EXT;
     ABTD_atomic_relaxed_store_int(&thread.state, ABT_THREAD_STATE_BLOCKED);
 
-    ABTI_spinlock_acquire(&p_cond->lock);
+    ABTD_spinlock_acquire(&p_cond->lock);
 
     if (p_cond->p_waiter_mutex == NULL) {
         p_cond->p_waiter_mutex = p_mutex;
     } else {
         if (p_cond->p_waiter_mutex != p_mutex) {
-            ABTI_spinlock_release(&p_cond->lock);
+            ABTD_spinlock_release(&p_cond->lock);
             ABTI_HANDLE_ERROR(ABT_ERR_INV_MUTEX);
         }
     }
@@ -288,9 +288,9 @@ int ABT_cond_signal(ABT_cond cond)
     ABTI_cond *p_cond = ABTI_cond_get_ptr(cond);
     ABTI_CHECK_NULL_COND_PTR(p_cond);
 
-    ABTI_spinlock_acquire(&p_cond->lock);
+    ABTD_spinlock_acquire(&p_cond->lock);
     ABTI_waitlist_signal(p_local, &p_cond->waitlist);
-    ABTI_spinlock_release(&p_cond->lock);
+    ABTD_spinlock_release(&p_cond->lock);
 
     return ABT_SUCCESS;
 }

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -49,7 +49,7 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
     abt_errno = ABTU_malloc(sizeof(ABTI_eventual), (void **)&p_eventual);
     ABTI_CHECK_ERROR(abt_errno);
 
-    ABTI_spinlock_clear(&p_eventual->lock);
+    ABTD_spinlock_clear(&p_eventual->lock);
     p_eventual->ready = ABT_FALSE;
     p_eventual->nbytes = arg_nbytes;
     if (arg_nbytes == 0) {
@@ -101,7 +101,7 @@ int ABT_eventual_free(ABT_eventual *eventual)
     /* The lock needs to be acquired to safely free the eventual structure.
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
-    ABTI_spinlock_acquire(&p_eventual->lock);
+    ABTD_spinlock_acquire(&p_eventual->lock);
 
     if (p_eventual->value)
         ABTU_free(p_eventual->value);
@@ -176,14 +176,14 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
     }
 #endif
 
-    ABTI_spinlock_acquire(&p_eventual->lock);
+    ABTD_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
         ABTI_waitlist_wait_and_unlock(&p_local, &p_eventual->waitlist,
                                       &p_eventual->lock, ABT_FALSE,
                                       ABT_SYNC_EVENT_TYPE_EVENTUAL,
                                       (void *)p_eventual);
     } else {
-        ABTI_spinlock_release(&p_eventual->lock);
+        ABTD_spinlock_release(&p_eventual->lock);
     }
     /* This value is updated outside the critical section, but it is okay since
      * the "pointer" to the memory buffer is constant and there is no way to
@@ -239,13 +239,13 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready)
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
     ABT_bool flag = ABT_FALSE;
 
-    ABTI_spinlock_acquire(&p_eventual->lock);
+    ABTD_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready != ABT_FALSE) {
         if (value)
             *value = p_eventual->value;
         flag = ABT_TRUE;
     }
-    ABTI_spinlock_release(&p_eventual->lock);
+    ABTD_spinlock_release(&p_eventual->lock);
 
     *is_ready = flag;
     return ABT_SUCCESS;
@@ -312,7 +312,7 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
     ABTI_CHECK_TRUE(arg_nbytes <= p_eventual->nbytes, ABT_ERR_INV_ARG);
 #endif
 
-    ABTI_spinlock_acquire(&p_eventual->lock);
+    ABTD_spinlock_acquire(&p_eventual->lock);
 
     ABT_bool ready = p_eventual->ready;
     if (ready == ABT_FALSE) {
@@ -321,9 +321,9 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
         p_eventual->ready = ABT_TRUE;
         /* Wake up all waiting ULTs */
         ABTI_waitlist_broadcast(p_local, &p_eventual->waitlist);
-        ABTI_spinlock_release(&p_eventual->lock);
+        ABTD_spinlock_release(&p_eventual->lock);
     } else {
-        ABTI_spinlock_release(&p_eventual->lock);
+        ABTD_spinlock_release(&p_eventual->lock);
         /* It has been ready.  Error. */
         ABTI_HANDLE_ERROR(ABT_ERR_EVENTUAL);
     }
@@ -361,8 +361,8 @@ int ABT_eventual_reset(ABT_eventual eventual)
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
 
-    ABTI_spinlock_acquire(&p_eventual->lock);
+    ABTD_spinlock_acquire(&p_eventual->lock);
     p_eventual->ready = ABT_FALSE;
-    ABTI_spinlock_release(&p_eventual->lock);
+    ABTD_spinlock_release(&p_eventual->lock);
     return ABT_SUCCESS;
 }

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -179,7 +179,7 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
     ABTD_spinlock_acquire(&p_eventual->lock);
     if (p_eventual->ready == ABT_FALSE) {
         ABTI_waitlist_wait_and_unlock(&p_local, &p_eventual->waitlist,
-                                      &p_eventual->lock, ABT_FALSE,
+                                      &p_eventual->lock,
                                       ABT_SYNC_EVENT_TYPE_EVENTUAL,
                                       (void *)p_eventual);
     } else {

--- a/src/futures.c
+++ b/src/futures.c
@@ -182,7 +182,7 @@ int ABT_future_wait(ABT_future future)
     if (ABTD_atomic_relaxed_load_size(&p_future->counter) <
         p_future->num_compartments) {
         ABTI_waitlist_wait_and_unlock(&p_local, &p_future->waitlist,
-                                      &p_future->lock, ABT_FALSE,
+                                      &p_future->lock,
                                       ABT_SYNC_EVENT_TYPE_FUTURE,
                                       (void *)p_future);
     } else {

--- a/src/global.c
+++ b/src/global.c
@@ -20,7 +20,7 @@ ABTI_global *gp_ABTI_global = NULL;
 /* To indicate how many times ABT_init is called. */
 static uint32_t g_ABTI_num_inits = 0;
 /* A global lock protecting the initialization/finalization process */
-static ABTI_spinlock g_ABTI_init_lock = ABTI_SPINLOCK_STATIC_INITIALIZER();
+static ABTD_spinlock g_ABTI_init_lock = ABTD_SPINLOCK_STATIC_INITIALIZER();
 /* A flag whether Argobots has been initialized or not */
 static ABTD_atomic_uint32 g_ABTI_initialized =
     ABTD_ATOMIC_UINT32_STATIC_INITIALIZER(0);
@@ -76,10 +76,10 @@ int ABT_init(int argc, char **argv)
     ABTI_UNUSED(argc);
     ABTI_UNUSED(argv);
     /* Take a global lock protecting the initialization/finalization process. */
-    ABTI_spinlock_acquire(&g_ABTI_init_lock);
+    ABTD_spinlock_acquire(&g_ABTI_init_lock);
     int abt_errno = init_library();
     /* Unlock a global lock */
-    ABTI_spinlock_release(&g_ABTI_init_lock);
+    ABTD_spinlock_release(&g_ABTI_init_lock);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
@@ -130,10 +130,10 @@ int ABT_init(int argc, char **argv)
 int ABT_finalize(void)
 {
     /* Take a global lock protecting the initialization/finalization process. */
-    ABTI_spinlock_acquire(&g_ABTI_init_lock);
+    ABTD_spinlock_acquire(&g_ABTI_init_lock);
     int abt_errno = finailze_library();
     /* Unlock a global lock */
-    ABTI_spinlock_release(&g_ABTI_init_lock);
+    ABTD_spinlock_release(&g_ABTI_init_lock);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
@@ -196,7 +196,7 @@ ABTU_ret_err static int init_library(void)
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
     /* Initialize the tool interface */
-    ABTI_spinlock_clear(&p_global->tool_writer_lock);
+    ABTD_spinlock_clear(&p_global->tool_writer_lock);
     p_global->tool_thread_cb_f = NULL;
     p_global->tool_thread_user_arg = NULL;
     ABTD_atomic_relaxed_store_uint64(&p_global->tool_thread_event_mask_tagged,
@@ -208,7 +208,7 @@ ABTU_ret_err static int init_library(void)
     p_global->num_xstreams = 0;
 
     /* Initialize a spinlock */
-    ABTI_spinlock_clear(&p_global->xstream_list_lock);
+    ABTD_spinlock_clear(&p_global->xstream_list_lock);
 
     /* Create the primary ES */
     ABTI_xstream *p_local_xstream;

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -11,6 +11,7 @@ noinst_HEADERS = \
 	include/abtd_atomic.h \
 	include/abtd_context.h \
 	include/abtd_fcontext.h \
+	include/abtd_futex.h \
 	include/abtd_spinlock.h \
 	include/abtd_ucontext.h \
 	include/abtd_ythread.h \

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -11,6 +11,7 @@ noinst_HEADERS = \
 	include/abtd_atomic.h \
 	include/abtd_context.h \
 	include/abtd_fcontext.h \
+	include/abtd_spinlock.h \
 	include/abtd_ucontext.h \
 	include/abtd_ythread.h \
 	include/abti.h \
@@ -32,7 +33,6 @@ noinst_HEADERS = \
 	include/abti_pool.h \
 	include/abti_sched.h \
 	include/abti_self.h \
-	include/abti_spinlock.h \
 	include/abti_stream.h \
 	include/abti_stream_barrier.h \
 	include/abti_sync_lifo.h \

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -619,6 +619,8 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND,
     /** Whether the stack overflow check is enabled or not */
     ABT_INFO_QUERY_KIND_ENABLED_STACK_OVERFLOW_CHECK,
+    /** Wait policy */
+    ABT_INFO_QUERY_KIND_WAIT_POLICY,
 };
 
 /**

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -11,6 +11,7 @@
 #include "abtd_atomic.h"
 #include "abtd_context.h"
 #include "abtd_spinlock.h"
+#include "abtd_futex.h"
 
 /* Data Types */
 typedef enum {

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -10,6 +10,7 @@
 #include <pthread.h>
 #include "abtd_atomic.h"
 #include "abtd_context.h"
+#include "abtd_spinlock.h"
 
 /* Data Types */
 typedef enum {

--- a/src/include/abtd_futex.h
+++ b/src/include/abtd_futex.h
@@ -1,0 +1,61 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTD_FUTEX_H_INCLUDED
+#define ABTD_FUTEX_H_INCLUDED
+
+#ifndef ABT_CONFIG_ACTIVE_WAIT_POLICY
+
+/* ABTD_futex_multiple supports a wait-broadcast pattern.  ABTD_futex_multiple
+ * allows multiple waiters. */
+typedef struct ABTD_futex_multiple ABTD_futex_multiple;
+
+/* Initialize ABTD_futex_multiple. */
+static inline void ABTD_futex_multiple_init(ABTD_futex_multiple *p_futex);
+
+/* This routine unlocks p_lock and makes the underlying Pthread block on
+ * p_futex.  Broadcast can wake up this waiter.  Spurious wakeup does not
+ * happen. */
+void ABTD_futex_wait_and_unlock(ABTD_futex_multiple *p_futex,
+                                ABTD_spinlock *p_lock);
+
+/* This routine unlocks p_lock and makes the underlying Pthread block on
+ * p_futex.  Broadcast can wake up this waiter.  By nature, spurious wakeup
+ * might happen, so the caller needs to check the current time if necessary. */
+void ABTD_futex_timedwait_and_unlock(ABTD_futex_multiple *p_futex,
+                                     ABTD_spinlock *p_lock,
+                                     double wait_time_sec);
+
+/* This routine wakes up waiters that are waiting on p_futex.  This function
+ * must be called when a lock (p_lock above) is taken. */
+void ABTD_futex_broadcast(ABTD_futex_multiple *p_futex);
+
+#ifdef ABT_CONFIG_USE_LINUX_FUTEX
+
+struct ABTD_futex_multiple {
+    ABTD_atomic_int val;
+};
+
+static inline void ABTD_futex_multiple_init(ABTD_futex_multiple *p_futex)
+{
+    ABTD_atomic_relaxed_store_int(&p_futex->val, 0);
+}
+
+#else /* ABT_CONFIG_USE_LINUX_FUTEX */
+
+struct ABTD_futex_multiple {
+    void *p_next; /* pthread_sync */
+};
+
+static inline void ABTD_futex_multiple_init(ABTD_futex_multiple *p_futex)
+{
+    p_futex->p_next = NULL;
+}
+
+#endif /* !ABT_CONFIG_USE_LINUX_FUTEX */
+
+#endif /* !ABT_CONFIG_ACTIVE_WAIT_POLICY */
+
+#endif /* ABTD_FUTEX_H_INCLUDED */

--- a/src/include/abtd_spinlock.h
+++ b/src/include/abtd_spinlock.h
@@ -3,45 +3,45 @@
  * See COPYRIGHT in top-level directory.
  */
 
-#ifndef ABTI_SPINLOCK_H_INCLUDED
-#define ABTI_SPINLOCK_H_INCLUDED
+#ifndef ABTD_SPINLOCK_H_INCLUDED
+#define ABTD_SPINLOCK_H_INCLUDED
 
-struct ABTI_spinlock {
+typedef struct ABTD_spinlock {
     ABTD_atomic_bool val;
-};
+} ABTD_spinlock;
 
-#define ABTI_SPINLOCK_STATIC_INITIALIZER()                                     \
+#define ABTD_SPINLOCK_STATIC_INITIALIZER()                                     \
     {                                                                          \
         ABTD_ATOMIC_BOOL_STATIC_INITIALIZER(0)                                 \
     }
 
-static inline ABT_bool ABTI_spinlock_is_locked(const ABTI_spinlock *p_lock)
+static inline ABT_bool ABTD_spinlock_is_locked(const ABTD_spinlock *p_lock)
 {
     return ABTD_atomic_acquire_load_bool(&p_lock->val);
 }
 
-static inline void ABTI_spinlock_clear(ABTI_spinlock *p_lock)
+static inline void ABTD_spinlock_clear(ABTD_spinlock *p_lock)
 {
     ABTD_atomic_relaxed_clear_bool(&p_lock->val);
 }
 
-static inline void ABTI_spinlock_acquire(ABTI_spinlock *p_lock)
+static inline void ABTD_spinlock_acquire(ABTD_spinlock *p_lock)
 {
     while (ABTD_atomic_test_and_set_bool(&p_lock->val)) {
-        while (ABTI_spinlock_is_locked(p_lock) != ABT_FALSE)
+        while (ABTD_spinlock_is_locked(p_lock) != ABT_FALSE)
             ;
     }
 }
 
 /* Return ABT_FALSE if the lock is acquired. */
-static inline ABT_bool ABTI_spinlock_try_acquire(ABTI_spinlock *p_lock)
+static inline ABT_bool ABTD_spinlock_try_acquire(ABTD_spinlock *p_lock)
 {
     return ABTD_atomic_test_and_set_bool(&p_lock->val) ? ABT_TRUE : ABT_FALSE;
 }
 
-static inline void ABTI_spinlock_release(ABTI_spinlock *p_lock)
+static inline void ABTD_spinlock_release(ABTD_spinlock *p_lock)
 {
     ABTD_atomic_release_clear_bool(&p_lock->val);
 }
 
-#endif /* ABTI_SPINLOCK_H_INCLUDED */
+#endif /* ABTD_SPINLOCK_H_INCLUDED */

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -154,6 +154,9 @@ typedef struct ABTI_thread_id_opaque *ABTI_thread_id;
 
 /* Definitions */
 struct ABTI_waitlist {
+#ifndef ABT_CONFIG_ACTIVE_WAIT_POLICY
+    ABTD_futex_multiple futex;
+#endif
     ABTI_thread *p_head;
     ABTI_thread *p_tail;
 };

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -148,10 +148,6 @@ typedef struct ABTI_thread_id_opaque *ABTI_thread_id;
 /* Architecture-Dependent Definitions */
 #include "abtd.h"
 
-/* Spinlock */
-typedef struct ABTI_spinlock ABTI_spinlock;
-#include "abti_spinlock.h"
-
 /* Basic data structure and memory pool. */
 #include "abti_sync_lifo.h"
 #include "abti_mem_pool.h"
@@ -170,11 +166,11 @@ struct ABTI_mutex {
     int attrs;               /* attributes copied from ABTI_mutex_attr.  Check
                               * ABT_(RECURSIVE_)MUTEX_INITIALIZER to see how
                               * this variable can be  initialized. */
-    ABTI_spinlock lock;      /* lock */
+    ABTD_spinlock lock;      /* lock */
     int nesting_cnt;         /* nesting count (if recursive) */
     ABTI_thread_id owner_id; /* owner's ID (if recursive) */
 #ifndef ABT_CONFIG_USE_SIMPLE_MUTEX
-    ABTI_spinlock waiter_lock; /* lock */
+    ABTD_spinlock waiter_lock; /* lock */
     ABTI_waitlist waitlist;    /* waiting list */
 #endif
 };
@@ -183,7 +179,7 @@ struct ABTI_global {
     int max_xstreams;             /* Largest rank used in Argobots. */
     int num_xstreams;             /* Current # of ESs */
     ABTI_xstream *p_xstream_head; /* List of ESs (head). The list is sorted. */
-    ABTI_spinlock
+    ABTD_spinlock
         xstream_list_lock; /* Spinlock protecting ES list. Any read and
                             * write to this list requires a lock.*/
 
@@ -214,9 +210,9 @@ struct ABTI_global {
                                                * store ABTI_task. */
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
     /* They are used for external threads. */
-    ABTI_spinlock mem_pool_stack_lock;
+    ABTD_spinlock mem_pool_stack_lock;
     ABTI_mem_pool_local_pool mem_pool_stack_ext;
-    ABTI_spinlock mem_pool_desc_lock;
+    ABTD_spinlock mem_pool_desc_lock;
     ABTI_mem_pool_local_pool mem_pool_desc_ext;
 #endif
 #endif
@@ -224,7 +220,7 @@ struct ABTI_global {
     ABT_bool print_config; /* Whether to print config on ABT_init */
 
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
-    ABTI_spinlock tool_writer_lock;
+    ABTD_spinlock tool_writer_lock;
 
     ABT_tool_thread_callback_fn tool_thread_cb_f;
     void *tool_thread_user_arg;
@@ -403,7 +399,7 @@ struct ABTI_ktelem {
 
 struct ABTI_ktable {
     int size;           /* size of the table */
-    ABTI_spinlock lock; /* Protects any new entry creation. */
+    ABTD_spinlock lock; /* Protects any new entry creation. */
     void *p_used_mem;
     void *p_extra_mem;
     size_t extra_mem_size;
@@ -411,7 +407,7 @@ struct ABTI_ktable {
 };
 
 struct ABTI_cond {
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     ABTI_mutex *p_waiter_mutex;
     ABTI_waitlist waitlist;
 };
@@ -424,7 +420,7 @@ struct ABTI_rwlock {
 };
 
 struct ABTI_eventual {
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     ABT_bool ready;
     void *value;
     size_t nbytes;
@@ -432,7 +428,7 @@ struct ABTI_eventual {
 };
 
 struct ABTI_future {
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     ABTD_atomic_size counter;
     size_t num_compartments;
     void **array;
@@ -443,7 +439,7 @@ struct ABTI_future {
 struct ABTI_barrier {
     size_t num_waiters;
     volatile size_t counter;
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     ABTI_waitlist waitlist;
 };
 
@@ -452,7 +448,7 @@ struct ABTI_xstream_barrier {
 #ifdef HAVE_PTHREAD_BARRIER_INIT
     ABTD_xstream_barrier bar;
 #else
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     uint32_t counter;
     ABTD_atomic_uint64 tag;
 #endif

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -12,7 +12,7 @@
 
 static inline void ABTI_cond_init(ABTI_cond *p_cond)
 {
-    ABTI_spinlock_clear(&p_cond->lock);
+    ABTD_spinlock_clear(&p_cond->lock);
     p_cond->p_waiter_mutex = NULL;
     ABTI_waitlist_init(&p_cond->waitlist);
 }
@@ -22,7 +22,7 @@ static inline void ABTI_cond_fini(ABTI_cond *p_cond)
     /* The lock needs to be acquired to safely free the condition structure.
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
-    ABTI_spinlock_acquire(&p_cond->lock);
+    ABTD_spinlock_acquire(&p_cond->lock);
 }
 
 static inline ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)
@@ -58,13 +58,13 @@ static inline ABT_cond ABTI_cond_get_handle(ABTI_cond *p_cond)
 ABTU_ret_err static inline int
 ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 {
-    ABTI_spinlock_acquire(&p_cond->lock);
+    ABTD_spinlock_acquire(&p_cond->lock);
 
     if (p_cond->p_waiter_mutex == NULL) {
         p_cond->p_waiter_mutex = p_mutex;
     } else {
         if (p_cond->p_waiter_mutex != p_mutex) {
-            ABTI_spinlock_release(&p_cond->lock);
+            ABTD_spinlock_release(&p_cond->lock);
             return ABT_ERR_INV_MUTEX;
         }
     }
@@ -80,10 +80,10 @@ ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 
 static inline void ABTI_cond_broadcast(ABTI_local *p_local, ABTI_cond *p_cond)
 {
-    ABTI_spinlock_acquire(&p_cond->lock);
+    ABTD_spinlock_acquire(&p_cond->lock);
     /* Wake up all waiting ULTs */
     ABTI_waitlist_broadcast(p_local, &p_cond->waitlist);
-    ABTI_spinlock_release(&p_cond->lock);
+    ABTD_spinlock_release(&p_cond->lock);
 }
 
 #endif /* ABTI_COND_H_INCLUDED */

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -71,8 +71,7 @@ ABTI_cond_wait(ABTI_local **pp_local, ABTI_cond *p_cond, ABTI_mutex *p_mutex)
 
     ABTI_mutex_unlock(*pp_local, p_mutex);
     ABTI_waitlist_wait_and_unlock(pp_local, &p_cond->waitlist, &p_cond->lock,
-                                  ABT_FALSE, ABT_SYNC_EVENT_TYPE_COND,
-                                  (void *)p_cond);
+                                  ABT_SYNC_EVENT_TYPE_COND, (void *)p_cond);
     /* Lock the mutex again */
     ABTI_mutex_lock(pp_local, p_mutex);
     return ABT_SUCCESS;

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -109,7 +109,7 @@ ABTU_ret_err static inline int ABTI_ktable_create(ABTI_global *p_global,
         p_ktable->extra_mem_size = 0;
     }
     p_ktable->size = key_table_size;
-    ABTI_spinlock_clear(&p_ktable->lock);
+    ABTD_spinlock_clear(&p_ktable->lock);
     memset(p_ktable->p_elems, 0, sizeof(ABTD_atomic_ptr) * key_table_size);
     *pp_ktable = p_ktable;
     return ABT_SUCCESS;
@@ -188,13 +188,13 @@ ABTI_ktable_set_impl(ABTI_local *p_local, ABTI_ktable *p_ktable,
 
     /* The table does not have the same key */
     if (is_safe)
-        ABTI_spinlock_acquire(&p_ktable->lock);
+        ABTD_spinlock_acquire(&p_ktable->lock);
     /* The linked list might have been extended. */
     p_elem = (ABTI_ktelem *)ABTD_atomic_acquire_load_ptr(pp_elem);
     while (p_elem) {
         if (p_elem->key_id == key_id) {
             if (is_safe)
-                ABTI_spinlock_release(&p_ktable->lock);
+                ABTD_spinlock_release(&p_ktable->lock);
             p_elem->value = value;
             return ABT_SUCCESS;
         }
@@ -209,7 +209,7 @@ ABTI_ktable_set_impl(ABTI_local *p_local, ABTI_ktable *p_ktable,
                                            (void **)&p_elem);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
         if (is_safe)
-            ABTI_spinlock_release(&p_ktable->lock);
+            ABTD_spinlock_release(&p_ktable->lock);
         return abt_errno;
     }
     p_elem->f_destructor = p_key->f_destructor;
@@ -218,7 +218,7 @@ ABTI_ktable_set_impl(ABTI_local *p_local, ABTI_ktable *p_ktable,
     ABTD_atomic_relaxed_store_ptr(&p_elem->p_next, NULL);
     ABTD_atomic_release_store_ptr(pp_elem, p_elem);
     if (is_safe)
-        ABTI_spinlock_release(&p_ktable->lock);
+        ABTD_spinlock_release(&p_ktable->lock);
     return ABT_SUCCESS;
 }
 

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -116,9 +116,9 @@ static inline void ABTI_mem_free_nythread(ABTI_global *p_global,
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (p_local_xstream == NULL) {
             /* Return a stack to the global pool. */
-            ABTI_spinlock_acquire(&p_global->mem_pool_desc_lock);
+            ABTD_spinlock_acquire(&p_global->mem_pool_desc_lock);
             ABTI_mem_pool_free(&p_global->mem_pool_desc_ext, p_thread);
-            ABTI_spinlock_release(&p_global->mem_pool_desc_lock);
+            ABTD_spinlock_release(&p_global->mem_pool_desc_lock);
             return;
         }
 #endif
@@ -292,9 +292,9 @@ static inline void ABTI_mem_free_thread(ABTI_global *p_global,
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
         if (p_local_xstream == NULL) {
             /* Return a stack to the global pool. */
-            ABTI_spinlock_acquire(&p_global->mem_pool_stack_lock);
+            ABTD_spinlock_acquire(&p_global->mem_pool_stack_lock);
             ABTI_mem_pool_free(&p_global->mem_pool_stack_ext, p_ythread);
-            ABTI_spinlock_release(&p_global->mem_pool_stack_lock);
+            ABTD_spinlock_release(&p_global->mem_pool_stack_lock);
             return;
         }
 #endif
@@ -368,9 +368,9 @@ static inline void ABTI_mem_free_desc(ABTI_global *p_global,
         return;
     } else if (!p_local_xstream) {
         /* Return a stack and a descriptor to their global pools. */
-        ABTI_spinlock_acquire(&p_global->mem_pool_desc_lock);
+        ABTD_spinlock_acquire(&p_global->mem_pool_desc_lock);
         ABTI_mem_pool_free(&p_global->mem_pool_desc_ext, p_desc);
-        ABTI_spinlock_release(&p_global->mem_pool_desc_lock);
+        ABTD_spinlock_release(&p_global->mem_pool_desc_lock);
         return;
     }
 #endif

--- a/src/include/abti_mem_pool.h
+++ b/src/include/abti_mem_pool.h
@@ -69,7 +69,7 @@ typedef struct ABTI_mem_pool_global_pool {
         /* List of the remaining headers that are not enough to create one
          * complete bucket. This is protected by a spinlock. The number of
          * headers is stored in partial_bucket.bucket_info.num_headers. */
-        ABTI_spinlock partial_bucket_lock;
+        ABTD_spinlock partial_bucket_lock;
     ABTI_mem_pool_header *partial_bucket;
 } ABTI_mem_pool_global_pool;
 

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -70,7 +70,7 @@ static inline void ABTI_mutex_lock_no_recursion(ABTI_local **pp_local,
         }
         /* Wait on waitlist. */
         ABTI_waitlist_wait_and_unlock(pp_local, &p_mutex->waitlist,
-                                      &p_mutex->waiter_lock, ABT_FALSE,
+                                      &p_mutex->waiter_lock,
                                       ABT_SYNC_EVENT_TYPE_MUTEX,
                                       (void *)p_mutex);
     }

--- a/src/include/abti_sync_lifo.h
+++ b/src/include/abti_sync_lifo.h
@@ -21,7 +21,7 @@ typedef __attribute__((aligned(ABT_CONFIG_STATIC_CACHELINE_SIZE))) struct {
 #if ABTD_ATOMIC_SUPPORT_TAGGED_PTR
     ABTD_atomic_tagged_ptr p_top;
 #else
-    ABTI_spinlock lock;
+    ABTD_spinlock lock;
     ABTD_atomic_ptr p_top;
 #endif
 } ABTI_sync_lifo;
@@ -32,7 +32,7 @@ static inline void ABTI_sync_lifo_init(ABTI_sync_lifo *p_lifo)
 #if ABTD_ATOMIC_SUPPORT_TAGGED_PTR
     ABTD_atomic_release_store_non_atomic_tagged_ptr(&p_lifo->p_top, NULL, 0);
 #else
-    ABTI_spinlock_clear(&p_lifo->lock);
+    ABTD_spinlock_clear(&p_lifo->lock);
     ABTD_atomic_relaxed_store_ptr(&p_lifo->p_top, NULL);
 #endif
 }
@@ -107,9 +107,9 @@ static inline void ABTI_sync_lifo_push(ABTI_sync_lifo *p_lifo,
         }
     }
 #else
-    ABTI_spinlock_acquire(&p_lifo->lock);
+    ABTD_spinlock_acquire(&p_lifo->lock);
     ABTI_sync_lifo_push_unsafe(p_lifo, p_elem);
-    ABTI_spinlock_release(&p_lifo->lock);
+    ABTD_spinlock_release(&p_lifo->lock);
 #endif
 }
 
@@ -135,9 +135,9 @@ static inline ABTI_sync_lifo_element *ABTI_sync_lifo_pop(ABTI_sync_lifo *p_lifo)
     }
 #else
     ABTI_sync_lifo_element *p_ret;
-    ABTI_spinlock_acquire(&p_lifo->lock);
+    ABTD_spinlock_acquire(&p_lifo->lock);
     p_ret = ABTI_sync_lifo_pop_unsafe(p_lifo);
-    ABTI_spinlock_release(&p_lifo->lock);
+    ABTD_spinlock_release(&p_lifo->lock);
     return p_ret;
 #endif
 }

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -56,7 +56,7 @@ ABTI_tool_event_thread_update_callback(ABTI_global *p_global,
                                        uint64_t event_mask, void *user_arg)
 {
     /* The spinlock is needed to avoid data race between two writers. */
-    ABTI_spinlock_acquire(&p_global->tool_writer_lock);
+    ABTD_spinlock_acquire(&p_global->tool_writer_lock);
 
     /*
      * This atomic writing process is needed to avoid data race between a reader
@@ -90,7 +90,7 @@ ABTI_tool_event_thread_update_callback(ABTI_global *p_global,
     ABTD_atomic_release_store_uint64(&p_global->tool_thread_event_mask_tagged,
                                      new_mask);
 
-    ABTI_spinlock_release(&p_global->tool_writer_lock);
+    ABTD_spinlock_release(&p_global->tool_writer_lock);
 }
 
 #endif /* !ABT_CONFIG_DISABLE_TOOL_INTERFACE */

--- a/src/include/abti_waitlist.h
+++ b/src/include/abti_waitlist.h
@@ -16,7 +16,7 @@ static inline void ABTI_waitlist_init(ABTI_waitlist *p_waitlist)
 
 static inline void
 ABTI_waitlist_wait_and_unlock(ABTI_local **pp_local, ABTI_waitlist *p_waitlist,
-                              ABTD_spinlock *p_lock, ABT_bool blocking,
+                              ABTD_spinlock *p_lock,
                               ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_ASSERT(ABTD_spinlock_is_locked(p_lock) == ABT_TRUE);
@@ -25,8 +25,8 @@ ABTI_waitlist_wait_and_unlock(ABTI_local **pp_local, ABTI_waitlist *p_waitlist,
     if (!ABTI_IS_EXT_THREAD_ENABLED || p_local_xstream) {
         p_ythread = ABTI_thread_get_ythread_or_null(p_local_xstream->p_thread);
     }
-    if (!p_ythread || blocking) {
-        /* External thread, non-yieldable thread, or asked to block */
+    if (!p_ythread) {
+        /* External thread or non-yieldable thread. */
         ABTI_thread thread;
         thread.type = ABTI_THREAD_TYPE_EXT;
         /* use state for synchronization */
@@ -68,8 +68,7 @@ ABTI_waitlist_wait_and_unlock(ABTI_local **pp_local, ABTI_waitlist *p_waitlist,
 /* Return ABT_TRUE if timed out. */
 static inline ABT_bool ABTI_waitlist_wait_timedout_and_unlock(
     ABTI_local **pp_local, ABTI_waitlist *p_waitlist, ABTD_spinlock *p_lock,
-    ABT_bool blocking, double target_time, ABT_sync_event_type sync_event_type,
-    void *p_sync)
+    double target_time, ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_ASSERT(ABTD_spinlock_is_locked(p_lock) == ABT_TRUE);
     ABTI_ythread *p_ythread = NULL;
@@ -144,7 +143,7 @@ static inline ABT_bool ABTI_waitlist_wait_timedout_and_unlock(
             ABTD_spinlock_release(p_lock);
             return is_timedout;
         }
-        if (p_ythread && !blocking) {
+        if (p_ythread) {
             ABTI_ythread_yield(&p_local_xstream, p_ythread, sync_event_type,
                                p_sync);
             *pp_local = ABTI_xstream_get_local(p_local_xstream);

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -249,26 +249,15 @@ static inline ABTI_ythread *ABTI_ythread_context_switch_to_child_internal(
             ABTD_ythread_context *p_ctx = &p_prev->ctx;
             ABTD_ythread_context *p_link =
                 ABTD_atomic_acquire_load_ythread_context_ptr(&p_ctx->p_link);
-            if (p_link) {
-                /* If p_link is set, it means that other ULT has called the
-                 * join. */
-                ABTI_ythread *p_joiner =
-                    ABTI_ythread_context_get_ythread(p_link);
-                /* The scheduler may not use a bypass mechanism, so just makes
-                 * p_joiner ready. */
-                ABTI_ythread_set_ready(ABTI_xstream_get_local(p_local_xstream),
-                                       p_joiner);
-
-                /* We don't need to use the atomic OR operation here because
-                 * the ULT will be terminated regardless of other requests. */
-                ABTD_atomic_release_store_uint32(&p_prev->thread.request,
-                                                 ABTI_THREAD_REQ_TERMINATE);
-            } else {
+            if (!p_link) {
                 uint32_t req =
                     ABTD_atomic_fetch_or_uint32(&p_prev->thread.request,
                                                 ABTI_THREAD_REQ_JOIN |
                                                     ABTI_THREAD_REQ_TERMINATE);
-                if (req & ABTI_THREAD_REQ_JOIN) {
+                if (!(req & ABTI_THREAD_REQ_JOIN)) {
+                    /* No join request.  Let's return. */
+                    return p_prev;
+                } else {
                     /* This case means there has been a join request and the
                      * joiner has blocked.  We have to wake up the joiner ULT.
                      */
@@ -276,12 +265,18 @@ static inline ABTI_ythread *ABTI_ythread_context_switch_to_child_internal(
                         p_link = ABTD_atomic_acquire_load_ythread_context_ptr(
                             &p_ctx->p_link);
                     } while (!p_link);
-                    ABTI_ythread_set_ready(ABTI_xstream_get_local(
-                                               p_local_xstream),
-                                           ABTI_ythread_context_get_ythread(
-                                               p_link));
                 }
             }
+            /* Now p_link != NULL. */
+            ABTI_ythread *p_joiner = ABTI_ythread_context_get_ythread(p_link);
+            /* The scheduler may not use a bypass mechanism, so just makes
+             * p_joiner ready. */
+            ABTI_ythread_set_ready(ABTI_xstream_get_local(p_local_xstream),
+                                   p_joiner);
+            /* We don't need to use the atomic OR operation here because
+             * the ULT will be terminated regardless of other requests. */
+            ABTD_atomic_release_store_uint32(&p_prev->thread.request,
+                                             ABTI_THREAD_REQ_TERMINATE);
         }
         return p_prev;
     }

--- a/src/info.c
+++ b/src/info.c
@@ -176,6 +176,12 @@ static void info_trigger_print_all_thread_stacks(
  *   if Argobots is configured to use a stack canary to check stack overflow.
  *   Otherwise, \c val is set to 0.
  *
+ * - \c ABT_INFO_QUERY_KIND_WAIT_POLICY
+ *
+ *   \c val must be a pointer to a variable of type \c int.  \c val is set to 0
+ *   if the wait policy of Argobots is passive.  \c val is set to 1 if the wait
+ *   policy of Argobots is active.
+ *
  * @changev20
  * \DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE
  * @endchangev20
@@ -352,6 +358,13 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_STACK_OVERFLOW_CHECK:
 #if ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_CANARY
+            *((int *)val) = 1;
+#else
+            *((int *)val) = 0;
+#endif
+            break;
+        case ABT_INFO_QUERY_KIND_WAIT_POLICY:
+#if ABT_CONFIG_ACTIVE_WAIT_POLICY
             *((int *)val) = 1;
 #else
             *((int *)val) = 0;
@@ -1061,6 +1074,13 @@ void ABTI_info_print_config(ABTI_global *p_global, FILE *fp)
                 "yes"
 #else
                 "no"
+#endif
+                "\n");
+    fprintf(fp, " - wait policy: "
+#ifdef ABT_CONFIG_ACTIVE_WAIT_POLICY
+                "active"
+#else
+                "passive"
 #endif
                 "\n");
     fprintf(fp, " - context-switch: "

--- a/src/info.c
+++ b/src/info.c
@@ -468,7 +468,7 @@ int ABT_info_print_all_xstreams(FILE *fp)
     }
 #endif
 
-    ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+    ABTD_spinlock_acquire(&p_global->xstream_list_lock);
 
     fprintf(fp, "# of created ESs: %d\n", p_global->num_xstreams);
 
@@ -478,7 +478,7 @@ int ABT_info_print_all_xstreams(FILE *fp)
         p_xstream = p_xstream->p_next;
     }
 
-    ABTI_spinlock_release(&p_global->xstream_list_lock);
+    ABTD_spinlock_release(&p_global->xstream_list_lock);
 
     fflush(fp);
     return ABT_SUCCESS;
@@ -950,7 +950,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
 
         /* xstreams_lock is acquired to avoid dynamic ES creation while
          * printing data. */
-        ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+        ABTD_spinlock_acquire(&p_global->xstream_list_lock);
         while (1) {
             if (ABTD_atomic_acquire_load_int(&print_stack_barrier) >=
                 p_global->num_xstreams) {
@@ -961,9 +961,9 @@ void ABTI_info_check_print_all_thread_stacks(void)
                 force_print = ABT_TRUE;
                 break;
             }
-            ABTI_spinlock_release(&p_global->xstream_list_lock);
+            ABTD_spinlock_release(&p_global->xstream_list_lock);
             ABTD_atomic_pause();
-            ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+            ABTD_spinlock_acquire(&p_global->xstream_list_lock);
         }
         /* All the available ESs are (supposed to be) stopped. We *assume* that
          * no ES is calling and will call Argobots functions except this
@@ -981,7 +981,7 @@ void ABTI_info_check_print_all_thread_stacks(void)
         }
         fflush(print_stack_fp);
         /* Release the lock that protects ES data. */
-        ABTI_spinlock_release(&p_global->xstream_list_lock);
+        ABTD_spinlock_release(&p_global->xstream_list_lock);
         if (print_cb_func)
             print_cb_func(force_print, print_arg);
         /* Update print_stack_flag to 3. */

--- a/src/mem/malloc.c
+++ b/src/mem/malloc.c
@@ -73,10 +73,10 @@ void ABTI_mem_init(ABTI_global *p_global)
                                    num_requested_types,
                                    p_global->mem_page_size);
 #ifndef ABT_CONFIG_DISABLE_EXT_THREAD
-    ABTI_spinlock_clear(&p_global->mem_pool_stack_lock);
+    ABTD_spinlock_clear(&p_global->mem_pool_stack_lock);
     ABTI_mem_pool_init_local_pool(&p_global->mem_pool_stack_ext,
                                   &p_global->mem_pool_stack);
-    ABTI_spinlock_clear(&p_global->mem_pool_desc_lock);
+    ABTD_spinlock_clear(&p_global->mem_pool_desc_lock);
     ABTI_mem_pool_init_local_pool(&p_global->mem_pool_desc_ext,
                                   &p_global->mem_pool_desc);
 #endif

--- a/src/mem/mem_pool.c
+++ b/src/mem/mem_pool.c
@@ -30,7 +30,7 @@ mem_pool_return_partial_bucket(ABTI_mem_pool_global_pool *p_global_pool,
     int i;
     const int num_headers_per_bucket = p_global_pool->num_headers_per_bucket;
     /* Return headers in the last bucket to partial_bucket. */
-    ABTI_spinlock_acquire(&p_global_pool->partial_bucket_lock);
+    ABTD_spinlock_acquire(&p_global_pool->partial_bucket_lock);
     if (!p_global_pool->partial_bucket) {
         p_global_pool->partial_bucket = bucket;
     } else {
@@ -71,7 +71,7 @@ mem_pool_return_partial_bucket(ABTI_mem_pool_global_pool *p_global_pool,
             p_global_pool->partial_bucket = new_partial_bucket;
         }
     }
-    ABTI_spinlock_release(&p_global_pool->partial_bucket_lock);
+    ABTD_spinlock_release(&p_global_pool->partial_bucket_lock);
 }
 
 void ABTI_mem_pool_init_global_pool(
@@ -98,7 +98,7 @@ void ABTI_mem_pool_init_global_pool(
     ABTI_sync_lifo_init(&p_global_pool->mem_page_lifo);
     ABTD_atomic_relaxed_store_ptr(&p_global_pool->p_mem_page_empty, NULL);
     ABTI_sync_lifo_init(&p_global_pool->bucket_lifo);
-    ABTI_spinlock_clear(&p_global_pool->partial_bucket_lock);
+    ABTD_spinlock_clear(&p_global_pool->partial_bucket_lock);
     p_global_pool->partial_bucket = NULL;
 }
 

--- a/src/mem/valgrind.c
+++ b/src/mem/valgrind.c
@@ -23,8 +23,8 @@ typedef struct ABTI_valgrind_id_list_t {
 } ABTI_valgrind_id_list;
 
 /* The list is protected by a global lock. */
-static ABTI_spinlock g_valgrind_id_list_lock =
-    ABTI_SPINLOCK_STATIC_INITIALIZER();
+static ABTD_spinlock g_valgrind_id_list_lock =
+    ABTD_SPINLOCK_STATIC_INITIALIZER();
 static int g_num_malloc_failures = 0;
 static ABTI_valgrind_id_list *gp_valgrind_id_list_head = NULL;
 static ABTI_valgrind_id_list *gp_valgrind_id_list_tail = NULL;
@@ -39,7 +39,7 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size)
     const void *p_start = (char *)(p_stack);
     const void *p_end = (char *)(p_stack) + size;
 
-    ABTI_spinlock_acquire(&g_valgrind_id_list_lock);
+    ABTD_spinlock_acquire(&g_valgrind_id_list_lock);
     ABTI_valgrind_id_list *p_valgrind_id_list =
         (ABTI_valgrind_id_list *)malloc(sizeof(ABTI_valgrind_id_list));
     if (p_valgrind_id_list) {
@@ -61,7 +61,7 @@ void ABTI_valgrind_register_stack(const void *p_stack, size_t size)
          * cannot deregister this stack region. */
         g_num_malloc_failures++;
     }
-    ABTI_spinlock_release(&g_valgrind_id_list_lock);
+    ABTD_spinlock_release(&g_valgrind_id_list_lock);
 }
 
 void ABTI_valgrind_unregister_stack(const void *p_stack)
@@ -69,7 +69,7 @@ void ABTI_valgrind_unregister_stack(const void *p_stack)
     if (p_stack == 0)
         return;
 
-    ABTI_spinlock_acquire(&g_valgrind_id_list_lock);
+    ABTD_spinlock_acquire(&g_valgrind_id_list_lock);
     if (gp_valgrind_id_list_head->p_stack == p_stack) {
         VALGRIND_STACK_DEREGISTER(gp_valgrind_id_list_head->valgrind_id);
         ABTI_valgrind_id_list *p_next = gp_valgrind_id_list_head->p_next;
@@ -104,7 +104,7 @@ void ABTI_valgrind_unregister_stack(const void *p_stack)
             g_num_malloc_failures--;
         }
     }
-    ABTI_spinlock_release(&g_valgrind_id_list_lock);
+    ABTD_spinlock_release(&g_valgrind_id_list_lock);
 }
 
 #endif

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -28,7 +28,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread);
 static void unit_free(ABT_unit *unit);
 
 struct data {
-    ABTI_spinlock mutex;
+    ABTD_spinlock mutex;
     size_t num_threads;
     ABTI_thread *p_head;
     ABTI_thread *p_tail;
@@ -99,7 +99,7 @@ static int pool_init(ABT_pool pool, ABT_pool_config config)
 
     if (access != ABT_POOL_ACCESS_PRIV) {
         /* Initialize the mutex */
-        ABTI_spinlock_clear(&p_data->mutex);
+        ABTD_spinlock_clear(&p_data->mutex);
     }
 
     p_data->num_threads = 0;
@@ -135,7 +135,7 @@ static void pool_push_shared(ABT_pool pool, ABT_unit unit)
     data_t *p_data = pool_get_data_ptr(p_pool->data);
     ABTI_thread *p_thread = (ABTI_thread *)unit;
 
-    ABTI_spinlock_acquire(&p_data->mutex);
+    ABTD_spinlock_acquire(&p_data->mutex);
     if (p_data->num_threads == 0) {
         p_thread->p_prev = p_thread;
         p_thread->p_next = p_thread;
@@ -153,7 +153,7 @@ static void pool_push_shared(ABT_pool pool, ABT_unit unit)
     p_data->num_threads++;
 
     ABTD_atomic_release_store_int(&p_thread->is_in_pool, 1);
-    ABTI_spinlock_release(&p_data->mutex);
+    ABTD_spinlock_release(&p_data->mutex);
 }
 
 static void pool_push_private(ABT_pool pool, ABT_unit unit)
@@ -191,7 +191,7 @@ static ABT_unit pool_pop_wait(ABT_pool pool, double time_secs)
     double time_start = 0.0;
 
     do {
-        ABTI_spinlock_acquire(&p_data->mutex);
+        ABTD_spinlock_acquire(&p_data->mutex);
         if (p_data->num_threads > 0) {
             p_thread = p_data->p_head;
             if (p_data->num_threads == 1) {
@@ -209,9 +209,9 @@ static ABT_unit pool_pop_wait(ABT_pool pool, double time_secs)
             ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
             h_unit = (ABT_unit)p_thread;
-            ABTI_spinlock_release(&p_data->mutex);
+            ABTD_spinlock_release(&p_data->mutex);
         } else {
-            ABTI_spinlock_release(&p_data->mutex);
+            ABTD_spinlock_release(&p_data->mutex);
             if (time_start == 0.0) {
                 time_start = ABTI_get_wtime();
             } else {
@@ -237,7 +237,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
     ABT_unit h_unit = ABT_UNIT_NULL;
 
     do {
-        ABTI_spinlock_acquire(&p_data->mutex);
+        ABTD_spinlock_acquire(&p_data->mutex);
         if (p_data->num_threads > 0) {
             p_thread = p_data->p_head;
             if (p_data->num_threads == 1) {
@@ -255,9 +255,9 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
             ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
             h_unit = (ABT_unit)p_thread;
-            ABTI_spinlock_release(&p_data->mutex);
+            ABTD_spinlock_release(&p_data->mutex);
         } else {
-            ABTI_spinlock_release(&p_data->mutex);
+            ABTD_spinlock_release(&p_data->mutex);
             /* Sleep. */
             const int sleep_nsecs = 100;
             struct timespec ts = { 0, sleep_nsecs };
@@ -278,7 +278,7 @@ static ABT_unit pool_pop_shared(ABT_pool pool)
     ABTI_thread *p_thread = NULL;
     ABT_unit h_unit = ABT_UNIT_NULL;
 
-    ABTI_spinlock_acquire(&p_data->mutex);
+    ABTD_spinlock_acquire(&p_data->mutex);
     if (p_data->num_threads > 0) {
         p_thread = p_data->p_head;
         if (p_data->num_threads == 1) {
@@ -297,7 +297,7 @@ static ABT_unit pool_pop_shared(ABT_pool pool)
 
         h_unit = (ABT_unit)p_thread;
     }
-    ABTI_spinlock_release(&p_data->mutex);
+    ABTD_spinlock_release(&p_data->mutex);
 
     return h_unit;
 }
@@ -341,7 +341,7 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) == 1,
                     ABT_ERR_POOL);
 
-    ABTI_spinlock_acquire(&p_data->mutex);
+    ABTD_spinlock_acquire(&p_data->mutex);
     if (p_data->num_threads == 1) {
         p_data->p_head = NULL;
         p_data->p_tail = NULL;
@@ -357,7 +357,7 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
     p_data->num_threads--;
 
     ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
-    ABTI_spinlock_release(&p_data->mutex);
+    ABTD_spinlock_release(&p_data->mutex);
 
     p_thread->p_prev = NULL;
     p_thread->p_next = NULL;
@@ -405,7 +405,7 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
     access = p_pool->access;
     if (access != ABT_POOL_ACCESS_PRIV) {
-        ABTI_spinlock_acquire(&p_data->mutex);
+        ABTD_spinlock_acquire(&p_data->mutex);
     }
 
     size_t num_threads = p_data->num_threads;
@@ -418,7 +418,7 @@ static int pool_print_all(ABT_pool pool, void *arg,
     }
 
     if (access != ABT_POOL_ACCESS_PRIV) {
-        ABTI_spinlock_release(&p_data->mutex);
+        ABTD_spinlock_release(&p_data->mutex);
     }
 
     return ABT_SUCCESS;

--- a/src/stream.c
+++ b/src/stream.c
@@ -2149,7 +2149,7 @@ static void xstream_remove_xstream_list(ABTI_global *p_global,
 static ABT_bool xstream_set_new_rank(ABTI_global *p_global,
                                      ABTI_xstream *p_newxstream, int rank)
 {
-    ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+    ABTD_spinlock_acquire(&p_global->xstream_list_lock);
 
     if (rank == -1) {
         /* Find an unused rank from 0. */
@@ -2169,7 +2169,7 @@ static ABT_bool xstream_set_new_rank(ABTI_global *p_global,
         ABTI_xstream *p_xstream = p_global->p_xstream_head;
         while (p_xstream) {
             if (p_xstream->rank == rank) {
-                ABTI_spinlock_release(&p_global->xstream_list_lock);
+                ABTD_spinlock_release(&p_global->xstream_list_lock);
                 return ABT_FALSE;
             } else if (p_xstream->rank > rank) {
                 break;
@@ -2183,7 +2183,7 @@ static ABT_bool xstream_set_new_rank(ABTI_global *p_global,
     xstream_update_max_xstreams(p_global, rank);
     p_global->num_xstreams++;
 
-    ABTI_spinlock_release(&p_global->xstream_list_lock);
+    ABTD_spinlock_release(&p_global->xstream_list_lock);
     return ABT_TRUE;
 }
 
@@ -2196,13 +2196,13 @@ static ABT_bool xstream_change_rank(ABTI_global *p_global,
         return ABT_TRUE;
     }
 
-    ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+    ABTD_spinlock_acquire(&p_global->xstream_list_lock);
 
     ABTI_xstream *p_next = p_global->p_xstream_head;
     /* Check if a certain rank is available. */
     while (p_next) {
         if (p_next->rank == rank) {
-            ABTI_spinlock_release(&p_global->xstream_list_lock);
+            ABTD_spinlock_release(&p_global->xstream_list_lock);
             return ABT_FALSE;
         } else if (p_next->rank > rank) {
             break;
@@ -2216,17 +2216,17 @@ static ABT_bool xstream_change_rank(ABTI_global *p_global,
     xstream_add_xstream_list(p_global, p_xstream);
     xstream_update_max_xstreams(p_global, rank);
 
-    ABTI_spinlock_release(&p_global->xstream_list_lock);
+    ABTD_spinlock_release(&p_global->xstream_list_lock);
     return ABT_TRUE;
 }
 
 static void xstream_return_rank(ABTI_global *p_global, ABTI_xstream *p_xstream)
 {
     /* Remove this xstream from the global ES list */
-    ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+    ABTD_spinlock_acquire(&p_global->xstream_list_lock);
 
     xstream_remove_xstream_list(p_global, p_xstream);
     p_global->num_xstreams--;
 
-    ABTI_spinlock_release(&p_global->xstream_list_lock);
+    ABTD_spinlock_release(&p_global->xstream_list_lock);
 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -1518,7 +1518,7 @@ int ABT_thread_migrate(ABT_thread thread)
     /* Copy the target execution streams. */
     int i, num_xstreams, abt_errno;
     ABTI_xstream **xstreams;
-    ABTI_spinlock_acquire(&p_global->xstream_list_lock);
+    ABTD_spinlock_acquire(&p_global->xstream_list_lock);
     num_xstreams = p_global->num_xstreams;
     abt_errno =
         ABTU_malloc(sizeof(ABTI_xstream *) * num_xstreams, (void **)&xstreams);
@@ -1530,7 +1530,7 @@ int ABT_thread_migrate(ABT_thread thread)
             p_xstream = p_xstream->p_next;
         }
     }
-    ABTI_spinlock_release(&p_global->xstream_list_lock);
+    ABTD_spinlock_release(&p_global->xstream_list_lock);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Choose the destination xstream.  The user needs to maintain all the pools

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -62,6 +62,12 @@ basic/self_rank_id
 basic/self_type
 basic/ext_thread
 basic/ext_thread2
+basic/ext_thread_barrier
+basic/ext_thread_cond
+basic/ext_thread_eventual
+basic/ext_thread_future
+basic/ext_thread_mutex
+basic/ext_thread_rwlock
 basic/timer
 basic/info_print
 basic/info_print_stack

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -66,6 +66,7 @@ basic/ext_thread_barrier
 basic/ext_thread_cond
 basic/ext_thread_eventual
 basic/ext_thread_future
+basic/ext_thread_join
 basic/ext_thread_mutex
 basic/ext_thread_rwlock
 basic/timer

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -71,6 +71,7 @@ TESTS = \
 	ext_thread_cond \
 	ext_thread_eventual \
 	ext_thread_future \
+	ext_thread_join \
 	ext_thread_mutex \
 	ext_thread_rwlock \
 	timer \
@@ -84,7 +85,7 @@ XFAIL_TESTS =
 if ABT_CONFIG_DISABLE_EXT_THREAD
 XFAIL_TESTS += self_type ext_thread ext_thread2 ext_thread_barrier \
                ext_thread_cond ext_thread_eventual ext_thread_future \
-               ext_thread_mutex ext_thread_rwlock
+               ext_thread_join ext_thread_mutex ext_thread_rwlock
 endif
 if ABT_CONFIG_DISABLE_ERROR_CHECK
 XFAIL_TESTS += self_type
@@ -162,6 +163,7 @@ ext_thread_barrier_SOURCES = ext_thread_barrier.c
 ext_thread_cond_SOURCES = ext_thread_cond.c
 ext_thread_eventual_SOURCES = ext_thread_eventual.c
 ext_thread_future_SOURCES = ext_thread_future.c
+ext_thread_join_SOURCES = ext_thread_join.c
 ext_thread_mutex_SOURCES = ext_thread_mutex.c
 ext_thread_rwlock_SOURCES = ext_thread_rwlock.c
 timer_SOURCES = timer.c
@@ -239,6 +241,7 @@ testing:
 	./ext_thread_cond
 	./ext_thread_eventual
 	./ext_thread_future
+	./ext_thread_join
 	./ext_thread_mutex
 	./ext_thread_rwlock
 	./timer

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -67,6 +67,12 @@ TESTS = \
 	self_type \
 	ext_thread \
 	ext_thread2 \
+	ext_thread_barrier \
+	ext_thread_cond \
+	ext_thread_eventual \
+	ext_thread_future \
+	ext_thread_mutex \
+	ext_thread_rwlock \
 	timer \
 	info_print \
 	info_print_stack \
@@ -76,7 +82,9 @@ TESTS = \
 
 XFAIL_TESTS =
 if ABT_CONFIG_DISABLE_EXT_THREAD
-XFAIL_TESTS += self_type ext_thread ext_thread2
+XFAIL_TESTS += self_type ext_thread ext_thread2 ext_thread_barrier \
+               ext_thread_cond ext_thread_eventual ext_thread_future \
+               ext_thread_mutex ext_thread_rwlock
 endif
 if ABT_CONFIG_DISABLE_ERROR_CHECK
 XFAIL_TESTS += self_type
@@ -150,6 +158,12 @@ self_rank_id_SOURCES = self_rank_id.c
 self_type_SOURCES = self_type.c
 ext_thread_SOURCES = ext_thread.c
 ext_thread2_SOURCES = ext_thread2.c
+ext_thread_barrier_SOURCES = ext_thread_barrier.c
+ext_thread_cond_SOURCES = ext_thread_cond.c
+ext_thread_eventual_SOURCES = ext_thread_eventual.c
+ext_thread_future_SOURCES = ext_thread_future.c
+ext_thread_mutex_SOURCES = ext_thread_mutex.c
+ext_thread_rwlock_SOURCES = ext_thread_rwlock.c
 timer_SOURCES = timer.c
 info_print_SOURCES = info_print.c
 info_print_stack_SOURCES = info_print_stack.c
@@ -221,6 +235,12 @@ testing:
 	./self_type
 	./ext_thread
 	./ext_thread2
+	./ext_thread_barrier
+	./ext_thread_cond
+	./ext_thread_eventual
+	./ext_thread_future
+	./ext_thread_mutex
+	./ext_thread_rwlock
 	./timer
 	./info_print
 	./info_print_stack

--- a/test/basic/ext_thread_barrier.c
+++ b/test/basic/ext_thread_barrier.c
@@ -1,0 +1,189 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_barrier works with external threads or not.  This
+ * test specifically focuses on whether ABT_barrier that internally uses
+ * pthread_cond_t or futex works even if it spuriously wakes up because of
+ * signals. */
+
+#define DEFAULT_NUM_TOTAL_THREADS 4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_ITER 1000
+
+typedef struct {
+    ABT_barrier barrier;
+    int counter;
+} barrier_set;
+barrier_set g_barrier_sets[1];
+int g_iter = DEFAULT_NUM_ITER;
+
+#define NUM_BARRIER_SETS                                                       \
+    ((int)(sizeof(g_barrier_sets) / sizeof(g_barrier_sets[0])))
+
+typedef struct {
+    int tid;
+    int num_total_threads;
+} thread_arg_t;
+
+void thread_func(void *arg)
+{
+    int i;
+    thread_arg_t *p_arg = (thread_arg_t *)arg;
+
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_BARRIER_SETS; j++) {
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                if (i == 0)
+                    g_barrier_sets[j].counter = 0;
+                g_barrier_sets[j].counter += 1;
+            }
+            ABT_barrier_wait(g_barrier_sets[j].barrier);
+            assert(g_barrier_sets[j].counter == i * NUM_BARRIER_SETS + j + 1);
+            ABT_barrier_wait(g_barrier_sets[j].barrier);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+    int num_total_threads = DEFAULT_NUM_TOTAL_THREADS;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_total_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+    assert(num_total_threads >= 1);
+    assert(num_xstreams >= 1);
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_total_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Set up a barrier. */
+    ret = ABT_barrier_create(num_total_threads, &g_barrier_sets[0].barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_total_threads);
+    pthread_t *pthreads =
+        (pthread_t *)malloc(sizeof(pthread_t) * num_total_threads);
+    thread_arg_t *thread_args =
+        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_total_threads);
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    for (i = 0; i < num_total_threads; i++) {
+        thread_args[i].tid = i;
+        thread_args[i].num_total_threads = num_total_threads;
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_create(pools[i % num_xstreams], thread_func,
+                                    &thread_args[i], ABT_THREAD_ATTR_NULL,
+                                    &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        /* Create Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func,
+                                 &thread_args[i]);
+            assert(ret == 0);
+        }
+        /* Join and free ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+        /* Join Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free barrier. */
+    ret = ABT_barrier_free(&g_barrier_sets[0].barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(threads);
+    free(pthreads);
+    free(thread_args);
+    free(pools);
+
+    return ret;
+}

--- a/test/basic/ext_thread_cond.c
+++ b/test/basic/ext_thread_cond.c
@@ -1,0 +1,248 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_cond works with external threads or not.  This test
+ * specifically focuses on whether ABT_con that internally uses pthread_cond_t
+ * or futex works even if it spuriously wakes up because of signals. */
+
+#define NUM_THREADS 4
+#define DEFAULT_NUM_ITER 500
+
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_cond_mem = ABT_COND_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    ABT_cond cond;
+    int counter;
+    ABT_bool is_dynamic; /* Dynamically allocated? */
+} mutex_cond_set;
+mutex_cond_set g_mutex_cond_sets[4];
+int g_iter = DEFAULT_NUM_ITER;
+
+#define NUM_MUTEX_COND_SETS                                                    \
+    ((int)(sizeof(g_mutex_cond_sets) / sizeof(g_mutex_cond_sets[0])))
+
+void thread_func(void *arg)
+{
+    int i;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        assert(NUM_MUTEX_COND_SETS % 2 == 0);
+        for (j = 0; j < NUM_MUTEX_COND_SETS; j += 2) {
+            if (g_mutex_cond_sets[j].mutex == ABT_MUTEX_NULL) {
+                assert(g_mutex_cond_sets[j + 1].mutex == ABT_MUTEX_NULL);
+                /* Not initialized, so let's skip. */
+                continue;
+            } else {
+                assert(g_mutex_cond_sets[j + 1].mutex != ABT_MUTEX_NULL);
+            }
+            int k;
+            for (k = 0; k < 2; k++) {
+                ABT_mutex mutex1 = g_mutex_cond_sets[j + k].mutex;
+                ABT_cond cond1 = g_mutex_cond_sets[j + k].cond;
+                int counter;
+                /* Check signal. */
+                ABT_mutex_lock(mutex1);
+                counter = g_mutex_cond_sets[j + k].counter++;
+                if (counter % NUM_THREADS < NUM_THREADS / 2) {
+                    ABT_cond_wait(cond1, mutex1);
+                    assert(g_mutex_cond_sets[j + k].counter > counter + 1);
+                } else if (counter % NUM_THREADS < (NUM_THREADS / 2) * 2) {
+                    ABT_cond_signal(cond1);
+                }
+                ABT_mutex_unlock(mutex1);
+
+                ABT_mutex mutex2 = g_mutex_cond_sets[j + 1 - k].mutex;
+                ABT_cond cond2 = g_mutex_cond_sets[j + 1 - k].cond;
+                /* Check broadcast.  This works as a "barrier". */
+                ABT_mutex_lock(mutex2);
+                counter = g_mutex_cond_sets[j + 1 - k].counter++;
+                if (counter % NUM_THREADS < NUM_THREADS - 1) {
+                    ABT_cond_wait(cond2, mutex2);
+                    assert(g_mutex_cond_sets[j + 1 - k].counter > counter + 1);
+                } else {
+                    ABT_cond_broadcast(cond2);
+                }
+                ABT_mutex_unlock(mutex2);
+            }
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+    int expected = 0, expected_dynamic = 0;
+    ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+    ABT_cond_memory cond_mem = ABT_COND_INITIALIZER;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Set up mutex and condition variable. */
+    g_mutex_cond_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_cond_sets[0].cond = ABT_COND_MEMORY_GET_HANDLE(&g_cond_mem);
+    g_mutex_cond_sets[0].counter = 0;
+    g_mutex_cond_sets[0].is_dynamic = ABT_FALSE;
+    g_mutex_cond_sets[1].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+    g_mutex_cond_sets[1].cond = ABT_COND_MEMORY_GET_HANDLE(&cond_mem);
+    g_mutex_cond_sets[1].counter = 0;
+    g_mutex_cond_sets[1].is_dynamic = ABT_FALSE;
+    g_mutex_cond_sets[2].mutex = ABT_MUTEX_NULL;
+    g_mutex_cond_sets[3].mutex = ABT_MUTEX_NULL;
+
+    /* Use cond before ABT_Init(). */
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * NUM_THREADS);
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        ATS_destroy_timer();
+        expected += 2 * NUM_THREADS * g_iter;
+        /* This test does not check dynamically allocated data since they have
+         * not been created. */
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, 1);
+
+    ATS_printf(1, "# of ULTs: %d\n", NUM_THREADS);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Allocate dynamically allocated cond and mutex. */
+    for (i = 2; i < 4; i++) {
+        ret = ABT_mutex_create(&g_mutex_cond_sets[i].mutex);
+        ATS_ERROR(ret, "ABT_mutex_create");
+        ret = ABT_cond_create(&g_mutex_cond_sets[i].cond);
+        ATS_ERROR(ret, "ABT_cond_create");
+        g_mutex_cond_sets[i].counter = 0;
+        g_mutex_cond_sets[i].is_dynamic = ABT_TRUE;
+    }
+
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * NUM_THREADS);
+
+    /* Set up an execution stream */
+    ABT_xstream xstream;
+    ret = ABT_xstream_self(&xstream);
+    ATS_ERROR(ret, "ABT_xstream_self");
+
+    ABT_pool pool;
+    ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+    ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create ULTs and Pthreads */
+        pthread_t *pthreads = (pthread_t *)malloc(
+            sizeof(pthread_t) * (NUM_THREADS - NUM_THREADS / 2));
+        for (i = 0; i < NUM_THREADS / 2; i++) {
+            ret = ABT_thread_create(pool, thread_func, NULL,
+                                    ABT_THREAD_ATTR_NULL, &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        for (i = 0; i < NUM_THREADS - NUM_THREADS / 2; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        /* Join and free ULTs and Pthreads */
+        for (i = 0; i < NUM_THREADS / 2; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+        for (i = 0; i < NUM_THREADS - NUM_THREADS / 2; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        ATS_destroy_timer();
+        expected += 2 * NUM_THREADS * g_iter;
+        expected_dynamic += 2 * NUM_THREADS * g_iter;
+    }
+
+    /* Free dynamically allocated mutex and cond. */
+    for (i = 2; i < 4; i++) {
+        ret = ABT_mutex_free(&g_mutex_cond_sets[i].mutex);
+        ATS_ERROR(ret, "ABT_mutex_free");
+        ret = ABT_cond_free(&g_mutex_cond_sets[i].cond);
+        ATS_ERROR(ret, "ABT_cond_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Use the mutex after finalization. */
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * NUM_THREADS);
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < NUM_THREADS; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        ATS_destroy_timer();
+        expected += 2 * NUM_THREADS * g_iter;
+        /* This test does not check dynamically allocated data since they have
+         * already been freed. */
+    }
+
+    /* Validation */
+    for (i = 0; i < NUM_MUTEX_COND_SETS; i++) {
+        if (g_mutex_cond_sets[i].is_dynamic) {
+            assert(g_mutex_cond_sets[i].counter == expected_dynamic);
+        } else {
+            assert(g_mutex_cond_sets[i].counter == expected);
+        }
+    }
+
+    free(threads);
+
+    return ret;
+}

--- a/test/basic/ext_thread_eventual.c
+++ b/test/basic/ext_thread_eventual.c
@@ -1,0 +1,203 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_eventual works with external threads or not.  This
+ * test specifically focuses on whether ABT_eventual that internally uses
+ * pthread_cond_t or futex works even if it spuriously wakes up because of
+ * signals. */
+
+#define DEFAULT_NUM_TOTAL_THREADS 4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_ITER 500
+
+typedef struct {
+    ABT_eventual eventual;
+    int counter;
+} eventual_set;
+eventual_set g_eventual_sets[1];
+int g_iter = DEFAULT_NUM_ITER;
+ABT_barrier g_barrier;
+
+#define NUM_EVENTUAL_SETS                                                      \
+    ((int)(sizeof(g_eventual_sets) / sizeof(g_eventual_sets[0])))
+
+typedef struct {
+    int tid;
+    int num_total_threads;
+} thread_arg_t;
+
+void thread_func(void *arg)
+{
+    int i;
+    thread_arg_t *p_arg = (thread_arg_t *)arg;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_EVENTUAL_SETS; j++) {
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                if (i == 0) {
+                    g_eventual_sets[j].counter = 0;
+                } else {
+                    assert(g_eventual_sets[j].counter ==
+                           i * NUM_EVENTUAL_SETS + j);
+                }
+                g_eventual_sets[j].counter += 1;
+                ABT_eventual_set(g_eventual_sets[j].eventual, NULL, 0);
+            } else {
+                ABT_eventual_wait(g_eventual_sets[j].eventual, NULL);
+            }
+            assert(g_eventual_sets[j].counter == i * NUM_EVENTUAL_SETS + j + 1);
+            ABT_barrier_wait(g_barrier);
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                ABT_eventual_reset(g_eventual_sets[j].eventual);
+            }
+            ABT_barrier_wait(g_barrier);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+    int num_total_threads = DEFAULT_NUM_TOTAL_THREADS;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_total_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+    assert(num_total_threads >= 1);
+    assert(num_xstreams >= 1);
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_total_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Set up eventual and g_barrier. */
+    ret = ABT_eventual_create(0, &g_eventual_sets[0].eventual);
+    ATS_ERROR(ret, "ABT_eventual_create");
+    ret = ABT_barrier_create(num_total_threads, &g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_total_threads);
+    pthread_t *pthreads =
+        (pthread_t *)malloc(sizeof(pthread_t) * num_total_threads);
+    thread_arg_t *thread_args =
+        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_total_threads);
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    for (i = 0; i < num_total_threads; i++) {
+        thread_args[i].tid = i;
+        thread_args[i].num_total_threads = num_total_threads;
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_create(pools[i % num_xstreams], thread_func,
+                                    &thread_args[i], ABT_THREAD_ATTR_NULL,
+                                    &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        /* Create Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func,
+                                 &thread_args[i]);
+            assert(ret == 0);
+        }
+        /* Join and free ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+        /* Join Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free eventual and g_barrier. */
+    ret = ABT_eventual_free(&g_eventual_sets[0].eventual);
+    ATS_ERROR(ret, "ABT_eventual_free");
+    ret = ABT_barrier_free(&g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(threads);
+    free(pthreads);
+    free(thread_args);
+    free(pools);
+
+    return ret;
+}

--- a/test/basic/ext_thread_future.c
+++ b/test/basic/ext_thread_future.c
@@ -1,0 +1,202 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_future works with external threads or not.  This test
+ * specifically focuses on whether ABT_future that internally uses
+ * pthread_cond_t or futex works even if it spuriously wakes up because of
+ * signals. */
+
+#define DEFAULT_NUM_TOTAL_THREADS 4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_ITER 500
+
+typedef struct {
+    ABT_future future;
+    int counter;
+} future_set;
+future_set g_future_sets[1];
+int g_iter = DEFAULT_NUM_ITER;
+ABT_barrier g_barrier;
+
+#define NUM_FUTURE_SETS                                                        \
+    ((int)(sizeof(g_future_sets) / sizeof(g_future_sets[0])))
+
+typedef struct {
+    int tid;
+    int num_total_threads;
+} thread_arg_t;
+
+void thread_func(void *arg)
+{
+    int i;
+    thread_arg_t *p_arg = (thread_arg_t *)arg;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_FUTURE_SETS; j++) {
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                if (i == 0) {
+                    g_future_sets[j].counter = 0;
+                } else {
+                    assert(g_future_sets[j].counter == i * NUM_FUTURE_SETS + j);
+                }
+                g_future_sets[j].counter += 1;
+                ABT_future_set(g_future_sets[j].future, NULL);
+            } else {
+                ABT_future_wait(g_future_sets[j].future);
+            }
+            assert(g_future_sets[j].counter == i * NUM_FUTURE_SETS + j + 1);
+            ABT_barrier_wait(g_barrier);
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                ABT_future_reset(g_future_sets[j].future);
+            }
+            ABT_barrier_wait(g_barrier);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+    int num_total_threads = DEFAULT_NUM_TOTAL_THREADS;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_total_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+    assert(num_total_threads >= 1);
+    assert(num_xstreams >= 1);
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_total_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Set up future and g_barrier. */
+    ret = ABT_future_create(1, NULL, &g_future_sets[0].future);
+    ATS_ERROR(ret, "ABT_future_create");
+    ret = ABT_barrier_create(num_total_threads, &g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_total_threads);
+    pthread_t *pthreads =
+        (pthread_t *)malloc(sizeof(pthread_t) * num_total_threads);
+    thread_arg_t *thread_args =
+        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_total_threads);
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    for (i = 0; i < num_total_threads; i++) {
+        thread_args[i].tid = i;
+        thread_args[i].num_total_threads = num_total_threads;
+    }
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_create(pools[i % num_xstreams], thread_func,
+                                    &thread_args[i], ABT_THREAD_ATTR_NULL,
+                                    &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        /* Create Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func,
+                                 &thread_args[i]);
+            assert(ret == 0);
+        }
+        /* Join and free ULTs */
+        for (i = 0; i < num_total_threads / 2; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+        /* Join Pthreads too. */
+        for (i = num_total_threads / 2; i < num_total_threads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free future and g_barrier. */
+    ret = ABT_future_free(&g_future_sets[0].future);
+    ATS_ERROR(ret, "ABT_future_free");
+    ret = ABT_barrier_free(&g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(threads);
+    free(pthreads);
+    free(thread_args);
+    free(pools);
+
+    return ret;
+}

--- a/test/basic/ext_thread_join.c
+++ b/test/basic/ext_thread_join.c
@@ -1,0 +1,189 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_barrier works with external threads or not.  This
+ * test specifically focuses on whether ABT_barrier that internally uses
+ * pthread_cond_t or futex works even if it spuriously wakes up because of
+ * signals. */
+
+#define NUM_PTHREADS 3
+#define NUM_CHILD_XSTEARMS 2 /* Don't create too many ESs */
+#define DEFAULT_NUM_THREADS 5
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_ITER 100
+
+ABT_barrier g_barrier;
+int g_iter = DEFAULT_NUM_ITER;
+int g_num_threads = DEFAULT_NUM_THREADS;
+int g_num_xstreams = DEFAULT_NUM_XSTREAMS;
+ABT_pool *g_pools;
+
+#define NUM_BARRIER_SETS                                                       \
+    ((int)(sizeof(g_barrier_sets) / sizeof(g_barrier_sets[0])))
+
+typedef struct {
+    int counter;
+} thread_arg_t;
+
+void thread_func(void *arg)
+{
+    thread_arg_t *p_arg = (thread_arg_t *)arg;
+    p_arg->counter += 1;
+}
+
+void *pthread_func(void *arg)
+{
+    int i, step, ret;
+    ABT_xstream xstreams[NUM_CHILD_XSTEARMS];
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * g_num_threads);
+    thread_arg_t *thread_args =
+        (thread_arg_t *)malloc(sizeof(thread_arg_t) * g_num_threads);
+    for (i = 0; i < g_num_threads; i++) {
+        thread_args[i].counter = 0;
+    }
+    for (step = 0; step < g_iter; step++) {
+        /* Create ULTs and execution streams. */
+        for (i = 0; i < g_num_threads; i++) {
+            ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func,
+                                    &thread_args[i], ABT_THREAD_ATTR_NULL,
+                                    &threads[i]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+        if (step % 10 == 0) { /* ES creation is heavy. */
+            for (i = 0; i < NUM_CHILD_XSTEARMS; i++) {
+                ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+                ATS_ERROR(ret, "ABT_xstream_create");
+            }
+        }
+        /* Join and free ULTs and execution streams. */
+        for (i = 0; i < g_num_threads; i++) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+            assert(thread_args[i].counter == step + 1);
+        }
+        if (step % 10 == 0) {
+            for (i = 0; i < NUM_CHILD_XSTEARMS; i++) {
+                ret = ABT_xstream_free(&xstreams[i]);
+                ATS_ERROR(ret, "ABT_xstream_free");
+            }
+        }
+    }
+
+    free(threads);
+    free(thread_args);
+    ret = ABT_barrier_wait(g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_wait");
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        g_num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        g_num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+    assert(g_num_threads >= 1);
+    assert(g_num_xstreams >= 1);
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, g_num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", g_num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", g_num_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Set up a barrier. */
+    ret = ABT_barrier_create(NUM_PTHREADS, &g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_create");
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * g_num_xstreams);
+    pthread_t *pthreads = (pthread_t *)malloc(sizeof(pthread_t) * NUM_PTHREADS);
+    g_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, g_pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create Pthreads. */
+        for (i = 1; i < NUM_PTHREADS; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        /* Note that this thread is a primary ES. */
+        pthread_func(NULL);
+        /* Join Pthreads. */
+        for (i = 1; i < NUM_PTHREADS; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free barrier. */
+    ret = ABT_barrier_free(&g_barrier);
+    ATS_ERROR(ret, "ABT_barrier_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    free(xstreams);
+    free(pthreads);
+    free(g_pools);
+
+    return ret;
+}

--- a/test/basic/ext_thread_mutex.c
+++ b/test/basic/ext_thread_mutex.c
@@ -1,0 +1,289 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_mutex works with external threads or not.  This test
+ * specifically focuses on whether ABT_mutex that internally uses pthread_cond_t
+ * or futex works even if it spuriously wakes up because of signals. */
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_PTHREADS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 5000
+
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    int counter;
+    ABT_bool is_recursive;
+    ABT_bool is_dynamic; /* Dynamically allocated? */
+} mutex_set;
+mutex_set g_mutex_sets[6];
+int g_iter = DEFAULT_NUM_ITER;
+
+#define NUM_MUTEX_SETS ((int)(sizeof(g_mutex_sets) / sizeof(g_mutex_sets[0])))
+
+static int trylock(ABT_mutex mutex)
+{
+    while (ABT_mutex_trylock(mutex) != ABT_SUCCESS)
+        ;
+    return ABT_SUCCESS;
+}
+
+void thread_func(void *arg)
+{
+    int (*lock_fs[])(ABT_mutex) = { ABT_mutex_lock, ABT_mutex_lock_high,
+                                    ABT_mutex_lock_low, trylock,
+                                    ABT_mutex_spinlock };
+    int (*unlock_fs[])(ABT_mutex) = { ABT_mutex_unlock, ABT_mutex_unlock_se,
+                                      ABT_mutex_unlock_de };
+
+    int i;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_MUTEX_SETS; j++) {
+            int k;
+            if (g_mutex_sets[j].mutex == ABT_MUTEX_NULL)
+                continue;
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++)
+                lock_fs[i % (sizeof(lock_fs) / sizeof(lock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+            g_mutex_sets[j].counter++;
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++)
+                unlock_fs[i % (sizeof(unlock_fs) / sizeof(unlock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j, kind, ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_pthreads = DEFAULT_NUM_PTHREADS;
+    int num_threads = DEFAULT_NUM_THREADS;
+    int expected = 0, expected_dynamic = 0;
+    ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+    ABT_mutex_memory rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Set up mutex. */
+    g_mutex_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_sets[0].counter = 0;
+    g_mutex_sets[0].is_recursive = ABT_FALSE;
+    g_mutex_sets[0].is_dynamic = ABT_FALSE;
+    g_mutex_sets[1].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_rec_mutex_mem);
+    g_mutex_sets[1].counter = 0;
+    g_mutex_sets[1].is_recursive = ABT_TRUE;
+    g_mutex_sets[1].is_dynamic = ABT_FALSE;
+    g_mutex_sets[2].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+    g_mutex_sets[2].counter = 0;
+    g_mutex_sets[2].is_recursive = ABT_FALSE;
+    g_mutex_sets[2].is_dynamic = ABT_FALSE;
+    g_mutex_sets[3].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&rec_mutex_mem);
+    g_mutex_sets[3].counter = 0;
+    g_mutex_sets[3].is_recursive = ABT_TRUE;
+    g_mutex_sets[4].is_dynamic = ABT_FALSE;
+    /* ABT_mutex_create() cannot be called before ABT_init() and after
+     * ABT_finalize() */
+    g_mutex_sets[4].mutex = ABT_MUTEX_NULL;
+    g_mutex_sets[5].mutex = ABT_MUTEX_NULL;
+
+    /* Use mutex before ABT_Init(). */
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        ATS_destroy_timer();
+        /* This loop does not test dynamically allocated mutex. */
+        expected += num_pthreads * g_iter;
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Allocate dynamically allocated mutex. */
+    ret = ABT_mutex_create(&g_mutex_sets[4].mutex);
+    ATS_ERROR(ret, "ABT_mutex_create");
+    g_mutex_sets[4].counter = 0;
+    g_mutex_sets[4].is_recursive = ABT_FALSE;
+    g_mutex_sets[4].is_dynamic = ABT_TRUE;
+    ABT_mutex_attr mutex_attr;
+    ret = ABT_mutex_attr_create(&mutex_attr);
+    ATS_ERROR(ret, "ABT_mutex_attr_create");
+    ret = ABT_mutex_attr_set_recursive(mutex_attr, ABT_TRUE);
+    ATS_ERROR(ret, "ABT_mutex_attr_set_recursive");
+    ret = ABT_mutex_create_with_attr(mutex_attr, &g_mutex_sets[5].mutex);
+    ATS_ERROR(ret, "ABT_mutex_create_with_attr");
+    ret = ABT_mutex_attr_free(&mutex_attr);
+    ATS_ERROR(ret, "ABT_mutex_attr_free");
+    g_mutex_sets[5].counter = 0;
+    g_mutex_sets[5].is_recursive = ABT_TRUE;
+    g_mutex_sets[5].is_dynamic = ABT_TRUE;
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_xstreams * num_threads);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        /* Create ULTs */
+        for (i = 0; i < num_xstreams; i++) {
+            for (j = 0; j < num_threads; j++) {
+                ret = ABT_thread_create(pools[i], thread_func, NULL,
+                                        ABT_THREAD_ATTR_NULL,
+                                        &threads[i * num_threads + j]);
+                ATS_ERROR(ret, "ABT_thread_create");
+            }
+        }
+        expected += num_xstreams * num_threads * g_iter;
+        expected_dynamic += num_xstreams * num_threads * g_iter;
+        /* Create Pthreads too. */
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        expected += num_pthreads * g_iter;
+        expected_dynamic += num_pthreads * g_iter;
+
+        /* Join and free ULTs */
+        for (i = 0; i < num_xstreams; i++) {
+            for (j = 0; j < num_threads; j++) {
+                ret = ABT_thread_free(&threads[i * num_threads + j]);
+                ATS_ERROR(ret, "ABT_thread_free");
+            }
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free dynamically allocated mutex. */
+    ret = ABT_mutex_free(&g_mutex_sets[4].mutex);
+    ATS_ERROR(ret, "ABT_mutex_free");
+    ret = ABT_mutex_free(&g_mutex_sets[5].mutex);
+    ATS_ERROR(ret, "ABT_mutex_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Use the mutex after finalization. */
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, NULL);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+        ATS_destroy_timer();
+        expected += num_pthreads * g_iter;
+        /* This test does not check dynamically allocated mutex since they have
+         * already been freed. */
+    }
+
+    /* Validation */
+    for (i = 0; i < NUM_MUTEX_SETS; i++) {
+        if (g_mutex_sets[i].is_dynamic) {
+            assert(g_mutex_sets[i].counter == expected_dynamic);
+        } else {
+            assert(g_mutex_sets[i].counter == expected);
+        }
+    }
+
+    free(threads);
+    free(xstreams);
+    free(pools);
+
+    return ret;
+}

--- a/test/basic/ext_thread_rwlock.c
+++ b/test/basic/ext_thread_rwlock.c
@@ -1,0 +1,185 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if ABT_rwlock works with external threads or not.  This test
+ * specifically focuses on whether ABT_rwlock that internally uses
+ * pthread_cond_t or futex works even if it spuriously wakes up because of
+ * signals. */
+
+#define DEFAULT_NUM_TOTAL_THREADS 4
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_ITER 500
+
+typedef struct {
+    ABT_rwlock rwlock;
+    int counter;
+} rwlock_set;
+rwlock_set g_rwlock_sets[1];
+int g_iter = DEFAULT_NUM_ITER;
+
+#define NUM_RWLOCK_SETS                                                        \
+    ((int)(sizeof(g_rwlock_sets) / sizeof(g_rwlock_sets[0])))
+
+void thread_func(void *arg)
+{
+    const int is_reader = arg ? 1 : 0;
+    int i;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_RWLOCK_SETS; j++) {
+            if (is_reader) {
+                /* Only one reader to avoid a conflict. */
+                ABT_rwlock_rdlock(g_rwlock_sets[j].rwlock);
+            } else {
+                ABT_rwlock_wrlock(g_rwlock_sets[j].rwlock);
+            }
+            g_rwlock_sets[j].counter += 1;
+            ABT_rwlock_unlock(g_rwlock_sets[j].rwlock);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, kind, ret;
+    int num_total_threads = DEFAULT_NUM_TOTAL_THREADS;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int expected = 0;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_total_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+    assert(num_total_threads >= 1);
+    assert(num_xstreams >= 1);
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+    if (!support_external_thread) {
+        ATS_ERROR(ABT_ERR_FEATURE_NA, "ABT_info_query_config");
+    }
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_total_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    /* Set up rwlock  */
+    ret = ABT_rwlock_create(&g_rwlock_sets[0].rwlock);
+    ATS_ERROR(ret, "ABT_rwlock_create");
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_total_threads);
+    pthread_t *pthreads =
+        (pthread_t *)malloc(sizeof(pthread_t) * num_total_threads);
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+
+    /* Create Execution Streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    for (kind = 0; kind < ATS_TIMER_KIND_LAST_; kind++) {
+        ATS_create_timer((ATS_timer_kind)kind);
+        int reader_tid;
+        for (reader_tid = 0; reader_tid < num_total_threads; reader_tid++) {
+            /* Create ULTs */
+            for (i = 0; i < num_total_threads / 2; i++) {
+                ret = ABT_thread_create(pools[i % num_xstreams], thread_func,
+                                        (i == reader_tid) ? &reader_tid : NULL,
+                                        ABT_THREAD_ATTR_NULL, &threads[i]);
+                ATS_ERROR(ret, "ABT_thread_create");
+            }
+            /* Create Pthreads too. */
+            for (i = num_total_threads / 2; i < num_total_threads; i++) {
+                ret = pthread_create(&pthreads[i], NULL, pthread_func,
+                                     (i == reader_tid) ? &reader_tid : NULL);
+                assert(ret == 0);
+            }
+            /* Join and free ULTs */
+            for (i = 0; i < num_total_threads / 2; i++) {
+                ret = ABT_thread_free(&threads[i]);
+                ATS_ERROR(ret, "ABT_thread_free");
+            }
+            /* Join Pthreads too. */
+            for (i = num_total_threads / 2; i < num_total_threads; i++) {
+                ret = pthread_join(pthreads[i], NULL);
+                assert(ret == 0);
+            }
+            expected += num_total_threads * g_iter;
+        }
+        ATS_destroy_timer();
+    }
+
+    /* Join Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free Execution Streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Free rwlock. */
+    ret = ABT_rwlock_free(&g_rwlock_sets[0].rwlock);
+    ATS_ERROR(ret, "ABT_rwlock_free");
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Validation */
+    for (i = 0; i < NUM_RWLOCK_SETS; i++) {
+        assert(g_rwlock_sets[i].counter == expected);
+    }
+
+    free(xstreams);
+    free(threads);
+    free(pthreads);
+    free(pools);
+
+    return ret;
+}

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -5,7 +5,7 @@
 
 AM_CPPFLAGS = $(DEPS_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)/src/include -I$(top_srcdir)/test/util
-AM_LDFLAGS = $(DEPS_LDFLAGS) -lrt
+AM_LDFLAGS = $(DEPS_LDFLAGS) @libabt_timer_library@
 
 noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = abttest.c

--- a/test/util/Makefile.am
+++ b/test/util/Makefile.am
@@ -5,7 +5,7 @@
 
 AM_CPPFLAGS = $(DEPS_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)/src/include -I$(top_srcdir)/test/util
-AM_LDFLAGS = $(DEPS_LDFLAGS)
+AM_LDFLAGS = $(DEPS_LDFLAGS) -lrt
 
 noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = abttest.c

--- a/test/util/abttest.c
+++ b/test/util/abttest.c
@@ -8,6 +8,7 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <signal.h>
 #include "abt.h"
 #include "abttest.h"
 
@@ -215,6 +216,79 @@ void ATS_print_line(FILE *fp, char c, int len)
     fprintf(fp, "\n");
     fflush(fp);
 }
+
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L
+
+static timer_t g_timerid;
+static void timer_handler(int sig, siginfo_t *si, void *uc)
+{
+    /* Do nothing. */
+}
+
+void ATS_create_timer(ATS_timer_kind kind)
+{
+    /* If the signal interval is too small, the program hangs on some systems.
+     * Let's choose a reasonably small value ... for example, 10ms. */
+    const int nsec = 100000;
+    int target_signo = 0;
+    if (kind == ATS_TIMER_KIND_SIGRTMIN ||
+        kind == ATS_TIMER_KIND_SIGRTMIN_RESTART) {
+        target_signo = SIGRTMIN;
+    } else {
+        target_signo = SIGUSR1;
+    }
+
+    /* Set a signal handler. */
+    struct sigaction sa;
+
+    sa.sa_flags = SA_SIGINFO;
+    if (kind == ATS_TIMER_KIND_SIGRTMIN_RESTART ||
+        kind == ATS_TIMER_KIND_SIGUSR1_RESTART)
+        sa.sa_flags |= SA_RESTART;
+    sa.sa_sigaction = timer_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(target_signo, &sa, NULL) == -1) {
+        exit(1);
+    }
+
+    /* Create and start a timer. */
+    struct sigevent sev;
+    struct itimerspec its;
+    sev.sigev_notify = SIGEV_SIGNAL; /* SIGEV_THREAD_ID is not */
+    sev.sigev_signo = target_signo;
+    sev.sigev_value.sival_ptr = &g_timerid;
+    if (timer_create(CLOCK_REALTIME, &sev, &g_timerid) == -1) {
+        exit(1);
+    }
+    its.it_value.tv_sec = 0;
+    its.it_value.tv_nsec = nsec;
+    its.it_interval.tv_sec = 0;
+    its.it_interval.tv_nsec = nsec;
+    if (timer_settime(g_timerid, 0, &its, NULL) == -1) {
+        exit(1);
+    }
+}
+
+void ATS_destroy_timer(void)
+{
+    /* Destroy a timer. */
+    timer_delete(g_timerid);
+}
+
+#else
+
+/* Some systems (e.g., macOS) do not have timer_create(). */
+void ATS_create_timer(ATS_timer_kind kind)
+{
+    ;
+}
+
+void ATS_destroy_timer(void)
+{
+    ;
+}
+
+#endif
 
 typedef enum {
     ATS_TOOL_UNIT_STATE_UNINIT = 0,

--- a/test/util/abttest.h
+++ b/test/util/abttest.h
@@ -126,6 +126,30 @@ int ATS_get_arg_val(ATS_arg arg);
  */
 void ATS_print_line(FILE *fp, char c, int len);
 
+typedef enum ATS_timer_kind {
+    ATS_TIMER_KIND_SIGRTMIN = 0,
+    ATS_TIMER_KIND_SIGRTMIN_RESTART = 1,
+    ATS_TIMER_KIND_SIGUSR1 = 2,
+    ATS_TIMER_KIND_SIGUSR1_RESTART = 3,
+    ATS_TIMER_KIND_LAST_ = 4,
+} ATS_timer_kind;
+
+/*
+ * Create a timer for signal.
+ *
+ * This routines creates a POSIX timer and lets it send a signal to this
+ * program.  Signal will fail system calls and cause spurious wakeup of futex
+ * and pthread_cond_t, which can break Argobots.  This timer intentionally
+ * increases such a weird system call failure and checks if Argobots works well
+ * under such a circumstance.
+ */
+void ATS_create_timer(ATS_timer_kind kind);
+
+/*
+ * Destroy a timer for signal.
+ */
+void ATS_destroy_timer(void);
+
 #define ATS_ERROR_IF(cond) ATS_error_if(cond, #cond, __FILE__, __LINE__)
 #define ATS_ERROR(e, m) ATS_error(e, m, __FILE__, __LINE__)
 #define ATS_UNUSED(a) (void)(a)


### PR DESCRIPTION
## Pull Request Description

### Problem

Most Argobots functions now support external threads; Pthreads can call Argobots synchronization functions such as `ABT_mutex_lock()`, `ABT_barrier_wait()`, and `ABT_thread_join()` together with ULTs.  However, the current implementation of Argobots uses spin-wait (maybe plus `pause` or `sched_yield()`), which burns cores if synchronization conditions are not satisfied soon.  This can cause a catastrophic performance degradation in cases where Pthreads would call such synchronization functions, for example, when users do not know who will call Argobots functions.  This issue can happen particularly when Argobots is used as a building block of another runtime system that is expected to be called by other high-level programs.

### Solution

**This change affects only cases where Pthreads (neither ULTs nor tasklets!) directly call Argobots synchronization functions.**

Argobots provides a futex-based suspension configuration that affects all the synchronization operations.  Currently, unless the user passes `--enable-wait-policy=active`, Argobots will make the underlying external thread block on a futex (like most POSIX synchronization operations internally do).  The underlying external thread will not use CPU resource in a busy loop, so it alleviates thread oversubscription.  This does not change the ULT performance, so if you call such synchronization objects on ULTs (this is a typical use case), this change does not affect the behavior (i.e., it does not increase the overheads of these operations).

### Developer Notes

This synchronization mechanism is a little bit complicated.  Just some notes:

1. futex is basically Linux only.  As a fallback, Argobots has a POSIX-based implementation (`pthread_mutex_t` and `pthread_cond_t`) for other UNIX systems.

2. Since we should not allocate large memory space just for this additional mechanism that not many programs use, `ABTD_futex_xxx_t` should be small and simple.  Currently, its size is 4 or 8 bytes.  This structure can be initialized by zero clear no matter whether POSIX or futex is used (note: `pthread_mutex_t` or `pthread_cond_t` can be 32 bytes or more (implementation dependent)).  This is also necessary to coexist this feature with static initializers of `ABT_mutex` and `ABT_cond`.

3. The synchronization semantics of some synchronization operations is different.  Specifically, `ABT_cond_wait()` does not allow spurious wakeup while `pthread_cond_wait()` allows it.  This causes a semantics mismatch and adds some overhead.

4. External signal can disrupt system calls (i.e., futex or `pthread_cond_wait`).  Seven tests are newly added to check if external threads work while receiving a lot of signals (`ext_thread_join`, `ext_thread_mutex`, ...).

### Performance

The following shows the performance of synchronization objects of the following:
 1. corresponding POSIX implementation (`pthread_mutex_lock()` etc)
 2. this PR with futex (I tried this on Linux so futex was available on all the machines)
 3. this PR without futex (for reference)
 4. this PR with the active wait policy (=the current Argobots behavior)

on those machines:

 1. Intel Skylake (Intel Xeon 8180M, 28 cores / 56 hardware threads * 2 sockets) / openSUSE 42.2 / GCC 7.5
 2. Summit-like POWER 9 (IBM S822LC 10 cores / 80 hardware threads * 2 sockets) / RedHat 7.6 / GCC 9.3
 3. 64-bit ARM (JLSE's 64-bit ARM for HPC, in total 112 hardware threads)/ RedHat 7.6 / GCC 9.3

All use Pthreads for underlying threads.

<details><summary>(The benchmark code is collapsed)</summary>
<p>

```c
/* gcc -O3 test.c -lpthread */
#include <abt.h>
#include <pthread.h>
#include <stdio.h>
#include <stdlib.h>
#include <assert.h>

int g_cond_val = 0;
pthread_barrier_t pth_barrier;
pthread_mutex_t pth_mutex;
pthread_cond_t pth_cond;

ABT_barrier abt_barrier;
ABT_mutex abt_mutex;
ABT_cond abt_cond;

int g_num_pthreads = 0;
int g_num_repeats = 0;
int g_type = 0;

typedef struct {
    int tid;
    pthread_t thread;
} pthread_arg_t;

void *pthread_func(void *arg)
{
    pthread_arg_t *p_arg = (pthread_arg_t *)arg;
    int tid = p_arg->tid;
    int num_pthreads = g_num_pthreads;
    int num_repeats = g_num_repeats;

    pthread_barrier_wait(&pth_barrier);
    g_cond_val = 0;
    double start_time = ABT_get_wtime();
    pthread_barrier_wait(&pth_barrier);

    if (g_type == 0) {
        /* Pthreads mutex */
        for (int i = 0; i < num_repeats; i++) {
            pthread_mutex_lock(&pth_mutex);
            /* Do nothing. */
            pthread_mutex_unlock(&pth_mutex);
        }
    } else if (g_type == 1) {
        /* Argobots mutex */
        for (int i = 0; i < num_repeats; i++) {
            ABT_mutex_lock(abt_mutex);
            /* Do nothing. */
            ABT_mutex_unlock(abt_mutex);
        }
    } else if (g_type == 2) {
        /* Pthreads cond broadcast */
        assert(g_num_pthreads >= 2);
        while (g_cond_val < num_repeats) {
            pthread_mutex_lock(&pth_mutex);
            if (g_cond_val % num_pthreads == tid) {
                g_cond_val += 1;
                pthread_cond_broadcast(&pth_cond);
            } else if (g_cond_val < num_repeats) {
                pthread_cond_wait(&pth_cond, &pth_mutex);
            }
            pthread_mutex_unlock(&pth_mutex);
        }
    } else if (g_type == 3) {
        /* Argobots cond broadcast */
        assert(g_num_pthreads >= 2);
        while (g_cond_val < num_repeats) {
            ABT_mutex_lock(abt_mutex);
            if (g_cond_val % num_pthreads == tid) {
                g_cond_val += 1;
                ABT_cond_broadcast(abt_cond);
            } else if (g_cond_val < num_repeats) {
                ABT_cond_wait(abt_cond, abt_mutex);
            }
            ABT_mutex_unlock(abt_mutex);
        }
    } else if (g_type == 4) {
        /* Pthreads barrier */
        for (int i = 0; i < num_repeats; i++)
            pthread_barrier_wait(&pth_barrier);
    } else if (g_type == 5) {
        /* Argobots barrier */
        for (int i = 0; i < num_repeats; i++)
            ABT_barrier_wait(abt_barrier);
    }
    pthread_barrier_wait(&pth_barrier);

    if (tid == 0) {
        double elapsed_time = ABT_get_wtime() - start_time;
        printf("Unit execution time: %.6f [us]\n",
               elapsed_time / num_repeats * 1.0e6);
    }
    return NULL;
}

int main(int argc, const char **argv)
{
    if (argc != 4) {
        printf("Usage: ./a.out NUM_THREADS NUM_REPEATS BENCH_TYPE\n");
        printf("BENCH_TYPE = 0: POSIX mutex\n");
        printf("           = 1: Argobots mutex\n");
        printf("           = 2: POSIX cond\n");
        printf("           = 3: Argobots cond\n");
        printf("           = 4: POSIX barrier\n");
        printf("           = 5: Argobots barrier\n");
        return -1;
    }
    g_num_pthreads = atoi(argv[1]);
    g_num_repeats = atoi(argv[2]);
    g_type = atoi(argv[3]);

    /* Performance check. */
    ABT_init(0, NULL);

    /* Allocate all synchronization objects. */
    pthread_barrier_init(&pth_barrier, NULL, g_num_pthreads);
    pthread_mutex_init(&pth_mutex, NULL);
    pthread_cond_init(&pth_cond, NULL);
    ABT_barrier_create(g_num_pthreads, &abt_barrier);
    ABT_mutex_create(&abt_mutex);
    ABT_cond_create(&abt_cond);

    pthread_arg_t *pthread_args =
        (pthread_arg_t *)malloc(sizeof(pthread_arg_t) * g_num_pthreads);

    /* Check the mutex performance.  Note that we do not consider a fairness
     * issue */
    for (int i = 0; i < g_num_pthreads; i++) {
        pthread_args[i].tid = i;
        pthread_create(&pthread_args[i].thread, NULL, pthread_func,
                       &pthread_args[i]);
    }
    for (int i = 0; i < g_num_pthreads; i++) {
        pthread_join(pthread_args[i].thread, NULL);
    }

    pthread_barrier_destroy(&pth_barrier);
    pthread_mutex_destroy(&pth_mutex);
    pthread_cond_destroy(&pth_cond);
    ABT_barrier_free(&abt_barrier);
    ABT_mutex_free(&abt_mutex);
    ABT_cond_free(&abt_cond);
    free(pthread_args);

    ABT_finalize();
    return 0;
}
```

<p>
</details>

<details><summary>(The experimental setting is collapsed)</summary>
<p>

Little contention:
Mutex: 1 thread (Skylake/ARM64/POWER9)
Cond: 2 threads (Skylake/ARM64/POWER9)
Barrier: 2 threads (Skylake/ARM64/POWER9)

High contention (not oversubscribed):
Mutex/Cond/Barrier: 28 threads (Skylake/ARM64), 40 threads (POWER9)

High contention (oversubscribed):
Mutex/Cond/Barrier: 256 threads (Skylake/ARM64), 320 threads (POWER9)

Results are the average of 6 time executions.  Each execution repeats these operations many times (around 100000 or more).  Argobots is compiled with `--enable-perf-opt`.

<p>
</details>

![image](https://user-images.githubusercontent.com/15073003/109452978-87bb4b80-7a16-11eb-9836-0342434b4374.png)

Please note that this result is to "understand" the performance.  This PR's change is qualitative, so bad performance of microbenchmarks does not lessen the value of this PR much.  This microbenchmark does not well represent a use case of Pthreads+Argobots: the purpose of this new mechanism is to sleep external threads while waiting for others' work that is moderately coarse-grained and if it is the case this PR works very well no matter POSIX or futex is used.  I also note that semantics (spurious wakeup or not), provided features (Pthreads only or ULT + Pthreads), and scheduling fairness (Argobots synchronization objects might not be as fair as those of Pthreads) are different, so this comparison is not fair.

We can observe the following:
1. In any case, this mechanism works on several architectures without hang.
2. If not contended, the performance of Argobots looks okay.
3. If contended, the performance of Argobots is not good.
4. If the wait policy is passive, overall the futex version is faster than the Pthreads version.
5. When Pthreads oversubscription happens, the performance of `ABT_barrier` and `ABT_cond` gets significantly bad when the wait policy of Argobots is active (because Argobots spins cores).

There is much room for improvement, so if further performance optimization is necessary, please let us know.

### Known issues

1. Some operations are obviously unoptimized (specifically `ABT_cond_signal()`).
2. A few operations still use busy-wait (as far as I checked, when a thread waits for completion of a tasklet).
3. Some users might want to set this configuration per synchronization objects.  Perhaps users wants to change this behavior per function (e.g., `ABT_mutex_lock_active()` and `ABT_mutex_lock_passive()`).  This is future work (if there is such a demand).

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
