### PR TITLE
fix memory leak

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -875,6 +875,67 @@ AC_CHECK_LIB(pthread, pthread_join)
 # check pthread_barrier
 AC_CHECK_FUNCS(pthread_barrier_init)
 
+# check dlvsym
+ABT_RT_CFLAGS=""
+ABT_RT_LDFLAGS=""
+AC_CHECK_LIB(dl, dlvsym)
+if test x"$ac_cv_lib_dl_dlvsym" = x"yes"; then
+    # dl can be used for testing.
+    # check objdump since it is needed
+    if test x"$(which objdump || true)" != x; then
+        # objdump exists.  Dump GLIBC versions.
+        AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([
+            #include <stdio.h>
+            #include <stdlib.h>
+            #include <sys/mman.h>
+            #include <pthread.h>
+            #include <stdint.h>
+            #include <unistd.h>
+        ],[[
+            typedef void *(*fty)(void *);
+            volatile fty fs[] = {
+                (fty)malloc, (fty)calloc, (fty)realloc, (fty)posix_memalign,
+                (fty)free, (fty)mmap, (fty)munmap, (fty)pthread_create,
+                (fty)pthread_join, (fty)pthread_mutex_init,
+                (fty)pthread_mutex_destroy, (fty)pthread_cond_init,
+                (fty)pthread_cond_destroy,
+            #if defined(_POSIX_BARRIERS) && _POSIX_BARRIERS > 0
+                (fty)pthread_barrier_init, (fty)pthread_barrier_destroy
+            #endif
+            };
+            int i;
+            for (i = 0; i < (int)(sizeof(fs)/ sizeof(fs[0])); i++) {
+                pthread_t pth;
+                volatile int r1 = pthread_create(&pth, 0, fs[i], 0);
+                volatile int r2 = pthread_join(pth, 0);
+                (void)r1; (void)r2;
+            }
+        ]])],[
+            dump="$(objdump -t conftest$EXEEXT 2>/dev/null || true)"
+
+            ABT_RT_CFLAGS="-DABT_RT_USE_DLVSYM=1"
+            for target_func in malloc calloc realloc posix_memalign free \
+                        mmap munmap pthread_create pthread_join \
+                        pthread_mutex_init pthread_mutex_destroy \
+                        pthread_cond_init pthread_cond_destroy \
+                        pthread_barrier_init pthread_barrier_destroy;
+            do
+                ABT_RT_VER="$(echo ${dump} | grep -E -o "${target_func}@@.*" \
+                           | sed -e s/${target_func}@@//g \
+                           | cut -d' ' -f1 \
+                           | sed -e 's/[^a-Z0-9._-]//g' \
+                           || true)"
+                ABT_RT_MACRO_NAME="ABT_RT_$(echo ${target_func} | tr a-z A-Z)_VER"
+                ABT_RT_CFLAGS="${ABT_RT_CFLAGS} -D${ABT_RT_MACRO_NAME}=${ABT_RT_VER}"
+            done
+        ],[])
+    fi
+    ABT_RT_LDFLAGS="-ldl"
+fi
+AC_SUBST(ABT_RT_LDFLAGS)
+AC_SUBST(ABT_RT_CFLAGS)
+
 # check -lrt library
 AC_CHECK_LIB(rt, timer_create)
 if test "$ac_cv_lib_rt" = "yes" ; then
@@ -1016,6 +1077,7 @@ AC_CONFIG_FILES([Makefile
                  test/Makefile
                  test/basic/Makefile
                  test/benchmark/Makefile
+                 test/leakcheck/Makefile
                  test/util/Makefile
                  examples/Makefile
                  examples/fibonacci/Makefile

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -299,47 +299,36 @@ void ABTD_affinity_init(ABTI_global *p_global, const char *affinity_str)
     g_affinity.cpusets = NULL;
     g_affinity.initial_cpuset.cpuids = NULL;
     pthread_t self_native_thread = pthread_self();
+    ABTD_affinity_list *p_list = NULL;
+
     uint32_t i;
     int ret;
     ret = get_num_cores(self_native_thread, &p_global->num_cores);
-    if (ret != ABT_SUCCESS || p_global->num_cores == 0) {
-        p_global->set_affinity = ABT_FALSE;
-        return;
-    }
+    if (ret != ABT_SUCCESS || p_global->num_cores == 0)
+        goto FAILED;
     ret = create_cpuset(self_native_thread, &g_affinity.initial_cpuset);
-    if (ret != ABT_SUCCESS) {
-        p_global->set_affinity = ABT_FALSE;
-        return;
-    } else if (g_affinity.initial_cpuset.num_cpuids == 0) {
-        ABTD_affinity_cpuset_destroy(&g_affinity.initial_cpuset);
-        p_global->set_affinity = ABT_FALSE;
-        return;
-    }
+    if (ret != ABT_SUCCESS || g_affinity.initial_cpuset.num_cpuids == 0)
+        goto FAILED;
     p_global->set_affinity = ABT_TRUE;
-    ABTD_affinity_list *p_list = ABTD_affinity_list_create(affinity_str);
-    if (p_list) {
-        if (p_list->num == 0) {
-            ABTD_affinity_list_free(p_list);
-            p_list = NULL;
-        }
+    p_list = ABTD_affinity_list_create(affinity_str);
+    if (p_list->num == 0) {
+        ABTD_affinity_list_free(p_list);
+        p_list = NULL;
     }
     if (p_list) {
         /* Create cpusets based on the affinity list.*/
-        g_affinity.num_cpusets = p_list->num;
-        ret = ABTU_calloc(g_affinity.num_cpusets, sizeof(ABTD_affinity_cpuset),
+        ret = ABTU_calloc(p_list->num, sizeof(ABTD_affinity_cpuset),
                           (void **)&g_affinity.cpusets);
-        ABTI_ASSERT(ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS)
+            goto FAILED;
+        g_affinity.num_cpusets = p_list->num;
         for (i = 0; i < p_list->num; i++) {
             const ABTD_affinity_id_list *p_id_list = p_list->p_id_lists[i];
             uint32_t j, num_cpuids = 0, len_cpuids = 8;
             ret = ABTU_malloc(sizeof(int) * len_cpuids,
                               (void **)&g_affinity.cpusets[i].cpuids);
-            ABTI_ASSERT(ret == ABT_SUCCESS);
-            if (ABTI_IS_ERROR_CHECK_ENABLED && ret != ABT_SUCCESS) {
-                ABTD_affinity_list_free(p_list);
-                p_global->set_affinity = ABT_FALSE;
-                return;
-            }
+            if (ret != ABT_SUCCESS)
+                goto FAILED;
             for (j = 0; j < p_id_list->num; j++) {
                 int cpuid_i = int_rem(p_id_list->ids[j],
                                       g_affinity.initial_cpuset.num_cpuids);
@@ -359,7 +348,8 @@ void ABTD_affinity_init(ABTI_global *p_global, const char *affinity_str)
                                            sizeof(int) * len_cpuids * 2,
                                            (void **)&g_affinity.cpusets[i]
                                                .cpuids);
-                        ABTI_ASSERT(ret == ABT_SUCCESS);
+                        if (ret != ABT_SUCCESS)
+                            goto FAILED;
                         len_cpuids *= 2;
                     }
                     g_affinity.cpusets[i].cpuids[num_cpuids] = cpuid;
@@ -367,29 +357,46 @@ void ABTD_affinity_init(ABTI_global *p_global, const char *affinity_str)
                 }
             }
             /* Adjust the size of cpuids. */
-            if (num_cpuids != len_cpuids)
+            if (num_cpuids != len_cpuids) {
                 ret = ABTU_realloc(sizeof(int) * len_cpuids,
                                    sizeof(int) * num_cpuids,
                                    (void **)&g_affinity.cpusets[i].cpuids);
-            ABTI_ASSERT(ret == ABT_SUCCESS);
+                if (ret != ABT_SUCCESS)
+                    goto FAILED;
+            }
             g_affinity.cpusets[i].num_cpuids = num_cpuids;
         }
         ABTD_affinity_list_free(p_list);
     } else {
         /* Create default cpusets. */
-        g_affinity.num_cpusets = g_affinity.initial_cpuset.num_cpuids;
-        ret = ABTU_calloc(g_affinity.num_cpusets, sizeof(ABTD_affinity_cpuset),
+        ret = ABTU_calloc(g_affinity.initial_cpuset.num_cpuids,
+                          sizeof(ABTD_affinity_cpuset),
                           (void **)&g_affinity.cpusets);
-        ABTI_ASSERT(ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS)
+            goto FAILED;
+        g_affinity.num_cpusets = g_affinity.initial_cpuset.num_cpuids;
         for (i = 0; i < g_affinity.num_cpusets; i++) {
             g_affinity.cpusets[i].num_cpuids = 1;
             ret = ABTU_malloc(sizeof(int) * g_affinity.cpusets[i].num_cpuids,
                               (void **)&g_affinity.cpusets[i].cpuids);
-            ABTI_ASSERT(ret == ABT_SUCCESS);
+            if (ret != ABT_SUCCESS)
+                goto FAILED;
             g_affinity.cpusets[i].cpuids[0] =
                 g_affinity.initial_cpuset.cpuids[i];
         }
     }
+    return;
+FAILED:
+    if (p_list)
+        ABTD_affinity_list_free(p_list);
+    ABTD_affinity_cpuset_destroy(&g_affinity.initial_cpuset);
+    for (i = 0; i < g_affinity.num_cpusets; i++)
+        ABTD_affinity_cpuset_destroy(&g_affinity.cpusets[i]);
+    g_affinity.num_cpusets = 0;
+    ABTU_free(g_affinity.cpusets);
+    g_affinity.cpusets = NULL;
+    p_global->set_affinity = ABT_FALSE;
+    return;
 }
 
 void ABTD_affinity_finalize(ABTI_global *p_global)
@@ -403,16 +410,17 @@ void ABTD_affinity_finalize(ABTI_global *p_global)
          * possibly the CPU affinity policy has been changed while running
          * a user program.  Let's ignore this error. */
         (void)abt_errno;
+
+        /* Free g_affinity. */
+        ABTD_affinity_cpuset_destroy(&g_affinity.initial_cpuset);
+        uint32_t i;
+        for (i = 0; i < g_affinity.num_cpusets; i++) {
+            ABTD_affinity_cpuset_destroy(&g_affinity.cpusets[i]);
+        }
+        ABTU_free(g_affinity.cpusets);
+        g_affinity.cpusets = NULL;
+        g_affinity.num_cpusets = 0;
     }
