### PR TITLE
mem: fix memory allocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1020,8 +1020,74 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #define FLAGS_HP    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB)
 #define PAGESIZE    (2 * 1024 * 1024)
 ],[void *ptr = mmap(NULL, PAGESIZE, PROTS, FLAGS_HP, 0, 0);])],
-[AC_DEFINE(HAVE_MAP_HUGETLB, 1, [Define if MAP_HUGETLB is supported])],,)
+[[have_map_hugetlb=yes]
+ AC_DEFINE(HAVE_MAP_HUGETLB, 1, [Define if MAP_HUGETLB is supported])],,)
 fi
+
+use_huge_page=no
+huge_page_size=0
+if test x"$have_map_hugetlb" = x"yes"; then
+    # check the huge page size.
+    if test -f "/proc/meminfo"; then
+        meminfoline="$(cat /proc/meminfo | grep Hugepagesize)"
+        huge_page_num="$(echo $meminfoline | sed -e 's/[[^0-9]]//g' || true)"
+        if test x"$huge_page_num" != x; then
+            # Units (usually kB)
+            if test "x$(echo $meminfoline | grep -i ' B' || true)" != x; then
+                huge_page_size="$huge_page_num"
+            elif test "x$(echo $meminfoline | grep -i ' kB' || true)" != x; then
+                huge_page_size="$(($huge_page_num * 1024))"
+            elif test "x$(echo $meminfoline | grep -i ' mB' || true)" != x; then
+                huge_page_size="$(($huge_page_num * 1024 * 1024))"
+            else
+                huge_page_size="0"
+            fi
+        fi
+        if test x"$huge_page_size" != x"0"; then
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([
+                #include <sys/types.h>
+                #include <sys/mman.h>
+                #include <assert.h>
+                #ifndef MAP_ANONYMOUS
+                #define MAP_ANONYMOUS   MAP_ANON
+                #endif
+            ],[
+                char *page = (char *)mmap(0, ${huge_page_size},
+                    (PROT_READ | PROT_WRITE),
+                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), 0, 0);
+                assert(page != MAP_FAILED);
+                *page = 0;
+                int ret = munmap(page, ${huge_page_size});
+                assert(ret == 0); /* This munmap() fails if huge_page_size is wrong. */
+            ])],[use_huge_page=yes])
+        fi
+        if test x"$use_huge_page" != x"yes" -a x"$huge_page_size" != x"2097152"; then
+            # Maybe 2 megabytes (= 2097152)
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([
+                #include <sys/types.h>
+                #include <sys/mman.h>
+                #include <assert.h>
+                #ifndef MAP_ANONYMOUS
+                #define MAP_ANONYMOUS   MAP_ANON
+                #endif
+            ],[
+                char *page = (char *)mmap(0, 2097152,
+                    (PROT_READ | PROT_WRITE),
+                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB), 0, 0);
+                assert(page != MAP_FAILED);
+                *page = 0;
+                int ret = munmap(page, 2097152);
+                assert(ret == 0); /* This munmap() fails if huge_page_size is wrong. */
+            ])],[use_huge_page=yes
+                 huge_page_size=2097152],[])
+        fi
+    fi
+fi
+
+AC_DEFINE_UNQUOTED([ABT_CONFIG_SYS_HUGE_PAGE_SIZE], [$huge_page_size],
+               [Define the default system huge page size detected at configure time])
+AS_IF([test x"$use_huge_page" = x"yes"],
+    [AC_DEFINE(ABT_CONFIG_USE_HUGE_PAGE_DEFAULT, 1, [Define if huge page is usable.])])
 
 # check for the availability of int128 CAS. It is hard to get availability of
 # instructions (and compiler support), so we rely on AC_RUN_IFELSE().


### PR DESCRIPTION
## Pull Request Description

This PR fixes #93 by detecting the huge page size at configure time.

This fix does not affect the most users who use x86/64 (huge page size was statically set to 2MB and will be set to 2MB by this auto detection system). On non-x86/64 machines, Argobots might start to use huge pages, which was disabled by default.

This PR also adds a size check to make `ABT_MEM_PAGE_SIZE` a power of two.


<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
