### PR TITLE
fix a ucontext + POWER9 + vectorization bug

### DIFF
--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -56,12 +56,16 @@ static inline void ABTD_ythread_context_init(ABTD_ythread_context *p_ctx,
     p_ctx->p_ctx = NULL;
     p_ctx->p_stack = p_stack;
     p_ctx->stacksize = stacksize;
+    int ret = getcontext(&p_ctx->uctx);
+    ABTI_ASSERT(ret == 0); /* getcontext() should not return an error. */
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
 }
 
 static inline void ABTD_ythread_context_reinit(ABTD_ythread_context *p_ctx)
 {
     p_ctx->p_ctx = NULL;
+    int ret = getcontext(&p_ctx->uctx);
+    ABTI_ASSERT(ret == 0); /* getcontext() should not return an error. */
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
 }
 
@@ -78,8 +82,6 @@ ABTD_ythread_context_get_stacksize(ABTD_ythread_context *p_ctx)
 
 static inline void ABTDI_ythread_context_make(ABTD_ythread_context *p_ctx)
 {
-    int ret = getcontext(&p_ctx->uctx);
-    ABTI_ASSERT(ret == 0); /* getcontext() should not return an error. */
     p_ctx->p_ctx = &p_ctx->uctx;
     /* uc_link is not used. */
     p_ctx->uctx.uc_link = NULL;


### PR DESCRIPTION
## Pull Request Description

This patch fixes a bug that can break the vectorized floating-point computation results on POWER9 (possibly only when Clang 10.0 is used). This PR introduces a workaround that works so far, but I did not identify the real cause.

I spent a day, but I could not identify the problem.  It seems that the VRSAVE register (precisely speaking, memory that saves the VRSAVE register's value in `ucontext_t`) gets broken if we lazily initialize `ucontext_t` via `getcontext()`, possibly because the VRSAVE value of a newly created POSIX-thread (via `pthread_create()`) is not proper to run vectorized floating-point operations.  To be honest, I don't know how this register affects the results and who should manage this value (the ABI specification says "Reserved for system use. This register should not be read or written by application software." while obviously the current ucontext implementation modifies it).  It happens only Clang 10.0 -- not XLC or GCC -- possibly because only Clang 10.0 vectorizes the stencil code I tested or (less likely but) maybe a compiler is also responsible for managing this register.  Manually rewriting the VRSAVE register solved the issue, but this register value itself might not be the root cause.

In any case, calling `getcontext()` eagerly seems to solve the issue.  I don't really know why---lazy `getcontext()` should be valid---, but as ucontext is a fallback option and anyway faster fcontext is provided for POWER9, this patch implements a safer option.

Note that the fcontext implementation does not modify the VRSAVE register since the specification says no, so this issue should not affect the correctness of the current fcontext implementation.  Nevertheless, we welcome any bug reports.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
