### PR TITLE
fix unit-pool mapping

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1902,6 +1902,8 @@ ALIASES += DOC_DESC_V10_CRUDE_TERMINATION_CHECK{2}="\DOC_V10 \2 is returned if t
 
 ALIASES += DOC_DESC_V10_REJECT_MUTEX_ATTR_NULL{1}="\DOC_V10 This routine returns \c ABT_ERR_INV_MUTEX_ATTR if \1 is \c ABT_MUTEX_ATTR_NULL.\n \DOC_V11 This routine uses the default mutex attributes if \1 is \c ABT_MUTEX_ATTR_NULL. @rationale Most of the Argobots routines use the default attributes when a NULL handle is passed as a configuration or an attribute.  This routine should follow this behavior. @endrationale"
 
+ALIASES += DOC_DESC_V10_UNIT_POOL_MAPPING="\DOC_V10 The user must explicitly call this routine to change the associated pool of \c ABT_unit.\n \DOC_V11 The Argobots runtime automatically changes the associated pool of \c ABT_unit if needed.  This routine is therefore unnecessary. @rationale The unit-pool association management is hard for the user who does not know the internal implementation of Argobots.  This change not only eases programming with Argobots but also addresses some issues without breaking the backward compatibility.  See https://github.com/pmodels/argobots/issues/317 for details. @endrationale"
+
 ALIASES += DOC_DESC_V1X_ERROR_CODE_CHANGE{3}="\DOC_V1X \1 is returned if \3.\n \DOC_V20 \2 is returned if \3. @rationale Argobots 2.0 changes the error code for consistent behavior with other Argobots routines. @endrationale"
 
 ALIASES += DOC_DESC_V1X_NOEXT{1}="\DOC_V1X If an external thread calls this routine, \1 is returned.\n \DOC_V20 An external thread may call this routine. @rationale Argobots 2.0 allows an external thread where possible unless it is semantically inappropriate. @endrationale"
@@ -2106,6 +2108,8 @@ ALIASES += DOC_ERROR_RESOURCE="\c ABT_ERR_MEM is returned if memory allocation f
 
 ALIASES += DOC_ERROR_RESOURCE_CONDITIONAL{1}="\c ABT_ERR_MEM is returned if memory allocation fails.  This error is returned only when \1.\n \c ABT_ERR_SYS is returned if an error related to system calls and standard libraries occurs.   This error is returned only when \1.\n"
 
+ALIASES += DOC_ERROR_RESOURCE_UNIT_CREATE="\c ABT_ERR_UNIT is returned if \c u_create_from_thread() fails.\n"
+
 ALIASES += DOC_ERROR_SCHED_GET_POOLS_IDX{3}="\c ABT_ERR_SCHED is returned if the summation of \1 and \2 is larger than the number of pools associated with \3."
 
 ALIASES += DOC_ERROR_SCHED_USED_CONDITIONAL{3}="\2 is returned if \3 and \1 is being used.\n"
@@ -2233,8 +2237,6 @@ ALIASES += DOC_UNDEFINED_WAITER{1}="If there is a waiter blocked on \1, the resu
 ALIASES += DOC_UNDEFINED_WORK_UNIT_BLOCKED{2}="If \1 is blocked on by a caller of \2, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_WORK_UNIT_IN_POOL{1}="If \1 is in a pool, the results are undefined.\n"
-
-ALIASES += DOC_UNDEFINED_WORK_UNIT_NOT_ASSOCIATED{2}="If \1 is not associated with \2, the results are undefined.\n"
 
 ALIASES += DOC_UNDEFINED_WORK_UNIT_NOT_IN_POOL{2}="If \2 is not in \1, the results are undefined.\n"
 

--- a/examples/scheduling/sched_and_pool_user.c
+++ b/examples/scheduling/sched_and_pool_user.c
@@ -262,7 +262,6 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit);
 static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 
 typedef struct example_unit unit_t;
-static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_bool unit_is_in_pool(ABT_unit unit);
 static ABT_unit unit_create_from_thread(ABT_thread thread);
 static void unit_free(ABT_unit *unit);
@@ -306,9 +305,9 @@ static int example_pool_get_def(ABT_pool_access access, ABT_pool_def *p_def)
     p_def->p_init = pool_init;
     p_def->p_free = pool_free;
     p_def->p_get_size = pool_get_size;
-    p_def->u_get_type = NULL; /* Unused. */
-    p_def->u_get_thread = unit_get_thread;
-    p_def->u_get_task = NULL; /* Unused. */
+    p_def->u_get_type = NULL;   /* Unused. */
+    p_def->u_get_thread = NULL; /* Unused. */
+    p_def->u_get_task = NULL;   /* Unused. */
     p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
     p_def->u_create_from_task = NULL; /* Unused. */
@@ -565,14 +564,6 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
 }
 
 /* Unit functions */
-
-static ABT_thread unit_get_thread(ABT_unit unit)
-{
-    ABT_thread h_thread;
-    unit_t *p_unit = (unit_t *)unit;
-    h_thread = p_unit->thread;
-    return h_thread;
-}
 
 static ABT_bool unit_is_in_pool(ABT_unit unit)
 {

--- a/examples/stencil/stencil_forkjoin_divconq_hrws.c
+++ b/examples/stencil/stencil_forkjoin_divconq_hrws.c
@@ -82,7 +82,6 @@ void sched_run(ABT_sched sched)
                 ABT_pool_pop(pools[victim], &unit);
             }
             if (unit != ABT_UNIT_NULL) {
-                ABT_unit_set_associated_pool(unit, pools[0]);
                 ABT_xstream_run_unit(unit, pools[0]);
                 goto EVENT_CHECK;
             }
@@ -93,7 +92,6 @@ void sched_run(ABT_sched sched)
                 ABT_pool_pop(pools[victim], &unit);
             }
             if (unit != ABT_UNIT_NULL) {
-                ABT_unit_set_associated_pool(unit, pools[0]);
                 ABT_xstream_run_unit(unit, pools[0]);
             }
         }

--- a/src/global.c
+++ b/src/global.c
@@ -213,6 +213,8 @@ ABTU_ret_err static int init_library(void)
     ABTD_atomic_relaxed_store_uint64(&p_global->tool_thread_event_mask_tagged,
                                      0);
 #endif
+    /* Initialize a unit-to-thread hash table. */
+    ABTI_unit_init_hash_table(p_global);
 
     /* Initialize the ES list */
     p_global->p_xstream_head = NULL;
@@ -337,6 +339,9 @@ ABTU_ret_err static int finailze_library(void)
 
     /* Restore the affinity */
     ABTD_affinity_finalize(p_global);
+
+    /* Free a unit-to-thread hash table. */
+    ABTI_unit_finalize_hash_table(p_global);
 
     /* Free the ABTI_global structure */
     ABTU_free(p_global);

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -38,6 +38,7 @@ noinst_HEADERS = \
 	include/abti_stream_barrier.h \
 	include/abti_sync_lifo.h \
 	include/abti_timer.h \
+	include/abti_unit.h \
 	include/abti_thread.h \
 	include/abti_thread_attr.h \
 	include/abti_waitlist.h \

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1441,39 +1441,18 @@ typedef struct {
      * @brief Unused function
      *
      * This function is not used.
-     *
-     * @changev11
-     * \DOC_DESC_V10_POOL_NOTASK
-     * @endchangev11
      */
     ABT_unit_get_type_fn           u_get_type;
     /**
-     * @fn    ABT_thread (*u_get_thread)(ABT_unit unit)
-     * @brief Function that extracts an \c ABT_thread handle from an \c ABT_unit
-     *        handle.
+     * @brief Unused function.
      *
-     * \c u_get_thread() returns a work unit handle from \c unit.  \c unit is
-     * not \c ABT_UNIT_NULL.
-     *
-     * \c u_get_thread() is not optional, so the user must implement this
-     * function.
-     *
-     * The caller of \c u_get_thread() is undefined, so a program that relies on
-     * the caller of \c u_get_thread() is non-conforming.
-     *
-     * @changev11
-     * \DOC_DESC_V10_POOL_NOTASK
-     * @endchangev11
+     * This function is not used.
      */
     ABT_unit_get_thread_fn         u_get_thread;
     /**
      * @brief Unused function.
      *
      * This function is not used.
-     *
-     * @changev11
-     * \DOC_DESC_V10_POOL_NOTASK
-     * @endchangev11
      */
     ABT_unit_get_task_fn           u_get_task;
     /**
@@ -1501,7 +1480,17 @@ typedef struct {
      *
      * \c u_create_from_thread() creates a user-defined \c ABT_unit handle that
      * is associated with the work-unit \c thread and returns.  \c thread is
-     * neither \c ABT_THREAD_NULL nor \c ABT_TASK_NULL.
+     * neither \c ABT_THREAD_NULL nor \c ABT_TASK_NULL.  The returned value must
+     * point to a 4-byte aligned memory address that is unique in the system.
+     * For example, a pointer that points to a sufficiently large memory block
+     * allocated by \c malloc() or \c mmap() satisfies this requirement.  This
+     * function may return \c ABT_UNIT_NULL if creation fails.
+     *
+     * @note
+     * Specifically, the Argobots implementation assumes that 1. the first 2
+     * least significant bits are zero and 2. all ABT_unit values are unique.
+     * Both requirements are satisfied if \c ABT_unit points to a 4-byte aligned
+     * memory block.
      *
      * \c u_create_from_thread() is not optional, so the user must implement
      * this function.
@@ -1532,7 +1521,7 @@ typedef struct {
      * \c u_create_from_thread().  Its associated entity (i.e., \c ABT_thread)
      * is freed by the Argobots runtime.  Neither \c NULL nor a pointer pointing
      * to \c ABT_UNIT_NULL is passed as \c unit to this function.  \c u_free()
-     * may modify the value pointed to be \c unit.
+     * may modify the value pointed to by \c unit.
      *
      * \c u_free() is not optional, so the user must implement this function.
      *

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -608,6 +608,7 @@ void ABTI_info_check_print_all_thread_stacks(void);
 #include "abti_config.h"
 #include "abti_stream.h"
 #include "abti_thread.h"
+#include "abti_unit.h"
 #include "abti_tool.h"
 #include "abti_ythread.h"
 #include "abti_thread_attr.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -331,7 +331,6 @@ struct ABTI_pool {
     uint64_t id;                   /* ID */
 
     /* Functions to manage units */
-    ABT_unit_get_thread_fn u_get_thread;
     ABT_unit_is_in_pool_fn u_is_in_pool;
     ABT_unit_create_from_thread_fn u_create_from_thread;
     ABT_unit_free_fn u_free;
@@ -565,7 +564,6 @@ ABTU_ret_err int ABTI_unit_map_thread(ABTI_global *p_global, ABT_unit unit,
 void ABTI_unit_unmap_thread(ABTI_global *p_global, ABT_unit unit);
 ABTI_thread *ABTI_unit_get_thread_from_user_defined_unit(ABTI_global *p_global,
                                                          ABT_unit unit);
-
 /* Threads */
 ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_global *p_global,
                                           ABTI_local *p_local,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -323,6 +323,7 @@ struct ABTI_sched_config {
 struct ABTI_pool {
     ABT_pool_access access; /* Access mode */
     ABT_bool automatic;     /* To know if automatic data free */
+    ABT_bool is_builtin;    /* Built-in pool. */
     /* NOTE: int32_t to check if still positive */
     ABTD_atomic_int32 num_scheds;  /* Number of associated schedulers */
     ABTD_atomic_int32 num_blocked; /* Number of blocked ULTs */
@@ -509,9 +510,9 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
 void ABTI_xstream_free(ABTI_global *p_global, ABTI_local *p_local,
                        ABTI_xstream *p_xstream, ABT_bool force_free);
 void ABTI_xstream_schedule(void *p_arg);
-void ABTI_xstream_run_unit(ABTI_global *p_global,
-                           ABTI_xstream **pp_local_xstream, ABT_unit unit,
-                           ABTI_pool *p_pool);
+void ABTI_xstream_run_thread(ABTI_global *p_global,
+                             ABTI_xstream **pp_local_xstream,
+                             ABTI_thread *p_thread);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);
@@ -557,21 +558,23 @@ void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent);
 void ABTI_pool_reset_id(void);
 
 /* Work Unit */
-void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool);
 void ABTI_unit_init_hash_table(ABTI_global *p_global);
 void ABTI_unit_finalize_hash_table(ABTI_global *p_global);
 ABTU_ret_err int ABTI_unit_map_thread(ABTI_global *p_global, ABT_unit unit,
                                       ABTI_thread *p_thread);
 void ABTI_unit_unmap_thread(ABTI_global *p_global, ABT_unit unit);
+ABTI_thread *ABTI_unit_get_thread_from_user_defined_unit(ABTI_global *p_global,
+                                                         ABT_unit unit);
 
 /* Threads */
 ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_global *p_global,
                                           ABTI_local *p_local,
                                           ABTI_thread *p_thread,
                                           ABTI_thread_mig_data **pp_mig_data);
