### PR TITLE
thread: fix mprotect-based stack guard 

### DIFF
--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -122,17 +122,31 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* ABT_THREAD_STACKSIZE, ABT_ENV_THREAD_STACKSIZE
      * Default stack size for ULT */
+    size_t default_thread_stacksize = ABTD_THREAD_DEFAULT_STACKSIZE;
+    if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT ||
+        p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT_STRICT) {
+        /* Maximum 2 pages are used for mprotect(), so let's increase the
+         * default stack size. */
+        default_thread_stacksize += p_global->sys_page_size * 2;
+    }
     p_global->thread_stacksize =
         ABTU_roundup_size(load_env_size("THREAD_STACKSIZE",
-                                        ABTD_THREAD_DEFAULT_STACKSIZE, 512,
+                                        default_thread_stacksize, 512,
                                         ABTD_ENV_SIZE_MAX),
                           ABT_CONFIG_STATIC_CACHELINE_SIZE);
 
     /* ABT_SCHED_STACKSIZE, ABT_ENV_SCHED_STACKSIZE
      * Default stack size for scheduler */
+    size_t default_sched_stacksize = ABTD_SCHED_DEFAULT_STACKSIZE;
+    if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT ||
+        p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT_STRICT) {
+        /* Maximum 2 pages are used for mprotect(), so let's increase the
+         * default stack size. */
+        default_sched_stacksize += p_global->sys_page_size * 2;
+    }
     p_global->sched_stacksize =
         ABTU_roundup_size(load_env_size("SCHED_STACKSIZE",
-                                        ABTD_SCHED_DEFAULT_STACKSIZE, 512,
+                                        default_sched_stacksize, 512,
                                         ABTD_ENV_SIZE_MAX),
                           ABT_CONFIG_STATIC_CACHELINE_SIZE);
 

--- a/test/basic/stack_guard.c
+++ b/test/basic/stack_guard.c
@@ -27,8 +27,10 @@ void segv_handler(int sig, siginfo_t *si, void *unused)
 {
     if (sig != SIGSEGV) {
         g_sig_err = 1; /* We cannot call assert(). */
+        signal(sig, SIG_DFL);
     } else if (si->si_addr != gp_stack) {
         g_sig_err = 2;
+        signal(SIGSEGV, SIG_DFL);
     } else {
         /* Since POSIX does not mark mprotect() as async-signal safe, we need to
          * ask another thread to call mprotect() instead of this thread even if


### PR DESCRIPTION
## Pull Request Description

PR #327 did not consider a system that has larger page sizes. For example, typically Intel x86/64 machines use 4KB pages while the other systems such as 64-bit ARM and POWER9 sometimes use 64KB pages or larger. This PR fixes the test as well as the stack size adjustment to support those systems.

This PR does not affect the behavior of Argobots unless you enable this stack guard.
<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
