### PR TITLE
configure: clean up --enable-debug option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,11 +96,12 @@ AC_ARG_ENABLE([debug],
 [  --enable-debug@<:@=OPTS@:>@   control the level of debugging. "OPTS" is a list of
                           comma separated names below. Default is "yes".
         yes   - add compiler flags, -g -Wall
-        log   - enable debug event logging
-        all   - all of the above choices
-        most  - same as "all" but not print logs by default
-                (set ABT_ENV_USE_LOG to 1 for logging)
         err   - print abt_errno information on standard error
+        log   - print debug event logging
+                (set ABT_USE_LOG to 0 to disable logging)
+        all   - all of the above choices (equal to "yes,err,log")
+        most  - same as "all" but not print logs by default
+                (set ABT_USE_LOG to 1 to enable logging)
         none  - no debugging, i.e., --disable-debug
 ],,[enable_debug=none])
 
@@ -346,12 +347,10 @@ for option in $enable_debug ; do
             # log will be discarded.
             debug_log=yes
             debug_log_print=discard
-            debug_err=yes
         ;;
         log)
             debug_log=yes
             debug_log_print=yes
-            debug_err=yes
         ;;
         all-discard)
             debug_flags=yes


### PR DESCRIPTION

## Pull Request Description

Debug-logging and error-code printing should be orthogonal, but the current Argobots enables error-code printing (`--enable-debug=err`) if debug-logging is enabled (`--enable-debug=log`). The idea behind this change is that relying on error handling of Argobots is totally legal; error handling in Argobots gets more mature.

This patch cleans up the `--enable-debug` option.
1. Remove `debug_err=yes`, which enables printing the error code, from `--enable-debug=log`.  To enable this, `--enable-debug=err` must be set.
2. Clarify that `--enable-debug=all` and `most` include `--enable-debug=err`.

### Compatibility
This PR changes the behavior of `--enable-debug=log`; it does not print the error code in the latest version.  The previous
`--enable-debug=log` is equivalent to the current `--enable-debug=log,err`.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