-void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
-                        void (*thread_func)(void *), void *arg,
-                        ABTI_thread *p_thread);
+ABTU_ret_err int ABTI_thread_revive(ABTI_global *p_global, ABTI_local *p_local,
+                                    ABTI_pool *p_pool,
+                                    void (*thread_func)(void *), void *arg,
+                                    ABTI_thread *p_thread);
 void ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_global *p_global, ABTI_local *p_local,
                       ABTI_thread *p_thread);

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -1,0 +1,35 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#ifndef ABTI_UNIT_H_INCLUDED
+#define ABTI_UNIT_H_INCLUDED
+
+/* A hash table is heavy.  It should be avoided as much as possible. */
+#define ABTI_UNIT_BUILTIN_POOL_BIT ((uintptr_t)0x1)
+
+static inline ABT_bool ABTI_unit_is_builtin(ABT_unit unit)
+{
+    if (((uintptr_t)unit) & ABTI_UNIT_BUILTIN_POOL_BIT) {
+        /* This must happen only when unit is associated with a built-in pool.
+         * See ABT_pool_def's u_create_from_thread() for details. */
+        return ABT_TRUE;
+    } else {
+        return ABT_FALSE;
+    }
+}
+
+static inline ABT_unit ABTI_unit_get_builtin_unit(ABTI_thread *p_thread)
+{
+    ABTI_ASSERT(!(((uintptr_t)p_thread) & ABTI_UNIT_BUILTIN_POOL_BIT));
+    return (ABT_unit)(((uintptr_t)p_thread) | ABTI_UNIT_BUILTIN_POOL_BIT);
+}
+
+static inline ABTI_thread *ABTI_unit_get_thread_from_builtin_unit(ABT_unit unit)
+{
+    ABTI_ASSERT(ABTI_unit_is_builtin(unit));
+    return (ABTI_thread *)(((uintptr_t)unit) & (~ABTI_UNIT_BUILTIN_POOL_BIT));
+}
+
+#endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/include/abti_unit.h
+++ b/src/include/abti_unit.h
@@ -26,10 +26,189 @@ static inline ABT_unit ABTI_unit_get_builtin_unit(ABTI_thread *p_thread)
     return (ABT_unit)(((uintptr_t)p_thread) | ABTI_UNIT_BUILTIN_POOL_BIT);
 }
 
+static inline void ABTI_unit_init_builtin(ABTI_thread *p_thread)
+{
+    p_thread->p_prev = NULL;
+    p_thread->p_next = NULL;
+    ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
+    p_thread->unit = ABTI_unit_get_builtin_unit(p_thread);
+}
+
 static inline ABTI_thread *ABTI_unit_get_thread_from_builtin_unit(ABT_unit unit)
 {
     ABTI_ASSERT(ABTI_unit_is_builtin(unit));
     return (ABTI_thread *)(((uintptr_t)unit) & (~ABTI_UNIT_BUILTIN_POOL_BIT));
+}
+
+static inline ABTI_thread *ABTI_unit_get_thread(ABTI_global *p_global,
+                                                ABT_unit unit)
+{
+    if (ABTU_likely(ABTI_unit_is_builtin(unit))) {
+        /* This unit is associated with a built-in pool. */
+        return ABTI_unit_get_thread_from_builtin_unit(unit);
+    } else {
+        return ABTI_unit_get_thread_from_user_defined_unit(p_global, unit);
+    }
+}
+
+ABTU_ret_err static inline int
+ABTI_unit_set_associated_pool(ABTI_global *p_global, ABT_unit unit,
+                              ABTI_pool *p_pool, ABTI_thread **pp_thread)
+{
+    if (ABTU_likely(ABTI_unit_is_builtin(unit))) {
+        ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
+        if (ABTU_likely(p_pool->is_builtin)) {
+            /* Do nothing since built-in pools share the implementation of
+             * ABT_unit. */
+            p_thread->p_pool = p_pool;
+            *pp_thread = p_thread;
+            return ABT_SUCCESS;
+        } else {
+            /* The new pool is a user-defined pool. */
+            ABT_unit new_unit =
+                p_pool->u_create_from_thread(ABTI_thread_get_handle(p_thread));
+            if (new_unit == ABT_UNIT_NULL)
+                return ABT_ERR_OTHER;
+            int ret = ABTI_unit_map_thread(p_global, new_unit, p_thread);
+            if (ret != ABT_SUCCESS) {
+                p_pool->u_free(&new_unit);
+                return ret;
+            }
+            p_thread->unit = new_unit;
+            p_thread->p_pool = p_pool;
+            *pp_thread = p_thread;
+            return ABT_SUCCESS;
+        }
+    } else {
+        /* Currently, unit is associated with a user-defined pool. */
+        ABTI_thread *p_thread =
+            ABTI_unit_get_thread_from_user_defined_unit(p_global, unit);
+        if (p_pool->is_builtin) {
+            /* The old unit is associated with a custom pool.  Remove the
+             * existing mapping. */
+            ABTI_unit_unmap_thread(p_global, unit);
+            p_thread->p_pool->u_free(&unit);
+            ABTI_unit_init_builtin(p_thread);
+            p_thread->p_pool = p_pool;
+            *pp_thread = p_thread;
+            return ABT_SUCCESS;
+        } else if (p_thread->p_pool == p_pool) {
+            /* Both are associated with the same custom pool. */
+            *pp_thread = p_thread;
+            return ABT_SUCCESS;
+        } else {
+            /* Both are associated with different custom pools. */
+            ABT_unit new_unit =
+                p_pool->u_create_from_thread(ABTI_thread_get_handle(p_thread));
+            if (new_unit == ABT_UNIT_NULL)
+                return ABT_ERR_OTHER;
+            int ret = ABTI_unit_map_thread(p_global, new_unit, p_thread);
+            if (ret != ABT_SUCCESS) {
+                p_pool->u_free(&new_unit);
+                return ret;
+            }
+            ABTI_unit_unmap_thread(p_global, unit);
+            p_thread->p_pool->u_free(&unit);
+            p_thread->unit = new_unit;
+            p_thread->p_pool = p_pool;
+            *pp_thread = p_thread;
+            return ABT_SUCCESS;
+        }
+    }
+}
+
+/* The following functions have ABTI_thread prefix, but they mainly manage
+ * thread-unit mapping, so they are placed in this header file so far. */
+ABTU_ret_err static inline int ABTI_thread_init_pool(ABTI_global *p_global,
+                                                     ABTI_thread *p_thread,
+                                                     ABTI_pool *p_pool)
+{
+    if (ABTU_likely(p_pool->is_builtin)) {
+        ABTI_unit_init_builtin(p_thread);
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    } else {
+        ABT_unit new_unit =
+            p_pool->u_create_from_thread(ABTI_thread_get_handle(p_thread));
+        if (new_unit == ABT_UNIT_NULL)
+            return ABT_ERR_OTHER;
+        int ret = ABTI_unit_map_thread(p_global, new_unit, p_thread);
+        if (ret != ABT_SUCCESS) {
+            p_pool->u_free(&new_unit);
+            return ret;
+        }
+        p_thread->unit = new_unit;
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    }
+}
+
+ABTU_ret_err static inline int
+ABTI_thread_set_associated_pool(ABTI_global *p_global, ABTI_thread *p_thread,
+                                ABTI_pool *p_pool)
+{
+    ABT_unit unit = p_thread->unit;
+    if (ABTU_likely(ABTI_unit_is_builtin(unit) && p_pool->is_builtin)) {
+        /* Do nothing since built-in pools share the implementation of
+         * ABT_unit. */
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    } else if (ABTI_unit_is_builtin(unit)) {
+        /* The new unit is associated with a custom pool.  Add a new mapping. */
+        ABT_unit new_unit =
+            p_pool->u_create_from_thread(ABTI_thread_get_handle(p_thread));
+        if (new_unit == ABT_UNIT_NULL)
+            return ABT_ERR_OTHER;
+        int ret = ABTI_unit_map_thread(p_global, new_unit, p_thread);
+        if (ret != ABT_SUCCESS) {
+            p_pool->u_free(&new_unit);
+            return ret;
+        }
+        p_thread->unit = new_unit;
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    } else if (p_pool->is_builtin) {
+        /* The old unit is associated with a custom pool.  Remove the existing
+         * mapping. */
+        ABTI_unit_unmap_thread(p_global, unit);
+        p_thread->p_pool->u_free(&unit);
+        ABTI_unit_init_builtin(p_thread);
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    } else if (p_thread->p_pool == p_pool) {
+        /* Both are associated with the same custom pool. */
+        return ABT_SUCCESS;
+    } else {
+        /* Both are associated with different custom pools. */
+        ABT_unit new_unit =
+            p_pool->u_create_from_thread(ABTI_thread_get_handle(p_thread));
+        if (new_unit == ABT_UNIT_NULL)
+            return ABT_ERR_OTHER;
+        int ret = ABTI_unit_map_thread(p_global, new_unit, p_thread);
+        if (ret != ABT_SUCCESS) {
+            p_pool->u_free(&new_unit);
+            return ret;
+        }
+        ABTI_unit_unmap_thread(p_global, unit);
+        p_thread->p_pool->u_free(&unit);
+        p_thread->unit = new_unit;
+        p_thread->p_pool = p_pool;
+        return ABT_SUCCESS;
+    }
+}
+
+static inline void ABTI_thread_unset_associated_pool(ABTI_global *p_global,
+                                                     ABTI_thread *p_thread)
+{
+    ABT_unit unit = p_thread->unit;
+    if (ABTU_unlikely(!ABTI_unit_is_builtin(unit))) {
+        ABTI_unit_unmap_thread(p_global, unit);
+        p_thread->p_pool->u_free(&unit);
+    }
+#if ABTI_IS_ERROR_CHECK_ENABLED
+    p_thread->unit = ABT_UNIT_NULL;
+    p_thread->p_pool = NULL;
+#endif
 }
 
 #endif /* ABTI_UNIT_H_INCLUDED */