-    /* Free g_afinity. */
-    ABTD_affinity_cpuset_destroy(&g_affinity.initial_cpuset);
-    uint32_t i;
-    for (i = 0; i < g_affinity.num_cpusets; i++) {
-        ABTD_affinity_cpuset_destroy(&g_affinity.cpusets[i]);
-    }
-    ABTU_free(g_affinity.cpusets);
-    g_affinity.cpusets = NULL;
-    g_affinity.num_cpusets = 0;
 }
 
 ABTU_ret_err int ABTD_affinity_cpuset_read(ABTD_xstream_context *p_ctx,

--- a/src/arch/abtd_affinity.c
+++ b/src/arch/abtd_affinity.c
@@ -310,10 +310,12 @@ void ABTD_affinity_init(ABTI_global *p_global, const char *affinity_str)
     if (ret != ABT_SUCCESS || g_affinity.initial_cpuset.num_cpuids == 0)
         goto FAILED;
     p_global->set_affinity = ABT_TRUE;
-    p_list = ABTD_affinity_list_create(affinity_str);
-    if (p_list->num == 0) {
-        ABTD_affinity_list_free(p_list);
-        p_list = NULL;
+    ret = ABTD_affinity_list_create(affinity_str, &p_list);
+    if (ret == ABT_SUCCESS) {
+        if (p_list->num == 0) {
+            ABTD_affinity_list_free(p_list);
+            p_list = NULL;
+        }
     }
     if (p_list) {
         /* Create cpusets based on the affinity list.*/

--- a/src/arch/abtd_affinity_parser.c
+++ b/src/arch/abtd_affinity_parser.c
@@ -8,80 +8,145 @@
 /* If the value is too big, the input should be wrong. */
 #define MAX_NUM_ELEMS (1024 * 1024)
 
-static ABTD_affinity_id_list *id_list_create(void)
+typedef struct alloc_header {
+    struct alloc_header *p_prev;
+    struct alloc_header *p_next;
+} alloc_header;
+#define ALLOC_HEADER_SIZE                                                      \
+    ((sizeof(alloc_header) + ABTU_MAX_ALIGNMENT - 1) / ABTU_MAX_ALIGNMENT *    \
+     ABTU_MAX_ALIGNMENT)
+
+typedef struct {
+    alloc_header *p_head;
+    alloc_header *p_tail;
+} alloc_list;
+
+/* Since it is extremely cumbersome to handle memory leaks on memory allocation
+ * failure, the following implementation uses a linked list. */
+ABTU_ret_err static int list_calloc(alloc_list *p_alloc_list, size_t size,
+                                    void **p_ptr)
 {
-    ABTD_affinity_id_list *p_id_list;
-    int ret =
-        ABTU_calloc(1, sizeof(ABTD_affinity_id_list), (void **)&p_id_list);
-    ABTI_ASSERT(ret == ABT_SUCCESS);
-    return p_id_list;
+    alloc_header *p_header;
+    int ret = ABTU_calloc(1, size + ALLOC_HEADER_SIZE, (void **)&p_header);
+    ABTI_CHECK_ERROR(ret);
+    /* Allocation succeeded. */
+    *p_ptr = (void *)(((char *)p_header) + ALLOC_HEADER_SIZE);
+    /* Append this header to alloc_list */
+    p_header->p_next = NULL;
+    p_header->p_prev = p_alloc_list->p_tail;
+    if (p_alloc_list->p_tail) {
+        p_alloc_list->p_tail->p_next = p_header;
+        p_alloc_list->p_tail = p_header;
+    } else {
+        p_alloc_list->p_head = p_header;
+        p_alloc_list->p_tail = p_header;
+    }
+    return ABT_SUCCESS;
 }
 
-static void id_list_free(ABTD_affinity_id_list *p_id_list)
+ABTU_ret_err static int list_realloc(alloc_list *p_alloc_list, size_t old_size,
+                                     size_t new_size, void **p_ptr)
 {
-    if (p_id_list)
-        ABTU_free(p_id_list->ids);
-    ABTU_free(p_id_list);
+    /* Read header information before realloc() */
+    if (old_size == 0) {
+        return list_calloc(p_alloc_list, new_size, p_ptr);
+    } else {
+        alloc_header *p_old_header =
+            (alloc_header *)(((char *)*p_ptr) - ALLOC_HEADER_SIZE);
+        alloc_header *p_old_prev_header = p_old_header->p_prev;
+        alloc_header *p_old_next_header = p_old_header->p_next;
+        alloc_header *p_new_header = p_old_header;
+        int ret =
+            ABTU_realloc(old_size + ALLOC_HEADER_SIZE,
+                         new_size + ALLOC_HEADER_SIZE, (void **)&p_new_header);
+        ABTI_CHECK_ERROR(ret);
+        /* Allocation succeeded. */
+        *p_ptr = (void *)(((char *)p_new_header) + ALLOC_HEADER_SIZE);
+        /* Replace p_old_header with p_new_header */
+        if (p_alloc_list->p_head == p_old_header)
+            p_alloc_list->p_head = p_new_header;
+        if (p_alloc_list->p_tail == p_old_header)
+            p_alloc_list->p_tail = p_new_header;
+        p_new_header->p_prev = p_old_prev_header;
+        if (p_old_prev_header)
+            p_old_prev_header->p_next = p_new_header;
+        p_new_header->p_next = p_old_next_header;
+        if (p_old_next_header)
+            p_old_next_header->p_prev = p_new_header;
+        return ABT_SUCCESS;
+    }
 }
 
-static void id_list_add(ABTD_affinity_id_list *p_id_list, int id, uint32_t num,
-                        int stride)
+static void list_free_all(void *p_head)
+{
+    alloc_header *p_cur = (alloc_header *)p_head;
+    while (p_cur) {
+        alloc_header *p_next = p_cur->p_next;
+        ABTU_free(p_cur);
+        p_cur = p_next;
+    }
+}
+
+ABTU_ret_err static int id_list_create(alloc_list *p_alloc_list,
+                                       ABTD_affinity_id_list **pp_id_list)
+{
+    return list_calloc(p_alloc_list, sizeof(ABTD_affinity_id_list),
+                       (void **)pp_id_list);
+}
+
+ABTU_ret_err static int id_list_add(alloc_list *p_alloc_list,
+                                    ABTD_affinity_id_list *p_id_list, int id,
+                                    uint32_t num, int stride)
 {
     /* Needs to add num ids. */
     uint32_t i;
-    int ret = ABTU_realloc(sizeof(int) * p_id_list->num,
+    int ret = list_realloc(p_alloc_list, sizeof(int) * p_id_list->num,
                            sizeof(int) * (p_id_list->num + num),
                            (void **)&p_id_list->ids);
-    ABTI_ASSERT(ret == ABT_SUCCESS);
+    ABTI_CHECK_ERROR(ret);
     for (i = 0; i < num; i++) {
         p_id_list->ids[p_id_list->num + i] = id + stride * i;
     }
     p_id_list->num += num;
+    return ABT_SUCCESS;
 }
 
-static ABTD_affinity_list *list_create(void)
+ABTU_ret_err static int list_create(alloc_list *p_alloc_list,
+                                    ABTD_affinity_list **pp_affinity_list)
 {
-
-    ABTD_affinity_list *p_list;
-    int ret = ABTU_calloc(1, sizeof(ABTD_affinity_list), (void **)&p_list);
-    ABTI_ASSERT(ret == ABT_SUCCESS);
-    return p_list;
+    return list_calloc(p_alloc_list, sizeof(ABTD_affinity_list),
+                       (void **)pp_affinity_list);
 }
 
-static void list_free(ABTD_affinity_list *p_list)
-{
-    if (p_list) {
-        uint32_t i;
-        for (i = 0; i < p_list->num; i++)
-            id_list_free(p_list->p_id_lists[i]);
-        free(p_list->p_id_lists);
-    }
-    free(p_list);
-}
-
-static void list_add(ABTD_affinity_list *p_list, ABTD_affinity_id_list *p_base,
-                     uint32_t num, int stride)
+ABTU_ret_err static int list_add(alloc_list *p_alloc_list,
+                                 ABTD_affinity_list *p_list,
+                                 ABTD_affinity_id_list *p_base, uint32_t num,
+                                 int stride)
 {
     /* Needs to add num id-lists. */
     uint32_t i, j;
     int ret;
 
-    ret = ABTU_realloc(sizeof(ABTD_affinity_id_list *) * p_list->num,
+    ret = list_realloc(p_alloc_list,
+                       sizeof(ABTD_affinity_id_list *) * p_list->num,
                        sizeof(ABTD_affinity_id_list *) * (p_list->num + num),
                        (void **)&p_list->p_id_lists);
-    ABTI_ASSERT(ret == ABT_SUCCESS);
+    ABTI_CHECK_ERROR(ret);
     for (i = 1; i < num; i++) {
-        ABTD_affinity_id_list *p_id_list = id_list_create();
+        ABTD_affinity_id_list *p_id_list;
+        ret = id_list_create(p_alloc_list, &p_id_list);
+        ABTI_CHECK_ERROR(ret);
         p_id_list->num = p_base->num;
-        ret =
-            ABTU_malloc(sizeof(int) * p_id_list->num, (void **)&p_id_list->ids);
-        ABTI_ASSERT(ret == ABT_SUCCESS);
+        ret = list_calloc(p_alloc_list, sizeof(int) * p_id_list->num,
+                          (void **)&p_id_list->ids);
+        ABTI_CHECK_ERROR(ret);
         for (j = 0; j < p_id_list->num; j++)
             p_id_list->ids[j] = p_base->ids[j] + stride * i;
         p_list->p_id_lists[p_list->num + i] = p_id_list;
     }
     p_list->p_id_lists[p_list->num] = p_base;
     p_list->num += num;
+    return ABT_SUCCESS;
 }
 
 static inline int is_whitespace(char c)
@@ -159,39 +224,46 @@ static int consume_symbol(const char *str, uint32_t *p_index, char symbol)
     }
 }
 
-static ABTD_affinity_id_list *parse_es_id_list(const char *affinity_str,
-                                               uint32_t *p_index)
+ABTU_ret_err static int
+parse_es_id_list(alloc_list *p_alloc_list, const char *affinity_str,
+                 uint32_t *p_index, ABTD_affinity_id_list **pp_affinity_id_list)
 {
-    ABTD_affinity_id_list *p_id_list = id_list_create();
-    int val;
+    int ret, val;
+    ABTD_affinity_id_list *p_affinity_id_list;
+    ret = id_list_create(p_alloc_list, &p_affinity_id_list);
+    ABTI_CHECK_ERROR(ret);
     /* Expect either <id> or { <id-list> } */
     if (consume_int(affinity_str, p_index, &val)) {
         /* If the first token is an integer, it is <id> */
-        id_list_add(p_id_list, val, 1, 1);
-        return p_id_list;
+        ret = id_list_add(p_alloc_list, p_affinity_id_list, val, 1, 1);
+        ABTI_CHECK_ERROR(ret);
+        *pp_affinity_id_list = p_affinity_id_list;
+        return ABT_SUCCESS;
     } else if (consume_symbol(affinity_str, p_index, '{')) {
         /* It should be "{" <id-list> "}".  Parse <id-list> and "}" */
         while (1) {
             int id, num = 1, stride = 1;
             /* Parse <id-interval>.  First, expect <id> */
             if (!consume_int(affinity_str, p_index, &id))
-                goto FAILED;
+                return ABT_ERR_OTHER;
             /* Optional: ":" <num> */
             if (consume_symbol(affinity_str, p_index, ':')) {
                 /* Expect <num> */
                 if (!consume_pint(affinity_str, p_index, &num))
-                    goto FAILED;
+                    return ABT_ERR_OTHER;
                 /* Optional: ":" <stride> */
                 if (consume_symbol(affinity_str, p_index, ':')) {
                     /* Expect <stride> */
                     if (!consume_int(affinity_str, p_index, &stride))
-                        goto FAILED;
+                        return ABT_ERR_OTHER;
                 }
             }
             if (num >= MAX_NUM_ELEMS)
-                goto FAILED;
+                return ABT_ERR_OTHER;
             /* Add ids based on <id-interval> */
-            id_list_add(p_id_list, id, num, stride);
+            ret =
+                id_list_add(p_alloc_list, p_affinity_id_list, id, num, stride);
+            ABTI_CHECK_ERROR(ret);
             /* After <id-interval>, we expect either "," (in <id-list>) or "}"
              * (in <es-id-list>) */
             if (consume_symbol(affinity_str, p_index, ',')) {
@@ -200,46 +272,51 @@ static ABTD_affinity_id_list *parse_es_id_list(const char *affinity_str,
             }
             /* Expect "}" */
             if (!consume_symbol(affinity_str, p_index, '}'))
-                goto FAILED;
+                return ABT_ERR_OTHER;
             /* Succeeded. */
-            return p_id_list;
+            *pp_affinity_id_list = p_affinity_id_list;
+            return ABT_SUCCESS;
         }
     }
-FAILED:
-    id_list_free(p_id_list);
-    return NULL; /* Failed. */
+    return ABT_ERR_OTHER;
 }
 
-static ABTD_affinity_list *parse_list(const char *affinity_str)
+ABTU_ret_err static int parse_list(alloc_list *p_alloc_list,
+                                   const char *affinity_str,
+                                   ABTD_affinity_list **pp_affinity_list)
 {
     if (!affinity_str)
-        return NULL;
+        return ABT_ERR_OTHER;
+    int ret;
     uint32_t index = 0;
-    ABTD_affinity_list *p_list = list_create();
+    ABTD_affinity_list *p_affinity_list;
+    ret = list_create(p_alloc_list, &p_affinity_list);
+    ABTI_CHECK_ERROR(ret);
+
     ABTD_affinity_id_list *p_id_list = NULL;
     while (1) {
         int num = 1, stride = 1;
         /* Parse <interval> */
         /* Expect <es-id-list> */
-        p_id_list = parse_es_id_list(affinity_str, &index);
-        if (!p_id_list)
-            goto FAILED;
+        ret = parse_es_id_list(p_alloc_list, affinity_str, &index, &p_id_list);
+        ABTI_CHECK_ERROR(ret);
         /* Optional: ":" <num> */
         if (consume_symbol(affinity_str, &index, ':')) {
             /* Expect <num> */
             if (!consume_pint(affinity_str, &index, &num))
-                goto FAILED;
+                return ABT_ERR_OTHER;
             /* Optional: ":" <stride> */
             if (consume_symbol(affinity_str, &index, ':')) {
                 /* Expect <stride> */
                 if (!consume_int(affinity_str, &index, &stride))
-                    goto FAILED;
+                    return ABT_ERR_OTHER;
             }
         }
         if (num >= MAX_NUM_ELEMS)
-            goto FAILED;
+            return ABT_ERR_OTHER;
         /* Add <es-id-list> based on <interval> */
-        list_add(p_list, p_id_list, num, stride);
+        ret = list_add(p_alloc_list, p_affinity_list, p_id_list, num, stride);
+        ABTI_CHECK_ERROR(ret);
         p_id_list = NULL;
         /* After <interval>, expect either "," (in <list>) or "\0" */
         if (consume_symbol(affinity_str, &index, ',')) {
@@ -248,24 +325,39 @@ static ABTD_affinity_list *parse_list(const char *affinity_str)
         }
         /* Expect "\0" */
         if (!consume_symbol(affinity_str, &index, '\0'))
-            goto FAILED;
+            return ABT_ERR_OTHER;
         /* Succeeded. */
-        return p_list;
+        *pp_affinity_list = p_affinity_list;
+        return ABT_SUCCESS;
     }
-FAILED:
-    list_free(p_list);
-    id_list_free(p_id_list);
-    return NULL; /* Failed. */
+    /* Unreachable. */
 }
 
-ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str)
+ABTU_ret_err int
+ABTD_affinity_list_create(const char *affinity_str,
+                          ABTD_affinity_list **pp_affinity_list)
 {
-    return parse_list(affinity_str);
+    ABTD_affinity_list *p_affinity_list;
+    alloc_list tmp_alloc_list = { NULL, NULL };
+    int ret = parse_list(&tmp_alloc_list, affinity_str, &p_affinity_list);
+    if (ret != ABT_SUCCESS) {
+        /* Free all the allocated memory. */
+        list_free_all((void *)tmp_alloc_list.p_head);
+        return ret;
+    } else {
+        /* Save p_head in p_affinity_list to free it in
+         * ABTD_affinity_list_free(). */
+        p_affinity_list->p_mem_head = (void *)tmp_alloc_list.p_head;
+        *pp_affinity_list = p_affinity_list;
+        return ABT_SUCCESS;
+    }
 }
 
-void ABTD_affinity_list_free(ABTD_affinity_list *p_list)
+void ABTD_affinity_list_free(ABTD_affinity_list *p_affinity_list)
 {
-    list_free(p_list);
+    if (p_affinity_list) {
+        list_free_all(p_affinity_list->p_mem_head);
+    }
 }
 
 #if 0
@@ -291,19 +383,24 @@ static int is_equal(const ABTD_affinity_list *a, const ABTD_affinity_list *b)
 static int is_equal_str(const char *a_str, const char *b_str)
 {
     int ret = 1;
-    ABTD_affinity_list *a = parse_list(a_str);
-    ABTD_affinity_list *b = parse_list(b_str);
-    ret = a && b && is_equal(a, b);
-    list_free(a);
-    list_free(b);
+    ABTD_affinity_list *a, *b;
+    alloc_list tmp_alloc_list1 = { NULL, NULL };
+    alloc_list tmp_alloc_list2 = { NULL, NULL };
+    int ret1 = parse_list(&tmp_alloc_list1, a_str, &a);
+    int ret2 = parse_list(&tmp_alloc_list2, b_str, &b);
+    ret = ret1 == ABT_SUCCESS && ret2 == ABT_SUCCESS && a && b && is_equal(a, b);
+    list_free_all((void *)tmp_alloc_list1.p_head);
+    list_free_all((void *)tmp_alloc_list2.p_head);
     return ret;
 }
 
 static int is_err_str(const char *str)
 {
-    ABTD_affinity_list *a = parse_list(str);
-    if (a) {
-        list_free(a);
+    alloc_list tmp_alloc_list = { NULL, NULL };
+    ABTD_affinity_list *a;
+    int ret = parse_list(&tmp_alloc_list, str, &a);
+    list_free_all((void *)tmp_alloc_list.p_head);
+    if (ret == ABT_SUCCESS) {
         return 0;
     }
     return 1;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -19,6 +19,7 @@ typedef enum {
     ABTD_XSTREAM_CONTEXT_STATE_WAITING,
     ABTD_XSTREAM_CONTEXT_STATE_REQ_JOIN,
     ABTD_XSTREAM_CONTEXT_STATE_REQ_TERMINATE,
+    ABTD_XSTREAM_CONTEXT_STATE_UNINIT,
 } ABTD_xstream_context_state;
 typedef struct ABTD_xstream_context {
     pthread_t native_thread;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -78,7 +78,9 @@ typedef struct ABTD_affinity_list {
     ABTD_affinity_id_list **p_id_lists;
     void *p_mem_head; /* List to free all the allocated memory easily */
 } ABTD_affinity_list;
-ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str);
+ABTU_ret_err int
+ABTD_affinity_list_create(const char *affinity_str,
+                          ABTD_affinity_list **pp_affinity_list);
 void ABTD_affinity_list_free(ABTD_affinity_list *p_list);
 
 #include "abtd_stream.h"

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -73,7 +73,7 @@ typedef struct ABTD_affinity_id_list {
     uint32_t num;
     int *ids; /* id here can be negative. */
 } ABTD_affinity_id_list;
-typedef struct ABTD_affinity_parser_list {
+typedef struct ABTD_affinity_list {
     uint32_t num;
     ABTD_affinity_id_list **p_id_lists;
 } ABTD_affinity_list;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -76,6 +76,7 @@ typedef struct ABTD_affinity_id_list {
 typedef struct ABTD_affinity_list {
     uint32_t num;
     ABTD_affinity_id_list **p_id_lists;
+    void *p_mem_head; /* List to free all the allocated memory easily */
 } ABTD_affinity_list;
 ABTD_affinity_list *ABTD_affinity_list_create(const char *affinity_str);
 void ABTD_affinity_list_free(ABTD_affinity_list *p_list);

--- a/src/include/abti_key.h
+++ b/src/include/abti_key.h
@@ -236,7 +236,10 @@ ABTU_ret_err static inline int ABTI_ktable_set(ABTI_global *p_global,
                                               ABTI_KTABLE_LOCKED)) {
                 /* The lock was acquired, so let's allocate this table. */
                 abt_errno = ABTI_ktable_create(p_global, p_local, &p_ktable);
-                ABTI_CHECK_ERROR(abt_errno);
+                if (abt_errno != ABT_SUCCESS) {
+                    ABTD_atomic_release_store_ptr(pp_ktable, NULL);
+                    ABTI_HANDLE_ERROR(abt_errno);
+                }
 
                 /* Write down the value.  The lock is released here. */
                 ABTD_atomic_release_store_ptr(pp_ktable, p_ktable);

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -22,8 +22,9 @@ enum {
     ABTI_MEM_LP_THP
 };
 
-void ABTI_mem_init(ABTI_global *p_global);
-void ABTI_mem_init_local(ABTI_global *p_global, ABTI_xstream *p_local_xstream);
+ABTU_ret_err int ABTI_mem_init(ABTI_global *p_global);
+ABTU_ret_err int ABTI_mem_init_local(ABTI_global *p_global,
+                                     ABTI_xstream *p_local_xstream);
 void ABTI_mem_finalize(ABTI_global *p_global);
 void ABTI_mem_finalize_local(ABTI_xstream *p_local_xstream);
 int ABTI_mem_check_lp_alloc(ABTI_global *p_global, int lp_alloc);

--- a/src/include/abti_mem_pool.h
+++ b/src/include/abti_mem_pool.h
@@ -103,8 +103,9 @@ void ABTI_mem_pool_init_global_pool(
     uint32_t num_lp_type_requests, size_t alignment_hint);
 void ABTI_mem_pool_destroy_global_pool(
     ABTI_mem_pool_global_pool *p_global_pool);
-void ABTI_mem_pool_init_local_pool(ABTI_mem_pool_local_pool *p_local_pool,
-                                   ABTI_mem_pool_global_pool *p_global_pool);
+ABTU_ret_err int
+ABTI_mem_pool_init_local_pool(ABTI_mem_pool_local_pool *p_local_pool,
+                              ABTI_mem_pool_global_pool *p_global_pool);
 void ABTI_mem_pool_destroy_local_pool(ABTI_mem_pool_local_pool *p_local_pool);
 int ABTI_mem_pool_take_bucket(ABTI_mem_pool_global_pool *p_global_pool,
                               ABTI_mem_pool_header **p_bucket);

--- a/src/include/abti_sched.h
+++ b/src/include/abti_sched.h
@@ -50,8 +50,10 @@ static inline void ABTI_sched_discard_and_free(ABTI_global *p_global,
         ABTI_sched_free(p_global, p_local, p_sched, force_free);
     } else {
         /* Threads should be discarded here. */
-        ABTI_thread_free(p_global, p_local, &p_sched->p_ythread->thread);
-        p_sched->p_ythread = NULL;
+        if (p_sched->p_ythread) {
+            ABTI_thread_free(p_global, p_local, &p_sched->p_ythread->thread);
+            p_sched->p_ythread = NULL;
+        }
     }
 }
 

--- a/src/mem/mem_pool.c
+++ b/src/mem/mem_pool.c
@@ -125,8 +125,9 @@ void ABTI_mem_pool_destroy_global_pool(ABTI_mem_pool_global_pool *p_global_pool)
     ABTI_sync_lifo_destroy(&p_global_pool->mem_page_lifo);
 }
 
-void ABTI_mem_pool_init_local_pool(ABTI_mem_pool_local_pool *p_local_pool,
-                                   ABTI_mem_pool_global_pool *p_global_pool)
+ABTU_ret_err int
+ABTI_mem_pool_init_local_pool(ABTI_mem_pool_local_pool *p_local_pool,
+                              ABTI_mem_pool_global_pool *p_global_pool)
 {
     p_local_pool->p_global_pool = p_global_pool;
     p_local_pool->num_headers_per_bucket =
@@ -135,8 +136,9 @@ void ABTI_mem_pool_init_local_pool(ABTI_mem_pool_local_pool *p_local_pool,
      * Let's take one bucket. */
     int abt_errno =
         ABTI_mem_pool_take_bucket(p_global_pool, &p_local_pool->buckets[0]);
-    ABTI_ASSERT(abt_errno == ABT_SUCCESS);
+    ABTI_CHECK_ERROR(abt_errno);
     p_local_pool->bucket_index = 0;
+    return ABT_SUCCESS;
 }
 
 void ABTI_mem_pool_destroy_local_pool(ABTI_mem_pool_local_pool *p_local_pool)

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -803,7 +803,10 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 #endif
     int abt_errno =
         ABTI_ythread_create_sched(p_global, p_local, p_pool, p_sched);
-    ABTI_CHECK_ERROR(abt_errno);
+    if (abt_errno != ABT_SUCCESS) {
+        p_sched->used = ABTI_SCHED_NOT_USED;
+        ABTI_HANDLE_ERROR(abt_errno);
+    }
     return ABT_SUCCESS;
 }
 

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -844,6 +844,12 @@ void ABTI_sched_free(ABTI_global *p_global, ABTI_local *p_local,
     size_t p;
     for (p = 0; p < p_sched->num_pools; p++) {
         ABTI_pool *p_pool = ABTI_pool_get_ptr(p_sched->pools[p]);
+        if (!p_pool) {
+            /* p_pool can be set to NULL when that p_pool must be preserved,
+             * for example, when this function is called because
+             * ABT_xstream_create_basic() fails. */
+            continue;
+        }
         int32_t num_scheds = ABTI_pool_release(p_pool);
         if ((p_pool->automatic == ABT_TRUE && num_scheds == 0) || force_free) {
             ABTI_pool_free(p_pool);

--- a/src/thread.c
+++ b/src/thread.c
@@ -2717,6 +2717,10 @@ static void thread_key_destructor_stackable_sched(void *p_value)
         p_sched->p_ythread = NULL;
         ABTI_sched_free(p_global, ABTI_local_get_local_uninlined(), p_sched,
                         ABT_FALSE);
+    } else {
+        /* If it is not automatic, p_ythread must be set to NULL to avoid double
+         * free corruption. */
+        p_sched->p_ythread = NULL;
     }
 }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -3,6 +3,6 @@
 # See COPYRIGHT in top-level directory.
 #
 
-SUBDIRS = util basic benchmark
+SUBDIRS = util basic leakcheck benchmark
 DIST_SUBDIRS = $(SUBDIRS)
 

--- a/test/leakcheck/.gitignore
+++ b/test/leakcheck/.gitignore
@@ -1,0 +1,16 @@
+librtrace*
+affinity
+barrier
+cond
+eventual
+future
+init_finalize
+key
+mutex
+pool
+rwlock
+sched
+thread
+timer
+xstream
+xstream_barrier

--- a/test/leakcheck/Makefile.am
+++ b/test/leakcheck/Makefile.am
@@ -1,0 +1,44 @@
+# -*- Mode: Makefile; -*-
+#
+# See COPYRIGHT in top-level directory.
+#
+
+TESTS = \
+	affinity \
+	barrier \
+	cond \
+	eventual \
+	future \
+	init_finalize \
+	key \
+	mutex \
+	pool \
+	rwlock \
+	sched \
+	thread \
+	timer \
+	xstream \
+	xstream_barrier
+
+check_PROGRAMS = $(TESTS)
+noinst_PROGRAMS = $(TESTS)
+
+noinst_LTLIBRARIES = librtrace.la
+
+librtrace_la_SOURCES = rtrace.c
+librtrace_la_LIBADD = @ABT_RT_LDFLAGS@
+
+if ABT_CONFIG_DISABLE_ERROR_CHECK
+# Do not compile rtrace with -DABT_RT_USE_DLVSYM
+librtrace_la_CFLAGS =
+else
+librtrace_la_CFLAGS = @ABT_RT_CFLAGS@
+endif
+librtrace_la_LDFLAGS = $(all_libraries)
+# librtrace_la_CFLAGS = -fpic -shared
+
+include $(top_srcdir)/test/Makefile.mk
+
+LDADD += librtrace.la
+
+testing:

--- a/test/leakcheck/affinity.c
+++ b/test/leakcheck/affinity.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_init() and ABT_finalize(). */
+
+void program(int must_succeed)
+{
+    int ret;
+    ret = ABT_init(0, 0);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        ret = ABT_finalize();
+        /* This ABT_finalize() should not fail. */
+        assert(ret == ABT_SUCCESS);
+    }
+}
+
+char *legal_affinity_strs[] = { "++1", "1:2,{1:2}" };
+
+char *illegal_affinity_strs[] = { "{}", "1:1:1:1", "{1:2:3}:2:" };
+
+int main()
+{
+    int i;
+    setup_env();
+    rtrace_init();
+
+    for (i = 0; i < (int)(sizeof(legal_affinity_strs) /
+                          sizeof(legal_affinity_strs[0]));
+         i++) {
+        int ret = setenv("ABT_SET_AFFINITY", legal_affinity_strs[i], 1);
+        assert(ret == 0);
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+        /* If no failure, it should succeed again. */
+        program(1);
+    }
+    /* Currently Argobots silently ignores an illegal affinity string. */
+    for (i = 0; i < (int)(sizeof(illegal_affinity_strs) /
+                          sizeof(illegal_affinity_strs[0]));
+         i++) {
+        int ret = setenv("ABT_SET_AFFINITY", illegal_affinity_strs[i], 1);
+        assert(ret == 0);
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+        /* If no failure, it should succeed again. */
+        program(1);
+    }
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/barrier.c
+++ b/test/leakcheck/barrier.c
@@ -1,0 +1,125 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_barrier. */
+
+void thread_func(void *arg)
+{
+    int ret = ABT_barrier_wait((ABT_barrier)arg);
+    assert(ret == ABT_SUCCESS);
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    ABT_barrier barrier = (ABT_barrier)RAND_PTR;
+    ret = ABT_barrier_create(2, &barrier);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        /* Make it large. */
+        ret = ABT_barrier_reinit(barrier, 128);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            /* Shrink again. */
+            ret = ABT_barrier_reinit(barrier, 2);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret != ABT_SUCCESS) {
+                /* If shrink fails, we cannot continue this test. */
+                ret = ABT_barrier_free(&barrier);
+                assert(ret == ABT_SUCCESS && barrier == ABT_BARRIER_NULL);
+                goto FINISH_TEST;
+            }
+        }
+        /* Now # of waiters must be 2. */
+        uint32_t num_waiters;
+        ret = ABT_barrier_get_num_waiters(barrier, &num_waiters);
+        assert(ret == ABT_SUCCESS && num_waiters == 2);
+        /* If an external thread is supported, use an external thread. */
+        ABT_bool external_thread_support;
+        ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                    &external_thread_support);
+        assert(ret == ABT_SUCCESS);
+        if (external_thread_support) {
+            pthread_t pthread;
+            ret = pthread_create(&pthread, NULL, pthread_func, (void *)barrier);
+            assert(!must_succeed || ret == 0);
+            if (ret == 0) {
+                ret = ABT_barrier_wait(barrier);
+                assert(ret == ABT_SUCCESS);
+                ret = pthread_join(pthread, NULL);
+                assert(ret == 0);
+            }
+        }
+        /* Create a ULT and wait on a barrier together. */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ABT_thread thread = (ABT_thread)RAND_PTR;
+        ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                           (void *)barrier,
+                                           ABT_THREAD_ATTR_NULL, &thread);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            ret = ABT_barrier_wait(barrier);
+            assert(ret == ABT_SUCCESS);
+            ret = ABT_thread_free(&thread);
+            assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+        } else {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(thread == (ABT_thread)RAND_PTR);
+#else
+            assert(thread == ABT_THREAD_NULL);
+#endif
+        }
+        /* Free barrier. */
+        ret = ABT_barrier_free(&barrier);
+        assert(ret == ABT_SUCCESS && barrier == ABT_BARRIER_NULL);
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(barrier == (ABT_barrier)RAND_PTR);
+#else
+        assert(barrier == ABT_BARRIER_NULL);
+#endif
+    }
+
+FINISH_TEST:
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/cond.c
+++ b/test/leakcheck/cond.c
@@ -1,0 +1,190 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* This test checks if ABT_cond works with external threads or not.  This test
+ * specifically focuses on whether ABT_con that internally uses pthread_cond_t
+ * or futex works even if it spuriously wakes up because of signals. */
+
+#define DEFAULT_NUM_ITER 20
+
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_cond_mem = ABT_COND_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    ABT_cond cond;
+    ABT_bool is_dynamic;
+} mutex_cond_set;
+mutex_cond_set g_mutex_cond_sets[2];
+
+#define NUM_MUTEX_COND_SETS                                                    \
+    ((int)(sizeof(g_mutex_cond_sets) / sizeof(g_mutex_cond_sets[0])))
+#define NUM_ITERS 5
+
+int g_val = 0;
+void thread_func(void *arg)
+{
+    (void)arg;
+    int i;
+    for (i = 0; i < NUM_ITERS; i++) {
+        int j;
+        for (j = 0; j < NUM_MUTEX_COND_SETS; j++) {
+            if (g_mutex_cond_sets[j].mutex == ABT_MUTEX_NULL)
+                continue;
+            int ret;
+            /* Check signal. */
+            ret = ABT_mutex_lock(g_mutex_cond_sets[j].mutex);
+            assert(ret == ABT_SUCCESS);
+            g_val++;
+            if (g_val % 2 == 1) {
+                ret = ABT_cond_wait(g_mutex_cond_sets[j].cond,
+                                    g_mutex_cond_sets[j].mutex);
+                assert(ret == ABT_SUCCESS);
+                ret = ABT_cond_broadcast(g_mutex_cond_sets[j].cond);
+                assert(ret == ABT_SUCCESS);
+            } else {
+                ret = ABT_cond_signal(g_mutex_cond_sets[j].cond);
+                assert(ret == ABT_SUCCESS);
+                ret = ABT_cond_wait(g_mutex_cond_sets[j].cond,
+                                    g_mutex_cond_sets[j].mutex);
+                assert(ret == ABT_SUCCESS);
+            }
+            ret = ABT_mutex_unlock(g_mutex_cond_sets[j].mutex);
+            assert(ret == ABT_SUCCESS);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int type, int must_succeed)
+{
+    int i, ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    if (type == 0)
+        rtrace_set_enabled(1);
+
+    /* Set up mutex and condition variable. */
+    g_mutex_cond_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_cond_sets[0].cond = ABT_COND_MEMORY_GET_HANDLE(&g_cond_mem);
+    g_mutex_cond_sets[0].is_dynamic = ABT_FALSE;
+
+    g_mutex_cond_sets[1].mutex = (ABT_mutex)RAND_PTR;
+    ret = ABT_mutex_create(&g_mutex_cond_sets[1].mutex);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        g_mutex_cond_sets[1].cond = (ABT_cond)RAND_PTR;
+        ret = ABT_cond_create(&g_mutex_cond_sets[1].cond);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            g_mutex_cond_sets[1].is_dynamic = ABT_TRUE;
+        } else {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(g_mutex_cond_sets[1].cond == (ABT_cond)RAND_PTR);
+            g_mutex_cond_sets[1].cond = ABT_COND_NULL;
+#else
+            assert(g_mutex_cond_sets[1].cond == ABT_COND_NULL);
+#endif
+            ret = ABT_mutex_free(&g_mutex_cond_sets[1].mutex);
+            assert(ret == ABT_SUCCESS &&
+                   g_mutex_cond_sets[1].mutex == ABT_MUTEX_NULL);
+        }
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(g_mutex_cond_sets[1].mutex == (ABT_mutex)RAND_PTR);
+        g_mutex_cond_sets[1].mutex = ABT_MUTEX_NULL;
+#else
+        assert(g_mutex_cond_sets[1].mutex == ABT_MUTEX_NULL);
+#endif
+    }
+    if (type == 1)
+        rtrace_set_enabled(1);
+
+    if (type == 0) {
+        /* Create a ULT and synchronize it with mutex. */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ABT_thread thread = (ABT_thread)RAND_PTR;
+        ret = ABT_thread_create_on_xstream(self_xstream, thread_func, NULL,
+                                           ABT_THREAD_ATTR_NULL, &thread);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            thread_func(NULL);
+            ret = ABT_thread_free(&thread);
+            assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+        } else {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(thread == (ABT_thread)RAND_PTR);
+#else
+            assert(thread == ABT_THREAD_NULL);
+#endif
+        }
+    } else if (type == 1) {
+        /* If an external thread is supported, use an external thread. */
+        ABT_bool external_thread_support;
+        ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                    &external_thread_support);
+        assert(ret == ABT_SUCCESS);
+        if (external_thread_support) {
+            pthread_t pthread;
+            ret = pthread_create(&pthread, NULL, pthread_func, NULL);
+            assert(!must_succeed || ret == 0);
+            if (ret == 0) {
+                thread_func(NULL);
+                ret = pthread_join(pthread, NULL);
+                assert(ret == 0);
+            }
+        }
+    }
+    /* Free data structure. */
+    for (i = 0; i < NUM_MUTEX_COND_SETS; i++) {
+        if (g_mutex_cond_sets[i].is_dynamic &&
+            g_mutex_cond_sets[i].mutex != ABT_MUTEX_NULL) {
+            ret = ABT_mutex_free(&g_mutex_cond_sets[i].mutex);
+            assert(ret == ABT_SUCCESS &&
+                   g_mutex_cond_sets[i].mutex == ABT_MUTEX_NULL);
+            ret = ABT_cond_free(&g_mutex_cond_sets[i].cond);
+            assert(ret == ABT_SUCCESS &&
+                   g_mutex_cond_sets[i].cond == ABT_COND_NULL);
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    int type;
+    for (type = 0; type < 2; type++) {
+        do {
+            rtrace_start();
+            program(type, 0);
+        } while (!rtrace_stop());
+
+        /* If no failure, it should succeed again. */
+        program(type, 1);
+    }
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/eventual.c
+++ b/test/leakcheck/eventual.c
@@ -1,0 +1,113 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_eventual. */
+
+void thread_func(void *arg)
+{
+    int ret;
+    ret = ABT_eventual_wait((ABT_eventual)arg, NULL);
+    assert(ret == ABT_SUCCESS);
+    ABT_bool is_ready;
+    ret = ABT_eventual_test((ABT_eventual)arg, NULL, &is_ready);
+    assert(ret == ABT_SUCCESS && is_ready == ABT_TRUE);
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int must_succeed)
+{
+    int ret, i;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    for (i = 0; i < 2; i++) {
+        int nbytes = i * 128;
+        ABT_eventual eventual = (ABT_eventual)RAND_PTR;
+        ret = ABT_eventual_create(nbytes, &eventual);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            /* If an external thread is supported, use an external thread. */
+            ABT_bool external_thread_support;
+            ret = ABT_info_query_config(
+                ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                &external_thread_support);
+            assert(ret == ABT_SUCCESS);
+            if (external_thread_support) {
+                pthread_t pthread;
+                ret = pthread_create(&pthread, NULL, pthread_func,
+                                     (void *)eventual);
+                assert(!must_succeed || ret == 0);
+                if (ret == 0) {
+                    ret = ABT_eventual_set(eventual, NULL, 0);
+                    assert(ret == ABT_SUCCESS);
+                    ret = pthread_join(pthread, NULL);
+                    assert(ret == 0);
+                    ret = ABT_eventual_reset(eventual);
+                    assert(ret == ABT_SUCCESS);
+                }
+            }
+            /* Create a ULT and synchronize it with eventual. */
+            ABT_xstream self_xstream;
+            ret = ABT_self_get_xstream(&self_xstream);
+            assert(ret == ABT_SUCCESS);
+            ABT_thread thread = (ABT_thread)RAND_PTR;
+            ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                               (void *)eventual,
+                                               ABT_THREAD_ATTR_NULL, &thread);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret == ABT_SUCCESS) {
+                ret = ABT_eventual_set(eventual, NULL, 0);
+                assert(ret == ABT_SUCCESS);
+                ret = ABT_thread_free(&thread);
+                assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+            } else {
+#ifdef ABT_ENABLE_VER_20_API
+                assert(thread == (ABT_thread)RAND_PTR);
+#else
+                assert(thread == ABT_THREAD_NULL);
+#endif
+            }
+            /* Free eventual. */
+            ret = ABT_eventual_free(&eventual);
+            assert(ret == ABT_SUCCESS && eventual == ABT_EVENTUAL_NULL);
+        } else {
+            assert(eventual == (ABT_eventual)RAND_PTR);
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/future.c
+++ b/test/leakcheck/future.c
@@ -1,0 +1,148 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_future. */
+
+#define NUM_COMPARTMENTS 64
+
+void thread_func(void *arg)
+{
+    int ret, i;
+    for (i = 0; i < NUM_COMPARTMENTS / 2; i++) {
+        ret = ABT_future_set((ABT_future)arg, &i);
+    }
+    ret = ABT_future_wait((ABT_future)arg);
+    assert(ret == ABT_SUCCESS);
+    ABT_bool is_ready;
+    ret = ABT_future_test((ABT_future)arg, &is_ready);
+    assert(ret == ABT_SUCCESS && is_ready == ABT_TRUE);
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void cb_func(void **arg)
+{
+    /* Only two values. */
+    void *ptr1 = NULL, *ptr2 = NULL;
+    int i, num1 = 0, num2 = 0;
+    for (i = 0; i < NUM_COMPARTMENTS; i++) {
+        assert(arg[i] != NULL);
+        if (ptr1 == NULL) {
+            ptr1 = arg[i];
+            num1++;
+        } else if (ptr1 == arg[i]) {
+            num1++;
+        } else if (ptr2 == NULL) {
+            ptr2 = arg[i];
+            num2++;
+        } else if (ptr2 == arg[i]) {
+            num2++;
+        } else {
+            assert(0);
+        }
+    }
+    assert(num1 == NUM_COMPARTMENTS / 2 && num2 == NUM_COMPARTMENTS / 2);
+}
+
+void program(int must_succeed)
+{
+    int ret, i, use_cb_func;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    for (use_cb_func = 0; use_cb_func < 2; use_cb_func++) {
+        ABT_future future = (ABT_future)RAND_PTR;
+        ret = ABT_future_create(NUM_COMPARTMENTS, use_cb_func ? cb_func : NULL,
+                                &future);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            /* If an external thread is supported, use an external thread. */
+            ABT_bool external_thread_support;
+            ret = ABT_info_query_config(
+                ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                &external_thread_support);
+            assert(ret == ABT_SUCCESS);
+            if (external_thread_support) {
+                pthread_t pthread;
+                ret = pthread_create(&pthread, NULL, pthread_func,
+                                     (void *)future);
+                assert(!must_succeed || ret == 0);
+                if (ret == 0) {
+                    for (i = 0; i < NUM_COMPARTMENTS / 2; i++) {
+                        ret = ABT_future_set(future, &i);
+                        assert(ret == ABT_SUCCESS);
+                    }
+                    ret = ABT_future_wait(future);
+                    assert(ret == ABT_SUCCESS);
+                    ret = pthread_join(pthread, NULL);
+                    assert(ret == 0);
+                    ret = ABT_future_reset(future);
+                    assert(ret == ABT_SUCCESS);
+                }
+            }
+            /* Create a ULT and synchronize it with future. */
+            ABT_xstream self_xstream;
+            ret = ABT_self_get_xstream(&self_xstream);
+            assert(ret == ABT_SUCCESS);
+            ABT_thread thread = (ABT_thread)RAND_PTR;
+            ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                               (void *)future,
+                                               ABT_THREAD_ATTR_NULL, &thread);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret == ABT_SUCCESS) {
+                for (i = 0; i < NUM_COMPARTMENTS / 2; i++) {
+                    ret = ABT_future_set(future, &i);
+                    assert(ret == ABT_SUCCESS);
+                }
+                ret = ABT_future_wait(future);
+                assert(ret == ABT_SUCCESS);
+                ret = ABT_thread_free(&thread);
+                assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+            } else {
+#ifdef ABT_ENABLE_VER_20_API
+                assert(thread == (ABT_thread)RAND_PTR);
+#else
+                assert(thread == ABT_THREAD_NULL);
+#endif
+            }
+            /* Free future. */
+            ret = ABT_future_free(&future);
+            assert(ret == ABT_SUCCESS && future == ABT_FUTURE_NULL);
+        } else {
+            assert(future == (ABT_future)RAND_PTR);
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+    rtrace_finalize();
+
+    /* If no failure, it should succeed again. */
+    program(1);
+    return 0;
+}

--- a/test/leakcheck/init_finalize.c
+++ b/test/leakcheck/init_finalize.c
@@ -1,0 +1,40 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_init() and ABT_finalize(). */
+
+void program(int must_succeed)
+{
+    int ret;
+    ret = ABT_init(0, 0);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        ret = ABT_finalize();
+        /* This ABT_finalize() should not fail. */
+        assert(ret == ABT_SUCCESS);
+    }
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/key.c
+++ b/test/leakcheck/key.c
@@ -1,0 +1,157 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_key. */
+
+ABT_key g_keys[3];
+
+void destructor(void *val)
+{
+    free(val);
+}
+
+void set_self_data(int i, int must_succeed)
+{
+    if (g_keys[i] != ABT_KEY_NULL) {
+        void *data;
+        int ret;
+        ret = ABT_self_get_specific(g_keys[i], &data);
+        assert(ret == ABT_SUCCESS);
+        if (data)
+            free(data);
+        data = malloc(128);
+        ret = ABT_self_set_specific(g_keys[i], data);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS)
+            free(data);
+    }
+}
+
+void set_thread_data(ABT_thread thread, int i, int must_succeed)
+{
+    if (g_keys[i] != ABT_KEY_NULL) {
+        void *data;
+        int ret;
+        ret = ABT_thread_get_specific(thread, g_keys[i], &data);
+        assert(ret == ABT_SUCCESS);
+        if (data)
+            free(data);
+        data = malloc(128);
+        ret = ABT_thread_set_specific(thread, g_keys[i], data);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS)
+            free(data);
+    }
+}
+
+void thread_func(void *must_succeed)
+{
+    set_self_data(1, must_succeed ? 1 : 0);
+    set_self_data(2, must_succeed ? 1 : 0);
+}
+
+void program(int must_succeed)
+{
+    int ret, i;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    /* Create keys. */
+    for (i = 0; i < 3; i++) {
+        g_keys[i] = (ABT_key)RAND_PTR;
+        ret = ABT_key_create(destructor, &g_keys[i]);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+            assert(g_keys[i] == (ABT_key)RAND_PTR);
+            g_keys[i] = ABT_KEY_NULL;
+        }
+    }
+
+    /* Create a ULT and use those keys. */
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+
+    ABT_thread threads[4] = { ABT_THREAD_NULL, ABT_THREAD_NULL, ABT_THREAD_NULL,
+                              ABT_THREAD_NULL };
+    for (i = 0; i < 4; i++) {
+        if (i == 2 && g_keys[2] != ABT_KEY_NULL) {
+            /* The destructor must be called even after ABT_key is freed. */
+            ret = ABT_key_free(&g_keys[2]);
+            assert(ret == ABT_SUCCESS && g_keys[2] == ABT_KEY_NULL);
+        }
+        if (i % 2 == 0) {
+            /* Named */
+            threads[i] = (ABT_thread)RAND_PTR;
+            ret =
+                ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                             must_succeed ? &must_succeed
+                                                          : NULL,
+                                             ABT_THREAD_ATTR_NULL, &threads[i]);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret == ABT_SUCCESS) {
+                set_thread_data(threads[i], 0, must_succeed);
+                set_thread_data(threads[i], 2, must_succeed);
+            } else {
+#ifdef ABT_ENABLE_VER_20_API
+                assert(threads[i] == (ABT_thread)RAND_PTR);
+                threads[i] = ABT_THREAD_NULL;
+#else
+                assert(threads[i] == ABT_THREAD_NULL);
+#endif
+            }
+        } else {
+            /* Unnamed */
+            ret = ABT_thread_create_on_xstream(self_xstream, thread_func, NULL,
+                                               ABT_THREAD_ATTR_NULL, NULL);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+        }
+    }
+    /* Run thread_func() on the primary ULT. */
+    thread_func(must_succeed ? &must_succeed : NULL);
+    for (i = 0; i < 4; i++) {
+        if (threads[i] != ABT_THREAD_NULL) {
+            ret = ABT_thread_free(&threads[i]);
+            assert(ret == ABT_SUCCESS && threads[i] == ABT_THREAD_NULL);
+        }
+    }
+
+    /* Free all the keys. */
+    for (i = 0; i < 3; i++) {
+        if (g_keys[i] != ABT_KEY_NULL) {
+            ret = ABT_key_free(&g_keys[i]);
+            assert(ret == ABT_SUCCESS && g_keys[i] == ABT_KEY_NULL);
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/mutex.c
+++ b/test/leakcheck/mutex.c
@@ -1,0 +1,210 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_mutex. */
+ABT_mutex_memory g_mutex_mem = ABT_MUTEX_INITIALIZER;
+ABT_mutex_memory g_rec_mutex_mem = ABT_RECURSIVE_MUTEX_INITIALIZER;
+
+typedef struct {
+    ABT_mutex mutex;
+    ABT_bool is_recursive;
+    ABT_bool is_dynamic;
+} mutex_set;
+mutex_set g_mutex_sets[4];
+#define NUM_MUTEX_SETS ((int)(sizeof(g_mutex_sets) / sizeof(g_mutex_sets[0])))
+
+#define NUM_ITERS 5
+
+static int trylock(ABT_mutex mutex)
+{
+    int ret;
+    while (1) {
+        ret = ABT_mutex_trylock(mutex);
+        if (ret == ABT_SUCCESS)
+            return ret;
+        assert(ret == ABT_ERR_MUTEX_LOCKED);
+        ABT_unit_type unit_type;
+        ret = ABT_self_get_type(&unit_type);
+#ifdef ABT_ENABLE_VER_20_API
+        assert(ret == ABT_SUCCESS);
+#else
+        assert(ret == ABT_SUCCESS || ret == ABT_ERR_INV_XSTREAM);
+#endif
+        if (unit_type == ABT_UNIT_TYPE_THREAD) {
+            ret = ABT_self_yield();
+            assert(ret == ABT_SUCCESS);
+        }
+    }
+}
+
+void thread_func(void *arg)
+{
+    (void)arg;
+    int (*lock_fs[])(ABT_mutex) = { ABT_mutex_lock, ABT_mutex_lock_high,
+                                    ABT_mutex_lock_low, trylock,
+                                    ABT_mutex_spinlock };
+    int (*unlock_fs[])(ABT_mutex) = { ABT_mutex_unlock, ABT_mutex_unlock_se,
+                                      ABT_mutex_unlock_de };
+
+    int i;
+    for (i = 0; i < NUM_ITERS; i++) {
+        int j;
+        for (j = 0; j < NUM_MUTEX_SETS; j++) {
+            int k;
+            if (g_mutex_sets[j].mutex == ABT_MUTEX_NULL)
+                continue;
+            int ret;
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++) {
+                ret = lock_fs[i % (sizeof(lock_fs) / sizeof(lock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+                assert(ret == ABT_SUCCESS);
+            }
+            for (k = 0; k < (g_mutex_sets[j].is_recursive ? 5 : 1); k++) {
+                ret = unlock_fs[i % (sizeof(unlock_fs) / sizeof(unlock_fs[0]))](
+                    g_mutex_sets[j].mutex);
+                assert(ret == ABT_SUCCESS);
+            }
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int must_succeed)
+{
+    int i, ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    /* Set up mutex. */
+    g_mutex_sets[0].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_mutex_mem);
+    g_mutex_sets[0].is_recursive = ABT_FALSE;
+    g_mutex_sets[0].is_dynamic = ABT_FALSE;
+    g_mutex_sets[1].mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&g_rec_mutex_mem);
+    g_mutex_sets[1].is_recursive = ABT_TRUE;
+    g_mutex_sets[1].is_dynamic = ABT_FALSE;
+
+    g_mutex_sets[2].mutex = (ABT_mutex)RAND_PTR;
+    ret = ABT_mutex_create(&g_mutex_sets[2].mutex);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        g_mutex_sets[2].is_recursive = ABT_FALSE;
+        g_mutex_sets[2].is_dynamic = ABT_TRUE;
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(g_mutex_sets[2].mutex == (ABT_mutex)RAND_PTR);
+        g_mutex_sets[2].mutex = ABT_MUTEX_NULL;
+#else
+        assert(g_mutex_sets[2].mutex == ABT_MUTEX_NULL);
+#endif
+    }
+    g_mutex_sets[3].mutex = ABT_MUTEX_NULL;
+    ABT_mutex_attr mutex_attr = (ABT_mutex_attr)RAND_PTR;
+    ret = ABT_mutex_attr_create(&mutex_attr);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        ret = ABT_mutex_attr_set_recursive(mutex_attr, ABT_TRUE);
+        assert(ret == ABT_SUCCESS);
+        g_mutex_sets[3].mutex = (ABT_mutex)RAND_PTR;
+        ret = ABT_mutex_create_with_attr(mutex_attr, &g_mutex_sets[3].mutex);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(g_mutex_sets[3].mutex == (ABT_mutex)RAND_PTR);
+#else
+            assert(g_mutex_sets[3].mutex == ABT_MUTEX_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            ret =
+                ABT_mutex_create_with_attr(mutex_attr, &g_mutex_sets[3].mutex);
+        }
+        if (ret == ABT_SUCCESS) {
+            g_mutex_sets[3].is_recursive = ABT_TRUE;
+            g_mutex_sets[3].is_dynamic = ABT_TRUE;
+        } else {
+            g_mutex_sets[3].mutex = ABT_MUTEX_NULL;
+        }
+        ret = ABT_mutex_attr_free(&mutex_attr);
+        assert(ret == ABT_SUCCESS);
+    } else {
+        assert(mutex_attr == (ABT_mutex_attr)RAND_PTR);
+    }
+    /* If an external thread is supported, use an external thread. */
+    ABT_bool external_thread_support;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                &external_thread_support);
+    assert(ret == ABT_SUCCESS);
+    if (external_thread_support) {
+        pthread_t pthread;
+        ret = pthread_create(&pthread, NULL, pthread_func, NULL);
+        assert(!must_succeed || ret == 0);
+        if (ret == 0) {
+            thread_func(NULL);
+            ret = pthread_join(pthread, NULL);
+            assert(ret == 0);
+        }
+    }
+    /* Create a ULT and synchronize it with mutex. */
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+    ABT_thread thread = (ABT_thread)RAND_PTR;
+    ret = ABT_thread_create_on_xstream(self_xstream, thread_func, NULL,
+                                       ABT_THREAD_ATTR_NULL, &thread);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        thread_func(NULL);
+        ret = ABT_thread_free(&thread);
+        assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(thread == (ABT_thread)RAND_PTR);
+#else
+        assert(thread == ABT_THREAD_NULL);
+#endif
+    }
+    /* Free mutex. */
+    for (i = 0; i < NUM_MUTEX_SETS; i++) {
+        if (g_mutex_sets[i].is_dynamic &&
+            g_mutex_sets[i].mutex != ABT_MUTEX_NULL) {
+            ret = ABT_mutex_free(&g_mutex_sets[i].mutex);
+            assert(ret == ABT_SUCCESS &&
+                   g_mutex_sets[i].mutex == ABT_MUTEX_NULL);
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/pool.c
+++ b/test/leakcheck/pool.c
@@ -1,0 +1,286 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_pool. */
+
+#define POOL_KIND_USER ((ABT_pool_kind)999)
+
+ABT_thread unit_get_thread(ABT_unit unit)
+{
+    return (ABT_thread)unit;
+}
+
+ABT_unit unit_create_from_thread(ABT_thread thread)
+{
+    return (ABT_unit)thread;
+}
+
+void unit_free(ABT_unit *p_unit)
+{
+    (void)p_unit;
+}
+
+typedef struct {
+    int num_units;
+    ABT_unit units[16];
+} pool_data_t;
+
+int pool_init(ABT_pool pool, ABT_pool_config config)
+{
+    (void)config;
+    pool_data_t *pool_data = (pool_data_t *)malloc(sizeof(pool_data_t));
+    if (!pool_data) {
+        return ABT_ERR_MEM;
+    }
+    pool_data->num_units = 0;
+    int ret = ABT_pool_set_data(pool, pool_data);
+    assert(ret == ABT_SUCCESS);
+    return ABT_SUCCESS;
+}
+
+size_t pool_get_size(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    return pool_data->num_units;
+}
+
+void pool_push(ABT_pool pool, ABT_unit unit)
+{
+    /* Very simple: no lock, fixed size.  This implementation is for simplicity,
+     * so don't use it in a real program unless you know what you are really
+     * doing. */
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    pool_data->units[pool_data->num_units++] = unit;
+}
+
+ABT_unit pool_pop(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    if (pool_data->num_units == 0)
+        return ABT_UNIT_NULL;
+    return pool_data->units[--pool_data->num_units];
+}
+
+int pool_free(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    free(pool_data);
+    return ABT_SUCCESS;
+}
+
+ABT_pool create_pool(int automatic, int must_succeed)
+{
+    if (automatic) {
+        /* Currently there's no way to create an automatic pool using
+         * ABT_pool_create(). */
+        return ABT_POOL_NULL;
+    }
+    int ret;
+    ABT_pool pool = (ABT_pool)RAND_PTR;
+
+    ABT_pool_def pool_def;
+    pool_def.access = ABT_POOL_ACCESS_MPMC;
+    pool_def.u_get_type = NULL;
+    pool_def.u_get_thread = unit_get_thread;
+    pool_def.u_get_task = NULL;
+    pool_def.u_is_in_pool = NULL;
+    pool_def.u_create_from_thread = unit_create_from_thread;
+    pool_def.u_create_from_task = NULL;
+    pool_def.u_free = unit_free;
+    pool_def.p_init = pool_init;
+    pool_def.p_get_size = pool_get_size;
+    pool_def.p_push = pool_push;
+    pool_def.p_pop = pool_pop;
+#ifdef ABT_ENABLE_VER_20_API
+    pool_def.p_pop_wait = NULL;
+#endif
+    pool_def.p_pop_timedwait = NULL;
+    pool_def.p_remove = NULL;
+    pool_def.p_free = pool_free;
+    pool_def.p_print_all = NULL;
+
+    ret = ABT_pool_create(&pool_def, ABT_POOL_CONFIG_NULL, &pool);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(pool == (ABT_pool)RAND_PTR);
+#else
+        assert(pool == ABT_POOL_NULL);
+#endif
+        return ABT_POOL_NULL;
+    }
+    return pool;
+}
+
+ABT_pool create_pool_basic(ABT_pool_kind kind, int automatic, int must_succeed)
+{
+    int ret;
+    ABT_pool pool = (ABT_pool)RAND_PTR;
+    ret = ABT_pool_create_basic(kind, ABT_POOL_ACCESS_MPMC,
+                                automatic ? ABT_TRUE : ABT_FALSE, &pool);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(pool == (ABT_pool)RAND_PTR);
+#else
+        assert(pool == ABT_POOL_NULL);
+#endif
+        return ABT_POOL_NULL;
+    }
+    return pool;
+}
+
+void program(ABT_pool_kind kind, int automatic, int type, int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+
+    ABT_pool pool;
+    if (kind == POOL_KIND_USER) {
+        pool = create_pool(automatic, must_succeed);
+    } else {
+        pool = create_pool_basic(kind, automatic, must_succeed);
+    }
+
+    if (pool == ABT_POOL_NULL) {
+        /* Allocation failed, so do nothing. */
+    } else if (type == 0) {
+        /* Just free.  We must free an automatic one too. */
+        ret = ABT_pool_free(&pool);
+        assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+    } else if (type == 1) {
+        /* Use it for ABT_sched_create_basic(). */
+        ABT_sched sched = (ABT_sched)RAND_PTR;
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool,
+                                     ABT_SCHED_CONFIG_NULL, &sched);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(sched == (ABT_sched)RAND_PTR);
+#else
+            assert(sched == ABT_SCHED_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, 1, &pool,
+                                         ABT_SCHED_CONFIG_NULL, &sched);
+            if (ret != ABT_SUCCESS) {
+                /* Second time failed.  Give up. */
+                ret = ABT_pool_free(&pool);
+                assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+                sched = ABT_SCHED_NULL;
+            }
+        }
+        if (sched != ABT_SCHED_NULL) {
+            ret = ABT_sched_free(&sched);
+            assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            if (!automatic) {
+                ret = ABT_pool_free(&pool);
+                assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+            }
+        }
+    } else if (type == 2) {
+        /* Use it for ABT_xstream_create_basic(). */
+        ABT_xstream xstream = (ABT_xstream)RAND_PTR;
+        ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pool,
+                                       ABT_SCHED_CONFIG_NULL, &xstream);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(xstream == (ABT_xstream)RAND_PTR);
+#else
+            assert(xstream == ABT_XSTREAM_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, &pool,
+                                           ABT_SCHED_CONFIG_NULL, &xstream);
+            if (ret != ABT_SUCCESS) {
+                /* Second time failed.  Give up. */
+                ret = ABT_pool_free(&pool);
+                assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+                xstream = ABT_XSTREAM_NULL;
+            }
+        }
+        if (xstream != ABT_XSTREAM_NULL) {
+            ret = ABT_xstream_free(&xstream);
+            assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+            if (!automatic) {
+                ret = ABT_pool_free(&pool);
+                assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+            }
+        }
+    } else if (type == 3) {
+        /* Use it for ABT_xstream_set_main_sched_basic() */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_xstream_set_main_sched_basic(self_xstream, ABT_SCHED_DEFAULT,
+                                               1, &pool);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+            ret = ABT_pool_free(&pool);
+            assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+        }
+    }
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    int i, automatic, type;
+    ABT_pool_kind kinds[] = { ABT_POOL_FIFO, POOL_KIND_USER };
+    /* Checking all takes too much time. */
+    for (i = 0; i < (int)(sizeof(kinds) / sizeof(kinds[0])); i++) {
+        for (automatic = 0; automatic <= 1; automatic++) {
+            for (type = 0; type < 4; type++) {
+                do {
+                    rtrace_start();
+                    program(kinds[i], automatic, type, 0);
+                } while (!rtrace_stop());
+
+                /* If no failure, it should succeed again. */
+                program(kinds[i], automatic, type, 1);
+            }
+        }
+    }
+
+    ABT_pool_kind extra_kinds[] = { ABT_POOL_FIFO_WAIT };
+    for (i = 0; i < (int)(sizeof(extra_kinds) / sizeof(extra_kinds[0])); i++) {
+        for (automatic = 0; automatic <= 1; automatic++) {
+            for (type = 0; type < 1; type++) {
+                do {
+                    rtrace_start();
+                    program(extra_kinds[i], automatic, type, 0);
+                } while (!rtrace_stop());
+
+                /* If no failure, it should succeed again. */
+                program(extra_kinds[i], automatic, type, 1);
+            }
+        }
+    }
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/rtrace.c
+++ b/test/leakcheck/rtrace.c
@@ -1,0 +1,1078 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+/*
+ * Simple resource tracer.
+ *
+ * This tracer assumes that each Pthread calls resource allocation functions
+ * in deterministic order.  If the execution order of resource allocation calls
+ * are not deterministic, this tracer does not work well.  This trace also
+ * assumes that the original resource allocation functions do not occasionally
+ * fail during the execution.
+ */
+
+#undef ABT_RT_ENABLED
+
+/* The following checks the following:
+ *
+ * 1. dlvsym() is available (this is basically Linux only).
+ * 2. symbol versions are correctly extracted.
+ * 3. Address sanitizers are not used.
+ *
+ * Symbol versions are necessary for correct execution (e.g., "GLIBC_2.3.2" in
+ * pthread_cond_init@@GLIBC_2.3.2).  dlsym(), which does not take a symbol
+ * version, often finds an old symbol and mysteriously crashes a program that
+ * assumes a newer symbol.  Since this rtrace is fairly optional and does not
+ * need to be run on every architecture, this library is disabled if the
+ * environment is doubtful.  Otherwise this rtace may crash a program for
+ * unknown reasons.
+ */
+#ifdef ABT_RT_USE_DLVSYM
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <unistd.h>
+
+#undef USE_PTHREAD_BARRIER
+#if defined(_POSIX_BARRIERS) && _POSIX_BARRIERS > 0
+#define USE_PTHREAD_BARRIER 1
+#else
+#define USE_PTHREAD_BARRIER 0
+#endif
+
+#undef ADDRESS_SANITIZER_ENABLED
+#if defined(__GNUC__) && defined(__SANITIZE_ADDRESS__)
+#define ADDRESS_SANITIZER_ENABLED 1
+#elif __clang__
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define ADDRESS_SANITIZER_ENABLED 1
+#endif /* __has_feature(address_sanitizer) */
+#endif /* defined(__has_feature) */
+#endif /* __clang__ */
+
+/* All symbol versions must be set */
+#if defined(ABT_RT_MALLOC_VER) && defined(ABT_RT_CALLOC_VER) &&                \
+    defined(ABT_RT_REALLOC_VER) && defined(ABT_RT_POSIX_MEMALIGN_VER) &&       \
+    defined(ABT_RT_FREE_VER) && defined(ABT_RT_MMAP_VER) &&                    \
+    defined(ABT_RT_MUNMAP_VER) && defined(ABT_RT_PTHREAD_CREATE_VER) &&        \
+    defined(ABT_RT_PTHREAD_JOIN_VER) &&                                        \
+    defined(ABT_RT_PTHREAD_MUTEX_INIT_VER) &&                                  \
+    defined(ABT_RT_PTHREAD_MUTEX_DESTROY_VER) &&                               \
+    defined(ABT_RT_PTHREAD_COND_INIT_VER) &&                                   \
+    defined(ABT_RT_PTHREAD_COND_DESTROY_VER) &&                                \
+    (!defined(USE_PTHREAD_BARRIER) ||                                          \
+     (defined(ABT_RT_PTHREAD_BARRIER_INIT_VER) &&                              \
+      defined(ABT_RT_PTHREAD_BARRIER_DESTROY_VER)))
+/* Address sanitizers are not supported. */
+#ifndef ADDRESS_SANITIZER_ENABLED
+#define ABT_RT_ENABLED 1
+#endif
+#endif
+
+#endif /* ABT_RT_USE_DLVSYM */
+
+#ifdef ABT_RT_ENABLED
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <sys/mman.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#undef USE_PTHREAD_BARRIER
+#if defined(_POSIX_BARRIERS) && _POSIX_BARRIERS > 0
+#define USE_PTHREAD_BARRIER 1
+#else
+#define USE_PTHREAD_BARRIER 0
+#endif
+
+typedef enum RTRACE_OP_KIND {
+    RTRACE_OP_KIND_MALLOC = 0,
+    RTRACE_OP_KIND_CALLOC,
+    RTRACE_OP_KIND_REALLOC,
+    RTRACE_OP_KIND_POSIX_MEMALIGN,
+    RTRACE_OP_KIND_MMAP,
+    RTRACE_OP_KIND_PTHREAD_CREATE,
+    RTRACE_OP_KIND_PTHREAD_MUTEX_INIT,
+    RTRACE_OP_KIND_PTHREAD_COND_INIT,
+    RTRACE_OP_KIND_PTHREAD_BARRIER_INIT,
+} RTRACE_OP_KIND;
+
+typedef enum RTRACE_RES_KIND {
+    RTRACE_RES_KIND_NORMAL_MEM = 0, /* memory released by free() */
+    RTRACE_RES_KIND_MMAP_MEM,
+    RTRACE_RES_KIND_PTHREAD_T,
+    RTRACE_RES_KIND_PTHREAD_MUTEX_T,
+    RTRACE_RES_KIND_PTHREAD_COND_T,
+    RTRACE_RES_KIND_PTHREAD_BARRIER_T,
+} RTRACE_RES_KIND;
+
+#define RTRACE_SUCCESS 0
+#define RTRACE_SUCCESS_FIXED 1
+#define RTRACE_FAILURE 2
+#define RTRACE_REAL_FAILURE 3 /* Error by nature (e.g., mmap()). */
+
+typedef struct rtrace_op_chain_t {
+    RTRACE_OP_KIND op_kind;
+    size_t val; /* Any operation-related value that helps identify the order.
+                 * This is just a hint, so if that operation does not have a
+                 * good value, zero should be substituted. */
+    int success;
+    struct rtrace_op_chain_t *p_next;
+} rtrace_op_chain_t;
+
+#define RTRACE_RES_HTABLE_SIZE 64
+
+typedef struct rtrace_res_elem {
+    RTRACE_RES_KIND res_kind;
+    void *ptr;
+    size_t val;
+    int id; /* -1 if it is allocated by a non-target thread. */
+    struct rtrace_res_elem *p_next;
+} rtrace_res_elem;
+
+typedef struct rtrace_res_table {
+    rtrace_res_elem *elems[RTRACE_RES_HTABLE_SIZE];
+    pthread_spinlock_t spinlock;
+} rtrace_res_table;
+
+/* free-able memory functions */
+typedef void *(*mallocf_t)(size_t);
+typedef void *(*callocf_t)(size_t, size_t);
+typedef void *(*reallocf_t)(void *, size_t);
+typedef int (*posix_memalignf_t)(void **, size_t, size_t);
+typedef void (*freef_t)(void *);
+/* mmap()/munmap() */
+typedef void *(*mmapf_t)(void *, size_t, int, int, int, off_t);
+typedef int (*munmapf_t)(void *, size_t);
+/* pthread_t */
+typedef int (*pthread_createf_t)(pthread_t *, const pthread_attr_t *,
+                                 void *(*)(void *), void *);
+typedef int (*pthread_joinf_t)(pthread_t, void **);
+/* pthread_mutex_t */
+typedef int (*pthread_mutex_initf_t)(pthread_mutex_t *,
+                                     const pthread_mutexattr_t *);
+typedef int (*pthread_mutex_destroyf_t)(pthread_mutex_t *);
+/* pthread_cond_t */
+typedef int (*pthread_cond_initf_t)(pthread_cond_t *,
+                                    const pthread_condattr_t *);
+typedef int (*pthread_cond_destroyf_t)(pthread_cond_t *);
+#ifdef USE_PTHREAD_BARRIER
+/* pthread_barrier_t */
+typedef int (*pthread_barrier_initf_t)(pthread_barrier_t *,
+                                       const pthread_barrierattr_t *, unsigned);
+typedef int (*pthread_barrier_destroyf_t)(pthread_barrier_t *);
+#endif
+
+typedef struct {
+    int enabled, check_failure, is_retrying;
+    int verbose;
+    int allocid,
+        break_allocid; /* The program stops when allocid = break_allocid */
+    pthread_t trace_thread;
+    rtrace_res_table res_table;
+    /* If not NULL, trace_thread will follow p_path. */
+    rtrace_op_chain_t *p_path;
+    rtrace_op_chain_t *p_path_cur;
+    /* Trace_thread's path will be saved in p_history. */
+    rtrace_op_chain_t *p_history;
+    rtrace_op_chain_t *p_history_cur;
+    /* Functions. */
+    mallocf_t real_malloc;
+    callocf_t real_calloc;
+    reallocf_t real_realloc;
+    posix_memalignf_t real_posix_memalign;
+    freef_t real_free;
+    mmapf_t real_mmap;
+    munmapf_t real_munmap;
+
+    pthread_createf_t real_pthread_create;
+    pthread_joinf_t real_pthread_join;
+    pthread_mutex_initf_t real_pthread_mutex_init;
+    pthread_mutex_destroyf_t real_pthread_mutex_destroy;
+    pthread_cond_initf_t real_pthread_cond_init;
+    pthread_cond_destroyf_t real_pthread_cond_destroy;
+#ifdef USE_PTHREAD_BARRIER
+    pthread_barrier_initf_t real_pthread_barrier_init;
+    pthread_barrier_destroyf_t real_pthread_barrier_destroy;
+#endif
+} rtrace_global_t;
+static rtrace_global_t g_rtrace_global;
+/**/
+static __thread int
+    l_rtrace_disabled; /* Some functions (e.g., pthread_create()) free their
+                          memory resources on terminating a process, so it is
+                          detected as a memory leak.  This flag temporarily
+                          disables resource tracing. */
+
+typedef struct {
+    rtrace_op_chain_t *p_chain;
+    rtrace_op_chain_t *p_history;
+} rtrace_local_t;
+
+#define STRINGIFY2(macro) #macro
+#define STRINGIFY(macro) STRINGIFY2(macro)
+
+static const char *dlvsym_ver_malloc = STRINGIFY(ABT_RT_MALLOC_VER);
+static const char *dlvsym_ver_calloc = STRINGIFY(ABT_RT_CALLOC_VER);
+static const char *dlvsym_ver_realloc = STRINGIFY(ABT_RT_REALLOC_VER);
+static const char *dlvsym_ver_posix_memalign =
+    STRINGIFY(ABT_RT_POSIX_MEMALIGN_VER);
+static const char *dlvsym_ver_free = STRINGIFY(ABT_RT_FREE_VER);
+static const char *dlvsym_ver_mmap = STRINGIFY(ABT_RT_MMAP_VER);
+static const char *dlvsym_ver_munmap = STRINGIFY(ABT_RT_MUNMAP_VER);
+static const char *dlvsym_ver_pthread_create =
+    STRINGIFY(ABT_RT_PTHREAD_CREATE_VER);
+static const char *dlvsym_ver_pthread_join = STRINGIFY(ABT_RT_PTHREAD_JOIN_VER);
+static const char *dlvsym_ver_pthread_mutex_init =
+    STRINGIFY(ABT_RT_PTHREAD_MUTEX_INIT_VER);
+static const char *dlvsym_ver_pthread_mutex_destroy =
+    STRINGIFY(ABT_RT_PTHREAD_MUTEX_DESTROY_VER);
+static const char *dlvsym_ver_pthread_cond_init =
+    STRINGIFY(ABT_RT_PTHREAD_COND_INIT_VER);
+static const char *dlvsym_ver_pthread_cond_destroy =
+    STRINGIFY(ABT_RT_PTHREAD_COND_DESTROY_VER);
+#ifdef USE_PTHREAD_BARRIER
+static const char *dlvsym_ver_pthread_barrier_init =
+    STRINGIFY(ABT_RT_PTHREAD_BARRIER_INIT_VER);
+static const char *dlvsym_ver_pthread_barrier_destroy =
+    STRINGIFY(ABT_RT_PTHREAD_BARRIER_DESTROY_VER);
+#endif
+
+/* Overwritten functions. */
+#define PREP_REAL_FUNC(func_name)                                              \
+    func_name##f_t real_##func_name =                                          \
+        __atomic_load_n(&g_rtrace_global.real_##func_name, __ATOMIC_RELAXED);  \
+    if (!real_##func_name) {                                                   \
+        /* We use dlvsym since dlsym may load an old symbol, which causes an   \
+         * error because of version mismatch (e.g., combining old              \
+         * pthread_cond_init() and new pthread_cond_wait() cause an error      \
+         *  since their struct usages are different. */                        \
+        typedef union {                                                        \
+            void *ptr;                                                         \
+            func_name##f_t fptr;                                               \
+        } func_conv_t;                                                         \
+        func_conv_t func_conv;                                                 \
+        if (dlvsym_ver_##func_name[0] == '\0') {                               \
+            func_conv.ptr = dlsym(RTLD_NEXT, #func_name);                      \
+        } else {                                                               \
+            func_conv.ptr =                                                    \
+                dlvsym(RTLD_NEXT, #func_name, dlvsym_ver_##func_name);         \
+        }                                                                      \
+        real_##func_name = func_conv.fptr;                                     \
+        __atomic_store_n(&g_rtrace_global.real_##func_name, real_##func_name,  \
+                         __ATOMIC_RELAXED);                                    \
+    }
+
+static inline uint32_t ptr_hash(void *ptr)
+{
+    /* Based on Xorshift:
+     * George Marsaglia, "Xorshift RNGs", Journal of Statistical Software,
+     * Articles, 2003 */
+    uint32_t seed = (uint32_t)((uintptr_t)ptr);
+    seed ^= seed << 13;
+    seed ^= seed >> 17;
+    seed ^= seed << 5;
+    return seed;
+}
+
+static const char *get_op_kind_str(RTRACE_OP_KIND op_kind)
+{
+    if (op_kind == RTRACE_OP_KIND_MALLOC) {
+        return "malloc";
+    } else if (op_kind == RTRACE_OP_KIND_CALLOC) {
+        return "calloc";
+    } else if (op_kind == RTRACE_OP_KIND_REALLOC) {
+        return "realloc";
+    } else if (op_kind == RTRACE_OP_KIND_POSIX_MEMALIGN) {
+        return "posix_memalign";
+    } else if (op_kind == RTRACE_OP_KIND_MMAP) {
+        return "mmap";
+    } else if (op_kind == RTRACE_OP_KIND_PTHREAD_CREATE) {
+        return "pthread_create";
+    } else if (op_kind == RTRACE_OP_KIND_PTHREAD_MUTEX_INIT) {
+        return "pthread_mutex_init";
+    } else if (op_kind == RTRACE_OP_KIND_PTHREAD_COND_INIT) {
+        return "pthread_cond_init";
+    } else if (op_kind == RTRACE_OP_KIND_PTHREAD_BARRIER_INIT) {
+        return "pthread_barrier_init";
+    } else {
+        return "UNKNOWN_OP_KIND";
+    }
+}
+
+static const char *get_success_str(int success)
+{
+    if (success == RTRACE_SUCCESS) {
+        return "success";
+    } else if (success == RTRACE_SUCCESS_FIXED) {
+        return "success (fixed)";
+    } else if (success == RTRACE_FAILURE) {
+        return "failure";
+    } else if (success == RTRACE_REAL_FAILURE) {
+        return "real failure";
+    } else {
+        return "unknown";
+    }
+}
+
+static void rtrace_res_init(void)
+{
+    memset(&g_rtrace_global.res_table, 0, sizeof(rtrace_res_table));
+    int ret = pthread_spin_init(&g_rtrace_global.res_table.spinlock, 0);
+    assert(ret == 0);
+}
+
+static void rtrace_res_finalize(int *p_retry)
+{
+    /* Check if all the resources are released. */
+    int i, leak_flag = 0;
+    for (i = 0; i < RTRACE_RES_HTABLE_SIZE; i++) {
+        rtrace_res_elem *p_elem = g_rtrace_global.res_table.elems[i];
+        while (p_elem) {
+            if (g_rtrace_global.is_retrying || g_rtrace_global.verbose) {
+                printf("%p [id = %d, val = %zu] is not released\n",
+                       (void *)p_elem, p_elem->id, p_elem->val);
+            }
+            leak_flag = 1;
+            p_elem = p_elem->p_next;
+        }
+    }
+    if (leak_flag != 0) {
+        if (g_rtrace_global.is_retrying) {
+            /* Resource is really leaked. */
+            assert(0);
+        } else {
+            /* Maybe some global functions (e.g., fprintf) internally caches
+             * resources.  Let's run it again to see if this happens again.  If
+             * someone caches resources, new resource allocation should not
+             * occur the next run. */
+            if (g_rtrace_global.verbose) {
+                printf("Memory leak is detected.  Run this configuration "
+                       "again.\n");
+            }
+            g_rtrace_global.is_retrying = 1;
+            *p_retry = 1;
+        }
+    } else {
+        *p_retry = 0;
+        g_rtrace_global.is_retrying = 0;
+        if (g_rtrace_global.verbose) {
+            printf("No memory is leaked [# of allocations: %d]\n",
+                   g_rtrace_global.allocid);
+        }
+    }
+    int ret = pthread_spin_destroy(&g_rtrace_global.res_table.spinlock);
+    assert(ret == 0);
+}
+
+static void rtrace_res_add(RTRACE_RES_KIND res_kind, void *ptr, size_t val)
+{
+    int ret;
+    ret = pthread_spin_lock(&g_rtrace_global.res_table.spinlock);
+    assert(ret == 0);
+
+    uint32_t hash_idx = ptr_hash(ptr) % RTRACE_RES_HTABLE_SIZE;
+    rtrace_res_elem **pp_elem = &g_rtrace_global.res_table.elems[hash_idx];
+    while (*pp_elem) {
+        pp_elem = &((*pp_elem)->p_next);
+    }
+
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(calloc);
+    rtrace_res_elem *p_new_elem = real_calloc(1, sizeof(rtrace_res_elem));
+    l_rtrace_disabled--;
+    if (!p_new_elem) {
+        pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+        assert(p_new_elem);
+    }
+    p_new_elem->res_kind = res_kind;
+    p_new_elem->ptr = ptr;
+    p_new_elem->val = val;
+    pthread_t self_thread = pthread_self();
+    if (!pthread_equal(self_thread, g_rtrace_global.trace_thread)) {
+        p_new_elem->id = -1;
+    } else {
+        p_new_elem->id = g_rtrace_global.allocid++;
+        if (p_new_elem->id == g_rtrace_global.break_allocid) {
+            pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+            assert(0);
+        }
+    }
+    *pp_elem = p_new_elem;
+
+    pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+}
+
+static void rtrace_res_remove(RTRACE_RES_KIND res_kind, void *ptr, size_t val)
+{
+    int ret;
+    ret = pthread_spin_lock(&g_rtrace_global.res_table.spinlock);
+    assert(ret == 0);
+
+    uint32_t hash_idx = ptr_hash(ptr) % RTRACE_RES_HTABLE_SIZE;
+    rtrace_res_elem **pp_elem = &g_rtrace_global.res_table.elems[hash_idx];
+    while (*pp_elem) {
+        rtrace_res_elem *p_elem = *pp_elem;
+        if (p_elem->ptr == ptr && p_elem->res_kind == res_kind &&
+            (val == 0 || p_elem->val == 0 || p_elem->val == val)) {
+            /* This element must be removed. */
+            *pp_elem = p_elem->p_next;
+            l_rtrace_disabled++;
+            PREP_REAL_FUNC(free);
+            real_free(p_elem);
+            l_rtrace_disabled--;
+            pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+            return;
+        }
+        pp_elem = &((*pp_elem)->p_next);
+    }
+    /* Removal failed: maybe memory that has been already allocated before
+     * rtrace_init() was released.  Let's ignore. */
+    pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+}
+
+static void rtrace_res_replace(RTRACE_RES_KIND res_kind, void *old_ptr,
+                               size_t old_val, void *new_ptr, size_t new_val)
+{
+    assert(old_ptr != NULL);
+
+    int ret;
+    ret = pthread_spin_lock(&g_rtrace_global.res_table.spinlock);
+    assert(ret == 0);
+
+    uint32_t hash_idx = ptr_hash(old_ptr) % RTRACE_RES_HTABLE_SIZE;
+    rtrace_res_elem *p_elem = g_rtrace_global.res_table.elems[hash_idx];
+    while (p_elem) {
+        if (p_elem->ptr == old_ptr && p_elem->res_kind == res_kind &&
+            (old_val == 0 || p_elem->val == 0 || p_elem->val == old_val)) {
+            /* This element must be replaced. */
+            p_elem->ptr = new_ptr;
+            p_elem->val = new_val;
+            ret = pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+            assert(ret == 0);
+            return;
+        }
+        p_elem = p_elem->p_next;
+    }
+    /* Replace failed: maybe memory that has been already allocated before
+     * rtrace_init() was released.  Let's ignore. */
+    pthread_spin_unlock(&g_rtrace_global.res_table.spinlock);
+}
+
+static int rtrace_log_success(RTRACE_OP_KIND op_kind, size_t val)
+{
+    if (!g_rtrace_global.p_path_cur) {
+        /* If p_path is not set, ignore. */
+        return 1;
+    }
+    pthread_t self_thread = pthread_self();
+    if (!pthread_equal(self_thread, g_rtrace_global.trace_thread)) {
+        /* It always succeeds if self_thread is not the target. */
+        return 1;
+    }
+    /* Check its path */
+    if (g_rtrace_global.p_path_cur->op_kind == op_kind &&
+        g_rtrace_global.p_path_cur->val == val) {
+        int success = g_rtrace_global.p_path_cur->success;
+        g_rtrace_global.p_path_cur = g_rtrace_global.p_path_cur->p_next;
+        return success == RTRACE_SUCCESS || success == RTRACE_SUCCESS_FIXED;
+    } else {
+        /* Maybe diverged. Let's make it succeed. */
+        return 1;
+    }
+}
+
+static void rtrace_op_add(RTRACE_OP_KIND op_kind, size_t val, int success)
+{
+    pthread_t self_thread = pthread_self();
+    if (!pthread_equal(self_thread, g_rtrace_global.trace_thread)) {
+        /* op is not added if self_thread is not the target. */
+        return;
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(malloc);
+    rtrace_op_chain_t *p_op =
+        (rtrace_op_chain_t *)real_malloc(sizeof(rtrace_op_chain_t));
+    l_rtrace_disabled--;
+    assert(p_op);
+    p_op->op_kind = op_kind;
+    p_op->val = val;
+    if (!g_rtrace_global.check_failure && success == RTRACE_SUCCESS) {
+        /* This operation won't fail in this testing. */
+        p_op->success = RTRACE_SUCCESS_FIXED;
+    } else {
+        p_op->success = success;
+    }
+    p_op->p_next = NULL;
+    if (g_rtrace_global.p_history_cur) {
+        g_rtrace_global.p_history_cur->p_next = p_op;
+        g_rtrace_global.p_history_cur = p_op;
+    } else {
+        g_rtrace_global.p_history = p_op;
+        g_rtrace_global.p_history_cur = p_op;
+    }
+}
+
+static void rtrace_free_chain(rtrace_op_chain_t *p_chain)
+{
+    l_rtrace_disabled++;
+    while (p_chain) {
+        rtrace_op_chain_t *p_next = p_chain->p_next;
+        PREP_REAL_FUNC(free);
+        real_free(p_next);
+        p_chain = p_next;
+    }
+    l_rtrace_disabled--;
+}
+
+void rtrace_init(void)
+{
+    assert(g_rtrace_global.enabled == 0);
+    char *env;
+    /* Let's set up all the function pointers here. */
+    {
+        PREP_REAL_FUNC(malloc);
+        PREP_REAL_FUNC(calloc);
+        PREP_REAL_FUNC(realloc);
+        PREP_REAL_FUNC(posix_memalign);
+        PREP_REAL_FUNC(free);
+        PREP_REAL_FUNC(mmap);
+        PREP_REAL_FUNC(munmap);
+        PREP_REAL_FUNC(pthread_create);
+        PREP_REAL_FUNC(pthread_join);
+        PREP_REAL_FUNC(pthread_mutex_init);
+        PREP_REAL_FUNC(pthread_mutex_destroy);
+        PREP_REAL_FUNC(pthread_cond_init);
+        PREP_REAL_FUNC(pthread_cond_destroy);
+#ifdef USE_PTHREAD_BARRIER
+        PREP_REAL_FUNC(pthread_barrier_init);
+        PREP_REAL_FUNC(pthread_barrier_destroy);
+#endif
+    }
+    env = getenv("RTRACE_VERBOSE");
+    if (env) {
+        g_rtrace_global.verbose = atoi(env);
+    } else {
+        g_rtrace_global.verbose = 0;
+    }
+    env = getenv("RTRACE_BREAK_ALLOCID");
+    if (env) {
+        g_rtrace_global.break_allocid = atoi(env);
+    } else {
+        g_rtrace_global.break_allocid = -1;
+    }
+    g_rtrace_global.p_path = NULL;
+    g_rtrace_global.p_path_cur = g_rtrace_global.p_path;
+    g_rtrace_global.p_history = NULL;
+    g_rtrace_global.p_history_cur = g_rtrace_global.p_history;
+    g_rtrace_global.is_retrying = 0;
+}
+
+void rtrace_finalize(void)
+{
+    assert(g_rtrace_global.enabled == 0);
+    rtrace_free_chain(g_rtrace_global.p_path);
+    g_rtrace_global.p_path = NULL;
+    g_rtrace_global.p_path_cur = NULL;
+    printf("No error\n");
+}
+
+void rtrace_start(void)
+{
+    assert(g_rtrace_global.enabled == 0);
+    g_rtrace_global.trace_thread = pthread_self();
+    rtrace_res_init();
+    if (g_rtrace_global.verbose >= 2) {
+        printf("[rtrace_start] execution chain:\n");
+        rtrace_op_chain_t *p_cur = g_rtrace_global.p_path;
+        int index = 0;
+        while (p_cur) {
+            printf("  [%3d] %-20s (val = %8zu): %s\n", index,
+                   get_op_kind_str(p_cur->op_kind), p_cur->val,
+                   get_success_str(p_cur->success));
+            index++;
+            p_cur = p_cur->p_next;
+        }
+        printf("  [%3s] %-20s (val = %8s): %s\n", "*", "*", "*",
+               get_success_str(RTRACE_SUCCESS));
+    }
+    g_rtrace_global.allocid = 0;
+    g_rtrace_global.enabled = 1;
+    g_rtrace_global.check_failure = 1;
+}
+
+int rtrace_stop(void)
+{
+    assert(g_rtrace_global.enabled == 1);
+    g_rtrace_global.enabled = 0;
+    if (g_rtrace_global.verbose >= 2) {
+        printf("[rtrace_stop] execution history:\n");
+        rtrace_op_chain_t *p_cur = g_rtrace_global.p_history;
+        int index = 0;
+        while (p_cur) {
+            printf("  [%3d] %-20s (val = %8zu): %s\n", index,
+                   get_op_kind_str(p_cur->op_kind), p_cur->val,
+                   get_success_str(p_cur->success));
+            index++;
+            p_cur = p_cur->p_next;
+        }
+    }
+    int retry = 0;
+    rtrace_res_finalize(&retry);
+
+    if (retry) {
+        /* Use the same configuration again. */
+        g_rtrace_global.p_path_cur = g_rtrace_global.p_path;
+        rtrace_free_chain(g_rtrace_global.p_history);
+        g_rtrace_global.p_history = NULL;
+        g_rtrace_global.p_history_cur = NULL;
+        return 0;
+    } else {
+        /* Try the next configuration. */
+        /* Free memory. */
+        rtrace_free_chain(g_rtrace_global.p_path);
+        g_rtrace_global.p_path = NULL;
+        g_rtrace_global.p_path_cur = NULL;
+
+        /* Check the history and see if there's success.  If there's no success,
+         * all the tests have been finished. */
+        rtrace_op_chain_t *p_cur = g_rtrace_global.p_history;
+        rtrace_op_chain_t *p_last_success = NULL;
+        while (p_cur) {
+            /* We do not count RTRACE_SUCCESS_FIXED */
+            if (p_cur->success == RTRACE_SUCCESS) {
+                p_last_success = p_cur;
+            }
+            p_cur = p_cur->p_next;
+        }
+        if (!p_last_success) {
+            /* All the tests have finished.  Let's free all the history. */
+            rtrace_free_chain(g_rtrace_global.p_history);
+            g_rtrace_global.p_history = NULL;
+            g_rtrace_global.p_history_cur = NULL;
+            return 1;
+        } else {
+            /* Let's create a new path by changing the last success to failure.
+             */
+            p_cur = g_rtrace_global.p_history;
+            while (p_cur) {
+                if (p_cur == p_last_success) {
+                    /* Intentional failure. */
+                    p_cur->success = RTRACE_FAILURE;
+                    /* Following operations should be successful, so we do not
+                     * need its chain. */
+                    rtrace_free_chain(p_cur->p_next);
+                    p_cur->p_next = NULL;
+                    break;
+                }
+                p_cur = p_cur->p_next;
+            }
+            g_rtrace_global.p_path = g_rtrace_global.p_history;
+            g_rtrace_global.p_path_cur = g_rtrace_global.p_path;
+            g_rtrace_global.p_history = NULL;
+            g_rtrace_global.p_history_cur = NULL;
+            return 0;
+        }
+    }
+}
+
+void rtrace_set_enabled(int enabled)
+{
+    g_rtrace_global.check_failure = enabled;
+}
+
+#define ALLOC_BUFFER_SIZE (32 * 1024)
+static size_t alloc_buffer[ALLOC_BUFFER_SIZE / sizeof(size_t)];
+static size_t alloc_buffer_index = 0;
+
+void *malloc(size_t size)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_CALLOC;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, size)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, size, RTRACE_FAILURE);
+        return NULL;
+    }
+    /* Success */
+    void *ret = NULL;
+    if (size <= ALLOC_BUFFER_SIZE) {
+        size_t aligned_size = ((size + 16 + 15) / 16) * 16;
+        if (aligned_size <=
+            ALLOC_BUFFER_SIZE -
+                __atomic_load_n(&alloc_buffer_index, __ATOMIC_ACQUIRE)) {
+            size_t new_index =
+                __atomic_fetch_add(&alloc_buffer_index, aligned_size,
+                                   __ATOMIC_ACQ_REL);
+            if (new_index + aligned_size <= ALLOC_BUFFER_SIZE) {
+                /* Allocation succeeded. */
+                ret =
+                    (void *)(&alloc_buffer[(new_index + 16) / sizeof(size_t)]);
+                /* Write the size of this memory in the first 4 * size_t bytes.
+                 */
+                alloc_buffer[new_index / sizeof(size_t)] = size;
+            }
+        }
+    }
+    if (ret == NULL) {
+        l_rtrace_disabled++;
+        PREP_REAL_FUNC(malloc);
+        ret = real_malloc(size);
+        l_rtrace_disabled--;
+    }
+    assert(ret);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_NORMAL_MEM, ret, size);
+        rtrace_op_add(op, size, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+void *calloc(size_t nmemb, size_t size)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_CALLOC;
+    const size_t val = nmemb * size;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, val)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, val, RTRACE_FAILURE);
+        return NULL;
+    }
+    /* Success */
+    /* dlsym() and dlvsym() uses calloc() (potentially malloc() too) internally,
+     * so it can cause an infinite recursion.  Let's use a statically allocated
+     * buffer to avoid such. */
+    void *ret = NULL;
+    if (nmemb * size <= ALLOC_BUFFER_SIZE) {
+        size_t aligned_size = ((nmemb * size + 16 + 15) / 16) * 16;
+        if (aligned_size <=
+            ALLOC_BUFFER_SIZE -
+                __atomic_load_n(&alloc_buffer_index, __ATOMIC_ACQUIRE)) {
+            size_t new_index =
+                __atomic_fetch_add(&alloc_buffer_index, aligned_size,
+                                   __ATOMIC_ACQ_REL);
+            if (new_index + aligned_size <= ALLOC_BUFFER_SIZE) {
+                /* Allocation succeeded. */
+                ret =
+                    (void *)(&alloc_buffer[(new_index + 16) / sizeof(size_t)]);
+                /* Write the size of this memory in the first 16 bytes. */
+                alloc_buffer[new_index / sizeof(size_t)] = nmemb * size;
+                /* Global variables are initialized with zero, so no need to
+                 * call memset() */
+            }
+        }
+    }
+    if (ret == NULL) {
+        l_rtrace_disabled++;
+        PREP_REAL_FUNC(calloc);
+        ret = real_calloc(nmemb, size);
+        l_rtrace_disabled--;
+    }
+    assert(ret);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_NORMAL_MEM, ret, val);
+        rtrace_op_add(op, val, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+void *realloc(void *ptr, size_t size)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_REALLOC;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, size)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, size, RTRACE_FAILURE);
+        return NULL;
+    }
+    /* Success */
+    void *ret;
+    if ((void *)alloc_buffer <= ptr &&
+        ptr < (void *)&alloc_buffer[ALLOC_BUFFER_SIZE / sizeof(size_t)]) {
+        /* Newly allocate the data since we cannot reallocate it. */
+        l_rtrace_disabled++;
+        PREP_REAL_FUNC(malloc);
+        ret = real_malloc(size);
+        l_rtrace_disabled--;
+        assert(ret);
+        size_t i, old_size = *(((size_t *)ptr) - 16 / sizeof(size_t));
+        size_t copy_size = old_size > size ? size : old_size;
+        for (i = 0; i < copy_size; i++)
+            ((char *)ret)[i] = ((char *)ptr)[i];
+    } else {
+        l_rtrace_disabled++;
+        PREP_REAL_FUNC(realloc);
+        ret = real_realloc(ptr, size);
+        l_rtrace_disabled--;
+        assert(ret);
+    }
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        if (ptr == NULL) {
+            rtrace_res_add(RTRACE_RES_KIND_NORMAL_MEM, ret, size);
+        } else {
+            rtrace_res_replace(RTRACE_RES_KIND_NORMAL_MEM, ptr, 0, ret, size);
+        }
+        rtrace_op_add(op, size, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_POSIX_MEMALIGN;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, size)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, size, RTRACE_FAILURE);
+        return ENOMEM;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(posix_memalign);
+    int ret = real_posix_memalign(memptr, alignment, size);
+    l_rtrace_disabled--;
+    assert(ret == 0);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_NORMAL_MEM, *memptr, size);
+        rtrace_op_add(op, size, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+void free(void *ptr)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_remove(RTRACE_RES_KIND_NORMAL_MEM, ptr, 0);
+    }
+    if ((void *)alloc_buffer <= ptr &&
+        ptr < (void *)&alloc_buffer[ALLOC_BUFFER_SIZE / sizeof(size_t)]) {
+        /* Skip since this ptr is statically allocated. */
+    } else {
+        l_rtrace_disabled++;
+        PREP_REAL_FUNC(free);
+        l_rtrace_disabled--;
+        real_free(ptr);
+    }
+}
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_MMAP;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, length)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, length, RTRACE_FAILURE);
+        return NULL;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(mmap);
+    void *ret = real_mmap(addr, length, prot, flags, fd, offset);
+    l_rtrace_disabled--;
+    /* mmap can actually fail. */
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        if (ret == MAP_FAILED) {
+            rtrace_op_add(op, length, RTRACE_REAL_FAILURE);
+        } else {
+            rtrace_res_add(RTRACE_RES_KIND_MMAP_MEM, ret, length);
+            rtrace_op_add(op, length, RTRACE_SUCCESS);
+        }
+    }
+    return ret;
+}
+
+int munmap(void *addr, size_t length)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_remove(RTRACE_RES_KIND_MMAP_MEM, addr, length);
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(munmap);
+    l_rtrace_disabled--;
+    int ret = real_munmap(addr, length);
+    assert(ret == 0);
+    return ret;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_PTHREAD_CREATE;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, 0)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, 0, RTRACE_FAILURE);
+        return EAGAIN;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_create);
+    /* pthread_create leaks memory, so let's disable its resource tracing. */
+    int ret = real_pthread_create(thread, attr, start_routine, arg);
+    l_rtrace_disabled--;
+    assert(ret == 0);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        void *thread_val = (void *)((uintptr_t)*thread);
+        rtrace_res_add(RTRACE_RES_KIND_PTHREAD_T, thread_val, 0);
+        rtrace_op_add(op, 0, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+int pthread_join(pthread_t thread, void **value_ptr)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        void *thread_val = (void *)((uintptr_t)thread);
+        rtrace_res_remove(RTRACE_RES_KIND_PTHREAD_T, thread_val, 0);
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_join);
+    l_rtrace_disabled--;
+    int ret = real_pthread_join(thread, value_ptr);
+    assert(ret == 0);
+    return ret;
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_PTHREAD_MUTEX_INIT;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, 0)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, 0, RTRACE_FAILURE);
+        return EAGAIN;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_mutex_init);
+    int ret = real_pthread_mutex_init(mutex, attr);
+    l_rtrace_disabled--;
+    assert(ret == 0);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_PTHREAD_MUTEX_T, mutex, 0);
+        rtrace_op_add(op, 0, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_remove(RTRACE_RES_KIND_PTHREAD_MUTEX_T, mutex, 0);
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_mutex_destroy);
+    l_rtrace_disabled--;
+    int ret = real_pthread_mutex_destroy(mutex);
+    assert(ret == 0);
+    return ret;
+}
+
+int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_PTHREAD_COND_INIT;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, 0)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, 0, RTRACE_FAILURE);
+        return EAGAIN;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_cond_init);
+    int ret = real_pthread_cond_init(cond, attr);
+    l_rtrace_disabled--;
+    assert(ret == 0);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_PTHREAD_COND_T, cond, 0);
+        rtrace_op_add(op, 0, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+int pthread_cond_destroy(pthread_cond_t *cond)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_remove(RTRACE_RES_KIND_PTHREAD_COND_T, cond, 0);
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_cond_destroy);
+    l_rtrace_disabled--;
+    int ret = real_pthread_cond_destroy(cond);
+    assert(ret == 0);
+    return ret;
+}
+
+#ifdef USE_PTHREAD_BARRIER
+int pthread_barrier_init(pthread_barrier_t *barrier,
+                         const pthread_barrierattr_t *attr, unsigned count)
+{
+    const RTRACE_OP_KIND op = RTRACE_OP_KIND_PTHREAD_BARRIER_INIT;
+    if (!l_rtrace_disabled && g_rtrace_global.enabled &&
+        !rtrace_log_success(op, 0)) {
+        /* Artificial failure. */
+        rtrace_op_add(op, 0, RTRACE_FAILURE);
+        return EAGAIN;
+    }
+    /* Success */
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_barrier_init);
+    int ret = real_pthread_barrier_init(barrier, attr, count);
+    l_rtrace_disabled--;
+    assert(ret == 0);
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_add(RTRACE_RES_KIND_PTHREAD_BARRIER_T, barrier, count);
+        rtrace_op_add(op, 0, RTRACE_SUCCESS);
+    }
+    return ret;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    if (!l_rtrace_disabled && g_rtrace_global.enabled) {
+        rtrace_res_remove(RTRACE_RES_KIND_PTHREAD_BARRIER_T, barrier, 0);
+    }
+    l_rtrace_disabled++;
+    PREP_REAL_FUNC(pthread_barrier_destroy);
+    l_rtrace_disabled--;
+    int ret = real_pthread_barrier_destroy(barrier);
+    assert(ret == 0);
+    return ret;
+}
+#endif /* USE_PTHREAD_BARRIER */
+
+#else /* !ABT_RT_ENABLED */
+
+#include <stdio.h>
+
+void rtrace_init(void)
+{
+    printf("rtrace is disabled.\n");
+}
+
+void rtrace_finalize(void)
+{
+    printf("No error\n");
+}
+
+void rtrace_start(void)
+{
+    /* Do nothing */
+}
+
+int rtrace_stop(void)
+{
+    return 1;
+}
+void rtrace_set_enabled(int enabled)
+{
+    /* Do nothing. */
+    (void)enabled;
+}
+
+#endif /* !ABT_RT_ENABLED */

