### PR TITLE
error: assert when undefined behavior may occur

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,14 +95,15 @@ AC_ARG_ENABLE([affinity],
 AC_ARG_ENABLE([debug],
 [  --enable-debug@<:@=OPTS@:>@   control the level of debugging. "OPTS" is a list of
                           comma separated names below. Default is "yes".
-        yes   - add compiler flags, -g -Wall
-        err   - print abt_errno information on standard error
-        log   - print debug event logging
-                (set ABT_USE_LOG to 0 to disable logging)
-        all   - all of the above choices (equal to "yes,err,log")
-        most  - same as "all" but not print logs by default
-                (set ABT_USE_LOG to 1 to enable logging)
-        none  - no debugging, i.e., --disable-debug
+        yes       - add compiler flags, -g -Wall
+        err       - print abt_errno information on standard error
+        log       - print debug event logging
+                    (set ABT_USE_LOG to 0 to disable logging)
+        ub_assert - assert if the runtime detects possible undefined behavior
+        all       - all of the above choices (equal to "yes,err,log,ub_assert")
+        most      - same as "all" but not print logs by default
+                    (set ABT_USE_LOG to 1 to enable logging)
+        none      - no debugging, i.e., --disable-debug
 ],,[enable_debug=none])
 
 # --enable-fast
@@ -336,6 +337,7 @@ debug_flags=no
 debug_log=no
 debug_log_print=no
 debug_err=no
+debug_ub_assert=no
 for option in $enable_debug ; do
     case "$option" in
         yes)
@@ -352,23 +354,29 @@ for option in $enable_debug ; do
             debug_log=yes
             debug_log_print=yes
         ;;
+        ub_assert)
+            debug_ub_assert=yes
+        ;;
         all-discard)
             debug_flags=yes
             debug_log=yes
             debug_log_print=discard
             debug_err=yes
+            debug_ub_assert=yes
         ;;
         all)
             debug_flags=yes
             debug_log=yes
             debug_log_print=yes
             debug_err=yes
+            debug_ub_assert=yes
         ;;
         most)
             debug_flags=yes
             debug_log=yes
             debug_log_print=no
             debug_err=yes
+            debug_ub_assert=yes
         ;;
         err)
             debug_err=yes
@@ -377,6 +385,7 @@ for option in $enable_debug ; do
             debug_err=no
             debug_flags=no
             debug_log=no
+            debug_ub_assert=no
         ;;
         *)
             IFS=$save_IFS
@@ -406,6 +415,9 @@ AS_IF([test "x$debug_log_print" = "xdiscard"],
 AS_IF([test "x$debug_err" = "xyes"],
     [AC_DEFINE(ABT_CONFIG_PRINT_ABT_ERRNO, 1,
         [Define to enable printing abt_errno upon abt call error])])
+AS_IF([test "x$debug_ub_assert" != "xyes"],
+    [AC_DEFINE(ABT_CONFIG_DISABLE_UB_ASSERT, 1,
+        [Define to disable undefined-behavior assertion])])
 
 
 # --enable-fast: compiler optimization flags

--- a/src/barrier.c
+++ b/src/barrier.c
@@ -46,6 +46,9 @@
  */
 int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newbarrier);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newbarrier to NULL on error. */
     *newbarrier = ABT_BARRIER_NULL;
@@ -98,9 +101,11 @@ int ABT_barrier_create(uint32_t num_waiters, ABT_barrier *newbarrier)
  */
 int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
-    ABTI_ASSERT(p_barrier->counter == 0);
+    ABTI_UB_ASSERT(p_barrier->counter == 0);
     ABTI_CHECK_TRUE(num_waiters != 0, ABT_ERR_INV_ARG);
     size_t arg_num_waiters = num_waiters;
 
@@ -138,6 +143,9 @@ int ABT_barrier_reinit(ABT_barrier barrier, uint32_t num_waiters)
  */
 int ABT_barrier_free(ABT_barrier *barrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(barrier);
+
     ABT_barrier h_barrier = *barrier;
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
@@ -148,7 +156,7 @@ int ABT_barrier_free(ABT_barrier *barrier)
     ABTD_spinlock_acquire(&p_barrier->lock);
 
     /* p_barrier->counter must be checked after taking a lock. */
-    ABTI_ASSERT(p_barrier->counter == 0);
+    ABTI_UB_ASSERT(p_barrier->counter == 0);
 
     ABTU_free(p_barrier);
 
@@ -188,6 +196,8 @@ int ABT_barrier_free(ABT_barrier *barrier)
  */
 int ABT_barrier_wait(ABT_barrier barrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
@@ -247,6 +257,9 @@ int ABT_barrier_wait(ABT_barrier barrier)
  */
 int ABT_barrier_get_num_waiters(ABT_barrier barrier, uint32_t *num_waiters)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(num_waiters);
+
     ABTI_barrier *p_barrier = ABTI_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_BARRIER_PTR(p_barrier);
 

--- a/src/eventual.c
+++ b/src/eventual.c
@@ -41,6 +41,9 @@
  */
 int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(neweventual);
+
     int abt_errno;
     ABTI_eventual *p_eventual;
     ABTI_CHECK_TRUE(nbytes >= 0, ABT_ERR_INV_ARG);
@@ -95,6 +98,9 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
  */
 int ABT_eventual_free(ABT_eventual *eventual)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(eventual);
+
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(*eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
 
@@ -102,6 +108,7 @@ int ABT_eventual_free(ABT_eventual *eventual)
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
     ABTD_spinlock_acquire(&p_eventual->lock);
+    ABTI_UB_ASSERT(ABTI_waitlist_is_empty(&p_eventual->waitlist));
 
     if (p_eventual->value)
         ABTU_free(p_eventual->value);
@@ -162,6 +169,8 @@ int ABT_eventual_free(ABT_eventual *eventual)
  */
 int ABT_eventual_wait(ABT_eventual eventual, void **value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
@@ -235,6 +244,9 @@ int ABT_eventual_wait(ABT_eventual eventual, void **value)
  */
 int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_ready);
+
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
     ABT_bool flag = ABT_FALSE;
@@ -299,6 +311,9 @@ int ABT_eventual_test(ABT_eventual eventual, void **value, ABT_bool *is_ready)
  */
 int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(value || nbytes <= 0);
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
@@ -358,10 +373,13 @@ int ABT_eventual_set(ABT_eventual eventual, void *value, int nbytes)
  */
 int ABT_eventual_reset(ABT_eventual eventual)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_eventual *p_eventual = ABTI_eventual_get_ptr(eventual);
     ABTI_CHECK_NULL_EVENTUAL_PTR(p_eventual);
 
     ABTD_spinlock_acquire(&p_eventual->lock);
+    ABTI_UB_ASSERT(ABTI_waitlist_is_empty(&p_eventual->waitlist));
     p_eventual->ready = ABT_FALSE;
     ABTD_spinlock_release(&p_eventual->lock);
     return ABT_SUCCESS;

--- a/src/futures.c
+++ b/src/futures.c
@@ -61,6 +61,9 @@
 int ABT_future_create(uint32_t num_compartments, void (*cb_func)(void **arg),
                       ABT_future *newfuture)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newfuture);
+
     int abt_errno;
     ABTI_future *p_future;
     size_t arg_num_compartments = num_compartments;
@@ -115,6 +118,9 @@ int ABT_future_create(uint32_t num_compartments, void (*cb_func)(void **arg),
  */
 int ABT_future_free(ABT_future *future)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(future);
+
     ABTI_future *p_future = ABTI_future_get_ptr(*future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
@@ -122,6 +128,7 @@ int ABT_future_free(ABT_future *future)
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
     ABTD_spinlock_acquire(&p_future->lock);
+    ABTI_UB_ASSERT(ABTI_waitlist_is_empty(&p_future->waitlist));
 
     ABTU_free(p_future->array);
     ABTU_free(p_future);
@@ -164,6 +171,8 @@ int ABT_future_free(ABT_future *future)
  */
 int ABT_future_wait(ABT_future future)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
@@ -219,6 +228,9 @@ int ABT_future_wait(ABT_future future)
  */
 int ABT_future_test(ABT_future future, ABT_bool *is_ready)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_ready);
+
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
@@ -257,6 +269,8 @@ int ABT_future_test(ABT_future future, ABT_bool *is_ready)
  */
 int ABT_future_set(ABT_future future, void *value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
@@ -322,10 +336,13 @@ int ABT_future_set(ABT_future future, void *value)
  */
 int ABT_future_reset(ABT_future future)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_future *p_future = ABTI_future_get_ptr(future);
     ABTI_CHECK_NULL_FUTURE_PTR(p_future);
 
     ABTD_spinlock_acquire(&p_future->lock);
+    ABTI_UB_ASSERT(ABTI_waitlist_is_empty(&p_future->waitlist));
     ABTD_atomic_release_store_size(&p_future->counter, 0);
     ABTD_spinlock_release(&p_future->lock);
     return ABT_SUCCESS;

--- a/src/global.c
+++ b/src/global.c
@@ -140,6 +140,8 @@ int ABT_init(int argc, char **argv)
  */
 int ABT_finalize(void)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     /* Take a global lock protecting the initialization/finalization process. */
     ABTD_spinlock_acquire(&g_ABTI_init_lock);
     int abt_errno = finailze_library();

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -28,6 +28,12 @@
 #define ABTI_IS_EXT_THREAD_ENABLED 1
 #endif
 
+#ifdef ABT_CONFIG_DISABLE_UB_ASSERT
+#define ABTI_IS_UB_ASSERT_ENABLED 0
+#else
+#define ABTI_IS_UB_ASSERT_ENABLED 1
+#endif
+
 #include "abtu.h"
 #include "abti_error.h"
 #include "abti_valgrind.h"

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -515,6 +515,9 @@ extern ABTI_local_func gp_ABTI_local_func;
 /* ES Local Data */
 extern ABTD_XSTREAM_LOCAL ABTI_local *lp_ABTI_local;
 
+/* Global information */
+ABT_bool ABTI_initialized(void);
+
 /* Execution Stream (ES) */
 ABTU_ret_err int ABTI_xstream_create_primary(ABTI_global *p_global,
                                              ABTI_xstream **pp_xstream);

--- a/src/include/abti_cond.h
+++ b/src/include/abti_cond.h
@@ -23,6 +23,7 @@ static inline void ABTI_cond_fini(ABTI_cond *p_cond)
      * However, we do not have to unlock it because the entire structure is
      * freed here. */
     ABTD_spinlock_acquire(&p_cond->lock);
+    ABTI_UB_ASSERT(ABTI_waitlist_is_empty(&p_cond->waitlist));
 }
 
 static inline ABTI_cond *ABTI_cond_get_ptr(ABT_cond cond)

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -23,6 +23,15 @@
         }                                                                      \
     } while (0)
 
+#define ABTI_UB_ASSERT_BOOL(bool_val)                                          \
+    do {                                                                       \
+        if (ABTI_IS_UB_ASSERT_ENABLED) {                                       \
+            ABT_bool bool_val_tmp = (bool_val);                                \
+            ABTI_ASSERT(bool_val_tmp == ABT_TRUE ||                            \
+                        bool_val_tmp == ABT_FALSE);                            \
+        }                                                                      \
+    } while (0)
+
 #define ABTI_STATIC_ASSERT(cond)                                               \
     do {                                                                       \
         ((void)sizeof(char[2 * !!(cond)-1]));                                  \

--- a/src/include/abti_error.h
+++ b/src/include/abti_error.h
@@ -16,6 +16,13 @@
         }                                                                      \
     } while (0)
 
