### PR TITLE
fcontext/arm64/osx: fix jump_fcontext for Apple M1 Chip

### DIFF
--- a/src/arch/fcontext/jump_arm64_aapcs_macho_gas.S
+++ b/src/arch/fcontext/jump_arm64_aapcs_macho_gas.S
@@ -54,7 +54,7 @@ _jump_fcontext:
     ; prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__)) && ABTD_FCONTEXT_PRESERVE_FPU
+#if ABTD_FCONTEXT_PRESERVE_FPU
     ; save d8 - d15
     stp  d8,  d9,  [sp, #0x00]
     stp  d10, d11, [sp, #0x10]
@@ -81,7 +81,7 @@ _jump_fcontext:
     ; restore RSP (pointing to context-data) from A2 (x1)
     mov  sp, x1
 
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__)) && ABTD_FCONTEXT_PRESERVE_FPU
+#if ABTD_FCONTEXT_PRESERVE_FPU
     ; load d8 - d15
     ldp  d8,  d9,  [sp, #0x00]
     ldp  d10, d11, [sp, #0x10]


### PR DESCRIPTION
## Pull Request Description

This PR fixes floating-point register management error on the new ARM-based Apple Chip.

Apple M1 Chip employs a 64-bit ARM-based architecture.  The default C compiler, as far as I checked, defines `__VFP_FP__` and/or `__SOFTFP__` differently.  Since people do not use ARM-based macOS other than the M1 chip, we should remove those macros to make Argobots work on M1.

Now Argobots passes all the tests on M1 as far as I checked.

We officially support the new Apple M1 Chip (as well as OSX), so please feel free to report any issues!
We note that, currently, the Argobots team cannot regularly access to M1. Once we deploy an M1 machine, we will test Argobots on M1 regularly.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