--- a/test/leakcheck/rtrace.h
+++ b/test/leakcheck/rtrace.h
@@ -1,0 +1,159 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+/*
+ * Resource allocation tracing library.
+ *
+ * This library checks resource leak especially when system resource allocation
+ * fails.  This library overrides resource allocation functions to realize such
+ * situations.
+ *
+ *
+ * ## Usage
+ *
+ *   rtrace_init();
+ *   do {
+ *       rtrace_start();
+ *       do_something();
+ *   } while (!rtrace_stop());
+ *   rtrace_finalize();
+ *
+ * This library checks if do_something() frees all the resources (malloc, mmap,
+ * pthread_mutex_t, ... ) that are allocated between rtrace_start() and
+ * rtrace_stop().  This library has a global state, so it can repeats the
+ * execution while changing the resource allocation patterns.
+ *
+ *
+ * ## Motivation drive by an example.
+ *
+ * Let's assume the following function.
+ *
+ *   void do_somthing() {
+ *       int num_strs = 3;
+ *       char **strs = (char **)malloc(sizeof(char *) * num_strs);
+ *       if (!strs) {
+ *           num_strs = 1; // Use a smaller number.
+ *           strs = (char **)malloc(sizeof(char *) * num_strs);
+ *       }
+ *       if (strs) {
+ *           for (int i = 0; i < num_strs; i++) {
+ *               strs[i] = (char *)malloc(sizeof(char) * 128);
+ *               if (strs[i] == NULL) {
+ *                   free(strs);
+ *                   return;
+ *               }
+ *           }
+ *           [Use strs];
+ *           for (int i = 0; i < num_strs; i++)
+ *               free(strs[i]);
+ *           free(strs);
+ *       }
+ *   }
+ *
+ * Normally, the program above successfully calls malloc() four times.  If so,
+ * this program frees all the memory resources properly.  However, this program
+ * leaks memory in the following case:
+ *
+ *   1st malloc() succeeds.
+ *   2nd malloc() succeeds.
+ *   3rd malloc() fails.
+ *
+ * In this case, the program returns without freeing the 2nd malloc()'ed memory.
+ *
+ * Some might fix this error as follows, which is also wrong.
+ *
+ *   for (int i = 0; i < num_strs; i++) {
+ *       strs[i] = (char *)malloc(sizeof(char) * 128);
+ *       if (strs[i] == NULL) {
+ *           for (int j = 0; j <= i; j++)
+ *               free(strs[j]);
+ *           free(strs);
+ *           return;
+ *       }
+ *   }
+ *
+ * The code above tries to free an invalid pointer (strs[i] is not allocated.
+ * j < i should be a correct condition).  However, this is never checked since
+ * malloc() usually succeeds in a testing environment.  Typically, any resource
+ * allocation error paths are never checked.
+ *
+ * This librtrace tool repeats the execution to cover all the memory allocation
+ * patterns.  For example, the original do_something() has the following
+ * patterns.
+ *
+ * S - S - S - S : OK (the default case: all succeed)
+ * S - S - S - F : memory leak
+ * S - S - F     : memory leak
+ * S - F         : OK
+ * F - S - S     : OK
+ * F - S - F     : OK
+ * F - F         ; OK
+ *
+ * The wrong fix of do_something() can cause the following:
+ *
+ * S - S - S - S : OK
+ * S - S - S - F : SEGV
+ *
+ * rtrace_start() - rtrace_stop() traces the memory allocation patterns and
+ * changes the pattern in the next iteration.  As a result, it can simulate all
+ * the possible patterns.
+ *
+ *
+ * ## Target routines
+ *
+ * malloc(), calloc(), realloc(), posix_memalign(), free(), mmap(), munmap(),
+ * pthread_create(), pthread_join(), pthread_mutex_init(),
+ * pthread_mutex_destroy(), pthread_cond_init(), pthread_cond_destroy(),
+ * pthread_barrier_init(), pthread_barrier_destroy()
+ *
+ * This library will support other functions (e.g., fopen(), valloc(), ...) if
+ * Argobots starts to use them.
+ *
+ *
+ * ## Assumption of this library
+ *
+ * Currently this library only controls success and failure of allocation
+ * functions called by a thread that calls rtrace_start().  (NOTE: rtrace tracks
+ * all the resources allocated by all the threads to check memory leak).
+ * Since this has a global state, do not call rtrace_start() from multiple
+ * threads.  This library assumes that the calling order of resource allocation
+ * functions called on the target thread is deterministic.  This library does
+ * not work if the code uses a singleton pattern, atexit(), or destructor of
+ * pthread_key_t (this library is aware of basic Pthread functions regarding the
+ * point above).
+ *
+ * This library is for a Linux machine.  Don't combine this library with other
+ * malloc()-overriding or memory-tracing libraries (such as valgrind and address
+ * sanitizers).
+ *
+ * Although this is developed for Argobots, this is not part of the Argobots
+ * library, so don't assume any nice support for this tool.
+ *
+ *
+ * ## Tips
+ *
+ * RTRACE_VERBOSE=0|1|2 would show information that would be useful for
+ * debugging.  To know which memory allocation fails, RTRACE_BREAK_ALLOCID=X
+ * would be helpful.
+ *
+ * To disable an artificial failure, rtrace_set_enabled() can be used.  For
+ * example, if ABT_init() is not your interest, you can put
+ * rtrace_set_enabled(0) and rtrace_set_enabled(1) to disable librtrace failure.
+ *
+ * Maybe you would like to use LD_PRELOAD to use this library.
+ */
+
+#ifndef RTRACE_H_INCLUDED
+#define RTRACE_H_INCLUDED
+
+void rtrace_init(void);
+void rtrace_finalize(void);
+void rtrace_start(void);
+/* Return 1 if there is no possible trace. */
+int rtrace_stop(void);
+/* enabled = 0 will succeed all the operations. */
+void rtrace_set_enabled(int enabled);
+
+#endif /* RTRACE_H_INCLUDED */