+#define ABTI_UB_ASSERT(cond)                                                   \
+    do {                                                                       \
+        if (ABTI_IS_UB_ASSERT_ENABLED) {                                       \
+            ABTI_ASSERT(cond);                                                 \
+        }                                                                      \
+    } while (0)
+
 #define ABTI_STATIC_ASSERT(cond)                                               \
     do {                                                                       \
         ((void)sizeof(char[2 * !!(cond)-1]));                                  \

--- a/src/include/abti_mutex.h
+++ b/src/include/abti_mutex.h
@@ -113,6 +113,11 @@ static inline void ABTI_mutex_lock(ABTI_local **pp_local, ABTI_mutex *p_mutex)
     }
 }
 
+static inline ABT_bool ABTI_mutex_is_locked(ABTI_mutex *p_mutex)
+{
+    return ABTD_spinlock_is_locked(&p_mutex->lock);
+}
+
 static inline int ABTI_mutex_trylock_no_recursion(ABTI_mutex *p_mutex)
 {
     return ABTD_spinlock_try_acquire(&p_mutex->lock) ? ABT_ERR_MUTEX_LOCKED

--- a/src/info.c
+++ b/src/info.c
@@ -209,6 +209,8 @@ static void info_trigger_print_all_thread_stacks(
  */
 int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 {
+    ABTI_UB_ASSERT(val);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
     ABTI_SETUP_GLOBAL(NULL);
@@ -420,6 +422,8 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
  */
 int ABT_info_print_config(FILE *fp)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_global *p_global;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
@@ -467,6 +471,8 @@ int ABT_info_print_config(FILE *fp)
  */
 int ABT_info_print_all_xstreams(FILE *fp)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_global *p_global;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x always requires an init check. */
@@ -528,6 +534,8 @@ int ABT_info_print_all_xstreams(FILE *fp)
  */
 int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -569,6 +577,8 @@ int ABT_info_print_xstream(FILE *fp, ABT_xstream xstream)
  */
 int ABT_info_print_sched(FILE *fp, ABT_sched sched)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -610,6 +620,8 @@ int ABT_info_print_sched(FILE *fp, ABT_sched sched)
  */
 int ABT_info_print_pool(FILE *fp, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -655,6 +667,8 @@ int ABT_info_print_pool(FILE *fp, ABT_pool pool)
  */
 int ABT_info_print_thread(FILE *fp, ABT_thread thread)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -696,6 +710,8 @@ int ABT_info_print_thread(FILE *fp, ABT_thread thread)
  */
 int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -742,6 +758,8 @@ int ABT_info_print_thread_attr(FILE *fp, ABT_thread_attr attr)
  */
 int ABT_info_print_task(FILE *fp, ABT_task task)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(task);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -788,6 +806,11 @@ int ABT_info_print_task(FILE *fp, ABT_task task)
  */
 int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
 {
+    ABTI_UB_ASSERT(fp);
+    /* We can check if thread is running or not in ABTI_UB_ASSERT(), but as this
+     * info function is basically used for debugging, printing a corrupted stack
+     * or even crashing a program would be fine. */
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -848,6 +871,8 @@ int ABT_info_print_thread_stack(FILE *fp, ABT_thread thread)
  */
 int ABT_info_print_thread_stacks_in_pool(FILE *fp, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(fp);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x requires a NULL-handle check. */
@@ -932,6 +957,7 @@ int ABT_info_trigger_print_all_thread_stacks(FILE *fp, double timeout,
                                              void (*cb_func)(ABT_bool, void *),
                                              void *arg)
 {
+    /* assert() is not signal safe, so we cannot validate variables. */
     info_trigger_print_all_thread_stacks(fp, timeout, cb_func, arg);
     return ABT_SUCCESS;
 }

--- a/src/key.c
+++ b/src/key.c
@@ -65,6 +65,9 @@ static ABTD_atomic_uint32 g_key_id =
  */
 int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newkey);
+
     ABTI_key *p_newkey;
     int abt_errno = ABTU_malloc(sizeof(ABTI_key), (void **)&p_newkey);
     ABTI_CHECK_ERROR(abt_errno);
@@ -108,6 +111,9 @@ int ABT_key_create(void (*destructor)(void *value), ABT_key *newkey)
  */
 int ABT_key_free(ABT_key *key)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(key);
+
     ABT_key h_key = *key;
     ABTI_key *p_key = ABTI_key_get_ptr(h_key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
@@ -155,6 +161,10 @@ int ABT_key_free(ABT_key *key)
  */
 int ABT_key_set(ABT_key key, void *value)
 {
+#ifdef ABT_CONFIG_ENABLE_VER_20_API
+    ABTI_UB_ASSERT(ABTI_initialized());
+#endif
+
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
@@ -210,6 +220,11 @@ int ABT_key_set(ABT_key key, void *value)
  */
 int ABT_key_get(ABT_key key, void **value)
 {
+    ABTI_UB_ASSERT(value);
+#ifdef ABT_CONFIG_ENABLE_VER_20_API
+    ABTI_UB_ASSERT(ABTI_initialized());
+#endif
+
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -38,6 +38,9 @@
  */
 int ABT_mutex_create(ABT_mutex *newmutex)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newmutex);
+
     /* Check if the size of ABT_mutex_memory is okay. */
     ABTI_STATIC_ASSERT(sizeof(ABTI_mutex) <= sizeof(ABT_mutex_memory));
 
@@ -97,6 +100,9 @@ int ABT_mutex_create(ABT_mutex *newmutex)
  */
 int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newmutex);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newmutex to NULL on error. */
     *newmutex = ABT_MUTEX_NULL;
@@ -144,10 +150,12 @@ int ABT_mutex_create_with_attr(ABT_mutex_attr attr, ABT_mutex *newmutex)
  */
 int ABT_mutex_free(ABT_mutex *mutex)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(mutex);
+
     ABT_mutex h_mutex = *mutex;
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(h_mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
-
     ABTU_free(p_mutex);
 
     /* Return value */
@@ -359,6 +367,14 @@ int ABT_mutex_unlock(ABT_mutex mutex)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
+
+    /* Check if a given mutex is legal. */
+    /* p_mutex must be locked. */
+    ABTI_UB_ASSERT(ABTI_mutex_is_locked(p_mutex));
+    /* If p_mutex is recursive, the caller of this function must be an owner. */
+    ABTI_UB_ASSERT(!((p_mutex->attrs & ABTI_MUTEX_ATTR_RECURSIVE) &&
+                     p_mutex->owner_id != ABTI_self_get_thread_id(p_local)));
+
     ABTI_mutex_unlock(p_local, p_mutex);
     return ABT_SUCCESS;
 }
@@ -403,6 +419,14 @@ int ABT_mutex_unlock_se(ABT_mutex mutex)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
+
+    /* Check if a given mutex is legal. */
+    /* p_mutex must be locked. */
+    ABTI_UB_ASSERT(ABTI_mutex_is_locked(p_mutex));
+    /* If p_mutex is recursive, the caller of this function must be an owner. */
+    ABTI_UB_ASSERT(!((p_mutex->attrs & ABTI_MUTEX_ATTR_RECURSIVE) &&
+                     p_mutex->owner_id != ABTI_self_get_thread_id(p_local)));
+
     ABTI_mutex_unlock(p_local, p_mutex);
     return ABT_SUCCESS;
 }
@@ -447,6 +471,14 @@ int ABT_mutex_unlock_de(ABT_mutex mutex)
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
+
+    /* Check if a given mutex is legal. */
+    /* p_mutex must be locked. */
+    ABTI_UB_ASSERT(ABTI_mutex_is_locked(p_mutex));
+    /* If p_mutex is recursive, the caller of this function must be an owner. */
+    ABTI_UB_ASSERT(!((p_mutex->attrs & ABTI_MUTEX_ATTR_RECURSIVE) &&
+                     p_mutex->owner_id != ABTI_self_get_thread_id(p_local)));
+
     ABTI_mutex_unlock(p_local, p_mutex);
     return ABT_SUCCESS;
 }
@@ -480,6 +512,8 @@ int ABT_mutex_unlock_de(ABT_mutex mutex)
  */
 int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
 {
+    ABTI_UB_ASSERT(result);
+
     ABTI_mutex *p_mutex1 = ABTI_mutex_get_ptr(mutex1);
     ABTI_mutex *p_mutex2 = ABTI_mutex_get_ptr(mutex2);
     *result = (p_mutex1 == p_mutex2) ? ABT_TRUE : ABT_FALSE;
@@ -513,6 +547,9 @@ int ABT_mutex_equal(ABT_mutex mutex1, ABT_mutex mutex2, ABT_bool *result)
  */
 int ABT_mutex_get_attr(ABT_mutex mutex, ABT_mutex_attr *attr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(attr);
+
     ABTI_mutex *p_mutex = ABTI_mutex_get_ptr(mutex);
     ABTI_CHECK_NULL_MUTEX_PTR(p_mutex);
 

--- a/src/mutex_attr.c
+++ b/src/mutex_attr.c
@@ -38,6 +38,9 @@
  */
 int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newattr);
+
     ABTI_mutex_attr *p_newattr;
 
     int abt_errno = ABTU_malloc(sizeof(ABTI_mutex_attr), (void **)&p_newattr);
@@ -75,6 +78,9 @@ int ABT_mutex_attr_create(ABT_mutex_attr *newattr)
  */
 int ABT_mutex_attr_free(ABT_mutex_attr *attr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(attr);
+
     ABT_mutex_attr h_attr = *attr;
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(h_attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
@@ -113,6 +119,9 @@ int ABT_mutex_attr_free(ABT_mutex_attr *attr)
  */
 int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT_BOOL(recursive);
+
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
 
@@ -152,6 +161,9 @@ int ABT_mutex_attr_set_recursive(ABT_mutex_attr attr, ABT_bool recursive)
  */
 int ABT_mutex_attr_get_recursive(ABT_mutex_attr attr, ABT_bool *recursive)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(recursive);
+
     ABTI_mutex_attr *p_attr = ABTI_mutex_attr_get_ptr(attr);
     ABTI_CHECK_NULL_MUTEX_ATTR_PTR(p_attr);
 

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -73,6 +73,15 @@ ABTU_ret_err static int pool_create(ABTI_pool_def *def, ABT_pool_config config,
 int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
                     ABT_pool *newpool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newpool);
+    ABTI_UB_ASSERT(def);
+    ABTI_UB_ASSERT(def->u_create_from_thread);
+    ABTI_UB_ASSERT(def->u_free);
+    ABTI_UB_ASSERT(def->p_get_size);
+    ABTI_UB_ASSERT(def->p_push);
+    ABTI_UB_ASSERT(def->p_pop);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newpool to NULL on error. */
     *newpool = ABT_POOL_NULL;
@@ -167,6 +176,10 @@ int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,
 int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
                           ABT_bool automatic, ABT_pool *newpool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT_BOOL(automatic);
+    ABTI_UB_ASSERT(newpool);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newpool to NULL on error. */
     *newpool = ABT_POOL_NULL;
@@ -210,9 +223,13 @@ int ABT_pool_create_basic(ABT_pool_kind kind, ABT_pool_access access,
  */
 int ABT_pool_free(ABT_pool *pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pool);
+
     ABT_pool h_pool = *pool;
     ABTI_pool *p_pool = ABTI_pool_get_ptr(h_pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_UB_ASSERT(p_pool->p_get_size(h_pool) == 0);
 
     ABTI_pool_free(p_pool);
 
@@ -244,6 +261,9 @@ int ABT_pool_free(ABT_pool *pool)
  */
 int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(access);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -290,6 +310,9 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access)
  */
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(size);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -333,6 +356,9 @@ int ABT_pool_get_total_size(ABT_pool pool, size_t *size)
  */
 int ABT_pool_get_size(ABT_pool pool, size_t *size)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(size);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -387,6 +413,9 @@ int ABT_pool_get_size(ABT_pool pool, size_t *size)
  */
 int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(p_unit);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -445,6 +474,9 @@ int ABT_pool_pop(ABT_pool pool, ABT_unit *p_unit)
  */
 int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(p_unit);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(p_pool->p_pop_wait, ABT_ERR_POOL);
@@ -509,6 +541,9 @@ int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *p_unit, double time_secs)
  */
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(p_unit);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(p_pool->p_pop_timedwait, ABT_ERR_POOL);
@@ -558,6 +593,8 @@ int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *p_unit, double abstime_secs)
  */
 int ABT_pool_push(ABT_pool pool, ABT_unit unit)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
@@ -616,6 +653,8 @@ int ABT_pool_push(ABT_pool pool, ABT_unit unit)
  */
 int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(p_pool->p_remove, ABT_ERR_POOL);
@@ -673,6 +712,9 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit)
 int ABT_pool_print_all(ABT_pool pool, void *arg,
                        void (*print_fn)(void *, ABT_unit))
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(print_fn);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(p_pool->p_print_all, ABT_ERR_POOL);
@@ -705,6 +747,8 @@ int ABT_pool_print_all(ABT_pool pool, void *arg,
  */
 int ABT_pool_set_data(ABT_pool pool, void *data)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -738,6 +782,9 @@ int ABT_pool_set_data(ABT_pool pool, void *data)
  */
 int ABT_pool_get_data(ABT_pool pool, void **data)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(data);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 
@@ -790,6 +837,8 @@ int ABT_pool_get_data(ABT_pool pool, void **data)
  */
 int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_global *p_global;
@@ -804,6 +853,8 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
     /* Mark the scheduler as it is used in pool */
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_INV_SCHED);
+#else
+    ABTI_UB_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
 #endif
     p_sched->used = ABTI_SCHED_IN_POOL;
 
@@ -843,6 +894,9 @@ int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched)
  */
 int ABT_pool_get_id(ABT_pool pool, int *id)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(id);
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
 

--- a/src/rwlock.c
+++ b/src/rwlock.c
@@ -39,6 +39,9 @@
  */
 int ABT_rwlock_create(ABT_rwlock *newrwlock)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newrwlock);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newrwlock to NULL on error. */
     *newrwlock = ABT_RWLOCK_NULL;
@@ -86,6 +89,9 @@ int ABT_rwlock_create(ABT_rwlock *newrwlock)
  */
 int ABT_rwlock_free(ABT_rwlock *rwlock)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(rwlock);
+
     ABT_rwlock h_rwlock = *rwlock;
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(h_rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
@@ -137,6 +143,8 @@ int ABT_rwlock_free(ABT_rwlock *rwlock)
  */
 int ABT_rwlock_rdlock(ABT_rwlock rwlock)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
@@ -198,6 +206,8 @@ int ABT_rwlock_rdlock(ABT_rwlock rwlock)
  */
 int ABT_rwlock_wrlock(ABT_rwlock rwlock)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
@@ -252,6 +262,8 @@ int ABT_rwlock_wrlock(ABT_rwlock rwlock)
  */
 int ABT_rwlock_unlock(ABT_rwlock rwlock)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_rwlock *p_rwlock = ABTI_rwlock_get_ptr(rwlock);
     ABTI_CHECK_NULL_RWLOCK_PTR(p_rwlock);
@@ -260,6 +272,7 @@ int ABT_rwlock_unlock(ABT_rwlock rwlock)
     if (p_rwlock->write_flag) {
         p_rwlock->write_flag = 0;
     } else {
+        ABTI_UB_ASSERT(p_rwlock->reader_count > 0);
         p_rwlock->reader_count--;
     }
     ABTI_cond_broadcast(p_local, &p_rwlock->cond);

--- a/src/sched/sched.c
+++ b/src/sched/sched.c
@@ -91,10 +91,17 @@ static inline uint64_t sched_get_new_id(void);
 int ABT_sched_create(ABT_sched_def *def, int num_pools, ABT_pool *pools,
                      ABT_sched_config config, ABT_sched *newsched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(def);
+    ABTI_UB_ASSERT(def->run);
+    ABTI_UB_ASSERT(pools || num_pools == 0);
+
     ABTI_sched *p_sched;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *newsched = ABT_SCHED_NULL;
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
+#else
+    ABTI_UB_ASSERT(newsched);
 #endif
     ABTI_CHECK_TRUE(num_pools >= 0, ABT_ERR_INV_ARG);
 
@@ -175,9 +182,13 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
                            ABT_pool *pools, ABT_sched_config config,
                            ABT_sched *newsched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *newsched = ABT_SCHED_NULL;
     ABTI_CHECK_TRUE(newsched != NULL, ABT_ERR_SCHED);
+#else
+    ABTI_UB_ASSERT(newsched);
 #endif
     ABTI_CHECK_TRUE(num_pools >= 0, ABT_ERR_INV_ARG);
 
@@ -233,6 +244,9 @@ int ABT_sched_create_basic(ABT_sched_predef predef, int num_pools,
  */
 int ABT_sched_free(ABT_sched *sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(sched);
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
     ABTI_local *p_local = ABTI_local_get_local();
@@ -240,6 +254,8 @@ int ABT_sched_free(ABT_sched *sched)
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED, ABT_ERR_SCHED);
+#else
+    ABTI_UB_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
 #endif
 
     /* Free the scheduler */
@@ -274,6 +290,9 @@ int ABT_sched_free(ABT_sched *sched)
  */
 int ABT_sched_get_num_pools(ABT_sched sched, int *num_pools)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(num_pools);
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -320,6 +339,9 @@ int ABT_sched_get_num_pools(ABT_sched sched, int *num_pools)
 int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
                         ABT_pool *pools)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pools || max_pools > 0);
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
     ABTI_CHECK_TRUE(max_pools >= 0, ABT_ERR_INV_ARG);
@@ -372,6 +394,8 @@ int ABT_sched_get_pools(ABT_sched sched, int max_pools, int idx,
  */
 int ABT_sched_finish(ABT_sched sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -409,6 +433,8 @@ int ABT_sched_finish(ABT_sched sched)
  */
 int ABT_sched_exit(ABT_sched sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -455,6 +481,9 @@ int ABT_sched_exit(ABT_sched sched)
  */
 int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(stop);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *stop = ABT_FALSE;
 #endif
@@ -493,6 +522,8 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop)
  */
 int ABT_sched_set_data(ABT_sched sched, void *data)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -525,6 +556,9 @@ int ABT_sched_set_data(ABT_sched sched, void *data)
  */
 int ABT_sched_get_data(ABT_sched sched, void **data)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(data);
+
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
     ABTI_CHECK_NULL_SCHED_PTR(p_sched);
 
@@ -567,6 +601,9 @@ int ABT_sched_get_data(ABT_sched sched, void **data)
  */
 int ABT_sched_get_size(ABT_sched sched, size_t *size)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(size);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *size = 0;
 #endif
@@ -615,6 +652,9 @@ int ABT_sched_get_size(ABT_sched sched, size_t *size)
  */
 int ABT_sched_get_total_size(ABT_sched sched, size_t *size)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(size);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *size = 0;
 #endif

--- a/src/self.c
+++ b/src/self.c
@@ -32,6 +32,9 @@
  */
 int ABT_self_get_xstream(ABT_xstream *xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(xstream);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -64,6 +67,9 @@ int ABT_self_get_xstream(ABT_xstream *xstream)
  */
 int ABT_self_get_xstream_rank(int *rank)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(rank);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     /* Return value */
@@ -94,6 +100,9 @@ int ABT_self_get_xstream_rank(int *rank)
  */
 int ABT_self_get_thread(ABT_thread *thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *thread = ABTI_thread_get_handle(p_local_xstream->p_thread);
@@ -123,6 +132,9 @@ int ABT_self_get_thread(ABT_thread *thread)
  */
 int ABT_self_get_thread_id(ABT_unit_id *id)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(id);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *id = ABTI_thread_get_id(p_local_xstream->p_thread);
@@ -178,6 +190,8 @@ int ABT_self_get_task_id(ABT_unit_id *id);
  */
 int ABT_self_set_specific(ABT_key key, void *value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
@@ -225,6 +239,9 @@ int ABT_self_set_specific(ABT_key key, void *value)
  */
 int ABT_self_get_specific(ABT_key key, void **value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(value);
+
     ABTI_key *p_key = ABTI_key_get_ptr(key);
     ABTI_CHECK_NULL_KEY_PTR(p_key);
 
@@ -273,6 +290,8 @@ int ABT_self_get_specific(ABT_key key, void **value)
  */
 int ABT_self_get_type(ABT_unit_type *type)
 {
+    ABTI_UB_ASSERT(type);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* By default, type is ABT_UNIT_TYPE_EXT in Argobots 1.x */
     *type = ABT_UNIT_TYPE_EXT;
@@ -281,6 +300,7 @@ int ABT_self_get_type(ABT_unit_type *type)
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *type = ABTI_thread_type_get_type(p_local_xstream->p_thread->type);
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream_or_null(ABTI_local_get_local());
     if (p_local_xstream) {
@@ -330,6 +350,8 @@ int ABT_self_get_type(ABT_unit_type *type)
  */
 int ABT_self_is_primary(ABT_bool *is_primary)
 {
+    ABTI_UB_ASSERT(is_primary);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *is_primary = ABT_FALSE;
     ABTI_SETUP_GLOBAL(NULL);
@@ -339,6 +361,7 @@ int ABT_self_is_primary(ABT_bool *is_primary)
                       ? ABT_TRUE
                       : ABT_FALSE;
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream_or_null(ABTI_local_get_local());
     if (p_local_xstream) {
@@ -390,6 +413,8 @@ int ABT_self_is_primary(ABT_bool *is_primary)
  */
 int ABT_self_on_primary_xstream(ABT_bool *on_primary)
 {
+    ABTI_UB_ASSERT(on_primary);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *on_primary = ABT_FALSE;
     ABTI_SETUP_GLOBAL(NULL);
@@ -399,6 +424,7 @@ int ABT_self_on_primary_xstream(ABT_bool *on_primary)
                       ? ABT_TRUE
                       : ABT_FALSE;
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream_or_null(ABTI_local_get_local());
     if (p_local_xstream) {
@@ -435,6 +461,9 @@ int ABT_self_on_primary_xstream(ABT_bool *on_primary)
  */
 int ABT_self_get_last_pool(ABT_pool *pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pool);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     ABTI_thread *p_self = p_local_xstream->p_thread;
@@ -473,6 +502,8 @@ int ABT_self_get_last_pool(ABT_pool *pool)
  */
 int ABT_self_get_last_pool_id(int *pool_id)
 {
+    ABTI_UB_ASSERT(pool_id);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *pool_id = -1;
@@ -482,6 +513,7 @@ int ABT_self_get_last_pool_id(int *pool_id)
     ABTI_ASSERT(p_self->p_pool);
     *pool_id = p_self->p_pool->id;
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     ABTI_thread *p_self = p_local_xstream->p_thread;
     ABTI_ASSERT(p_self->p_pool);
@@ -517,6 +549,8 @@ int ABT_self_get_last_pool_id(int *pool_id)
  */
 int ABT_self_set_associated_pool(ABT_pool pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
@@ -552,6 +586,9 @@ int ABT_self_set_associated_pool(ABT_pool pool)
  */
 int ABT_self_get_unit(ABT_unit *unit)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(unit);
+
     /* We don't allow an external thread to call this routine. */
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
@@ -582,6 +619,8 @@ int ABT_self_get_unit(ABT_unit *unit)
  */
 int ABT_self_yield(void)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_ythread;
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
@@ -622,6 +661,8 @@ int ABT_self_yield(void)
  */
 int ABT_self_suspend(void)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_self;
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_self);
@@ -654,6 +695,8 @@ int ABT_self_suspend(void)
  */
 int ABT_self_exit(void)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_ythread;
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
@@ -698,6 +741,8 @@ int ABT_self_set_arg(void *arg)
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -736,10 +781,14 @@ int ABT_self_set_arg(void *arg)
  */
 int ABT_self_get_arg(void **arg)
 {
+    ABTI_UB_ASSERT(arg);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *arg = NULL;
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -770,6 +819,9 @@ int ABT_self_get_arg(void **arg)
  */
 int ABT_self_get_thread_func(void (**thread_func)(void *))
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_func);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -802,6 +854,9 @@ int ABT_self_get_thread_func(void (**thread_func)(void *))
  */
 int ABT_self_is_unnamed(ABT_bool *is_unnamed)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_unnamed);
+
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -86,6 +86,9 @@ ABTU_ret_err static int xstream_migrate_thread(ABTI_global *p_global,
  */
 int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newxstream);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newxstream to NULL on error. */
     *newxstream = ABT_XSTREAM_NULL;
@@ -105,6 +108,8 @@ int ABT_xstream_create(ABT_sched sched, ABT_xstream *newxstream)
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
                         ABT_ERR_INV_SCHED);
+#else
+        ABTI_UB_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
 #endif
     }
 
@@ -180,6 +185,10 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
                              ABT_pool *pools, ABT_sched_config config,
                              ABT_xstream *newxstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pools || num_pools <= 0);
+    ABTI_UB_ASSERT(newxstream);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newxstream to NULL on error. */
     *newxstream = ABT_XSTREAM_NULL;
@@ -272,6 +281,9 @@ int ABT_xstream_create_basic(ABT_sched_predef predef, int num_pools,
 int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
                                  ABT_xstream *newxstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newxstream);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newxstream to NULL on error. */
     *newxstream = ABT_XSTREAM_NULL;
@@ -293,6 +305,8 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
                         ABT_ERR_INV_SCHED);
+#else
+        ABTI_UB_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
 #endif
     }
 
@@ -343,6 +357,8 @@ int ABT_xstream_create_with_rank(ABT_sched sched, int rank,
  */
 int ABT_xstream_revive(ABT_xstream xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
@@ -420,6 +436,9 @@ int ABT_xstream_revive(ABT_xstream xstream)
  */
 int ABT_xstream_free(ABT_xstream *xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(xstream);
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -484,6 +503,8 @@ int ABT_xstream_free(ABT_xstream *xstream)
  */
 int ABT_xstream_join(ABT_xstream xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
@@ -533,6 +554,8 @@ int ABT_xstream_exit(void)
     ABTI_ythread *p_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
     /* Check if the target is the primary execution stream. */
@@ -579,6 +602,8 @@ int ABT_xstream_exit(void)
  */
 int ABT_xstream_cancel(ABT_xstream xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
     ABTI_CHECK_TRUE(p_xstream->type != ABTI_XSTREAM_TYPE_PRIMARY,
@@ -624,10 +649,14 @@ int ABT_xstream_cancel(ABT_xstream xstream)
  */
 int ABT_xstream_self(ABT_xstream *xstream)
 {
+    ABTI_UB_ASSERT(xstream);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *xstream = ABT_XSTREAM_NULL;
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -667,9 +696,13 @@ int ABT_xstream_self(ABT_xstream *xstream)
  */
 int ABT_xstream_self_rank(int *rank)
 {
+    ABTI_UB_ASSERT(rank);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     /* Return value */
@@ -714,6 +747,8 @@ int ABT_xstream_self_rank(int *rank)
  */
 int ABT_xstream_set_rank(ABT_xstream xstream, int rank)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -759,6 +794,9 @@ int ABT_xstream_set_rank(ABT_xstream xstream, int rank)
  */
 int ABT_xstream_get_rank(ABT_xstream xstream, int *rank)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(rank);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -846,6 +884,8 @@ int ABT_xstream_get_rank(ABT_xstream xstream, int *rank)
  */
 int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -877,6 +917,8 @@ int ABT_xstream_set_main_sched(ABT_xstream xstream, ABT_sched sched)
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
         ABTI_CHECK_TRUE(p_sched->used == ABTI_SCHED_NOT_USED,
                         ABT_ERR_INV_SCHED);
+#else
+        ABTI_UB_ASSERT(p_sched->used == ABTI_SCHED_NOT_USED);
 #endif
     }
 
@@ -953,6 +995,9 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
                                      ABT_sched_predef predef, int num_pools,
                                      ABT_pool *pools)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pools || num_pools <= 0);
+
     int abt_errno;
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
@@ -1002,6 +1047,9 @@ int ABT_xstream_set_main_sched_basic(ABT_xstream xstream,
  */
 int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(sched);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1040,6 +1088,9 @@ int ABT_xstream_get_main_sched(ABT_xstream xstream, ABT_sched *sched)
 int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
                                ABT_pool *pools)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pools || max_pools <= 0);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1075,6 +1126,9 @@ int ABT_xstream_get_main_pools(ABT_xstream xstream, int max_pools,
  */
 int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(state);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1112,6 +1166,8 @@ int ABT_xstream_get_state(ABT_xstream xstream, ABT_xstream_state *state)
 int ABT_xstream_equal(ABT_xstream xstream1, ABT_xstream xstream2,
                       ABT_bool *result)
 {
+    ABTI_UB_ASSERT(result);
+
     ABTI_xstream *p_xstream1 = ABTI_xstream_get_ptr(xstream1);
     ABTI_xstream *p_xstream2 = ABTI_xstream_get_ptr(xstream2);
     *result = (p_xstream1 == p_xstream2) ? ABT_TRUE : ABT_FALSE;
@@ -1148,6 +1204,11 @@ int ABT_xstream_equal(ABT_xstream xstream1, ABT_xstream xstream2,
  */
 int ABT_xstream_get_num(int *num_xstreams)
 {
+    ABTI_UB_ASSERT(num_xstreams);
+#ifdef ABT_CONFIG_ENABLE_VER_20_API
+    ABTI_UB_ASSERT(ABTI_initialized());
+#endif
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -1181,6 +1242,9 @@ int ABT_xstream_get_num(int *num_xstreams)
  */
 int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *is_primary)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_primary);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1220,6 +1284,8 @@ int ABT_xstream_is_primary(ABT_xstream xstream, ABT_bool *is_primary)
  */
 int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(unit != ABT_UNIT_NULL, ABT_ERR_INV_UNIT);
@@ -1274,6 +1340,8 @@ int ABT_xstream_check_events(ABT_sched sched)
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 
@@ -1316,6 +1384,8 @@ int ABT_xstream_check_events(ABT_sched sched)
  */
 int ABT_xstream_set_cpubind(ABT_xstream xstream, int cpuid)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1365,6 +1435,9 @@ int ABT_xstream_set_cpubind(ABT_xstream xstream, int cpuid)
  */
 int ABT_xstream_get_cpubind(ABT_xstream xstream, int *cpuid)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(cpuid);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
 
@@ -1414,6 +1487,9 @@ int ABT_xstream_get_cpubind(ABT_xstream xstream, int *cpuid)
  */
 int ABT_xstream_set_affinity(ABT_xstream xstream, int num_cpuids, int *cpuids)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(cpuids || num_cpuids <= 0);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
     ABTI_CHECK_TRUE(num_cpuids >= 0, ABT_ERR_INV_ARG);
@@ -1478,6 +1554,9 @@ int ABT_xstream_set_affinity(ABT_xstream xstream, int num_cpuids, int *cpuids)
 int ABT_xstream_get_affinity(ABT_xstream xstream, int max_cpuids, int *cpuids,
                              int *num_cpuids)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(cpuids || max_cpuids <= 0);
+
     ABTI_xstream *p_xstream = ABTI_xstream_get_ptr(xstream);
     ABTI_CHECK_NULL_XSTREAM_PTR(p_xstream);
     ABTI_CHECK_TRUE(max_cpuids >= 0, ABT_ERR_INV_ARG);

--- a/src/stream_barrier.c
+++ b/src/stream_barrier.c
@@ -44,6 +44,9 @@
 int ABT_xstream_barrier_create(uint32_t num_waiters,
                                ABT_xstream_barrier *newbarrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newbarrier);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newbarrier to NULL on error. */
     *newbarrier = ABT_XSTREAM_BARRIER_NULL;
@@ -100,6 +103,9 @@ int ABT_xstream_barrier_create(uint32_t num_waiters,
  */
 int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(barrier);
+
     ABT_xstream_barrier h_barrier = *barrier;
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(h_barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
@@ -139,6 +145,8 @@ int ABT_xstream_barrier_free(ABT_xstream_barrier *barrier)
  */
 int ABT_xstream_barrier_wait(ABT_xstream_barrier barrier)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream_barrier *p_barrier = ABTI_xstream_barrier_get_ptr(barrier);
     ABTI_CHECK_NULL_XSTREAM_BARRIER_PTR(p_barrier);
 

--- a/src/task.c
+++ b/src/task.c
@@ -56,6 +56,9 @@ ABTU_ret_err static int task_create(ABTI_global *p_global, ABTI_local *p_local,
 int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
                     ABT_task *newtask)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(task_func);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newtask to NULL on error. */
     if (newtask)
@@ -120,6 +123,9 @@ int ABT_task_create(ABT_pool pool, void (*task_func)(void *), void *arg,
 int ABT_task_create_on_xstream(ABT_xstream xstream, void (*task_func)(void *),
                                void *arg, ABT_task *newtask)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(task_func);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newtask to NULL on error. */
     if (newtask)
@@ -260,6 +266,8 @@ int ABT_task_cancel(ABT_task task)
  */
 int ABT_task_self(ABT_task *task)
 {
+    ABTI_UB_ASSERT(task);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *task = ABT_TASK_NULL;
@@ -269,6 +277,7 @@ int ABT_task_self(ABT_task *task)
                       ABTI_THREAD_TYPE_YIELDABLE),
                     ABT_ERR_INV_TASK);
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 #endif
     *task = ABTI_thread_get_handle(p_local_xstream->p_thread);
@@ -309,6 +318,8 @@ int ABT_task_self(ABT_task *task)
  */
 int ABT_task_self_id(ABT_unit_id *id)
 {
+    ABTI_UB_ASSERT(id);
+
     ABTI_xstream *p_local_xstream;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
@@ -317,6 +328,7 @@ int ABT_task_self_id(ABT_unit_id *id)
                       ABTI_THREAD_TYPE_YIELDABLE),
                     ABT_ERR_INV_TASK);
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
 #endif
     *id = ABTI_thread_get_id(p_local_xstream->p_thread);
@@ -372,6 +384,9 @@ int ABT_task_get_xstream(ABT_task task, ABT_xstream *xstream)
  */
 int ABT_task_get_state(ABT_task task, ABT_task_state *state)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(state);
+
     ABT_thread_state thread_state;
     int abt_errno = ABT_thread_get_state(task, &thread_state);
     ABTI_CHECK_TRUE(abt_errno != ABT_ERR_INV_THREAD, ABT_ERR_INV_TASK);

--- a/src/thread.c
+++ b/src/thread.c
@@ -88,6 +88,9 @@ static ABTI_key g_thread_mig_data_key =
 int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
                       ABT_thread_attr attr, ABT_thread *newthread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_func);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newthread to NULL on error. */
     if (newthread)
@@ -169,6 +172,9 @@ int ABT_thread_create_on_xstream(ABT_xstream xstream,
                                  void (*thread_func)(void *), void *arg,
                                  ABT_thread_attr attr, ABT_thread *newthread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_func);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newthread to NULL on error. */
     if (newthread)
@@ -356,6 +362,10 @@ int ABT_thread_create_many(int num_threads, ABT_pool *pool_list,
 int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
                       ABT_thread *thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_func);
+    ABTI_UB_ASSERT(thread);
+
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_local *p_local = ABTI_local_get_local();
 
@@ -417,6 +427,9 @@ int ABT_thread_revive(ABT_pool pool, void (*thread_func)(void *), void *arg,
  */
 int ABT_thread_free(ABT_thread *thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread);
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
     ABTI_local *p_local = ABTI_local_get_local();
@@ -535,6 +548,8 @@ int ABT_thread_free_many(int num_threads, ABT_thread *thread_list)
  */
 int ABT_thread_join(ABT_thread thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
@@ -628,6 +643,8 @@ int ABT_thread_exit(void)
     ABTI_ythread *p_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
+#else
+    ABTI_UB_ASSERT(ABTI_initialized());
 #endif
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_ythread);
     ABTI_CHECK_TRUE(!(p_ythread->thread.type & ABTI_THREAD_TYPE_PRIMARY),
@@ -671,6 +688,8 @@ int ABT_thread_exit(void)
  */
 int ABT_thread_cancel(ABT_thread thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifdef ABT_CONFIG_DISABLE_THREAD_CANCEL
     ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
@@ -722,6 +741,8 @@ int ABT_thread_cancel(ABT_thread thread)
  */
 int ABT_thread_self(ABT_thread *thread)
 {
+    ABTI_UB_ASSERT(thread);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *thread = ABT_THREAD_NULL;
     ABTI_SETUP_GLOBAL(NULL);
@@ -729,6 +750,7 @@ int ABT_thread_self(ABT_thread *thread)
     ABTI_SETUP_LOCAL_YTHREAD(NULL, &p_self);
     *thread = ABTI_thread_get_handle(&p_self->thread);
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *thread = ABTI_thread_get_handle(p_local_xstream->p_thread);
@@ -771,12 +793,15 @@ int ABT_thread_self(ABT_thread *thread)
  */
 int ABT_thread_self_id(ABT_unit_id *id)
 {
+    ABTI_UB_ASSERT(id);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     ABTI_SETUP_GLOBAL(NULL);
     ABTI_ythread *p_self;
     ABTI_SETUP_LOCAL_YTHREAD(NULL, &p_self);
     *id = ABTI_thread_get_id(&p_self->thread);
 #else
+    ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_xstream *p_local_xstream;
     ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
     *id = ABTI_thread_get_id(p_local_xstream->p_thread);
@@ -814,6 +839,9 @@ int ABT_thread_self_id(ABT_unit_id *id)
  */
 int ABT_thread_get_last_xstream(ABT_thread thread, ABT_xstream *xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(xstream);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -855,6 +883,9 @@ int ABT_thread_get_last_xstream(ABT_thread thread, ABT_xstream *xstream)
  */
 int ABT_thread_get_state(ABT_thread thread, ABT_thread_state *state)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(state);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -895,6 +926,9 @@ int ABT_thread_get_state(ABT_thread thread, ABT_thread_state *state)
  */
 int ABT_thread_get_last_pool(ABT_thread thread, ABT_pool *pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(pool);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -935,6 +969,9 @@ int ABT_thread_get_last_pool(ABT_thread thread, ABT_pool *pool)
  */
 int ABT_thread_get_last_pool_id(ABT_thread thread, int *id)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(id);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     *id = (int)p_thread->p_pool->id;
@@ -965,6 +1002,9 @@ int ABT_thread_get_last_pool_id(ABT_thread thread, int *id)
  */
 int ABT_thread_get_unit(ABT_thread thread, ABT_unit *unit)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(unit);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     *unit = p_thread->unit;
@@ -1006,6 +1046,8 @@ int ABT_thread_get_unit(ABT_thread thread, ABT_unit *unit)
  */
 int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
@@ -1064,6 +1106,8 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
  */
 int ABT_thread_yield_to(ABT_thread thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_cur_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
@@ -1178,6 +1222,8 @@ int ABT_thread_yield_to(ABT_thread thread)
  */
 int ABT_thread_yield(void)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_ythread;
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
@@ -1230,6 +1276,8 @@ int ABT_thread_yield(void)
  */
 int ABT_thread_resume(ABT_thread thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_local *p_local = ABTI_local_get_local();
 
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
@@ -1242,6 +1290,9 @@ int ABT_thread_resume(ABT_thread thread)
     ABTI_CHECK_TRUE(ABTD_atomic_acquire_load_int(&p_ythread->thread.state) ==
                         ABT_THREAD_STATE_BLOCKED,
                     ABT_ERR_THREAD);
+#else
+    ABTI_UB_ASSERT(ABTD_atomic_acquire_load_int(&p_ythread->thread.state) ==
+                   ABT_THREAD_STATE_BLOCKED);
 #endif
 
     ABTI_ythread_set_ready(p_local, p_ythread);
@@ -1301,6 +1352,8 @@ int ABT_thread_resume(ABT_thread thread)
  */
 int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
@@ -1387,6 +1440,8 @@ int ABT_thread_migrate_to_xstream(ABT_thread thread, ABT_xstream xstream)
  */
 int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
@@ -1470,6 +1525,8 @@ int ABT_thread_migrate_to_sched(ABT_thread thread, ABT_sched sched)
  */
 int ABT_thread_migrate_to_pool(ABT_thread thread, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
@@ -1547,6 +1604,8 @@ int ABT_thread_migrate_to_pool(ABT_thread thread, ABT_pool pool)
  */
 int ABT_thread_migrate(ABT_thread thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     /* TODO: fix the bug(s) */
     ABTI_global *p_global;
@@ -1661,6 +1720,8 @@ int ABT_thread_set_callback(ABT_thread thread,
                             void (*cb_func)(ABT_thread thread, void *cb_arg),
                             void *cb_arg)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
@@ -1721,6 +1782,9 @@ int ABT_thread_set_callback(ABT_thread thread,
  */
 int ABT_thread_set_migratable(ABT_thread thread, ABT_bool migratable)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT_BOOL(migratable);
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
@@ -1778,6 +1842,9 @@ int ABT_thread_set_migratable(ABT_thread thread, ABT_bool migratable)
  */
 int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *is_migratable)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_migratable);
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
@@ -1812,7 +1879,7 @@ int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *is_migratable)
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
- * \DOC_UNDEFINED_NULL_PTR{\c flag}
+ * \DOC_UNDEFINED_NULL_PTR{\c is_primary}
  *
  * @param[in]  thread      work unit handle
  * @param[out] is_primary  result (\c ABT_TRUE: primary ULT, \c ABT_FALSE: not)
@@ -1820,6 +1887,9 @@ int ABT_thread_is_migratable(ABT_thread thread, ABT_bool *is_migratable)
  */
 int ABT_thread_is_primary(ABT_thread thread, ABT_bool *is_primary)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_primary);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -1858,6 +1928,9 @@ int ABT_thread_is_primary(ABT_thread thread, ABT_bool *is_primary)
  */
 int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *is_unnamed)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(is_unnamed);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -1905,6 +1978,8 @@ int ABT_thread_is_unnamed(ABT_thread thread, ABT_bool *is_unnamed)
  */
 int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
 {
+    ABTI_UB_ASSERT(result);
+
     ABTI_thread *p_thread1 = ABTI_thread_get_ptr(thread1);
     ABTI_thread *p_thread2 = ABTI_thread_get_ptr(thread2);
     *result = (p_thread1 == p_thread2) ? ABT_TRUE : ABT_FALSE;
@@ -1941,6 +2016,9 @@ int ABT_thread_equal(ABT_thread thread1, ABT_thread thread2, ABT_bool *result)
  */
 int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(stacksize);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
     ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
@@ -1980,6 +2058,9 @@ int ABT_thread_get_stacksize(ABT_thread thread, size_t *stacksize)
  */
 int ABT_thread_get_id(ABT_thread thread, ABT_unit_id *thread_id)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_id);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -2015,6 +2096,8 @@ int ABT_thread_get_id(ABT_thread thread, ABT_unit_id *thread_id)
  */
 int ABT_thread_set_arg(ABT_thread thread, void *arg)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -2050,6 +2133,9 @@ int ABT_thread_set_arg(ABT_thread thread, void *arg)
  */
 int ABT_thread_get_arg(ABT_thread thread, void **arg)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(arg);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -2081,6 +2167,9 @@ int ABT_thread_get_arg(ABT_thread thread, void **arg)
  */
 int ABT_thread_get_thread_func(ABT_thread thread, void (**thread_func)(void *))
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread_func);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -2116,6 +2205,8 @@ int ABT_thread_get_thread_func(ABT_thread thread, void (**thread_func)(void *))
  */
 int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -2165,6 +2256,9 @@ int ABT_thread_set_specific(ABT_thread thread, ABT_key key, void *value)
  */
 int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(value);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 
@@ -2210,6 +2304,9 @@ int ABT_thread_get_specific(ABT_thread thread, ABT_key key, void **value)
  */
 int ABT_thread_get_attr(ABT_thread thread, ABT_thread_attr *attr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(attr);
+
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_thread);
 

--- a/src/thread_attr.c
+++ b/src/thread_attr.c
@@ -49,6 +49,9 @@ static void thread_attr_set_stack(ABTI_global *p_global,
  */
 int ABT_thread_attr_create(ABT_thread_attr *newattr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(newattr);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     /* Argobots 1.x sets newattr to NULL on error. */
     *newattr = ABT_THREAD_ATTR_NULL;
@@ -91,6 +94,9 @@ int ABT_thread_attr_create(ABT_thread_attr *newattr)
  */
 int ABT_thread_attr_free(ABT_thread_attr *attr)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(attr);
+
     ABT_thread_attr h_attr = *attr;
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(h_attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
@@ -152,6 +158,8 @@ int ABT_thread_attr_free(ABT_thread_attr *attr)
 int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
                               size_t stacksize)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -192,6 +200,10 @@ int ABT_thread_attr_set_stack(ABT_thread_attr attr, void *stackaddr,
 int ABT_thread_attr_get_stack(ABT_thread_attr attr, void **stackaddr,
                               size_t *stacksize)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(stackaddr);
+    ABTI_UB_ASSERT(stacksize);
+
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
@@ -226,6 +238,8 @@ int ABT_thread_attr_get_stack(ABT_thread_attr attr, void **stackaddr,
  */
 int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_global *p_global;
     ABTI_SETUP_GLOBAL(&p_global);
 
@@ -260,6 +274,9 @@ int ABT_thread_attr_set_stacksize(ABT_thread_attr attr, size_t stacksize)
  */
 int ABT_thread_attr_get_stacksize(ABT_thread_attr attr, size_t *stacksize)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(stacksize);
+
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
 
@@ -306,6 +323,8 @@ int ABT_thread_attr_set_callback(ABT_thread_attr attr,
                                                  void *cb_arg),
                                  void *cb_arg)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);
@@ -348,6 +367,9 @@ int ABT_thread_attr_set_callback(ABT_thread_attr attr,
  */
 int ABT_thread_attr_set_migratable(ABT_thread_attr attr, ABT_bool is_migratable)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT_BOOL(is_migratable);
+
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABTI_thread_attr *p_attr = ABTI_thread_attr_get_ptr(attr);
     ABTI_CHECK_NULL_THREAD_ATTR_PTR(p_attr);

--- a/src/timer.c
+++ b/src/timer.c
@@ -59,6 +59,8 @@ double ABT_get_wtime(void)
  */
 int ABT_timer_create(ABT_timer *newtimer)
 {
+    ABTI_UB_ASSERT(newtimer);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *newtimer = ABT_TIMER_NULL;
 #endif
@@ -101,6 +103,8 @@ int ABT_timer_create(ABT_timer *newtimer)
  */
 int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
 {
+    ABTI_UB_ASSERT(newtimer);
+
 #ifndef ABT_CONFIG_ENABLE_VER_20_API
     *newtimer = ABT_TIMER_NULL;
 #endif
@@ -139,6 +143,8 @@ int ABT_timer_dup(ABT_timer timer, ABT_timer *newtimer)
  */
 int ABT_timer_free(ABT_timer *timer)
 {
+    ABTI_UB_ASSERT(timer);
+
     ABTI_timer *p_timer = ABTI_timer_get_ptr(*timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
@@ -236,6 +242,8 @@ int ABT_timer_stop(ABT_timer timer)
  */
 int ABT_timer_read(ABT_timer timer, double *secs)
 {
+    ABTI_UB_ASSERT(secs);
+
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
@@ -274,6 +282,8 @@ int ABT_timer_read(ABT_timer timer, double *secs)
  */
 int ABT_timer_stop_and_read(ABT_timer timer, double *secs)
 {
+    ABTI_UB_ASSERT(secs);
+
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
@@ -313,6 +323,8 @@ int ABT_timer_stop_and_read(ABT_timer timer, double *secs)
  */
 int ABT_timer_stop_and_add(ABT_timer timer, double *secs)
 {
+    ABTI_UB_ASSERT(secs);
+
     ABTI_timer *p_timer = ABTI_timer_get_ptr(timer);
     ABTI_CHECK_NULL_TIMER_PTR(p_timer);
 
@@ -354,6 +366,8 @@ int ABT_timer_stop_and_add(ABT_timer timer, double *secs)
  */
 int ABT_timer_get_overhead(double *overhead)
 {
+    ABTI_UB_ASSERT(overhead);
+
     int abt_errno;
     ABT_timer h_timer;
     int i;

--- a/src/tool.c
+++ b/src/tool.c
@@ -83,6 +83,8 @@ ABTU_ret_err static inline int tool_query(ABTI_tool_context *p_tctx,
 int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
                                       uint64_t event_mask, void *user_arg)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
     ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
@@ -233,6 +235,9 @@ int ABT_tool_register_thread_callback(ABT_tool_thread_callback_fn cb_func,
 int ABT_tool_query_thread(ABT_tool_context context, uint64_t event,
                           ABT_tool_query_kind query_kind, void *val)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(val);
+
 #ifdef ABT_CONFIG_DISABLE_TOOL_INTERFACE
     ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else

--- a/src/unit.c
+++ b/src/unit.c
@@ -47,6 +47,8 @@ unit_get_thread_from_user_defined_unit(ABTI_global *p_global, ABT_unit unit);
  */
 int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
     ABTI_CHECK_NULL_POOL_PTR(p_pool);
     ABTI_CHECK_TRUE(unit != ABT_UNIT_NULL, ABT_ERR_INV_UNIT);
@@ -77,6 +79,9 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool)
  */
 int ABT_unit_get_thread(ABT_unit unit, ABT_thread *thread)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread);
+
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_CHECK_TRUE(unit != ABT_UNIT_NULL, ABT_ERR_INV_UNIT);
     ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);


### PR DESCRIPTION
## Pull Request Description

This PR closes #315.

Argobots defines when undefined behaviors may happen but the runtime does not actively detect such since such a check is either mostly unnecessary (e.g., check if Argobots is initialized or not) or extremely costly (e.g., detection of double-freeing an Argobots object). This PR provides an option to check some of them on a best efforts basis.

Even after this PR, Argobots checks only runtime initialization and NULL arguments in most places. Some checks regarding synchronization objects, however, would be generally useful (e.g., check if there's no waiter when freeing `ABT_eventual`). We might add more expensive checks if needed.

Note that this does not break the current API since "undefined behavior" can cause anything, including failure of `assert()`. At the same time, please do not rely on this assertion behavior since at any rate this is part of undefined behavior. These checks can be removed or relaxed in the future for code readability or performance optimization.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