--- a/src/info.c
+++ b/src/info.c
@@ -1166,7 +1166,6 @@ void ABTI_info_print_config(ABTI_global *p_global, FILE *fp)
 
 struct info_print_unit_arg_t {
     FILE *fp;
-    ABT_pool pool;
 };
 
 struct info_pool_set_t {
@@ -1182,10 +1181,8 @@ static void info_print_unit(void *arg, ABT_unit unit)
     struct info_print_unit_arg_t *p_arg;
     p_arg = (struct info_print_unit_arg_t *)arg;
     FILE *fp = p_arg->fp;
-    ABT_pool pool = p_arg->pool;
-    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-    ABT_thread thread = p_pool->u_get_thread(unit);
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+    ABTI_thread *p_thread =
+        ABTI_unit_get_thread(ABTI_global_get_global(), unit);
 
     if (!p_thread) {
         fprintf(fp, "=== unknown (%p) ===\n", (void *)unit);
@@ -1218,7 +1215,6 @@ ABTU_ret_err static int info_print_thread_stacks_in_pool(FILE *fp,
     fprintf(fp, "== pool (%p) ==\n", (void *)p_pool);
     struct info_print_unit_arg_t arg;
     arg.fp = fp;
-    arg.pool = pool;
     p_pool->p_print_all(pool, &arg, info_print_unit);
     fflush(fp);
     return ABT_SUCCESS;

--- a/src/log.c
+++ b/src/log.c
@@ -93,7 +93,7 @@ void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit)
     if (unit == ABT_UNIT_NULL)
         return;
 
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
     char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
     if (p_thread->p_last_xstream) {
         LOG_DEBUG("[%c%" PRIu64 ":E%d] pushed to P%" PRIu64 "\n", unit_type,
@@ -113,7 +113,7 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
     if (unit == ABT_UNIT_NULL)
         return;
 
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
     char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
     if (p_thread->p_last_xstream) {
         LOG_DEBUG("[%c%" PRIu64 ":E%d] removed from P%" PRIu64 "\n", unit_type,
@@ -133,7 +133,7 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
     if (unit == ABT_UNIT_NULL)
         return;
 
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(p_pool->u_get_thread(unit));
+    ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
     char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
     if (p_thread->p_last_xstream) {
         LOG_DEBUG("[%c%" PRIu64 ":E%d] popped from P%" PRIu64 "\n", unit_type,

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -159,7 +159,7 @@ static void pool_push_shared(ABT_pool pool, ABT_unit unit)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
 
     ABTD_spinlock_acquire(&p_data->mutex);
     if (p_data->num_threads == 0) {
@@ -188,7 +188,7 @@ static void pool_push_private(ABT_pool pool, ABT_unit unit)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
 
     if (p_data->num_threads == 0) {
         p_thread->p_prev = p_thread;
@@ -240,7 +240,7 @@ static ABT_unit pool_pop_wait(ABT_pool pool, double time_secs)
                 p_thread->p_next = NULL;
                 ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
-                h_unit = (ABT_unit)p_thread;
+                h_unit = ABTI_unit_get_builtin_unit(p_thread);
             }
             ABTD_spinlock_release(&p_data->mutex);
             if (h_unit != ABT_UNIT_NULL)
@@ -287,7 +287,7 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs)
                 p_thread->p_next = NULL;
                 ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
-                h_unit = (ABT_unit)p_thread;
+                h_unit = ABTI_unit_get_builtin_unit(p_thread);
             }
             ABTD_spinlock_release(&p_data->mutex);
             if (h_unit != ABT_UNIT_NULL)
@@ -328,7 +328,7 @@ static ABT_unit pool_pop_shared(ABT_pool pool)
             p_thread->p_next = NULL;
             ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
-            h_unit = (ABT_unit)p_thread;
+            h_unit = ABTI_unit_get_builtin_unit(p_thread);
         }
         ABTD_spinlock_release(&p_data->mutex);
         return h_unit;
@@ -362,7 +362,7 @@ static ABT_unit pool_pop_private(ABT_pool pool)
         p_thread->p_next = NULL;
         ABTD_atomic_release_store_int(&p_thread->is_in_pool, 0);
 
-        h_unit = (ABT_unit)p_thread;
+        h_unit = ABTI_unit_get_builtin_unit(p_thread);
     }
     return h_unit;
 }
@@ -371,7 +371,7 @@ static int pool_remove_shared(ABT_pool pool, ABT_unit unit)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
 
     ABTI_CHECK_TRUE(p_data->num_threads != 0, ABT_ERR_POOL);
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) == 1,
@@ -407,7 +407,7 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit)
 {
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     data_t *p_data = pool_get_data_ptr(p_pool->data);
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
 
     ABTI_CHECK_TRUE(p_data->num_threads != 0, ABT_ERR_POOL);
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) == 1,
@@ -452,7 +452,7 @@ static int pool_print_all(ABT_pool pool, void *arg,
     ABTI_thread *p_thread = p_data->p_head;
     while (num_threads--) {
         ABTI_ASSERT(p_thread);
-        ABT_unit unit = (ABT_unit)p_thread;
+        ABT_unit unit = ABTI_unit_get_builtin_unit(p_thread);
         print_fn(arg, unit);
         p_thread = p_thread->p_next;
     }
@@ -468,13 +468,13 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 static ABT_thread unit_get_thread(ABT_unit unit)
 {
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
     return ABTI_thread_get_handle(p_thread);
 }
 
 static ABT_bool unit_is_in_pool(ABT_unit unit)
 {
-    ABTI_thread *p_thread = (ABTI_thread *)unit;
+    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
     return ABTD_atomic_acquire_load_int(&p_thread->is_in_pool) ? ABT_TRUE
                                                                : ABT_FALSE;
 }
@@ -486,7 +486,7 @@ static ABT_unit unit_create_from_thread(ABT_thread thread)
     p_thread->p_next = NULL;
     ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
 
-    return (ABT_unit)p_thread;
+    return ABTI_unit_get_builtin_unit(p_thread);
 }
 
 static void unit_free(ABT_unit *unit)

--- a/src/pool/fifo.c
+++ b/src/pool/fifo.c
@@ -22,7 +22,6 @@ static int pool_remove_private(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
 
-static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_bool unit_is_in_pool(ABT_unit unit);
 static ABT_unit unit_create_from_thread(ABT_thread thread);
 static void unit_free(ABT_unit *unit);
@@ -99,7 +98,6 @@ ABTU_ret_err int ABTI_pool_get_fifo_def(ABT_pool_access access,
     p_def->p_pop_wait = pool_pop_wait;
     p_def->p_pop_timedwait = pool_pop_timedwait;
     p_def->p_print_all = pool_print_all;
-    p_def->u_get_thread = unit_get_thread;
     p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
     p_def->u_free = unit_free;
@@ -466,12 +464,6 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 /* Unit functions */
 
-static ABT_thread unit_get_thread(ABT_unit unit)
-{
-    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
-    return ABTI_thread_get_handle(p_thread);
-}
-
 static ABT_bool unit_is_in_pool(ABT_unit unit)
 {
     ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
@@ -481,15 +473,14 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    p_thread->p_prev = NULL;
-    p_thread->p_next = NULL;
-    ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-
-    return ABTI_unit_get_builtin_unit(p_thread);
+    /* Call ABTI_unit_init_builtin() instead. */
+    ABTI_ASSERT(0);
+    return ABT_UNIT_NULL;
 }
 
 static void unit_free(ABT_unit *unit)
 {
-    *unit = ABT_UNIT_NULL;
+    /* A built-in unit does not need to be freed.  This function may not be
+     * called. */
+    ABTI_ASSERT(0);
 }

--- a/src/pool/fifo_wait.c
+++ b/src/pool/fifo_wait.c
@@ -17,7 +17,6 @@ static ABT_unit pool_pop_timedwait(ABT_pool pool, double abstime_secs);
 static int pool_remove(ABT_pool pool, ABT_unit unit);
 static int pool_print_all(ABT_pool pool, void *arg,
                           void (*print_fn)(void *, ABT_unit));
-static ABT_thread unit_get_thread(ABT_unit unit);
 static ABT_bool unit_is_in_pool(ABT_unit unit);
 static ABT_unit unit_create_from_thread(ABT_thread thread);
 static void unit_free(ABT_unit *unit);
@@ -50,7 +49,6 @@ ABTU_ret_err int ABTI_pool_get_fifo_wait_def(ABT_pool_access access,
     p_def->p_pop_timedwait = pool_pop_timedwait;
     p_def->p_remove = pool_remove;
     p_def->p_print_all = pool_print_all;
-    p_def->u_get_thread = unit_get_thread;
     p_def->u_is_in_pool = unit_is_in_pool;
     p_def->u_create_from_thread = unit_create_from_thread;
     p_def->u_free = unit_free;
@@ -346,12 +344,6 @@ static int pool_print_all(ABT_pool pool, void *arg,
 
 /* Unit functions */
 
-static ABT_thread unit_get_thread(ABT_unit unit)
-{
-    ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
-    return ABTI_thread_get_handle(p_thread);
-}
-
 static ABT_bool unit_is_in_pool(ABT_unit unit)
 {
     ABTI_thread *p_thread = ABTI_unit_get_thread_from_builtin_unit(unit);
@@ -361,15 +353,14 @@ static ABT_bool unit_is_in_pool(ABT_unit unit)
 
 static ABT_unit unit_create_from_thread(ABT_thread thread)
 {
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-    p_thread->p_prev = NULL;
-    p_thread->p_next = NULL;
-    ABTD_atomic_relaxed_store_int(&p_thread->is_in_pool, 0);
-
-    return ABTI_unit_get_builtin_unit(p_thread);
+    /* Call ABTI_unit_init_builtin() instead. */
+    ABTI_ASSERT(0);
+    return ABT_UNIT_NULL;
 }
 
 static void unit_free(ABT_unit *unit)
 {
-    *unit = ABT_UNIT_NULL;
+    /* A built-in unit does not need to be freed.  This function may not be
+     * called. */
+    ABTI_ASSERT(0);
 }

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -546,10 +546,11 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
  * \DOC_ERROR_INV_UNIT_HANDLE{\c unit}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
- * \DOC_UNDEFINED_WORK_UNIT_NOT_ASSOCIATED{\c unit, \c pool}
  *
  * @param[in] pool  pool handle
  * @param[in] unit  unit handle

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -6,7 +6,8 @@
 #include "abti.h"
 
 ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
-                                    ABT_bool automatic, ABTI_pool **pp_newpool);
+                                    ABT_bool automatic, ABT_bool is_builtin,
+                                    ABTI_pool **pp_newpool);
 
 /** @defgroup POOL Pool
  * This group is for Pool.
@@ -99,7 +100,8 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     internal_def.p_print_all = def->p_print_all;
 
     ABTI_pool *p_newpool;
-    int abt_errno = pool_create(&internal_def, config, ABT_FALSE, &p_newpool);
+    int abt_errno =
+        pool_create(&internal_def, config, ABT_FALSE, ABT_FALSE, &p_newpool);
     ABTI_CHECK_ERROR(abt_errno);
 
     *newpool = ABTI_pool_get_handle(p_newpool);
@@ -556,13 +558,19 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
  */
 int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     ABTI_CHECK_TRUE(unit != ABT_UNIT_NULL, ABT_ERR_INV_UNIT);
 
-    /* Save the producer ES information in the pool */
-    ABTI_pool_push(p_pool, unit);
+    ABTI_thread *p_thread;
+    int abt_errno =
+        ABTI_unit_set_associated_pool(p_global, unit, p_pool, &p_thread);
+    ABTI_CHECK_ERROR(abt_errno);
+    /* ABTI_unit_set_associated_pool() might change unit, so "unit" must be read
+     * again from p_thread. */
+    ABTI_pool_push(p_pool, p_thread->unit);
     return ABT_SUCCESS;
 }
 
@@ -612,6 +620,8 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(p_pool->p_remove, ABT_ERR_POOL);
 
+    /* unit must be in this pool, so we do not need to reset its associated
+     * pool. */
     int abt_errno = ABTI_pool_remove(p_pool, unit);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
@@ -871,7 +881,8 @@ ABTU_ret_err int ABTI_pool_create_basic(ABT_pool_kind kind,
     }
     ABTI_CHECK_ERROR(abt_errno);
 
-    abt_errno = pool_create(&def, ABT_POOL_CONFIG_NULL, automatic, pp_newpool);
+    abt_errno = pool_create(&def, ABT_POOL_CONFIG_NULL, automatic, ABT_TRUE,
+                            pp_newpool);
     ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
@@ -946,7 +957,8 @@ void ABTI_pool_reset_id(void)
 
 static inline uint64_t pool_get_new_id(void);
 ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
-                                    ABT_bool automatic, ABTI_pool **pp_newpool)
+                                    ABT_bool automatic, ABT_bool is_builtin,
+                                    ABTI_pool **pp_newpool)
 {
     int abt_errno;
     ABTI_pool *p_pool;
@@ -955,6 +967,7 @@ ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
 
     p_pool->access = def->access;
     p_pool->automatic = automatic;
+    p_pool->is_builtin = is_builtin;
     ABTD_atomic_release_store_int32(&p_pool->num_scheds, 0);
     ABTD_atomic_release_store_int32(&p_pool->num_blocked, 0);
     p_pool->data = NULL;

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -81,7 +81,6 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
     ABTI_pool_def internal_def;
 
     internal_def.access = def->access;
-    internal_def.u_get_thread = def->u_get_thread;
     internal_def.u_is_in_pool = def->u_is_in_pool;
     internal_def.u_create_from_thread = def->u_create_from_thread;
     internal_def.u_free = def->u_free;
@@ -973,7 +972,6 @@ ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
     p_pool->data = NULL;
 
     /* Set up the pool functions from def */
-    p_pool->u_get_thread = def->u_get_thread;
     p_pool->u_is_in_pool = def->u_is_in_pool;
     p_pool->u_create_from_thread = def->u_create_from_thread;
     p_pool->u_free = def->u_free;

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -116,7 +116,8 @@ static void sched_run(ABT_sched sched)
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[i]);
             ++pop_count;
             if ((unit = ABTI_pool_pop(p_pool)) != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
                 break;
             }
         }

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -113,7 +113,8 @@ static void sched_run(ABT_sched sched)
             /* Pop one work unit */
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
                 run_cnt_nowait++;
                 break;
             }
@@ -133,8 +134,8 @@ static void sched_run(ABT_sched sched)
                 unit = ABTI_pool_pop(p_pool);
             }
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit,
-                                      ABTI_pool_get_ptr(pools[0]));
+                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
                 break;
             }
         }

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -113,7 +113,8 @@ static void sched_run(ABT_sched sched)
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
                 break;
             }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -108,7 +108,8 @@ static void sched_run(ABT_sched sched)
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
         unit = ABTI_pool_pop(p_pool);
         if (unit != ABT_UNIT_NULL) {
-            ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+            ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
@@ -119,8 +120,8 @@ static void sched_run(ABT_sched sched)
             unit = ABTI_pool_pop(p_pool);
             LOG_DEBUG_POOL_POP(p_pool, unit);
             if (unit != ABT_UNIT_NULL) {
-                ABTI_unit_set_associated_pool(unit, p_pool);
-                ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
             }
         }