--- a/test/leakcheck/rwlock.c
+++ b/test/leakcheck/rwlock.c
@@ -1,0 +1,118 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_rwlock. */
+
+void thread_func(void *arg)
+{
+    int ret, i, repeat;
+    ABT_rwlock rwlock = (ABT_rwlock)arg;
+    for (repeat = 0; repeat < 100; repeat++) {
+        for (i = 0; i < 5; i++) {
+            ret = ABT_rwlock_rdlock(rwlock);
+            assert(ret == ABT_SUCCESS);
+        }
+        for (i = 0; i < 5; i++) {
+            ret = ABT_rwlock_unlock(rwlock);
+            assert(ret == ABT_SUCCESS);
+        }
+        ret = ABT_rwlock_wrlock(rwlock);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_rwlock_unlock(rwlock);
+        assert(ret == ABT_SUCCESS);
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    ABT_rwlock rwlock = (ABT_rwlock)RAND_PTR;
+    ret = ABT_rwlock_create(&rwlock);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        /* If an external thread is supported, use an external thread. */
+        ABT_bool external_thread_support;
+        ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                    &external_thread_support);
+        assert(ret == ABT_SUCCESS);
+        if (external_thread_support) {
+            pthread_t pthread;
+            ret = pthread_create(&pthread, NULL, pthread_func, (void *)rwlock);
+            assert(!must_succeed || ret == 0);
+            if (ret == 0) {
+                thread_func((void *)rwlock);
+                ret = pthread_join(pthread, NULL);
+                assert(ret == 0);
+            }
+        }
+        /* Create a ULT and synchronize it with rwlock. */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ABT_thread thread = (ABT_thread)RAND_PTR;
+        ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                           (void *)rwlock, ABT_THREAD_ATTR_NULL,
+                                           &thread);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            thread_func((void *)rwlock);
+            ret = ABT_thread_free(&thread);
+            assert(ret == ABT_SUCCESS && thread == ABT_THREAD_NULL);
+        } else {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(thread == (ABT_thread)RAND_PTR);
+#else
+            assert(thread == ABT_THREAD_NULL);
+#endif
+        }
+        /* Free rwlock. */
+        ret = ABT_rwlock_free(&rwlock);
+        assert(ret == ABT_SUCCESS && rwlock == ABT_RWLOCK_NULL);
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(rwlock == (ABT_rwlock)RAND_PTR);
+#else
+        assert(rwlock == ABT_RWLOCK_NULL);
+#endif
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/sched.c
+++ b/test/leakcheck/sched.c
@@ -1,0 +1,421 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_sched. */
+
+#define SCHED_PREDEF_USER ((ABT_sched_predef)999)
+
+int sched_init(ABT_sched sched, ABT_sched_config config)
+{
+    (void)config;
+    void *p_data = malloc(128);
+    if (!p_data)
+        return ABT_ERR_MEM;
+    ABT_sched_set_data(sched, (void *)p_data);
+    return ABT_SUCCESS;
+}
+
+void sched_run(ABT_sched sched)
+{
+    ABT_pool pools[16];
+    int ret, num_pools;
+    ret = ABT_sched_get_num_pools(sched, &num_pools);
+    assert(ret == ABT_SUCCESS);
+    if (num_pools > 16)
+        num_pools = 16;
+    ret = ABT_sched_get_pools(sched, num_pools, 0, pools);
+    assert(ret == ABT_SUCCESS);
+
+    while (1) {
+        int i;
+        ABT_unit unit;
+        for (i = 0; i < num_pools; i++) {
+            ret = ABT_pool_pop(pools[0], &unit);
+            assert(ret == ABT_SUCCESS);
+            if (unit != ABT_UNIT_NULL) {
+                ret = ABT_xstream_run_unit(unit, pools[0]);
+                assert(ret == ABT_SUCCESS);
+            }
+        }
+        ABT_bool stop;
+        ABT_sched_has_to_stop(sched, &stop);
+        if (stop == ABT_TRUE)
+            break;
+        ABT_xstream_check_events(sched);
+    }
+}
+
+int sched_free(ABT_sched sched)
+{
+    void *p_data;
+    ABT_sched_get_data(sched, (void **)&p_data);
+    free(p_data);
+    return ABT_SUCCESS;
+}
+
+ABT_sched create_sched(int automatic, int must_succeed)
+{
+    int ret;
+    ABT_pool pool = (ABT_pool)RAND_PTR;
+    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE,
+                                &pool);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(pool == (ABT_pool)RAND_PTR);
+#else
+        assert(pool == ABT_POOL_NULL);
+#endif
+        return ABT_SCHED_NULL;
+    }
+
+    ABT_sched_def sched_def;
+    sched_def.type = ABT_SCHED_TYPE_ULT;
+    sched_def.init = sched_init;
+    sched_def.run = sched_run;
+    sched_def.free = sched_free;
+    sched_def.get_migr_pool = NULL;
+    ABT_sched_config sched_config;
+    if (automatic) {
+        /* The default "automatic" configuration of ABT_sched_create() is
+         * "false". */
+        sched_config = (ABT_sched_config)RAND_PTR;
+        ret = ABT_sched_config_create(&sched_config, ABT_sched_config_automatic,
+                                      ABT_TRUE, ABT_sched_config_var_end);
+        if (ret != ABT_SUCCESS) {
+            assert(sched_config == (ABT_sched_config)RAND_PTR);
+            ret = ABT_pool_free(&pool);
+            assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+            return ABT_SCHED_NULL;
+        }
+    } else {
+        sched_config = ABT_SCHED_CONFIG_NULL;
+    }
+    ABT_sched sched = (ABT_sched)RAND_PTR;
+    ret = ABT_sched_create(&sched_def, 1, &pool, sched_config, &sched);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(sched == (ABT_sched)RAND_PTR);
+#else
+        assert(sched == ABT_SCHED_NULL);
+#endif
+        /* Maybe the second time will succeed. */
+        ret = ABT_sched_create(&sched_def, 1, &pool, sched_config, &sched);
+        if (ret != ABT_SUCCESS) {
+            /* Second time failed.  Give up. */
+            ret = ABT_pool_free(&pool);
+            assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+            sched = ABT_SCHED_NULL;
+        }
+    }
+    if (sched_config != ABT_SCHED_CONFIG_NULL) {
+        ret = ABT_sched_config_free(&sched_config);
+        assert(ret == ABT_SUCCESS && sched_config == ABT_SCHED_CONFIG_NULL);
+    }
+    return sched;
+}
+
+ABT_sched create_sched_basic(ABT_sched_predef predef, int automatic,
+                             int must_succeed)
+{
+    int ret;
+    ABT_pool pools[3] = { ABT_POOL_NULL, ABT_POOL_NULL, ABT_POOL_NULL };
+    pools[1] = (ABT_pool)RAND_PTR;
+    ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE,
+                                &pools[1]);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(pools[1] == (ABT_pool)RAND_PTR);
+#else
+        assert(pools[1] == ABT_POOL_NULL);
+#endif
+        return ABT_SCHED_NULL;
+    }
+    /* The default "automatic" configuration of ABT_sched_create_basic() is
+     * "true". */
+    ABT_sched_config sched_config;
+    if (!automatic) {
+        sched_config = (ABT_sched_config)RAND_PTR;
+        ret = ABT_sched_config_create(&sched_config, ABT_sched_config_automatic,
+                                      ABT_FALSE, ABT_sched_config_var_end);
+        if (ret != ABT_SUCCESS) {
+            assert(sched_config == (ABT_sched_config)RAND_PTR);
+            ret = ABT_pool_free(&pools[1]);
+            assert(ret == ABT_SUCCESS && pools[1] == ABT_POOL_NULL);
+            return ABT_SCHED_NULL;
+        }
+    } else {
+        sched_config = ABT_SCHED_CONFIG_NULL;
+    }
+    ABT_sched sched = (ABT_sched)RAND_PTR;
+    ret = ABT_sched_create_basic(predef, 3, pools, sched_config, &sched);
+
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(sched == (ABT_sched)RAND_PTR);
+#else
+        assert(sched == ABT_SCHED_NULL);
+#endif
+        /* Maybe the second time will succeed. */
+        ret = ABT_sched_create_basic(predef, 3, pools, sched_config, &sched);
+        if (ret != ABT_SUCCESS) {
+            /* Second time failed.  Give up. */
+            ret = ABT_pool_free(&pools[1]);
+            assert(ret == ABT_SUCCESS && pools[1] == ABT_POOL_NULL);
+            sched = ABT_SCHED_NULL;
+        }
+    }
+    if (sched_config != ABT_SCHED_CONFIG_NULL) {
+        ret = ABT_sched_config_free(&sched_config);
+        assert(ret == ABT_SUCCESS && sched_config == ABT_SCHED_CONFIG_NULL);
+    }
+    return sched;
+}
+
+void program(ABT_sched_predef predef, int automatic, int type, int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    if (type == 0)
+        rtrace_set_enabled(1);
+
+    ABT_sched sched;
+    if (predef == SCHED_PREDEF_USER) {
+        sched = create_sched(automatic, must_succeed);
+    } else {
+        sched = create_sched_basic(predef, automatic, must_succeed);
+    }
+    if (type != 0)
+        rtrace_set_enabled(1);
+
+    if (sched == ABT_SCHED_NULL) {
+        /* Allocation failed, so do nothing. */
+    } else if (type == 0) {
+        /* Just free.  We must free even an automatic one. */
+        ret = ABT_sched_free(&sched);
+        assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+    } else if (type == 1) {
+        /* Use it for ABT_xstream_create(). */
+        ABT_xstream xstream = (ABT_xstream)RAND_PTR;
+        ret = ABT_xstream_create(sched, &xstream);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            ret = ABT_xstream_free(&xstream);
+            assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+            if (!automatic) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            }
+        } else {
+            ret = ABT_sched_free(&sched);
+            assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+        }
+    } else if (type == 2) {
+        /* Stackable scheduler. */
+        if (automatic) {
+            /* Try to use it's own pool. */
+            ABT_xstream self_xstream;
+            ret = ABT_self_get_xstream(&self_xstream);
+            assert(ret == ABT_SUCCESS);
+            ABT_pool pool;
+            ret = ABT_xstream_get_main_pools(self_xstream, 1, &pool);
+            assert(ret == ABT_SUCCESS);
+            ret = ABT_pool_add_sched(pool, sched);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret != ABT_SUCCESS) {
+                /* The second attempt might succeed. */
+                ret = ABT_pool_add_sched(pool, sched);
+                /* For some reasons, it fails, but then let's use another ES.*/
+            }
+            if (ret == ABT_SUCCESS) {
+                ret = ABT_sched_finish(sched);
+                assert(ret == ABT_SUCCESS);
+                sched = ABT_SCHED_NULL;
+            }
+        }
+        if (sched != ABT_SCHED_NULL) {
+            /* Need to use another ES's pool since otherwise there's no way to
+             * know if sched has been finished. */
+            ABT_pool pools[2] = { ABT_POOL_NULL, ABT_POOL_NULL };
+            ABT_xstream xstream;
+            ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 2, pools,
+                                           ABT_SCHED_CONFIG_NULL, &xstream);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret != ABT_SUCCESS) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            } else {
+                ABT_pool pool;
+                ret = ABT_xstream_get_main_pools(xstream, 1, &pool);
+                assert(ret == ABT_SUCCESS);
+                ret = ABT_pool_add_sched(pool, sched);
+                assert(!must_succeed || ret == ABT_SUCCESS);
+                if (ret != ABT_SUCCESS) {
+                    /* The second attempt might succeed. */
+                    ret = ABT_pool_add_sched(pool, sched);
+                    if (ret != ABT_SUCCESS) {
+                        ret = ABT_sched_free(&sched);
+                        assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+                    }
+                }
+                if (sched != ABT_SCHED_NULL) {
+                    /* Finish that scheduler. */
+                    ret = ABT_sched_finish(sched);
+                    assert(ret == ABT_SUCCESS);
+                }
+                ret = ABT_xstream_free(&xstream);
+                assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+                if (!automatic && sched != ABT_SCHED_NULL) {
+                    ret = ABT_sched_free(&sched);
+                    assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+                }
+            }
+        }
+    } else if (type == 3) {
+        /* ABT_xstream_set_main_sched() (primary xstream).  Automatic pool
+         * should be freed in ABT_finialze(). */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_xstream_set_main_sched(self_xstream, sched);
+        assert(ret == ABT_SUCCESS);
+    } else if (type == 4) {
+        /* ABT_xstream_set_main_sched() (secondary xstream). */
+        ABT_pool pools[2] = { ABT_POOL_NULL, ABT_POOL_NULL };
+        ABT_xstream xstream;
+        ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 2, pools,
+                                       ABT_SCHED_CONFIG_NULL, &xstream);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+            ret = ABT_sched_free(&sched);
+            assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+        } else {
+            /* Terminate xstream. */
+            ret = ABT_xstream_join(xstream);
+            assert(ret == ABT_SUCCESS);
+            ret = ABT_xstream_set_main_sched(xstream, sched);
+            assert(ret == ABT_SUCCESS);
+            /* Finish that execution stream. */
+            ret = ABT_xstream_revive(xstream);
+            assert(ret == ABT_SUCCESS);
+            ret = ABT_xstream_free(&xstream);
+            assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+            if (!automatic) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            }
+        }
+    } else if (type == 5) {
+        /* Replaced by ABT_xstream_set_main_sched() (primary xstream) */
+        ABT_xstream self_xstream;
+        ret = ABT_self_get_xstream(&self_xstream);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_xstream_set_main_sched(self_xstream, sched);
+        assert(ret == ABT_SUCCESS);
+        ABT_pool pools[2] = { ABT_POOL_NULL, ABT_POOL_NULL };
+        ret = ABT_xstream_set_main_sched_basic(self_xstream, ABT_SCHED_DEFAULT,
+                                               2, pools);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS && !automatic) {
+            ret = ABT_sched_free(&sched);
+            assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+        }
+    } else if (type == 6) {
+        /* Replaced by ABT_xstream_set_main_sched() (secondary xstream) */
+        ABT_xstream xstream;
+        ret = ABT_xstream_create(sched, &xstream);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+            ret = ABT_sched_free(&sched);
+            assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+        } else {
+            /* Terminate xstream. */
+            ret = ABT_xstream_join(xstream);
+            assert(ret == ABT_SUCCESS);
+            ABT_pool pools[2] = { ABT_POOL_NULL, ABT_POOL_NULL };
+            ret = ABT_xstream_set_main_sched_basic(xstream, ABT_SCHED_DEFAULT,
+                                                   2, pools);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret == ABT_SUCCESS && !automatic) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            }
+            /* Finish that execution stream. */
+            ret = ABT_xstream_revive(xstream);
+            assert(ret == ABT_SUCCESS);
+            ret = ABT_xstream_free(&xstream);
+            assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+            if (!automatic && sched != ABT_SCHED_NULL) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+            }
+        }
+    }
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    int i, automatic, type;
+#ifdef COMPLETE_CHECK
+    ABT_sched_predef predefs[] = { ABT_SCHED_DEFAULT,    ABT_SCHED_BASIC,
+                                   ABT_SCHED_PRIO,       ABT_SCHED_RANDWS,
+                                   ABT_SCHED_BASIC_WAIT, SCHED_PREDEF_USER };
+#else
+    ABT_sched_predef predefs[] = { ABT_SCHED_DEFAULT, SCHED_PREDEF_USER };
+#endif
+    /* Checking all takes too much time. */
+    for (i = 0; i < (int)(sizeof(predefs) / sizeof(predefs[0])); i++) {
+        for (automatic = 0; automatic <= 1; automatic++) {
+            for (type = 0; type < 7; type++) {
+                do {
+                    rtrace_start();
+                    program(predefs[i], automatic, type, 0);
+                } while (!rtrace_stop());
+
+                /* If no failure, it should succeed again. */
+                program(predefs[i], automatic, type, 1);
+            }
+        }
+    }
+#ifndef COMPLETE_CHECK
+    ABT_sched_predef extra_predefs[] = { ABT_SCHED_BASIC, ABT_SCHED_PRIO,
+                                         ABT_SCHED_RANDWS,
+                                         ABT_SCHED_BASIC_WAIT };
+    for (i = 0; i < (int)(sizeof(extra_predefs) / sizeof(extra_predefs[0]));
+         i++) {
+        for (automatic = 0; automatic <= 1; automatic++) {
+            for (type = 0; type < 2; type++) { /* Only check 0 and 1. */
+                do {
+                    rtrace_start();
+                    program(extra_predefs[i], automatic, type, 0);
+                } while (!rtrace_stop());
+
+                /* If no failure, it should succeed again. */
+                program(extra_predefs[i], automatic, type, 1);
+            }
+        }
+    }
+#endif
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/thread.c
+++ b/test/leakcheck/thread.c
@@ -1,0 +1,216 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_thread. */
+
+#define MAX_THREADS 8
+#define THREAD_STACK_SIZE (512 * 1024)
+
+void thread_func(void *arg)
+{
+    if (arg) {
+        int ret = ABT_self_yield();
+        assert(ret == ABT_SUCCESS);
+    }
+}
+
+int create_thread_default(int push_to_pool, ABT_thread *p_thread,
+                          int must_succeed)
+{
+    int ret;
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+    if (p_thread)
+        *p_thread = (ABT_thread)RAND_PTR;
+    if (push_to_pool) {
+        ABT_pool pool;
+        ret = ABT_xstream_get_main_pools(self_xstream, 1, &pool);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_thread_create(pool, thread_func, (void *)&ret,
+                                ABT_THREAD_ATTR_NULL, p_thread);
+    } else {
+        ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                           (void *)&ret, ABT_THREAD_ATTR_NULL,
+                                           p_thread);
+    }
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS && p_thread) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(*p_thread == (ABT_thread)RAND_PTR);
+        *p_thread = ABT_THREAD_NULL;
+#else
+        assert(*p_thread == ABT_THREAD_NULL);
+#endif
+    }
+    return ret;
+}
+
+int create_thread_usersize(int push_to_pool, ABT_thread *p_thread,
+                           int must_succeed)
+{
+    int ret;
+    ABT_thread_attr attr = (ABT_thread_attr)RAND_PTR;
+    ret = ABT_thread_attr_create(&attr);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(attr == (ABT_thread_attr)RAND_PTR);
+#else
+        assert(attr == ABT_THREAD_ATTR_NULL);
+#endif
+        return ret;
+    }
+    ret = ABT_thread_attr_set_stacksize(attr, THREAD_STACK_SIZE);
+    assert(ret == ABT_SUCCESS);
+
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+    if (p_thread)
+        *p_thread = (ABT_thread)RAND_PTR;
+    if (push_to_pool) {
+        ABT_pool pool;
+        ret = ABT_xstream_get_main_pools(self_xstream, 1, &pool);
+        assert(ret == ABT_SUCCESS);
+        ret =
+            ABT_thread_create(pool, thread_func, (void *)&ret, attr, p_thread);
+    } else {
+        ret = ABT_thread_create_on_xstream(self_xstream, thread_func,
+                                           (void *)&ret, attr, p_thread);
+    }
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS && p_thread) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(*p_thread == (ABT_thread)RAND_PTR);
+        *p_thread = ABT_THREAD_NULL;
+#else
+        assert(*p_thread == ABT_THREAD_NULL);
+#endif
+    }
+    ret = ABT_thread_attr_free(&attr);
+    assert(ret == ABT_SUCCESS && attr == ABT_THREAD_ATTR_NULL);
+    return ret;
+}
+
+int create_thread_nonyieldable(int push_to_pool, ABT_thread *p_thread,
+                               int must_succeed)
+{
+    int ret;
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+    if (p_thread)
+        *p_thread = (ABT_thread)RAND_PTR;
+    if (push_to_pool) {
+        ABT_pool pool;
+        ret = ABT_xstream_get_main_pools(self_xstream, 1, &pool);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_task_create(pool, thread_func, NULL, p_thread);
+    } else {
+        ret = ABT_task_create_on_xstream(self_xstream, thread_func, NULL,
+                                         p_thread);
+    }
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret != ABT_SUCCESS && p_thread) {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(*p_thread == (ABT_thread)RAND_PTR);
+        *p_thread = ABT_THREAD_NULL;
+#else
+        assert(*p_thread == ABT_TASK_NULL);
+#endif
+    }
+    return ret;
+}
+
+void program(int push_to_pool, int named, int type, int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    int i;
+
+    ABT_thread threads[MAX_THREADS];
+    for (i = 0; i < MAX_THREADS; i++) {
+        threads[i] = ABT_THREAD_NULL;
+    }
+
+    for (i = 0; i < MAX_THREADS; i++) {
+        if (type == 0) {
+            ret =
+                create_thread_default(push_to_pool, named ? &threads[i] : NULL,
+                                      must_succeed);
+        } else if (type == 1) {
+            ret =
+                create_thread_usersize(push_to_pool, named ? &threads[i] : NULL,
+                                       must_succeed);
+        } else if (type == 2) {
+            ret = create_thread_nonyieldable(push_to_pool,
+                                             named ? &threads[i] : NULL,
+                                             must_succeed);
+        }
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+            threads[i] = ABT_THREAD_NULL;
+            if (i < MAX_THREADS - 2) {
+                i = MAX_THREADS - 2; /* Create at most one more. */
+            }
+        }
+    }
+    if (named) {
+        for (i = 0; i < MAX_THREADS; i++) {
+            if (threads[i] != ABT_THREAD_NULL) {
+                ret = ABT_thread_free(&threads[i]);
+                assert(ret == ABT_SUCCESS && threads[i] == ABT_THREAD_NULL);
+            }
+        }
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    /* Set a large stack size to use multiple buckets of the memory pool. */
+    int ret;
+    ret = setenv("ABT_THREAD_STACKSIZE", "512000", 1);
+    assert(ret == 0);
+    ret = setenv("ABT_MEM_MAX_NUM_STACKS", "4", 1);
+    assert(ret == 0);
+    ret = setenv("MEM_MAX_NUM_DESCS", "4", 1);
+    assert(ret == 0);
+
+    int push_to_pool, named, type;
+    for (push_to_pool = 0; push_to_pool <= 1; push_to_pool++) {
+        for (named = 0; named <= 1; named++) {
+            for (type = 0; type < 3; type++) {
+                do {
+                    rtrace_start();
+                    program(push_to_pool, named, type, 0);
+                } while (!rtrace_stop());
+
+                /* If no failure, it should succeed again. */
+                program(push_to_pool, named, type, 1);
+            }
+        }
+    }
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/timer.c
+++ b/test/leakcheck/timer.c
@@ -1,0 +1,90 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_init() and ABT_finalize(). */
+
+void program(int must_succeed)
+{
+    int ret;
+
+    /* ABT_get_wtime() */
+    double wtime = ABT_get_wtime();
+    (void)wtime;
+
+    /* ABT_timer start-stop-read functions */
+    ABT_timer timer = (ABT_timer)RAND_PTR;
+    ret = ABT_timer_create(&timer);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        double t;
+        ret = ABT_timer_start(timer);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_timer_stop(timer);
+        assert(ret == ABT_SUCCESS);
+        ret = ABT_timer_read(timer, &t);
+        assert(ret == ABT_SUCCESS && t >= 0.0);
+        ret = ABT_timer_stop_and_add(timer, &t);
+        assert(ret == ABT_SUCCESS && t >= 0.0);
+        ret = ABT_timer_stop_and_read(timer, &t);
+        assert(ret == ABT_SUCCESS && t >= 0.0);
+
+        ABT_timer timer2 = (ABT_timer)RAND_PTR;
+        ret = ABT_timer_dup(timer, &timer2);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret == ABT_SUCCESS) {
+            double t2;
+            ret = ABT_timer_read(timer2, &t2);
+            assert(ret == ABT_SUCCESS && t == t2);
+            ret = ABT_timer_free(&timer2);
+            assert(ret == ABT_SUCCESS && timer2 == ABT_TIMER_NULL);
+        } else {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(timer2 == (ABT_timer)RAND_PTR);
+#else
+            assert(timer2 == ABT_TIMER_NULL);
+#endif
+        }
+        ret = ABT_timer_free(&timer);
+        assert(ret == ABT_SUCCESS && timer == ABT_TIMER_NULL);
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(timer == (ABT_timer)RAND_PTR);
+#else
+        assert(timer == ABT_TIMER_NULL);
+#endif
+    }
+
+    /* ABT_timer_get_overhead() */
+    double overhead = 999.9;
+    ret = ABT_timer_get_overhead(&overhead);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        assert(overhead >= 0.0);
+    } else {
+        assert(overhead == 999.9);
+    }
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/util.h
+++ b/test/leakcheck/util.h
@@ -1,0 +1,23 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef UTIL_H_INCLUDED
+#define UTIL_H_INCLUDED
+
+#include <abt.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#define RAND_PTR ((void *)(intptr_t)0x12345678)
+static void setup_env(void)
+{
+    /* The following speeds up ABT_init(). */
+    int ret;
+    ret = setenv("ABT_MEM_MAX_NUM_DESCS", "4", 1);
+    assert(ret == 0);
+    ret = setenv("ABT_MEM_MAX_NUM_STACKS", "4", 1);
+    assert(ret == 0);
+}
+#endif /* UTIL_H_INCLUDED */

