### PR TITLE
info: suppress raw stack dump when it is requested

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,8 +253,11 @@ AC_ARG_WITH([libunwind],
 
 # --enable-stack-unwind
 AC_ARG_ENABLE([stack-unwind],
-    AS_HELP_STRING([--enable-stack-unwind],
-                   [enable stack unwinding, which is disabled by default.]))
+[  --enable-stack-unwind@<:@=OPTS@:>@ enable stack unwinding, which is disabled by default.
+        yes|verbose  - enable stack unwinding.  Dump the raw stack information too
+        unwind-only  - enable stack unwinding.  Do not dump the raw stack information
+        no|none      - disable stack unwinding
+],,[enable_stack_unwind=no])
 
 # --with-papi
 AC_ARG_WITH([papi],
@@ -843,7 +846,7 @@ if test "x$with_hugetlbfs" != "x"; then
 fi
 
 # --enable-stack-unwind
-if test "x$enable_stack_unwind" = "xyes"; then
+if test "x$enable_stack_unwind" = "xyes" -o "x$enable_stack_unwind" = "xverbose" -o "x$enable_stack_unwind" = "xunwind-only"; then
     # --with-libunwind
     if test "x$with_libunwind" != "x"; then
         PAC_PREPEND_FLAG([-I${with_libunwind}/include], [CFLAGS])
@@ -854,6 +857,9 @@ if test "x$enable_stack_unwind" = "xyes"; then
     if test x"$ac_cv_header_libunwind_h" = x"yes" -a x"$ac_cv_lib_unwind_unw_backtrace" = x"yes" ; then
         AC_DEFINE(ABT_CONFIG_ENABLE_STACK_UNWIND, 1, [Define to use the stack unwinding feature.])
         PAC_PREPEND_FLAG([-lunwind], [LDFLAGS])
+        AS_IF([test "x$enable_stack_unwind" = "xunwind-only"],
+              [AC_DEFINE(ABT_CONFIG_DISABLE_STACK_UNWIND_DUMP_RAW_STACK, 1,
+                         [Define to disable the raw stack dump by default.])])
     else
         AC_MSG_ERROR([libunwind is not found.  Either remove --enable-stack-unwind or \
 set --with-libunwind=LIBUNWIND_PREFIX_PATH.])

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -172,6 +172,13 @@ void ABTD_env_init(ABTI_global *p_global)
     p_global->mutex_max_wakeups =
         load_env_uint32("MUTEX_MAX_WAKEUPS", 1, 1, ABTD_ENV_UINT32_MAX);
 
+    /* ABT_PRINT_RAW_STACK, ABT_ENV_PRINT_RAW_STACK */
+    ABT_bool default_print_raw_stack = ABT_TRUE;
+#ifdef ABT_CONFIG_DISABLE_STACK_UNWIND_DUMP_RAW_STACK
+    default_print_raw_stack = ABT_FALSE;
+#endif
+    p_global->print_raw_stack =
+        load_env_bool("PRINT_RAW_STACK", default_print_raw_stack);
     /* ABT_HUGE_PAGE_SIZE, ABT_ENV_HUGE_PAGE_SIZE
      * Huge page size */
     size_t default_huge_page_size = (ABT_CONFIG_SYS_HUGE_PAGE_SIZE != 0)

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -214,6 +214,7 @@ struct ABTI_global {
     ABT_bool set_affinity;     /* Whether CPU affinity is used */
     ABT_bool use_logging;      /* Whether logging is used */
     ABT_bool use_debug;        /* Whether debug output is used */
+    ABT_bool print_raw_stack;  /* Print raw stack or not. */
     uint32_t key_table_size;   /* Default key table size */
     size_t thread_stacksize;   /* Default stack size for ULT (in bytes) */
     size_t sched_stacksize;    /* Default stack size for sched (in bytes) */
@@ -623,7 +624,8 @@ void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
                           ABTI_ythread *p_ythread,
                           ABT_sync_event_type sync_event_type, void *p_sync);
 void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread);
-void ABTI_ythread_print_stack(ABTI_ythread *p_ythread, FILE *p_os);
+void ABTI_ythread_print_stack(ABTI_global *p_global, ABTI_ythread *p_ythread,
+                              FILE *p_os);
 
 /* Thread attributes */
 void ABTI_thread_attr_print(ABTI_thread_attr *p_attr, FILE *p_os, int indent);

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -118,6 +118,8 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
             struct unwind_stack_t arg;
             arg.fp = p_os;
             ABTI_ythread_context_peek(p_ythread, ythread_unwind_stack, &arg);
+        } else {
+            fprintf(p_os, "failed to unwind a stack.\n");
         }
     }
 #endif


### PR DESCRIPTION
## Pull Request Description

This PR fixes #329.

Even if the stack unwinding feature is enabled (i.e., Argobots is compiled with libunwind) , Argobots dumps the raw ULT stack as well as the human-readable function trace. However, most developers cannot understand the raw stack.
```
...
000055f0d40accd0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
000055f0d40accf0: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
000055f0d40acd10: 0000000000000000 00000000000202f1 000055f0d40acbd0 00007f6b11440be0
000055f0d40acd30: 0000000000000020 0000000000000050 000055f0d40acd80 0000000000008000
...
```
This PR adds two ways to disable it.

#### Method A.
Pass `--enable-stack-unwind=unwind-only` at configure time.  This disables the raw stack dump by default.
```sh
./configure --enable-stack-unwind=unwind-only
```

***OR***

#### Method B.
Set `ABT_PRINT_RAW_STACK=false/no/off/n/0` (case insensitive) at execution time.  This **does not** require a configure-time setting.
```sh
ABT_PRINT_RAW_STACK=false ./prog.out
```

This PR does not add overheads in performance-critical paths. You can try this by running `test/basic/info_stackdump` and `test/basic/info_stackdump2`.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