--- a/src/stream.c
+++ b/src/stream.c
@@ -1194,9 +1194,9 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *is_primary)
  * @ingroup ES
  * @brief   Execute a work unit.
  *
- * \c ABT_xstream_run_unit() runs the work unit \c unit associated with the pool
- * \c pool as a child ULT on the calling ULT, which becomes a parent ULT.  The
- * calling ULT will be resumed when \c unit finishes or yields.
+ * \c ABT_xstream_run_unit() associates the work unit \c unit with the pool
+ * \c pool and runs \c unit as a child ULT on the calling ULT, which becomes a
+ * parent ULT.  The calling ULT will be resumed when \c unit finishes or yields.
  *
  * @contexts
  * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
@@ -1207,11 +1207,12 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *is_primary)
  * \DOC_ERROR_INV_THREAD_NY
  * \DOC_ERROR_INV_UNIT_HANDLE{\c unit}
  * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
  * \DOC_UNDEFINED_WORK_UNIT_NOT_READY{\c unit}
- * \DOC_UNDEFINED_WORK_UNIT_NOT_ASSOCIATED{\c unit, \c pool}
  *
  * @param[in] unit  unit handle
  * @param[in] pool  pool handle

--- a/src/stream.c
+++ b/src/stream.c
@@ -25,10 +25,10 @@ static inline void xstream_schedule_task(ABTI_global *p_global,
                                          ABTI_thread *p_task);
 static void xstream_init_main_sched(ABTI_xstream *p_xstream,
                                     ABTI_sched *p_sched);
-static void xstream_update_main_sched(ABTI_global *p_global,
-                                      ABTI_xstream **pp_local_xstream,
-                                      ABTI_xstream *p_xstream,
-                                      ABTI_sched *p_sched);
+ABTU_ret_err static int
+xstream_update_main_sched(ABTI_global *p_global,
+                          ABTI_xstream **pp_local_xstream,
+                          ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 static void *xstream_launch_root_ythread(void *p_xstream);
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
 ABTU_ret_err static int xstream_migrate_thread(ABTI_global *p_global,
@@ -343,6 +343,7 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
  */
 int ABT_xstream_revive(ABT_xstream xstream)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
@@ -362,10 +363,14 @@ int ABT_xstream_revive(ABT_xstream xstream)
                                     ? ABTI_local_get_xstream(p_local)->p_thread
                                     : NULL);
 
-    ABTI_thread_revive(p_local, p_xstream->p_root_pool,
-                       p_main_sched_ythread->thread.f_thread,
-                       p_main_sched_ythread->thread.p_arg,
-                       &p_main_sched_ythread->thread);
+    int abt_errno =
+        ABTI_thread_revive(p_global, p_local, p_xstream->p_root_pool,
+                           p_main_sched_ythread->thread.f_thread,
+                           p_main_sched_ythread->thread.p_arg,
+                           &p_main_sched_ythread->thread);
+    /* ABTI_thread_revive() never fails since it does not update an associated
+     * pool.*/
+    assert(abt_errno == ABT_SUCCESS);
 
     ABTD_atomic_relaxed_store_int(&p_xstream->state, ABT_XSTREAM_STATE_RUNNING);
     ABTD_xstream_context_revive(&p_xstream->ctx);
@@ -875,7 +880,15 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 #endif
     }
 
-    xstream_update_main_sched(p_global, &p_local_xstream, p_xstream, p_sched);
+    int abt_errno = xstream_update_main_sched(p_global, &p_local_xstream,
+                                              p_xstream, p_sched);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        if (!ABTI_sched_get_ptr(sched)) {
+            ABTI_sched_free(p_global, ABTI_local_get_local_uninlined(), p_sched,
+                            ABT_FALSE);
+        }
+        ABTI_HANDLE_ERROR(abt_errno);
+    }
     return ABT_SUCCESS;
 }
 
@@ -940,6 +953,7 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
                                      ABT_sched_predef predef, int num_pools,
                                      ABT_pool *pools)
 {
+    int abt_errno;
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -950,11 +964,17 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
     ABTI_sched *p_sched;
-    int abt_errno =
+    abt_errno =
         ABTI_sched_create_basic(predef, num_pools, pools, NULL, &p_sched);
     ABTI_CHECK_ERROR(abt_errno);
 
-    xstream_update_main_sched(p_global, &p_local_xstream, p_xstream, p_sched);
+    abt_errno = xstream_update_main_sched(p_global, &p_local_xstream, p_xstream,
+                                          p_sched);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTI_sched_free(p_global, ABTI_local_get_local_uninlined(), p_sched,
+                        ABT_FALSE);
+        ABTI_HANDLE_ERROR(abt_errno);
+    }
     return ABT_SUCCESS;
 }
 
@@ -1208,7 +1228,11 @@ int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, NULL);
 
-    ABTI_xstream_run_unit(p_global, &p_local_xstream, unit, p_pool);
+    ABTI_thread *p_thread;
+    int abt_errno =
+        ABTI_unit_set_associated_pool(p_global, unit, p_pool, &p_thread);
+    ABTI_CHECK_ERROR(abt_errno);
+    ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
     return ABT_SUCCESS;
 }
 
@@ -1521,13 +1545,10 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
     (*pp_local_xstream)->p_thread = &p_ythread->thread;
 }
 
