### PR TITLE
util: fix an argument of mmap

### DIFF
--- a/src/util/largepage.c
+++ b/src/util/largepage.c
@@ -33,7 +33,7 @@
 static void *mmap_regular(size_t size)
 {
 #if ABTU_LP_USE_MMAP
-    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_RP, 0, 0);
+    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_RP, -1, 0);
     return p_page != MAP_FAILED ? p_page : NULL;
 #else
     return NULL;
@@ -43,7 +43,7 @@ static void *mmap_regular(size_t size)
 static void *mmap_hugepage(size_t size)
 {
 #if ABTU_LP_USE_MMAP && ABTU_LP_USE_MMAP_HUGEPAGE
-    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_HP, 0, 0);
+    void *p_page = mmap(NULL, size, ABTU_LP_PROTS, ABTU_LP_FLAGS_HP, -1, 0);
     return p_page != MAP_FAILED ? p_page : NULL;
 #else
     return NULL;


### PR DESCRIPTION
## Pull Request Description

`fd` must be `-1` when `MAP_ANONYMOUS` or `MAP_ANON` is set for portability. For example, `mmap()` fails on FreeBSD if `fd` is `0`.  Note that Linux accepts both `0` and `-1`.

Linux `mmap()`:
https://man7.org/linux/man-pages/man2/mmap.2.html
FreeBSD `mmap()`:
https://www.freebsd.org/cgi/man.cgi?query=mmap&sektion=2&format=html
<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
