### PR TITLE
waitlist: fix ABTI_waitlist_is_empty

### DIFF
--- a/src/cond.c
+++ b/src/cond.c
@@ -93,7 +93,7 @@ int ABT_cond_free(ABT_cond *cond)
     ABTI_CHECK_NULL_COND_PTR(p_cond);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* This check will be removed in Argobots 2.0 */
-    ABTI_CHECK_TRUE(!ABTI_waitlist_is_empty(&p_cond->waitlist), ABT_ERR_COND);
+    ABTI_CHECK_TRUE(ABTI_waitlist_is_empty(&p_cond->waitlist), ABT_ERR_COND);
 #endif
 
     ABTI_cond_fini(p_cond);

--- a/src/include/abti_waitlist.h
+++ b/src/include/abti_waitlist.h
@@ -282,7 +282,7 @@ static inline void ABTI_waitlist_broadcast(ABTI_local *p_local,
 
 static inline ABT_bool ABTI_waitlist_is_empty(ABTI_waitlist *p_waitlist)
 {
-    return p_waitlist->p_head ? ABT_TRUE : ABT_FALSE;
+    return p_waitlist->p_head ? ABT_FALSE : ABT_TRUE;
 }
 
 #endif /* ABTI_WAITLIST_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

`ABTI_waitlist_is_empty()` returned `ABT_TRUE` if the `ABTI_waitlist` is "not" empty, but it worked correctly since its caller (`ABT_cond_free()`) also misused this function as if this function is "`ABTI_waitlist_not_empty()`". 

This patch fixes the implementation of `ABTI_waitlist_is_empty()` so that its name correctly explains what its body.

Note that this fix does not affect the behavior of Argobots.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
