### PR TITLE
abt.h: fix comments on ABT_mutex_memory and ABT_cond_memory

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1081,8 +1081,8 @@ typedef enum ABT_sync_event_type            ABT_sync_event_type;
  *
  * \c ABT_mutex_memory is a struct to statically allocate and initialize
  * \c ABT_mutex.  \c ABT_mutex_memory can be statically initialized by
- * \c ABT_MUTEX_MEMORY_INITIALIZER and \c ABT_RECURSIVE_MUTEX_INITIALIZER and
- * can be converted to \c ABT_mutex by \c ABT_MUTEX_MEMORY_GET_HANDLE().
+ * \c ABT_MUTEX_INITIALIZER and \c ABT_RECURSIVE_MUTEX_INITIALIZER and can be
+ * converted to \c ABT_mutex by \c ABT_MUTEX_MEMORY_GET_HANDLE().
  *
  * \c dummy may not be accessed by a user.
  */
@@ -1164,7 +1164,7 @@ typedef struct {
  *
  * \c ABT_cond_memory is a struct to statically allocate and initialize
  * \c ABT_cond.  \c ABT_cond_memory can be statically initialized by
- * \c ABT_COND_MEMORY_INITIALIZER and converted to \c ABT_cond by
+ * \c ABT_COND_INITIALIZER and converted to \c ABT_cond by
  * \c ABT_COND_MEMORY_GET_HANDLE().
  *
  * \c dummy may not be accessed by a user.


### PR DESCRIPTION

## Pull Request Description

`ABT_XXX_MEMORY_INITIALIZER` does not exist.  The correct name is `ABT_XXX_INITIALIZER` (e.g., `ABT_MUTEX_MEMORY_INITIALIZER`).  This patch fixes the comments.

Note that this patch does not affect any existing functionalities.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