--- a/test/leakcheck/xstream.c
+++ b/test/leakcheck/xstream.c
@@ -1,0 +1,175 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_xstream. */
+
+int sched_init(ABT_sched sched, ABT_sched_config config)
+{
+    (void)config;
+    void *p_data = malloc(128);
+    if (!p_data)
+        return ABT_ERR_MEM;
+    ABT_sched_set_data(sched, (void *)p_data);
+    return ABT_SUCCESS;
+}
+
+void sched_run(ABT_sched sched)
+{
+    while (1) {
+        ABT_bool stop;
+        ABT_sched_has_to_stop(sched, &stop);
+        if (stop == ABT_TRUE)
+            break;
+        ABT_xstream_check_events(sched);
+    }
+}
+
+int sched_free(ABT_sched sched)
+{
+    void *p_data;
+    ABT_sched_get_data(sched, (void **)&p_data);
+    free(p_data);
+    return ABT_SUCCESS;
+}
+
+void program(int type, int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    ABT_xstream xstream = (ABT_xstream)RAND_PTR;
+    ABT_sched sched = ABT_SCHED_NULL;
+    if (type == 0 || type == 2) {
+        /* Use ABT_xstream_create() or use ABT_xstream_create_with_rank(). */
+        ABT_pool pool = (ABT_pool)RAND_PTR;
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &pool);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(pool == (ABT_pool)RAND_PTR);
+#else
+            assert(pool == ABT_POOL_NULL);
+#endif
+            goto FAILED;
+        }
+        sched = (ABT_sched)RAND_PTR;
+        ABT_sched_def sched_def;
+        sched_def.type = ABT_SCHED_TYPE_ULT;
+        sched_def.init = sched_init;
+        sched_def.run = sched_run;
+        sched_def.free = sched_free;
+        sched_def.get_migr_pool = NULL;
+        ret = ABT_sched_create(&sched_def, 1, &pool, ABT_SCHED_CONFIG_NULL,
+                               &sched);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(sched == (ABT_sched)RAND_PTR);
+#else
+            assert(sched == ABT_SCHED_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            ret = ABT_sched_create(&sched_def, 1, &pool, ABT_SCHED_CONFIG_NULL,
+                                   &sched);
+            if (ret != ABT_SUCCESS) {
+                /* Second time failed.  Give up. */
+                ret = ABT_pool_free(&pool);
+                assert(ret == ABT_SUCCESS && pool == ABT_POOL_NULL);
+                goto FAILED;
+            }
+        }
+        if (type == 0) {
+            ret = ABT_xstream_create(sched, &xstream);
+        } else {
+            int new_rank = 39; /* Any number is fine. */
+            ret = ABT_xstream_create_with_rank(sched, new_rank, &xstream);
+        }
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(xstream == (ABT_xstream)RAND_PTR);
+#else
+            assert(xstream == ABT_XSTREAM_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            if (type == 0) {
+                ret = ABT_xstream_create(sched, &xstream);
+            } else {
+                int new_rank = 39; /* Any number is fine. */
+                ret = ABT_xstream_create_with_rank(sched, new_rank, &xstream);
+            }
+            if (ret != ABT_SUCCESS) {
+                ret = ABT_sched_free(&sched);
+                assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+                /* ABT_sched_free() will free its automatic pool. */
+                goto FAILED;
+            }
+        }
+    } else if (type == 1) {
+        /* Use ABT_xstream_create_basic(). */
+        ABT_pool pools[1] = { ABT_POOL_NULL };
+        ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, pools,
+                                       ABT_SCHED_CONFIG_NULL, &xstream);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(xstream == (ABT_xstream)RAND_PTR);
+#else
+            assert(xstream == ABT_XSTREAM_NULL);
+#endif
+            /* Maybe the second time will succeed. */
+            ret = ABT_xstream_create_basic(ABT_SCHED_DEFAULT, 1, pools,
+                                           ABT_SCHED_CONFIG_NULL, &xstream);
+            if (ret != ABT_SUCCESS) {
+                goto FAILED;
+            }
+        }
+    }
+    ret = ABT_xstream_join(xstream);
+    assert(ret == ABT_SUCCESS);
+    ret = ABT_xstream_revive(xstream);
+    assert(ret == ABT_SUCCESS);
+    ret = ABT_xstream_free(&xstream);
+    assert(ret == ABT_SUCCESS && xstream == ABT_XSTREAM_NULL);
+    if (sched != ABT_SCHED_NULL) {
+        ret = ABT_sched_free(&sched);
+        assert(ret == ABT_SUCCESS && sched == ABT_SCHED_NULL);
+    }
+
+FAILED:
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    int type;
+    for (type = 0; type < 3; type++) {
+        do {
+            rtrace_start();
+            program(type, 0);
+        } while (!rtrace_stop());
+
+        /* If no failure, it should succeed again. */
+        program(type, 1);
+    }
+
+    rtrace_finalize();
+    return 0;
+}