-void ABTI_xstream_run_unit(ABTI_global *p_global,
-                           ABTI_xstream **pp_local_xstream, ABT_unit unit,
-                           ABTI_pool *p_pool)
+void ABTI_xstream_run_thread(ABTI_global *p_global,
+                             ABTI_xstream **pp_local_xstream,
+                             ABTI_thread *p_thread)
 {
-    ABT_thread thread = p_pool->u_get_thread(unit);
-    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
-
     if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
         ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
         /* Execute a ULT */
@@ -1912,8 +1933,7 @@ static inline void xstream_schedule_ythread(ABTI_global *p_global,
                   ABTI_thread_get_id(&p_ythread->thread),
                   p_local_xstream->rank);
         ABTI_thread_unset_request(&p_ythread->thread, ABTI_THREAD_REQ_ORPHAN);
-        p_ythread->thread.p_pool->u_free(&p_ythread->thread.unit);
-        p_ythread->thread.p_pool = NULL;
+        ABTI_thread_unset_associated_pool(p_global, &p_ythread->thread);
     } else {
         ABTI_ASSERT(0);
         ABTU_unreachable();
@@ -1981,6 +2001,13 @@ ABTU_ret_err static int xstream_migrate_thread(ABTI_global *p_global,
         ABTI_thread_get_mig_data(p_global, p_local, p_thread, &p_mig_data);
     ABTI_CHECK_ERROR(abt_errno);
 
+    /* Extracting an argument embedded in a migration request. */
+    p_pool = ABTD_atomic_relaxed_load_ptr(&p_mig_data->p_migration_pool);
+
+    /* Change the associated pool */
+    abt_errno = ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+    ABTI_CHECK_ERROR(abt_errno);
+
     /* callback function */
     if (p_mig_data->f_migration_cb) {
         ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
@@ -1994,12 +2021,8 @@ ABTU_ret_err static int xstream_migrate_thread(ABTI_global *p_global,
     ABTI_ASSERT(ABTD_atomic_acquire_load_uint32(&p_thread->request) &
                 ABTI_THREAD_REQ_MIGRATE);
 
-    /* Extracting argument in migration request. */
-    p_pool = ABTD_atomic_relaxed_load_ptr(&p_mig_data->p_migration_pool);
+    /* Unset the migration request. */
     ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
-
-    /* Change the associated pool */
-    p_thread->p_pool = p_pool;
 
     /* Add the unit to the scheduler's pool */
     ABTI_pool_push(p_pool, p_thread->unit);
@@ -2017,29 +2040,32 @@ static void xstream_init_main_sched(ABTI_xstream *p_xstream,
     p_xstream->p_main_sched = p_sched;
 }
 
-static void xstream_update_main_sched(ABTI_global *p_global,
-                                      ABTI_xstream **pp_local_xstream,
-                                      ABTI_xstream *p_xstream,
-                                      ABTI_sched *p_sched)
+static int xstream_update_main_sched(ABTI_global *p_global,
+                                     ABTI_xstream **pp_local_xstream,
+                                     ABTI_xstream *p_xstream,
+                                     ABTI_sched *p_sched)
 {
-    /* Set the scheduler as a main scheduler */
-    p_sched->used = ABTI_SCHED_MAIN;
-
     ABTI_sched *p_main_sched = p_xstream->p_main_sched;
     if (p_main_sched == NULL) {
+        /* Set the scheduler as a main scheduler */
+        p_sched->used = ABTI_SCHED_MAIN;
         /* Set the scheduler */
         p_xstream->p_main_sched = p_sched;
-        return;
+        return ABT_SUCCESS;
     } else if (*pp_local_xstream != p_xstream) {
         /* Changing the scheduler of another execution stream. */
         ABTI_ASSERT(p_xstream->ctx.state == ABTD_XSTREAM_CONTEXT_STATE_WAITING);
-        /* Use the original scheduler's thread. */
-        p_main_sched->p_ythread->thread.p_pool->u_free(
-            &p_main_sched->p_ythread->thread.unit);
+        /* Use the original scheduler's thread.  Unit creation might fail, so it
+         * should be done first. */
         ABTI_pool *p_tar_pool = ABTI_pool_get_ptr(p_sched->pools[0]);
-        ABT_thread h_thread = ABTI_ythread_get_handle(p_main_sched->p_ythread);
-        p_main_sched->p_ythread->thread.unit =
-            p_tar_pool->u_create_from_thread(h_thread);
+        int abt_errno =
+            ABTI_thread_set_associated_pool(p_global,
+                                            &p_main_sched->p_ythread->thread,
+                                            p_tar_pool);
+        ABTI_CHECK_ERROR(abt_errno);
+
+        /* Set the scheduler as a main scheduler */
+        p_sched->used = ABTI_SCHED_MAIN;
         p_sched->p_ythread = p_main_sched->p_ythread;
         p_main_sched->p_ythread = NULL;
         /* p_main_sched is no longer used. */
@@ -2050,7 +2076,7 @@ static void xstream_update_main_sched(ABTI_global *p_global,
                             p_xstream->p_main_sched, ABT_FALSE);
         }
         p_xstream->p_main_sched = p_sched;
-        return;
+        return ABT_SUCCESS;
     } else {
         /* If the ES has a main scheduler, we have to free it */
         ABTI_thread *p_thread = (*pp_local_xstream)->p_thread;
@@ -2065,14 +2091,17 @@ static void xstream_update_main_sched(ABTI_global *p_global,
             if (p_ythread->thread.p_pool ==
                 ABTI_pool_get_ptr(p_main_sched->pools[p])) {
                 /* Associate the work unit to the first pool of new scheduler */
-                p_ythread->thread.p_pool->u_free(&p_ythread->thread.unit);
-                ABT_thread h_thread = ABTI_ythread_get_handle(p_ythread);
-                p_ythread->thread.unit =
-                    p_tar_pool->u_create_from_thread(h_thread);
-                p_ythread->thread.p_pool = p_tar_pool;
+                int abt_errno =
+                    ABTI_thread_set_associated_pool(p_global,
+                                                    &p_ythread->thread,
+                                                    p_tar_pool);
+                ABTI_CHECK_ERROR(abt_errno);
                 break;
             }
         }
+
+        /* Set the scheduler as a main scheduler */
+        p_sched->used = ABTI_SCHED_MAIN;
 
         /* Finish the current main scheduler */
         ABTI_sched_set_request(p_main_sched, ABTI_SCHED_REQ_FINISH);
@@ -2098,6 +2127,7 @@ static void xstream_update_main_sched(ABTI_global *p_global,
         ABTI_sched_discard_and_free(p_global,
                                     ABTI_xstream_get_local(*pp_local_xstream),
                                     p_main_sched, ABT_FALSE);
+        return ABT_SUCCESS;
     }
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -41,6 +41,7 @@ ABTU_ret_err static int task_create(ABTI_global *p_global, ABTI_local *p_local,
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
  * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
@@ -104,6 +105,7 @@ int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_XSTREAM_HANDLE{\c xstream}
  * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT

--- a/src/task.c
+++ b/src/task.c
@@ -5,7 +5,8 @@
 
 #include "abti.h"
 
-ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+ABTU_ret_err static int task_create(ABTI_global *p_global, ABTI_local *p_local,
+                                    ABTI_pool *p_pool,
                                     void (*task_func)(void *), void *arg,
                                     ABTI_sched *p_sched, int refcount,
                                     ABTI_thread **pp_newtask);
@@ -59,14 +60,15 @@ int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
     if (newtask)
         *newtask = ABT_TASK_NULL;
 #endif
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newtask;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
     int refcount = (newtask != NULL) ? 1 : 0;
-    int abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
-                                &p_newtask);
+    int abt_errno = task_create(p_global, p_local, p_pool, task_func, arg, NULL,
+                                refcount, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -121,6 +123,7 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     if (newtask)
         *newtask = ABT_TASK_NULL;
 #endif
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_newtask;
 
@@ -130,8 +133,8 @@ int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
     /* TODO: need to consider the access type of target pool */
     ABTI_pool *p_pool = ABTI_xstream_get_main_pool(p_xstream);
     int refcount = (newtask != NULL) ? 1 : 0;
-    int abt_errno = task_create(p_local, p_pool, task_func, arg, NULL, refcount,
-                                &p_newtask);
+    int abt_errno = task_create(p_global, p_local, p_pool, task_func, arg, NULL,
+                                refcount, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
 
     /* Return value */
@@ -549,17 +552,22 @@ int ABT_task_get_specific(ABT_task task, ABT_key key, void **value);
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
+ABTU_ret_err static int task_create(ABTI_global *p_global, ABTI_local *p_local,
+                                    ABTI_pool *p_pool,
                                     void (*task_func)(void *), void *arg,
                                     ABTI_sched *p_sched, int refcount,
                                     ABTI_thread **pp_newtask)
 {
     ABTI_thread *p_newtask;
-    ABT_task h_newtask;
 
     /* Allocate a task object */
     int abt_errno = ABTI_mem_alloc_nythread(p_local, &p_newtask);
     ABTI_CHECK_ERROR(abt_errno);
+    abt_errno = ABTI_thread_init_pool(p_global, p_newtask, p_pool);
+    if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
+        ABTI_mem_free_nythread(p_global, p_local, p_newtask);
+        ABTI_HANDLE_ERROR(abt_errno);
+    }
 
     p_newtask->p_last_xstream = NULL;
     p_newtask->p_parent = NULL;
@@ -567,12 +575,10 @@ ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     ABTD_atomic_relaxed_store_uint32(&p_newtask->request, 0);
     p_newtask->f_thread = task_func;
     p_newtask->p_arg = arg;
-    p_newtask->p_pool = p_pool;
     ABTD_atomic_relaxed_store_ptr(&p_newtask->p_keytable, NULL);
     p_newtask->id = ABTI_TASK_INIT_ID;
 
     /* Create a wrapper work unit */
-    h_newtask = ABTI_thread_get_handle(p_newtask);
     ABTI_thread_type thread_type =
         refcount ? (ABTI_THREAD_TYPE_THREAD | ABTI_THREAD_TYPE_NAMED)
                  : ABTI_THREAD_TYPE_THREAD;
@@ -580,7 +586,6 @@ ABTU_ret_err static int task_create(ABTI_local *p_local, ABTI_pool *p_pool,
     thread_type |= ABTI_THREAD_TYPE_MIGRATABLE;
 #endif
     p_newtask->type |= thread_type;
-    p_newtask->unit = p_pool->u_create_from_thread(h_newtask);
 
     ABTI_tool_event_thread_create(p_local, p_newtask,
                                   ABTI_local_get_xstream_or_null(p_local)

--- a/src/thread.c
+++ b/src/thread.c
@@ -353,6 +353,7 @@ int ABT_thread_create_many(int num_threads, ABT_pool *pool_list,
 int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
                       ABT_thread *thread)
 {
+    ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_thread *p_thread = ABTI_thread_get_ptr(*thread);
@@ -365,8 +366,9 @@ int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
-    ABTI_thread_revive(p_local, p_pool, thread_func, arg, p_thread);
-
+    int abt_errno = ABTI_thread_revive(p_global, p_local, p_pool, thread_func,
+                                       arg, p_thread);
+    ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
 
@@ -967,8 +969,10 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_global *p_global = ABTI_global_get_global();
 
-    p_thread->p_pool = p_pool;
+    int abt_errno = ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+    ABTI_CHECK_ERROR(abt_errno);
     return ABT_SUCCESS;
 }
 
@@ -2176,12 +2180,17 @@ int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
 /* Private APIs                                                              */
 /*****************************************************************************/
 
-void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
-                        void (*thread_func)(void *), void *arg,
-                        ABTI_thread *p_thread)
+ABTU_ret_err int ABTI_thread_revive(ABTI_global *p_global, ABTI_local *p_local,
+                                    ABTI_pool *p_pool,
+                                    void (*thread_func)(void *), void *arg,
+                                    ABTI_thread *p_thread)
 {
     ABTI_ASSERT(ABTD_atomic_relaxed_load_int(&p_thread->state) ==
                 ABT_THREAD_STATE_TERMINATED);
+    /* Set the new pool */
+    int abt_errno = ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+    ABTI_CHECK_ERROR(abt_errno);
+
     p_thread->f_thread = thread_func;
     p_thread->p_arg = arg;
 
@@ -2191,17 +2200,6 @@ void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
     p_thread->p_parent = NULL;
 
     ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
-    if (p_thread->p_pool != p_pool) {
-        /* Free the unit for the old pool */
-        p_thread->p_pool->u_free(&p_thread->unit);
-
-        /* Set the new pool */
-        p_thread->p_pool = p_pool;
-
-        /* Create a wrapper unit */
-        ABT_thread h_thread = ABTI_thread_get_handle(p_thread);
-        p_thread->unit = p_pool->u_create_from_thread(h_thread);
-    }
 
     if (p_ythread) {
         /* Create a ULT context */
@@ -2222,6 +2220,7 @@ void ABTI_thread_revive(ABTI_local *p_local, ABTI_pool *p_pool,
 
     /* Add this thread to the pool */
     ABTI_pool_push(p_pool, p_thread->unit);
+    return ABT_SUCCESS;
 }
 
 ABTU_ret_err int ABTI_ythread_create_primary(ABTI_global *p_global,
@@ -2508,7 +2507,6 @@ ythread_create(ABTI_global *p_global, ABTI_local *p_local, ABTI_pool *p_pool,
 {
     int abt_errno;
     ABTI_ythread *p_newthread;
-    ABT_thread h_newthread;
     ABTI_ktable *p_keytable = NULL;
 
     /* Allocate a ULT object and its stack, then create a thread context. */
@@ -2604,7 +2602,6 @@ ythread_create(ABTI_global *p_global, ABTI_local *p_local, ABTI_pool *p_pool,
     ABTD_atomic_release_store_uint32(&p_newthread->thread.request, 0);
     p_newthread->thread.p_last_xstream = NULL;
     p_newthread->thread.p_parent = NULL;
-    p_newthread->thread.p_pool = p_pool;
     p_newthread->thread.type |= thread_type;
     p_newthread->thread.id = ABTI_THREAD_INIT_ID;
     if (p_sched && !(thread_type & (ABTI_THREAD_TYPE_PRIMARY |
@@ -2633,22 +2630,36 @@ ythread_create(ABTI_global *p_global, ABTI_local *p_local, ABTI_pool *p_pool,
     }
 #endif
 
-    /* Invoke a thread creation event. */
-    ABTI_tool_event_thread_create(p_local, &p_newthread->thread,
-                                  ABTI_local_get_xstream_or_null(p_local)
-                                      ? ABTI_local_get_xstream(p_local)
-                                            ->p_thread
-                                      : NULL,
-                                  push_pool ? p_pool : NULL);
-
     /* Create a wrapper unit */
-    h_newthread = ABTI_ythread_get_handle(p_newthread);
     if (push_pool) {
-        p_newthread->thread.unit = p_pool->u_create_from_thread(h_newthread);
+        abt_errno =
+            ABTI_thread_init_pool(p_global, &p_newthread->thread, p_pool);
+        if (ABTI_IS_ERROR_CHECK_ENABLED &&
+            ABTU_unlikely(abt_errno != ABT_SUCCESS)) {
+            if (p_keytable)
+                ABTI_ktable_free(p_global, p_local, p_keytable);
+            ABTI_mem_free_thread(p_global, p_local, &p_newthread->thread);
+            return abt_errno;
+        }
+        /* Invoke a thread creation event. */
+        ABTI_tool_event_thread_create(p_local, &p_newthread->thread,
+                                      ABTI_local_get_xstream_or_null(p_local)
+                                          ? ABTI_local_get_xstream(p_local)
+                                                ->p_thread
+                                          : NULL,
+                                      p_pool);
         /* Add this thread to the pool */
         ABTI_pool_push(p_pool, p_newthread->thread.unit);
     } else {
+        p_newthread->thread.p_pool = p_pool;
         p_newthread->thread.unit = ABT_UNIT_NULL;
+        /* Invoke a thread creation event. */
+        ABTI_tool_event_thread_create(p_local, &p_newthread->thread,
+                                      ABTI_local_get_xstream_or_null(p_local)
+                                          ? ABTI_local_get_xstream(p_local)
+                                                ->p_thread
+                                          : NULL,
+                                      NULL);
     }
 
     /* Return value */
@@ -2691,7 +2702,7 @@ static inline void thread_free(ABTI_global *p_global, ABTI_local *p_local,
 
     /* Free the unit */
     if (free_unit) {
-        p_thread->p_pool->u_free(&p_thread->unit);
+        ABTI_thread_unset_associated_pool(p_global, p_thread);
     }
 
     /* Free the key-value table */
@@ -2898,7 +2909,9 @@ static void thread_root_func(void *arg)
         ABT_unit unit = ABTI_pool_pop(p_root_pool);
         if (unit != ABT_UNIT_NULL) {
             ABTI_xstream *p_xstream = p_local_xstream;
-            ABTI_xstream_run_unit(p_global, &p_xstream, unit, p_root_pool);
+            ABTI_thread *p_thread =
+                ABTI_unit_get_thread_from_builtin_unit(unit);
+            ABTI_xstream_run_thread(p_global, &p_xstream, p_thread);
             /* The root thread must be executed on the same execution stream. */
             ABTI_ASSERT(p_xstream == p_local_xstream);
         }

--- a/src/thread.c
+++ b/src/thread.c
@@ -72,6 +72,7 @@ static ABTI_key g_thread_mig_data_key =
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
  * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
@@ -151,6 +152,7 @@ int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_XSTREAM_HANDLE{\c xstream}
  * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
@@ -336,6 +338,7 @@ int ABT_thread_create_many(int num_threads, ABT_pool *pool_list,
  * \DOC_ERROR_INV_THREAD_PTR{\c thread}
  * \DOC_ERROR_INV_THREAD_NOT_TERMINATED{\c thread}
  * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
@@ -953,6 +956,8 @@ int ABT_thread_get_last_pool_id(ABT_thread thread, int *id)
  * \DOC_ERROR_SUCCESS
  * \DOC_ERROR_INV_THREAD_HANDLE{\c thread}
  * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT

--- a/src/unit.c
+++ b/src/unit.c
@@ -19,12 +19,16 @@ unit_get_thread_from_user_defined_unit(ABTI_global *p_global, ABT_unit unit);
 
 /**
  * @ingroup UNIT
- * @brief   Set the associated pool for a work unit.
+ * @brief   No operation.
  *
- * \c ABT_unit_set_associated_pool() changes the associated pool of the target
- * work unit \c unit to the pool \c pool.  This routine must be called
- * after \c unit is popped from its original associated pool (i.e., \c unit must
- * not be inside any pool).
+ * \c ABT_unit_set_associated_pool() does nothing.  This routine was originally
+ * provided for setting the associated pool for a work unit, but Argobots 1.1
+ * manages this mapping when \c ABT_pool_push() or \c ABT_xstream_run_unit() is
+ * called.  This routine is for the backward compatibility.
+ *
+ * @changev11
+ * \DOC_DESC_V10_UNIT_POOL_MAPPING
+ * @endchangev11
  *
  * @contexts
  * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
@@ -36,8 +40,6 @@ unit_get_thread_from_user_defined_unit(ABTI_global *p_global, ABT_unit unit);
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
- * \DOC_UNDEFINED_WORK_UNIT_IN_POOL{\c unit}
- * \DOC_UNDEFINED_THREAD_UNSAFE{\c unit}
  *
  * @param[in] unit  work unit handle
  * @param[in] pool  pool handle

--- a/src/unit.c
+++ b/src/unit.c
@@ -5,6 +5,12 @@
 
 #include "abti.h"
 
+static void unit_init_hash_table(ABTI_global *p_global);
+static void unit_finalize_hash_table(ABTI_global *p_global);
+ABTU_ret_err static inline int
+unit_map_thread(ABTI_global *p_global, ABT_unit unit, ABTI_thread *p_thread);
+static inline void unit_unmap_thread(ABTI_global *p_global, ABT_unit unit);
+
 /** @defgroup UNIT  Work Unit
  * This group is for work units.
  */
@@ -54,4 +60,184 @@ void ABTI_unit_set_associated_pool(ABT_unit unit, ABTI_pool *p_pool)
     ABT_thread thread = p_pool->u_get_thread(unit);
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     p_thread->p_pool = p_pool;
+}
+
+void ABTI_unit_init_hash_table(ABTI_global *p_global)
+{
+    unit_init_hash_table(p_global);
+}
+
+void ABTI_unit_finalize_hash_table(ABTI_global *p_global)
+{
+    unit_finalize_hash_table(p_global);
+}
+
+ABTU_ret_err int ABTI_unit_map_thread(ABTI_global *p_global, ABT_unit unit,
+                                      ABTI_thread *p_thread)
+{
+    return unit_map_thread(p_global, unit, p_thread);
+}
+
+void ABTI_unit_unmap_thread(ABTI_global *p_global, ABT_unit unit)
+{
+    unit_unmap_thread(p_global, unit);
+}
+
+/*****************************************************************************/
+/* Internal static functions                                                 */
+/*****************************************************************************/
+
+static inline size_t unit_get_hash_index(ABT_unit unit)
+{
+    size_t val = (uintptr_t)unit;
+    /* Let's ignore the first 3 bits and use the next 29 bits. */
+    size_t base_val = val >> 3;
+#if ABTI_UNIT_HASH_TABLE_SIZE_EXP <= 14
+    base_val += val >> (ABTI_UNIT_HASH_TABLE_SIZE_EXP + 3);
+#endif
+#if ABTI_UNIT_HASH_TABLE_SIZE_EXP <= 9
+    base_val += val >> (ABTI_UNIT_HASH_TABLE_SIZE_EXP * 2 + 3);
+#endif
+    return base_val & (ABTI_UNIT_HASH_TABLE_SIZE - 1);
+}
+
+typedef struct atomic_unit {
+    ABTD_atomic_ptr val;
+} atomic_unit;
+
+static inline ABT_unit atomic_relaxed_load_unit(const atomic_unit *p_ptr)
+{
+    return (ABT_unit)ABTD_atomic_relaxed_load_ptr(&p_ptr->val);
+}
+
+static inline void atomic_relaxed_store_unit(atomic_unit *p_ptr, ABT_unit val)
+{
+    ABTD_atomic_relaxed_store_ptr(&p_ptr->val, (void *)val);
+}
+
+typedef struct unit_to_thread {
+    /* This is updated in a relaxed manner.  Relaxed access is fine since the
+     * semantics guarantees that all operations that "hit" are performed after
+     * map() from the memory order viewpoint; we just need to guarantee that the
+     * other parallel entities that call unmap() and get() (consequently, they
+     * do not "hit") do not see a corrupted value that is neither a new ABT_unit
+     * handle nor ABT_UNIT_NULL. */
+    atomic_unit unit;
+    ABTI_thread *p_thread;
+    struct unit_to_thread *p_next;
+} unit_to_thread;
+
+static inline unit_to_thread *
+atomic_acquire_load_unit_to_thread(const ABTI_atomic_unit_to_thread *p_ptr)
+{
+    return (unit_to_thread *)ABTD_atomic_acquire_load_ptr(&p_ptr->val);
+}
+
+static inline unit_to_thread *
+atomic_relaxed_load_unit_to_thread(const ABTI_atomic_unit_to_thread *p_ptr)
+{
+    return (unit_to_thread *)ABTD_atomic_relaxed_load_ptr(&p_ptr->val);
+}
+
+static inline void
+atomic_release_store_unit_to_thread(ABTI_atomic_unit_to_thread *p_ptr,
+                                    unit_to_thread *val)
+{
+    ABTD_atomic_release_store_ptr(&p_ptr->val, (void *)val);
+}
+
+static inline void
+atomic_relaxed_store_unit_to_thread(ABTI_atomic_unit_to_thread *p_ptr,
+                                    unit_to_thread *val)
+{
+    ABTD_atomic_relaxed_store_ptr(&p_ptr->val, (void *)val);
+}
+
+static void unit_init_hash_table(ABTI_global *p_global)
+{
+    int i;
+    for (i = 0; i < (int)ABTI_UNIT_HASH_TABLE_SIZE; i++) {
+        atomic_relaxed_store_unit_to_thread(&p_global->unit_to_thread_entires[i]
+                                                 .list,
+                                            NULL);
+        ABTD_spinlock_clear(&p_global->unit_to_thread_entires[i].lock);
+    }
+}
+
+static void unit_finalize_hash_table(ABTI_global *p_global)
+{
+    int i;
+    for (i = 0; i < (int)ABTI_UNIT_HASH_TABLE_SIZE; i++) {
+        ABTI_ASSERT(!ABTD_spinlock_is_locked(
+            &p_global->unit_to_thread_entires[i].lock));
+        unit_to_thread *p_cur = atomic_relaxed_load_unit_to_thread(
+            &p_global->unit_to_thread_entires[i].list);
+        while (p_cur) {
+            ABTI_ASSERT(atomic_relaxed_load_unit(&p_cur->unit) ==
+                        ABT_UNIT_NULL);
+            unit_to_thread *p_next = p_cur->p_next;
+            ABTU_free(p_cur);
+            p_cur = p_next;
+        }
+    }
+}
+
+ABTU_ret_err static inline int
+unit_map_thread(ABTI_global *p_global, ABT_unit unit, ABTI_thread *p_thread)
+{
+    ABTI_ASSERT(!ABTI_unit_is_builtin(unit));
+    size_t hash_index = unit_get_hash_index(unit);
+    ABTI_unit_to_thread_entry *p_entry =
+        &p_global->unit_to_thread_entires[hash_index];
+
+    ABTD_spinlock_acquire(&p_entry->lock);
+    unit_to_thread *p_cur = atomic_relaxed_load_unit_to_thread(&p_entry->list);
+    while (p_cur) {
+        if (atomic_relaxed_load_unit(&p_cur->unit) == ABT_UNIT_NULL) {
+            /* Empty element has been found.  Let's use this. */
+            atomic_relaxed_store_unit(&p_cur->unit, unit);
+            /* p_cur is associated with this unit. */
+            p_cur->p_thread = p_thread;
+            ABTD_spinlock_release(&p_entry->lock);
+            return ABT_SUCCESS;
+        }
+        p_cur = p_cur->p_next;
+    }
+    /* It seems that all the elements are in use.  Let's allocate a new one. */
+    unit_to_thread *p_new;
+    p_cur = atomic_relaxed_load_unit_to_thread(&p_entry->list);
+    /* Let's dynamically allocate memory. */
+    int ret = ABTU_malloc(sizeof(unit_to_thread), (void **)&p_new);
+    if (ret != ABT_SUCCESS) {
+        ABTD_spinlock_release(&p_entry->lock);
+        return ret;
+    }
+    /* Initialize the new unit. */
+    atomic_relaxed_store_unit(&p_new->unit, unit);
+    p_new->p_thread = p_thread;
+    p_new->p_next = p_cur;
+    atomic_release_store_unit_to_thread(&p_entry->list, p_new);
+    ABTD_spinlock_release(&p_entry->lock);
+    return ABT_SUCCESS;
+}
+
+static inline void unit_unmap_thread(ABTI_global *p_global, ABT_unit unit)
+{
+    ABTI_ASSERT(!ABTI_unit_is_builtin(unit));
+    size_t hash_index = unit_get_hash_index(unit);
+    ABTI_unit_to_thread_entry *p_entry =
+        &p_global->unit_to_thread_entires[hash_index];
+
+    ABTD_spinlock_acquire(&p_entry->lock);
+    unit_to_thread *p_cur = atomic_relaxed_load_unit_to_thread(&p_entry->list);
+    /* Update the corresponding unit to "NULL". */
+    while (1) {
+        if (atomic_relaxed_load_unit(&p_cur->unit) == unit) {
+            atomic_relaxed_store_unit(&p_cur->unit, ABT_UNIT_NULL);
+            break;
+        }
+        p_cur = p_cur->p_next;
+        ABTI_ASSERT(p_cur); /* unmap() must succeed. */
+    }
+    ABTD_spinlock_release(&p_entry->lock);
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -38,6 +38,7 @@ basic/sched_set_main
 basic/sched_stack
 basic/sched_config
 basic/sched_user_ws
+basic/pool_custom
 basic/sync_no_contention
 basic/main_sched
 basic/mutex

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -43,6 +43,7 @@ TESTS = \
 	sched_stack \
 	sched_config \
 	sched_user_ws \
+	pool_custom \
 	sync_no_contention \
 	main_sched \
 	mutex \
@@ -135,6 +136,7 @@ sched_set_main_SOURCES = sched_set_main.c
 sched_stack_SOURCES = sched_stack.c
 sched_config_SOURCES = sched_config.c
 sched_user_ws_SOURCES = sched_user_ws.c
+pool_custom_SOURCES = pool_custom.c
 sync_no_contention_SOURCES = sync_no_contention.c
 main_sched_SOURCES = main_sched.c
 mutex_SOURCES = mutex.c
@@ -213,6 +215,7 @@ testing:
 	./sched_stack
 	./sched_config
 	./sched_user_ws
+	./pool_custom
 	./sync_no_contention
 	./main_sched
 	./mutex

--- a/test/basic/pool_custom.c
+++ b/test/basic/pool_custom.c
@@ -1,0 +1,476 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+/* Several types of pools are used.  This test checks if corresponding pool
+ * operations are called properly. */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+void create_sched_def(ABT_sched_def *p_def);
+void create_pool1_def(ABT_pool_def *p_def);
+void create_pool2_def(ABT_pool_def *p_def);
+
+#define DEFAULT_NUM_XSTREAMS 2
+#define DEFAULT_NUM_THREADS 100
+#define NUM_POOLS 4
+
+void thread_func(void *arg)
+{
+    int ret, i;
+    for (i = 0; i < 10; i++) {
+        if (i % 3 == 0) {
+            ABT_pool target_pool = (ABT_pool)arg;
+            ABT_thread thread;
+            ret = ABT_self_get_thread(&thread);
+            ATS_ERROR(ret, "ABT_self_get_thread");
+            /* Let's change the associated pool sometimes. */
+            ret = ABT_thread_set_associated_pool(thread, target_pool);
+            ATS_ERROR(ret, "ABT_thread_set_associated_pool");
+        }
+        ret = ABT_thread_yield();
+        ATS_ERROR(ret, "ABT_thread_yield");
+    }
+}
+
+ABT_pool create_pool(int pool_type)
+{
+    ABT_pool newpool = ABT_POOL_NULL;
+    if (pool_type == 0) {
+        /* Built-in FIFO pool. */
+        int ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                        ABT_FALSE, &newpool);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    } else if (pool_type == 1) {
+        /* Built-in FIFOWAIT pool. */
+        int ret =
+            ABT_pool_create_basic(ABT_POOL_FIFO_WAIT, ABT_POOL_ACCESS_MPMC,
+                                  ABT_FALSE, &newpool);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    } else if (pool_type == 2) {
+        /* User-defined basic pool 1. */
+        ABT_pool_def pool_def;
+        create_pool1_def(&pool_def);
+        int ret = ABT_pool_create(&pool_def, ABT_POOL_CONFIG_NULL, &newpool);
+        ATS_ERROR(ret, "ABT_pool_create");
+    } else if (pool_type == 3) {
+        /* User-defined basic pool 2. */
+        ABT_pool_def pool_def;
+        create_pool2_def(&pool_def);
+        int ret = ABT_pool_create(&pool_def, ABT_POOL_CONFIG_NULL, &newpool);
+        ATS_ERROR(ret, "ABT_pool_create");
+    }
+    return newpool;
+}
+
+int sched_init(ABT_sched sched, ABT_sched_config config)
+{
+    return ABT_SUCCESS;
+}
+
+void sched_run(ABT_sched sched)
+{
+    int ret;
+    ABT_pool pools[NUM_POOLS];
+    ret = ABT_sched_get_pools(sched, NUM_POOLS, 0, pools);
+    ATS_ERROR(ret, "ABT_sched_get_pools");
+    int work_count = 0;
+    while (1) {
+        ABT_unit unit;
+        ABT_pool victim_pool = pools[work_count % NUM_POOLS];
+        int no_run = (work_count % 3) == 0;
+
+        ret = ABT_pool_pop(victim_pool, &unit);
+        ATS_ERROR(ret, "ABT_pool_pop");
+        if (unit != ABT_UNIT_NULL) {
+            ABT_pool target_pool = pools[(work_count / 2) % NUM_POOLS];
+            if (no_run) {
+                /* Push back to the pool. */
+                ret = ABT_pool_push(target_pool, unit);
+                ATS_ERROR(ret, "ABT_pool_push");
+            } else {
+                ret = ABT_xstream_run_unit(unit, target_pool);
+                ATS_ERROR(ret, "ABT_xstream_run_unit");
+            }
+        }
+        if (work_count++ % 100 == 0) {
+            ABT_bool stop;
+            ret = ABT_sched_has_to_stop(sched, &stop);
+            ATS_ERROR(ret, "ABT_sched_has_to_stop");
+            if (stop == ABT_TRUE)
+                break;
+            ret = ABT_xstream_check_events(sched);
+            ATS_ERROR(ret, "ABT_xstream_check_events");
+        }
+    }
+}
+
+int sched_free(ABT_sched sched)
+{
+    return ABT_SUCCESS;
+}
+
+void create_sched_def(ABT_sched_def *p_def)
+{
+    p_def->type = ABT_SCHED_TYPE_ULT;
+    p_def->init = sched_init;
+    p_def->run = sched_run;
+    p_def->free = sched_free;
+    p_def->get_migr_pool = NULL;
+}
+
+ABT_sched create_sched(int num_pools, ABT_pool *pools)
+{
+    int ret;
+    ABT_sched sched;
+    ABT_sched_def sched_def;
+    create_sched_def(&sched_def);
+    ret = ABT_sched_create(&sched_def, num_pools, pools, ABT_SCHED_CONFIG_NULL,
+                           &sched);
+    ATS_ERROR(ret, "ABT_sched_create");
+    return sched;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_threads = DEFAULT_NUM_THREADS;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    if (argc > 1) {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+    }
+
+    /* Allocate memory. */
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_pool *pools = (ABT_pool *)malloc(sizeof(ABT_pool) * NUM_POOLS);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * num_xstreams);
+
+    /* Initialize Argobots. */
+    ATS_init(argc, argv, num_xstreams);
+
+    /* Create pools. */
+    for (i = 0; i < NUM_POOLS; i++) {
+        pools[i] = create_pool(i);
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < num_xstreams; i++) {
+        scheds[i] = create_sched(NUM_POOLS, pools);
+    }
+
+    /* Create secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(scheds[i], &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+    /* Update the main scheduler of the primary execution stream. */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    ret = ABT_xstream_set_main_sched(xstreams[0], scheds[0]);
+    ATS_ERROR(ret, "ABT_xstream_set_main_sched");
+
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
+    /* Create threads. */
+    for (i = 0; i < num_threads; i++) {
+        ABT_pool target_pool = pools[i % NUM_POOLS];
+        ABT_pool arg_pool = pools[(i / 2) % NUM_POOLS];
+        ret = ABT_thread_create(target_pool, thread_func, (void *)arg_pool,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Join and revive threads. */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_join(threads[i]);
+        ATS_ERROR(ret, "ABT_thread_join");
+        ABT_pool target_pool = pools[(i / 3) % NUM_POOLS];
+        ABT_pool arg_pool = pools[(i / 4) % NUM_POOLS];
+        ret = ABT_thread_revive(target_pool, thread_func, (void *)arg_pool,
+                                &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_revive");
+    }
+
+    /* Free threads. */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    free(threads);
+
+    /* Join and free secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        while (1) {
+            ABT_bool on_primary_xstream = ABT_FALSE;
+            ret = ABT_self_on_primary_xstream(&on_primary_xstream);
+            ATS_ERROR(ret, "ABT_self_on_primary_xstream");
+            if (on_primary_xstream)
+                break;
+            ret = ABT_thread_yield();
+            ATS_ERROR(ret, "ABT_thread_yield");
+        }
+        /* Yield myself until this thread is running on the primary execution
+         * stream. */
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Move this thread to the main pool.  This is needed since the following
+     * user-defined pool_free() checks whether the pool is empty or not. */
+    ABT_thread self_thread;
+    ret = ABT_self_get_thread(&self_thread);
+    ATS_ERROR(ret, "ABT_thread_self");
+    /* Let's change the associated pool sometimes. */
+    ret = ABT_thread_set_associated_pool(self_thread, pools[0]);
+    ATS_ERROR(ret, "ABT_thread_set_associated_pool");
+
+    /* Free schedulers of the secondary execution streams (since the scheduler
+     * created by ABT_sched_create() are not automatically freed). */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_sched_free(&scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_free");
+    }
+    /* The scheduler of the primary execution stream will be freed by
+     * ABT_finalize().  Pools are associated with the scheduler of the primary
+     * execution stream, so they will be freed by ABT_finallize(), too. */
+
+    /* Finalize Argobots. */
+    ret = ATS_finalize(0);
+
+    /* Free allocated memory. */
+    free(xstreams);
+    free(pools);
+    free(scheds);
+
+    return ret;
+}
+
+/******************************************************************************/
+
+typedef struct unit_t {
+    int dummy[64]; /* If a built-in pool accesses this, SEGV should happen. */
+    int pool_type;
+    ABT_thread thread;
+    struct unit_t *p_prev, *p_next;
+} unit_t;
+
+typedef struct queue_t {
+    unit_t list;
+    int size;
+    int num_units;
+    pthread_mutex_t lock;
+} queue_t;
+
+static inline void queue_push(queue_t *p_queue, unit_t *p_unit)
+{
+    pthread_mutex_lock(&p_queue->lock);
+    p_unit->p_next = &p_queue->list;
+    p_unit->p_prev = p_queue->list.p_prev;
+    p_queue->list.p_prev->p_next = p_unit;
+    p_queue->list.p_prev = p_unit;
+    p_queue->size++;
+    pthread_mutex_unlock(&p_queue->lock);
+}
+
+static inline unit_t *queue_pop(queue_t *p_queue)
+{
+    pthread_mutex_lock(&p_queue->lock);
+    if (p_queue->size == 0) {
+        pthread_mutex_unlock(&p_queue->lock);
+        /* Empty. */
+        return NULL;
+    } else {
+        p_queue->size--;
+        unit_t *p_ret = p_queue->list.p_next;
+        p_queue->list.p_next = p_ret->p_next;
+        p_queue->list.p_next->p_prev = &p_queue->list;
+        pthread_mutex_unlock(&p_queue->lock);
+        return p_ret;
+    }
+}
+
+static inline unit_t *create_unit(queue_t *p_queue, ABT_thread thread,
+                                  int pool_type)
+{
+    int i;
+    unit_t *p_unit = (unit_t *)malloc(sizeof(unit_t));
+    for (i = 0; i < 64; i++) {
+        p_unit->dummy[i] = (int)0xbaadc0de; /* Canary. */
+    }
+    p_unit->thread = thread;
+    p_unit->pool_type = pool_type;
+
+    pthread_mutex_lock(&p_queue->lock);
+    p_queue->num_units++;
+    pthread_mutex_unlock(&p_queue->lock);
+    return p_unit;
+}
+
+static inline void free_unit(queue_t *p_queue, unit_t *p_unit)
+{
+    int i;
+    for (i = 0; i < 64; i++) {
+        assert(p_unit->dummy[i] == (int)0xbaadc0de);
+    }
+    free(p_unit);
+    pthread_mutex_lock(&p_queue->lock);
+    p_queue->num_units--;
+    assert(p_queue->num_units >= 0);
+    pthread_mutex_unlock(&p_queue->lock);
+}
+
+/******************************************************************************/
+/* Pool 1 */
+/******************************************************************************/
+
+queue_t pool1_queue;
+
+ABT_unit pool1_unit_create_from_thread(ABT_thread thread)
+{
+    return (ABT_unit)create_unit(&pool1_queue, thread, 1);
+}
+
+void pool1_unit_free(ABT_unit *p_unit)
+{
+    free_unit(&pool1_queue, (unit_t *)(*p_unit));
+}
+
+int pool1_init(ABT_pool pool, ABT_pool_config config)
+{
+    pool1_queue.list.p_prev = &pool1_queue.list;
+    pool1_queue.list.p_next = &pool1_queue.list;
+    pool1_queue.size = 0;
+    pool1_queue.num_units = 0;
+    pthread_mutex_init(&pool1_queue.lock, NULL);
+    return ABT_SUCCESS;
+}
+
+size_t pool1_get_size(ABT_pool pool)
+{
+    return pool1_queue.size;
+}
+
+void pool1_push(ABT_pool pool, ABT_unit unit)
+{
+    unit_t *p_unit = (unit_t *)unit;
+    assert(p_unit->pool_type == 1);
+    queue_push(&pool1_queue, p_unit);
+}
+
+ABT_unit pool1_pop(ABT_pool pool)
+{
+    unit_t *p_unit = queue_pop(&pool1_queue);
+    return p_unit ? ((ABT_unit)p_unit) : ABT_UNIT_NULL;
+}
+
+int pool1_free(ABT_pool pool)
+{
+    assert(pool1_queue.size == 0);
+    assert(pool1_queue.num_units == 0);
+    pthread_mutex_destroy(&pool1_queue.lock);
+    return ABT_SUCCESS;
+}
+
+void create_pool1_def(ABT_pool_def *p_def)
+{
+    p_def->access = ABT_POOL_ACCESS_MPMC;
+    p_def->u_create_from_thread = pool1_unit_create_from_thread;
+    p_def->u_free = pool1_unit_free;
+    p_def->p_init = pool1_init;
+    p_def->p_get_size = pool1_get_size;
+    p_def->p_push = pool1_push;
+    p_def->p_pop = pool1_pop;
+    p_def->p_free = pool1_free;
+
+    /* Optional. */
+    p_def->u_is_in_pool = NULL;
+#ifdef ABT_ENABLE_VER_20_API
+    p_def->p_pop_wait = NULL;
+#endif
+    p_def->p_pop_timedwait = NULL;
+    p_def->p_remove = NULL;
+    p_def->p_print_all = NULL;
+}
+
+/******************************************************************************/
+/* Pool 2 */
+/******************************************************************************/
+
+queue_t pool2_queue;
+
+ABT_unit pool2_unit_create_from_thread(ABT_thread thread)
+{
+    return (ABT_unit)create_unit(&pool2_queue, thread, 2);
+}
+
+void pool2_unit_free(ABT_unit *p_unit)
+{
+    free_unit(&pool2_queue, (unit_t *)(*p_unit));
+}
+
+int pool2_init(ABT_pool pool, ABT_pool_config config)
+{
+    pool2_queue.list.p_prev = &pool2_queue.list;
+    pool2_queue.list.p_next = &pool2_queue.list;
+    pool2_queue.size = 0;
+    pool2_queue.num_units = 0;
+    pthread_mutex_init(&pool2_queue.lock, NULL);
+    return ABT_SUCCESS;
+}
+
+size_t pool2_get_size(ABT_pool pool)
+{
+    return pool2_queue.size;
+}
+
+void pool2_push(ABT_pool pool, ABT_unit unit)
+{
+    unit_t *p_unit = (unit_t *)unit;
+    assert(p_unit->pool_type == 2);
+    queue_push(&pool2_queue, p_unit);
+}
+
+ABT_unit pool2_pop(ABT_pool pool)
+{
+    unit_t *p_unit = queue_pop(&pool2_queue);
+    return p_unit ? ((ABT_unit)p_unit) : ABT_UNIT_NULL;
+}
+
+int pool2_free(ABT_pool pool)
+{
+    assert(pool2_queue.size == 0);
+    assert(pool2_queue.num_units == 0);
+    pthread_mutex_destroy(&pool2_queue.lock);
+    return ABT_SUCCESS;
+}
+
+void create_pool2_def(ABT_pool_def *p_def)
+{
+    p_def->access = ABT_POOL_ACCESS_MPMC;
+    p_def->u_create_from_thread = pool2_unit_create_from_thread;
+    p_def->u_free = pool2_unit_free;
+    p_def->p_init = pool2_init;
+    p_def->p_get_size = pool2_get_size;
+    p_def->p_push = pool2_push;
+    p_def->p_pop = pool2_pop;
+    p_def->p_free = pool2_free;
+
+    /* Optional. */
+    p_def->u_is_in_pool = NULL;
+#ifdef ABT_ENABLE_VER_20_API
+    p_def->p_pop_wait = NULL;
+#endif
+    p_def->p_pop_timedwait = NULL;
+    p_def->p_remove = NULL;
+    p_def->p_print_all = NULL;
+}

--- a/test/leakcheck/.gitignore
+++ b/test/leakcheck/.gitignore
@@ -12,5 +12,6 @@ rwlock
 sched
 thread
 timer
+unit
 xstream
 xstream_barrier

--- a/test/leakcheck/Makefile.am
+++ b/test/leakcheck/Makefile.am
@@ -17,6 +17,7 @@ TESTS = \
 	sched \
 	thread \
 	timer \
+	unit \
 	xstream \
 	xstream_barrier
 

--- a/test/leakcheck/pool.c
+++ b/test/leakcheck/pool.c
@@ -13,11 +13,6 @@
 
 #define POOL_KIND_USER ((ABT_pool_kind)999)
 
-ABT_thread unit_get_thread(ABT_unit unit)
-{
-    return (ABT_thread)unit;
-}
-
 ABT_unit unit_create_from_thread(ABT_thread thread)
 {
     return (ABT_unit)thread;
@@ -97,7 +92,7 @@ ABT_pool create_pool(int automatic, int must_succeed)
     ABT_pool_def pool_def;
     pool_def.access = ABT_POOL_ACCESS_MPMC;
     pool_def.u_get_type = NULL;
-    pool_def.u_get_thread = unit_get_thread;
+    pool_def.u_get_thread = NULL;
     pool_def.u_get_task = NULL;
     pool_def.u_is_in_pool = NULL;
     pool_def.u_create_from_thread = unit_create_from_thread;
@@ -153,6 +148,7 @@ void program(ABT_pool_kind kind, int automatic, int type, int must_succeed)
     /* Checking ABT_init() should be done by other tests. */
     ret = ABT_init(0, 0);
     assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
 
     ABT_pool pool;
     if (kind == POOL_KIND_USER) {

--- a/test/leakcheck/unit.c
+++ b/test/leakcheck/unit.c
@@ -1,0 +1,225 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdlib.h>
+#include <assert.h>
+#include <abt.h>
+#include "rtrace.h"
+#include "util.h"
+
+/* Check ABT_pool. */
+
+#define POOL_KIND_USER ((ABT_pool_kind)999)
+
+typedef struct unit_t {
+    ABT_thread thread;
+} unit_t;
+
+ABT_unit unit_create_from_thread(ABT_thread thread)
+{
+    unit_t *p_unit = (unit_t *)malloc(sizeof(unit_t));
+    if (!p_unit) {
+        return ABT_UNIT_NULL;
+    }
+    p_unit->thread = thread;
+    return (ABT_unit)p_unit;
+}
+
+void unit_free(ABT_unit *p_unit)
+{
+    free(*p_unit);
+}
+
+typedef struct {
+    int num_units;
+    ABT_unit units[16];
+} pool_data_t;
+
+int pool_init(ABT_pool pool, ABT_pool_config config)
+{
+    (void)config;
+    pool_data_t *pool_data = (pool_data_t *)malloc(sizeof(pool_data_t));
+    assert(pool_data);
+    pool_data->num_units = 0;
+    int ret = ABT_pool_set_data(pool, pool_data);
+    assert(ret == ABT_SUCCESS);
+    return ABT_SUCCESS;
+}
+
+size_t pool_get_size(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    return pool_data->num_units;
+}
+
+void pool_push(ABT_pool pool, ABT_unit unit)
+{
+    /* Very simple: no lock, fixed size.  This implementation is for simplicity,
+     * so don't use it in a real program unless you know what you are really
+     * doing. */
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    pool_data->units[pool_data->num_units++] = unit;
+}
+
+ABT_unit pool_pop(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    if (pool_data->num_units == 0)
+        return ABT_UNIT_NULL;
+    return pool_data->units[--pool_data->num_units];
+}
+
+int pool_free(ABT_pool pool)
+{
+    pool_data_t *pool_data;
+    int ret = ABT_pool_get_data(pool, (void **)&pool_data);
+    assert(ret == ABT_SUCCESS);
+    free(pool_data);
+    return ABT_SUCCESS;
+}
+
+ABT_pool create_pool(void)
+{
+    int ret;
+    ABT_pool pool;
+
+    ABT_pool_def pool_def;
+    pool_def.access = ABT_POOL_ACCESS_MPMC;
+    pool_def.u_get_type = NULL;
+    pool_def.u_get_thread = NULL;
+    pool_def.u_get_task = NULL;
+    pool_def.u_is_in_pool = NULL;
+    pool_def.u_create_from_thread = unit_create_from_thread;
+    pool_def.u_create_from_task = NULL;
+    pool_def.u_free = unit_free;
+    pool_def.p_init = pool_init;
+    pool_def.p_get_size = pool_get_size;
+    pool_def.p_push = pool_push;
+    pool_def.p_pop = pool_pop;
+#ifdef ABT_ENABLE_VER_20_API
+    pool_def.p_pop_wait = NULL;
+#endif
+    pool_def.p_pop_timedwait = NULL;
+    pool_def.p_remove = NULL;
+    pool_def.p_free = pool_free;
+    pool_def.p_print_all = NULL;
+
+    ret = ABT_pool_create(&pool_def, ABT_POOL_CONFIG_NULL, &pool);
+    assert(ret == ABT_SUCCESS);
+    return pool;
+}
+
+void thread_func(void *arg)
+{
+    int ret;
+    ABT_thread thread;
+    ret = ABT_self_get_thread(&thread);
+    assert(ret == ABT_SUCCESS);
+    ret = ABT_thread_set_associated_pool(thread, (ABT_pool)arg);
+    /* ABT_thread_set_associated_pool() might fail. */
+    (void)ret;
+    ret = ABT_thread_yield();
+    assert(ret == ABT_SUCCESS);
+}
+
+void program(int use_predef, int must_succeed)
+{
+    int ret, i;
+    rtrace_set_enabled(0);
+    /* Checking ABT_init() should be done by other tests. */
+    ret = ABT_init(0, 0);
+    assert(ret == ABT_SUCCESS);
+    /* Pool creation should be covered by other tests. */
+    ABT_pool pools[2];
+    pools[0] = create_pool();
+    if (!use_predef) {
+        pools[1] = create_pool();
+    } else {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_FALSE, &pools[1]);
+        assert(ret == ABT_SUCCESS);
+    }
+    /* ABT_xstream_set_main_sched_basic() should be checked by other tests. */
+    ABT_xstream self_xstream;
+    ret = ABT_self_get_xstream(&self_xstream);
+    assert(ret == ABT_SUCCESS);
+    ret = ABT_xstream_set_main_sched_basic(self_xstream, ABT_SCHED_DEFAULT, 2,
+                                           pools);
+    assert(ret == ABT_SUCCESS);
+    rtrace_set_enabled(1);
+
+    ABT_thread threads[4];
+    for (i = 0; i < 4; i++) {
+        ABT_pool target_pool = pools[i % 2];
+        ABT_pool mig_pool = pools[(i / 2) % 2];
+        threads[i] = (ABT_thread)RAND_PTR;
+        ret = ABT_thread_create(target_pool, thread_func, (void *)mig_pool,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        assert(!must_succeed || ret == ABT_SUCCESS);
+        if (ret != ABT_SUCCESS) {
+#ifdef ABT_ENABLE_VER_20_API
+            assert(threads[i] == (ABT_thread)RAND_PTR);
+            threads[i] = ABT_THREAD_NULL;
+#else
+            assert(threads[i] == ABT_THREAD_NULL);
+#endif
+        }
+    }
+    /* Push and pop some threads. */
+    for (i = 0; i < 4; i++) {
+        ABT_pool target_pool = pools[i % 2];
+        ABT_pool mig_pool = pools[(i / 2) % 2];
+        ABT_unit unit;
+        ret = ABT_pool_pop(target_pool, &unit);
+        assert(ret == ABT_SUCCESS);
+        if (unit != ABT_UNIT_NULL) {
+            /* Push back to the pool. */
+            ret = ABT_pool_push(mig_pool, unit);
+            assert(!must_succeed || ret == ABT_SUCCESS);
+            if (ret != ABT_SUCCESS) {
+                /* If it is pushed to the same pool, the push operation may not
+                 * fail though this behavior is not clearly mentioned in the
+                 * specification. */
+                assert(mig_pool != target_pool);
+                ret = ABT_pool_push(target_pool, unit);
+                assert(ret == ABT_SUCCESS);
+            }
+        }
+    }
+    /* Execute these threads. */
+    for (i = 0; i < 4; i++) {
+        if (threads[i] != ABT_THREAD_NULL) {
+            ret = ABT_thread_free(&threads[i]);
+            assert(ret == ABT_SUCCESS);
+        }
+    }
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+}
+
+int main()
+{
+    setup_env();
+    rtrace_init();
+
+    int use_predef;
+    for (use_predef = 0; use_predef <= 1; use_predef++) {
+        do {
+            rtrace_start();
+            program(use_predef, 0);
+        } while (!rtrace_stop());
+        /* If no failure, it should succeed again. */
+        program(use_predef, 1);
+    }
+
+    rtrace_finalize();
+    return 0;
+}


### PR DESCRIPTION
This patch fixes #316.

## Problem

Whenever Argobots changes the unit-pool association (e.g., by using `ABT_unit_set_associated_pool()`, `ABT_xstream_set_main_sched()`, `ABT_pool_push()`, or `ABT_xstream_run_unit()`), the unit associated with the old pool must be freed (`u_free()`) and its thread's "unit" must be renewed by a new pool (`u_create_from_thread()`).

Argobots does not do this, which leaks resources and/or calls pool/unit functions that are not associated with a given `ABT_unit`.  This is also an API-level issue: `ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)` changes the associated pool of \c unit to \c pool, but then \c unit should be changed according to the new pool's `ABT_unit` representation.  Since this function does not take an old pool, the Argobots runtime cannot find a proper `u_free()` to free this the given `unit`.

This is not observed if the user uses a built-in pool (i.e., a pool that is *not* created by `ABT_pool_create()`).

## Solution

This PR fixes this issue by a new `ABT_unit` - `ABTI_pool` (via `ABTI_thread`) hash table so that the runtime can get the pool information from `ABT_unit`. This PR adds a new restriction to `ABT_unit` that `u_create_from_thread()` can return.
1. `ABT_unit` must be 4-byte aligned (so that Argobots can internally use the first 2 bits for built-in pools).
2. The value of `ABT_unit` is unique across systems.  For example, it can be `ABT_thread` or any memory region allocated by `malloc()`.

Specifically, Argobots internally has a hash table for `ABT_unit` and user-defined `ABTI_pool` mapping.  To use a hash table, `ABT_unit` must be unique.  `ABTI_unit` must be 4-byte aligned (or the first two bits are zero) so that the built-in `ABT_unit`, which most Argobots programs use, can be quickly distinguished and avoid using a relatively heavy hash table.

`ABT_unit_set_associated_pool()` becomes an empty function, but it does not change the existing program.  A typical use case of `ABT_unit_set_associated_pool()` should be as follows:
```c
ABT_unit unit;
ABT_pool_pop(remote_pool, &unit)
if (unit != ABT_UNIT_NULL) {
    ABT_unit_set_associated_pool(unit, local_pool);
    ABT_xstream_run_unit(unit, local_pool);
}
```
In this case, `ABT_xstream_run_unit()` will change the `unit`'s pool, so `ABT_unit_set_associated_pool()` gets unnecessary.
```c
ABT_unit unit;
ABT_pool_pop(remote_pool, &unit)
if (unit != ABT_UNIT_NULL) {
    // ABT_unit_set_associated_pool is not harmful, though.
    // ABT_unit_set_associated_pool(unit, local_pool);
    ABT_xstream_run_unit(unit, local_pool);
}
```

This automatic unit-pool association is done for all functions that change the unit/thread-pool mapping such as `ABT_xstream_run_unit()`, `ABT_pool_push()`, `ABT_thread_set_associated_pool()`, `ABT_xstream_set_main_sched()`, and `ABT_thread_revive()`.

### Performance Impact

This adds several branches, so this change should negatively affect the performance even for built-in pools.  To compensate the performance degradation, this PR inlines some unit functions, which would improve the performance.  Overall, the performance difference should be little.  In any case, this is for correctness and no matter how much it affects the performance, this fix should be merged.

If the user uses a user-defined pool, this PR adds a quite large overhead, but without this PR, a user-defined pool is not functional (unlike built-in pools, which work well without this PR).