--- a/test/leakcheck/xstream_barrier.c
+++ b/test/leakcheck/xstream_barrier.c
@@ -1,0 +1,91 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_xstream_barrier. */
+
+void thread_func(void *arg)
+{
+    int ret = ABT_xstream_barrier_wait((ABT_xstream_barrier)arg);
+    assert(ret == ABT_SUCCESS);
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+void program(int must_succeed)
+{
+    int ret;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    ABT_bool external_thread_support;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                &external_thread_support);
+    assert(ret == ABT_SUCCESS);
+
+    ABT_xstream_barrier barrier = (ABT_xstream_barrier)RAND_PTR;
+    ret = ABT_xstream_barrier_create(external_thread_support ? 2 : 1, &barrier);
+    assert(!must_succeed || ret == ABT_SUCCESS);
+    if (ret == ABT_SUCCESS) {
+        if (external_thread_support) {
+            /* num_waiters = 2.  If an external thread is supported, use an
+             * external thread. */
+            pthread_t pthread;
+            ret = pthread_create(&pthread, NULL, pthread_func, (void *)barrier);
+            assert(!must_succeed || ret == 0);
+            if (ret == 0) {
+                ret = ABT_xstream_barrier_wait(barrier);
+                assert(ret == ABT_SUCCESS);
+                ret = pthread_join(pthread, NULL);
+                assert(ret == 0);
+            }
+        } else {
+            /* num_waiters = 1 */
+            ret = ABT_xstream_barrier_wait(barrier);
+            assert(ret == ABT_SUCCESS);
+        }
+        /* Free barrier. */
+        ret = ABT_xstream_barrier_free(&barrier);
+        assert(ret == ABT_SUCCESS && barrier == ABT_XSTREAM_BARRIER_NULL);
+    } else {
+#ifdef ABT_ENABLE_VER_20_API
+        assert(barrier == (ABT_xstream_barrier)RAND_PTR);
+#else
+        assert(barrier == ABT_XSTREAM_BARRIER_NULL);
+#endif
+    }
+
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    do {
+        rtrace_start();
+        program(0);
+    } while (!rtrace_stop());
+
+    /* If no failure, it should succeed again. */
+    program(1);
+
+    rtrace_finalize();
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description

### Problem

Resource allocation errors do not usually occur in testing, so these error handling paths are not tested. As a result, some Argobots functions leak resources, exit while keeping a lock, or cause a double-free corruption when such an error happens.

For example, `ABT_init()` (the default configuration) calls 17 `malloc()` / `mmap()` operations. Usually all the operations succeed (since a machine has enough memory), but Argobots is not tested if any of them fail.  `ABT_init()` should succeed even if some of those operations fail while it "should" return an error after properly freeing already allocated resources if others fail. We want to fix it, but at the same time we should test if that fix is correct.

### What this PR does

This PR fixes those issues the new testing library found. The new testing mechanism overrides `malloc()`, `calloc()`, `mmap()`, `pthread_xxx_init()`, ... functions by using `dlsym()` (actually `dlvsym()`) and simulates all the possible allocation success/failure patterns while tracking allocated resources to detect memory leak. This adds new 15 tests that cover most of the Argobots functions that incur resource allocation (including `ABT_init()` and `ABT_thread_create()`).

See `test/leakcheck/rtrace.h` for details.

### Impact

This PR fixes several bugs, which is great, but user programs do not usually encounter those issues since those issues happen only when resource allocation fails.

This PR closes #116.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
