### PR TITLE
improve ULT stack size configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,13 @@ AC_ARG_ENABLE([static-cacheline-size],
         <value>             - assume [value] bytes (e.g., <value> = 64)
 ],,[enable_static_cacheline_size=auto])
 
+# --enable-default-stacksize
+AC_ARG_ENABLE([default-stacksize],
+[  --enable-default-stacksize@<:@=SIZE@:>@
+                          set a default ULT stack size in bytes (default: 16384)
+                          ABT_THREAD_STACKSIZE=SIZE at run-time supersedes this setting.
+],,[enable_default_stacksize=16384])
+
 # --enable-ver20-api
 AC_ARG_ENABLE([ver20-api],
     AS_HELP_STRING([--enable-ver20-api],
@@ -246,14 +253,6 @@ AC_ARG_WITH([hugetlbfs],
 AC_ARG_WITH([libunwind],
     AS_HELP_STRING([--with-libunwind=PATH],
         [specify path where libunwind include directory and lib directory can be found]))
-
-# --enable-stack-unwind
-AC_ARG_ENABLE([stack-unwind],
-[  --enable-stack-unwind@<:@=OPTS@:>@ enable stack unwinding, which is disabled by default.
-        yes|verbose  - enable stack unwinding.  Dump the raw stack information too
-        unwind-only  - enable stack unwinding.  Do not dump the raw stack information
-        no|none      - disable stack unwinding
-],,[enable_stack_unwind=no])
 
 # --with-papi
 AC_ARG_WITH([papi],
@@ -816,6 +815,13 @@ fi
 AC_DEFINE_UNQUOTED(ABT_CONFIG_STATIC_CACHELINE_SIZE, [$static_cacheline_size],
                    [Define to use static cache-line size])
 
+# --enable-default-stacksize
+if test x"`echo $enable_default_stacksize | sed -e 's/[[0-9]]//g'`" != x"" ; then
+  # enable_default_stacksize is not numeric
+  AC_MSG_WARN([Unknown value $enable_default_stacksize for --enable-default-stacksize])
+  enable_default_stacksize=16384
+fi
+AC_DEFINE_UNQUOTED(ABT_CONFIG_DEFAULT_THREAD_STACKSIZE, [$enable_default_stacksize], [Define to set the default ULT stack size])
 
 # --with-lts
 if test "x$with_lts" != "x"; then

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -8,7 +8,6 @@
 #include <strings.h>
 
 #define ABTD_KEY_TABLE_DEFAULT_SIZE 4
-#define ABTD_THREAD_DEFAULT_STACKSIZE 16384
 #define ABTD_SCHED_DEFAULT_STACKSIZE (4 * 1024 * 1024)
 #define ABTD_SCHED_EVENT_FREQ 50
 #define ABTD_SCHED_SLEEP_NSEC 100
@@ -122,7 +121,7 @@ void ABTD_env_init(ABTI_global *p_global)
 
     /* ABT_THREAD_STACKSIZE, ABT_ENV_THREAD_STACKSIZE
      * Default stack size for ULT */
-    size_t default_thread_stacksize = ABTD_THREAD_DEFAULT_STACKSIZE;
+    size_t default_thread_stacksize = ABT_CONFIG_DEFAULT_THREAD_STACKSIZE;
     if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT ||
         p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT_STRICT) {
         /* Maximum 2 pages are used for mprotect(), so let's increase the

--- a/src/arch/abtd_env.c
+++ b/src/arch/abtd_env.c
@@ -59,107 +59,36 @@ void ABTD_env_init(ABTI_global *p_global)
         ABTD_affinity_init(p_global, env);
     }
 
-#ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
-    /* If the debug log printing is set in configure, logging is turned on by
-     * default. */
-    const ABT_bool default_use_logging = ABT_TRUE;
-    const ABT_bool default_use_debug = ABT_TRUE;
-#else
-    /* Otherwise, logging is not turned on by default. */
-    const ABT_bool default_use_logging = ABT_FALSE;
-    const ABT_bool default_use_debug = ABT_FALSE;
-#endif
-    /* ABT_USE_LOG, ABT_ENV_USE_LOG */
-    p_global->use_logging = load_env_bool("USE_LOG", default_use_logging);
-
-    /* ABT_USE_DEBUG, ABT_ENV_USE_DEBUG */
-    p_global->use_debug = load_env_bool("USE_DEBUG", default_use_debug);
-
-    /* ABT_MAX_NUM_XSTREAMS, ABT_ENV_MAX_NUM_XSTREAMS
-     * Maximum size of the internal ES array */
-    p_global->max_xstreams =
-        load_env_int("MAX_NUM_XSTREAMS", p_global->num_cores, 1,
-                     ABTD_ENV_INT_MAX);
-
-    /* ABT_KEY_TABLE_SIZE, ABT_ENV_KEY_TABLE_SIZE
-     * Default key table size */
-    p_global->key_table_size = roundup_pow2_uint32(
-        load_env_uint32("KEY_TABLE_SIZE", ABTD_KEY_TABLE_DEFAULT_SIZE, 1,
-                        ABTD_ENV_UINT32_MAX));
-
-    /* ABT_STACK_OVERFLOW_CHECK, ABT_ENV_STACK_OVERFLOW_CHECK */
-    env = get_abt_env("STACK_OVERFLOW_CHECK");
-    if (env) {
-        if (strcasecmp(env, "mprotect_strict") == 0) {
+    /* Log setting */
+    p_global->use_logging = ABTD_env_get_use_logging();
+    /* Debug setting (unused) */
+    p_global->use_debug = ABTD_env_get_use_debug();
+    /* Maximum size of the internal ES array */
+    p_global->max_xstreams = ABTD_env_get_max_xstreams();
+    /* Default key table size */
+    p_global->key_table_size = ABTD_env_key_table_size();
+    /* mprotect-based stack guard setting */
+    ABT_bool is_strict;
+    if (ABTD_env_get_stack_guard_mprotect(&is_strict)) {
+        if (is_strict) {
             p_global->stack_guard_kind = ABTI_STACK_GUARD_MPROTECT_STRICT;
-        } else if (strcasecmp(env, "mprotect") == 0) {
-            p_global->stack_guard_kind = ABTI_STACK_GUARD_MPROTECT;
         } else {
-            /* Otherwise, disable mprotect-based stack guard. */
-            p_global->stack_guard_kind = ABTI_STACK_GUARD_NONE;
+            p_global->stack_guard_kind = ABTI_STACK_GUARD_MPROTECT;
         }
     } else {
-        /* Set the default mode. */
-#if ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_MPROTECT
-        p_global->stack_guard_kind = ABTI_STACK_GUARD_MPROTECT;
-#elif ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_MPROTECT_STRICT
-        p_global->stack_guard_kind = ABTI_STACK_GUARD_MPROTECT_STRICT;
-#else
         /* Stack canary is compile-time setting. */
         p_global->stack_guard_kind = ABTI_STACK_GUARD_NONE;
-#endif
     }
-
-    /* ABT_SYS_PAGE_SIZE, ABT_ENV_SYS_PAGE_SIZE
-     * System page size.  It must be 2^N. */
-    size_t sys_page_size = ABTD_SYS_PAGE_SIZE;
-#if HAVE_GETPAGESIZE
-    sys_page_size = getpagesize();
-#endif
-    p_global->sys_page_size = roundup_pow2_size(
-        load_env_size("SYS_PAGE_SIZE", sys_page_size, 64, ABTD_ENV_SIZE_MAX));
-
-    /* ABT_THREAD_STACKSIZE, ABT_ENV_THREAD_STACKSIZE
-     * Default stack size for ULT */
-    size_t default_thread_stacksize = ABT_CONFIG_DEFAULT_THREAD_STACKSIZE;
-    if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT ||
-        p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT_STRICT) {
-        /* Maximum 2 pages are used for mprotect(), so let's increase the
-         * default stack size. */
-        default_thread_stacksize += p_global->sys_page_size * 2;
-    }
-    p_global->thread_stacksize =
-        ABTU_roundup_size(load_env_size("THREAD_STACKSIZE",
-                                        default_thread_stacksize, 512,
-                                        ABTD_ENV_SIZE_MAX),
-                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
-
-    /* ABT_SCHED_STACKSIZE, ABT_ENV_SCHED_STACKSIZE
-     * Default stack size for scheduler */
-    size_t default_sched_stacksize = ABTD_SCHED_DEFAULT_STACKSIZE;
-    if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT ||
-        p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT_STRICT) {
-        /* Maximum 2 pages are used for mprotect(), so let's increase the
-         * default stack size. */
-        default_sched_stacksize += p_global->sys_page_size * 2;
-    }
-    p_global->sched_stacksize =
-        ABTU_roundup_size(load_env_size("SCHED_STACKSIZE",
-                                        default_sched_stacksize, 512,
-                                        ABTD_ENV_SIZE_MAX),
-                          ABT_CONFIG_STATIC_CACHELINE_SIZE);
-
-    /* ABT_SCHED_EVENT_FREQ, ABT_ENV_SCHED_EVENT_FREQ
-     * Default frequency for event checking by the scheduler */
-    p_global->sched_event_freq =
-        load_env_uint32("SCHED_EVENT_FREQ", ABTD_SCHED_EVENT_FREQ, 1,
-                        ABTD_ENV_UINT32_MAX);
-
-    /* ABT_SCHED_SLEEP_NSEC, ABT_ENV_SCHED_SLEEP_NSEC
-     * Default nanoseconds for scheduler sleep */
-    p_global->sched_sleep_nsec =
-        load_env_uint64("SCHED_SLEEP_NSEC", ABTD_SCHED_SLEEP_NSEC, 0,
-                        ABTD_ENV_UINT64_MAX);
+    /* System page size. */
+    p_global->sys_page_size = ABTD_env_get_sys_pagesize();
+    /* Default stack size for ULT */
+    p_global->thread_stacksize = ABTD_env_get_thread_stacksize();
+    /* Default stack size for scheduler */
+    p_global->sched_stacksize = ABTD_env_get_sched_stacksize();
+    /* Default frequency for event checking by the scheduler */
+    p_global->sched_event_freq = ABTD_env_get_sched_event_freq();
+    /* Default nanoseconds for scheduler sleep */
+    p_global->sched_sleep_nsec = ABTD_env_get_sched_sleep_nsec();
 
     /* ABT_MUTEX_MAX_HANDOVERS, ABT_ENV_MUTEX_MAX_HANDOVERS
      * Default maximum number of mutex handover */
@@ -291,12 +220,150 @@ void ABTD_env_init(ABTI_global *p_global)
     }
 #endif
 
-    /* ABT_PRINT_CONFIG, ABT_ENV_PRINT_CONFIG
-     * Whether to print the configuration on ABT_init() */
-    p_global->print_config = load_env_bool("PRINT_CONFIG", ABT_FALSE);
+    /* Whether to print the configuration on ABT_init() */
+    p_global->print_config = ABTD_env_get_print_config();
 
     /* Init timer */
     ABTD_time_init();
+}
+
+ABT_bool ABTD_env_get_use_debug(void)
+{
+#ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
+    const ABT_bool default_use_debug = ABT_TRUE;
+#else
+    const ABT_bool default_use_debug = ABT_FALSE;
+#endif
+    /* ABT_USE_DEBUG, ABT_ENV_USE_DEBUG */
+    return load_env_bool("USE_DEBUG", default_use_debug);
+}
+
+ABT_bool ABTD_env_get_use_logging(void)
+{
+#ifdef ABT_CONFIG_USE_DEBUG_LOG_PRINT
+    /* If the debug log printing is set in configure, logging is turned on by
+     * default. */
+    const ABT_bool default_use_logging = ABT_TRUE;
+#else
+    /* Otherwise, logging is not turned on by default. */
+    const ABT_bool default_use_logging = ABT_FALSE;
+#endif
+    /* ABT_USE_LOG, ABT_ENV_USE_LOG */
+    return load_env_bool("USE_LOG", default_use_logging);
+}
+
+ABT_bool ABTD_env_get_print_config(void)
+{
+    /* ABT_PRINT_CONFIG, ABT_ENV_PRINT_CONFIG */
+    return load_env_bool("PRINT_CONFIG", ABT_FALSE);
+}
+
+int ABTD_env_get_max_xstreams(void)
+{
+    const int num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+    /* ABT_MAX_NUM_XSTREAMS, ABT_ENV_MAX_NUM_XSTREAMS */
+    return load_env_int("MAX_NUM_XSTREAMS", num_cores, 1, ABTD_ENV_INT_MAX);
+}
+
+uint32_t ABTD_env_key_table_size(void)
+{
+    /* ABT_KEY_TABLE_SIZE, ABT_ENV_KEY_TABLE_SIZE */
+    return roundup_pow2_uint32(load_env_uint32("KEY_TABLE_SIZE",
+                                               ABTD_KEY_TABLE_DEFAULT_SIZE, 1,
+                                               ABTD_ENV_UINT32_MAX));
+}
+
+size_t ABTD_env_get_sys_pagesize(void)
+{
+    /* ABT_SYS_PAGE_SIZE, ABT_ENV_SYS_PAGE_SIZE
+     * System page size.  It must be 2^N. */
+    size_t sys_page_size = ABTD_SYS_PAGE_SIZE;
+#if HAVE_GETPAGESIZE
+    sys_page_size = getpagesize();
+#endif
+    return roundup_pow2_size(
+        load_env_size("SYS_PAGE_SIZE", sys_page_size, 64, ABTD_ENV_SIZE_MAX));
+}
+
+size_t ABTD_env_get_thread_stacksize(void)
+{
+    size_t default_thread_stacksize = ABT_CONFIG_DEFAULT_THREAD_STACKSIZE;
+    if (ABTD_env_get_stack_guard_mprotect(NULL)) {
+        /* Maximum 2 pages are used for mprotect(), so let's increase the
+         * default stack size. */
+        const size_t sys_page_size = ABTD_env_get_sys_pagesize();
+        default_thread_stacksize += sys_page_size * 2;
+    }
+    /* ABT_THREAD_STACKSIZE, ABT_ENV_THREAD_STACKSIZE */
+    return ABTU_roundup_size(load_env_size("THREAD_STACKSIZE",
+                                           default_thread_stacksize, 512,
+                                           ABTD_ENV_SIZE_MAX),
+                             ABT_CONFIG_STATIC_CACHELINE_SIZE);
+}
+
+size_t ABTD_env_get_sched_stacksize(void)
+{
+    size_t default_sched_stacksize = ABTD_SCHED_DEFAULT_STACKSIZE;
+    if (ABTD_env_get_stack_guard_mprotect(NULL)) {
+        /* Maximum 2 pages are used for mprotect(), so let's increase the
+         * default stack size. */
+        const size_t sys_page_size = ABTD_env_get_sys_pagesize();
+        default_sched_stacksize += sys_page_size * 2;
+    }
+    /* ABT_SCHED_STACKSIZE, ABT_ENV_SCHED_STACKSIZE */
+    return ABTU_roundup_size(load_env_size("SCHED_STACKSIZE",
+                                           default_sched_stacksize, 512,
+                                           ABTD_ENV_SIZE_MAX),
+                             ABT_CONFIG_STATIC_CACHELINE_SIZE);
+}
+
+uint32_t ABTD_env_get_sched_event_freq(void)
+{
+    /* ABT_SCHED_EVENT_FREQ, ABT_ENV_SCHED_EVENT_FREQ */
+    return load_env_uint32("SCHED_EVENT_FREQ", ABTD_SCHED_EVENT_FREQ, 1,
+                           ABTD_ENV_UINT32_MAX);
+}
+
+uint64_t ABTD_env_get_sched_sleep_nsec(void)
+{
+    /* ABT_SCHED_SLEEP_NSEC, ABT_ENV_SCHED_SLEEP_NSEC */
+    return load_env_uint64("SCHED_SLEEP_NSEC", ABTD_SCHED_SLEEP_NSEC, 0,
+                           ABTD_ENV_UINT64_MAX);
+}
+
+ABT_bool ABTD_env_get_stack_guard_mprotect(ABT_bool *is_strict)
+{
+    /* ABT_STACK_OVERFLOW_CHECK, ABT_ENV_STACK_OVERFLOW_CHECK */
+    const char *env = get_abt_env("STACK_OVERFLOW_CHECK");
+    ABT_bool strict_val, mprotect_val;
+    if (env) {
+        if (strcasecmp(env, "mprotect_strict") == 0) {
+            strict_val = ABT_TRUE;
+            mprotect_val = ABT_TRUE;
+        } else if (strcasecmp(env, "mprotect") == 0) {
+            strict_val = ABT_FALSE;
+            mprotect_val = ABT_TRUE;
+        } else {
+            /* Otherwise, disable mprotect-based stack guard. */
+            strict_val = ABT_FALSE;
+            mprotect_val = ABT_FALSE;
+        }
+    } else {
+        /* Set the default mode. */
+#if ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_MPROTECT
+        strict_val = ABT_FALSE;
+        mprotect_val = ABT_TRUE;
+#elif ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_MPROTECT_STRICT
+        strict_val = ABT_TRUE;
+        mprotect_val = ABT_TRUE;
+#else
+        strict_val = ABT_FALSE;
+        mprotect_val = ABT_FALSE;
+#endif
+    }
+    if (is_strict)
+        *is_strict = strict_val;
+    return mprotect_val;
 }
 
 /*****************************************************************************/

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -45,6 +45,18 @@ typedef struct ABTD_affinity_cpuset {
 
 /* Environment */
 void ABTD_env_init(ABTI_global *p_global);
+/* Following does not need p_global. */
+ABT_bool ABTD_env_get_use_debug(void);
+ABT_bool ABTD_env_get_use_logging(void);
+ABT_bool ABTD_env_get_print_config(void);
+int ABTD_env_get_max_xstreams(void);
+uint32_t ABTD_env_key_table_size(void);
+size_t ABTD_env_get_sys_pagesize(void);
+size_t ABTD_env_get_thread_stacksize(void);
+size_t ABTD_env_get_sched_stacksize(void);
+uint32_t ABTD_env_get_sched_event_freq(void);
+uint64_t ABTD_env_get_sched_sleep_nsec(void);
+ABT_bool ABTD_env_get_stack_guard_mprotect(ABT_bool *is_strict);
 
 /* ES Context */
 ABTU_ret_err int ABTD_xstream_context_create(void *(*f_xstream)(void *),

--- a/src/info.c
+++ b/src/info.c
@@ -217,9 +217,12 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
     switch (query_kind) {
         case ABT_INFO_QUERY_KIND_ENABLED_DEBUG: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((ABT_bool *)val) = p_global->use_debug;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((ABT_bool *)val) = p_global->use_debug;
+            } else {
+                *((ABT_bool *)val) = ABTD_env_get_use_debug();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO:
 #ifdef ABT_CONFIG_PRINT_ABT_ERRNO
@@ -229,9 +232,12 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_LOG: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((ABT_bool *)val) = p_global->use_logging;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((ABT_bool *)val) = p_global->use_logging;
+            } else {
+                *((ABT_bool *)val) = ABTD_env_get_use_logging();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_ENABLED_VALGRIND:
 #ifdef HAVE_VALGRIND_SUPPORT
@@ -300,39 +306,58 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((ABT_bool *)val) = p_global->print_config;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((ABT_bool *)val) = p_global->print_config;
+            } else {
+                *((ABT_bool *)val) = ABTD_env_get_print_config();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_ENABLED_AFFINITY: {
             ABTI_global *p_global;
+            /* This check needs runtime check in ABT_init(). */
             ABTI_SETUP_GLOBAL(&p_global);
             *((ABT_bool *)val) = p_global->set_affinity;
         } break;
         case ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((unsigned int *)val) = p_global->max_xstreams;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((unsigned int *)val) = p_global->max_xstreams;
+            } else {
+                *((unsigned int *)val) = ABTD_env_get_max_xstreams();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((size_t *)val) = p_global->thread_stacksize;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((size_t *)val) = p_global->thread_stacksize;
+            } else {
+                *((size_t *)val) = ABTD_env_get_thread_stacksize();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((size_t *)val) = p_global->sched_stacksize;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((size_t *)val) = p_global->sched_stacksize;
+            } else {
+                *((size_t *)val) = ABTD_env_get_sched_stacksize();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((uint64_t *)val) = p_global->sched_event_freq;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((uint64_t *)val) = p_global->sched_event_freq;
+            } else {
+                *((uint64_t *)val) = ABTD_env_get_sched_event_freq();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            *((uint64_t *)val) = p_global->sched_sleep_nsec;
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                *((uint64_t *)val) = p_global->sched_sleep_nsec;
+            } else {
+                *((uint64_t *)val) = ABTD_env_get_sched_sleep_nsec();
+            }
         } break;
         case ABT_INFO_QUERY_KIND_ENABLED_TOOL:
 #ifndef ABT_CONFIG_DISABLE_TOOL_INTERFACE
@@ -359,19 +384,35 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_STACK_OVERFLOW_CHECK: {
-            ABTI_global *p_global;
-            ABTI_SETUP_GLOBAL(&p_global);
-            if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT) {
-                *((int *)val) = 2;
-            } else if (p_global->stack_guard_kind ==
-                       ABTI_STACK_GUARD_MPROTECT_STRICT) {
-                *((int *)val) = 3;
-            } else {
+            ABTI_global *p_global = ABTI_global_get_global_or_null();
+            if (p_global) {
+                if (p_global->stack_guard_kind == ABTI_STACK_GUARD_MPROTECT) {
+                    *((int *)val) = 2;
+                } else if (p_global->stack_guard_kind ==
+                           ABTI_STACK_GUARD_MPROTECT_STRICT) {
+                    *((int *)val) = 3;
+                } else {
 #if ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_CANARY
-                *((int *)val) = 1;
+                    *((int *)val) = 1;
 #else
-                *((int *)val) = 0;
+                    *((int *)val) = 0;
 #endif
+                }
+            } else {
+                ABT_bool is_strict;
+                if (ABTD_env_get_stack_guard_mprotect(&is_strict)) {
+                    if (is_strict) {
+                        *((int *)val) = 3;
+                    } else {
+                        *((int *)val) = 2;
+                    }
+                } else {
+#if ABT_CONFIG_STACK_CHECK_TYPE == ABTI_STACK_CHECK_TYPE_CANARY
+                    *((int *)val) = 1;
+#else
+                    *((int *)val) = 0;
+#endif
+                }
             }
         } break;
         case ABT_INFO_QUERY_KIND_WAIT_POLICY:

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -76,6 +76,7 @@ basic/stack_guard
 basic/timer
 basic/info_print
 basic/info_print_stack
+basic/info_query
 basic/info_stackdump
 basic/info_stackdump2
 basic/unit

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -81,6 +81,7 @@ TESTS = \
 	timer \
 	info_print \
 	info_print_stack \
+	info_query \
 	info_stackdump \
 	info_stackdump2 \
 	unit \
@@ -178,6 +179,7 @@ stack_guard_SOURCES = stack_guard.c
 timer_SOURCES = timer.c
 info_print_SOURCES = info_print.c
 info_print_stack_SOURCES = info_print_stack.c
+info_query_SOURCES = info_query.c
 info_stackdump_SOURCES = info_stackdump.c
 info_stackdump2_SOURCES = info_stackdump2.c
 unit_SOURCES = unit.c
@@ -261,6 +263,7 @@ testing:
 	./timer
 	./info_print
 	./info_print_stack
+	./info_query
 	./info_stackdump
 	./info_stackdump2
 	./unit

--- a/test/basic/info_query.c
+++ b/test/basic/info_query.c
@@ -1,0 +1,187 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* Check if ABT_info_query_config() returns a consistent result. */
+
+enum val_type_kind {
+    VAL_TYPE_ABT_BOOL,
+    VAL_TYPE_INT,
+    VAL_TYPE_UNSIGNED_INT,
+    VAL_TYPE_UINT64_T,
+    VAL_TYPE_SIZE_T,
+};
+
+typedef enum val_type_kind val_type_kind;
+
+typedef struct info_query_t {
+    ABT_info_query_kind query_kind;
+    ABT_bool need_init; /* Experimental ver-2.0 API */
+    val_type_kind type;
+
+    int buffer_idx;
+    uint64_t buffers[64];
+    struct info_query_t *p_next;
+} info_query_t;
+
+info_query_t *gp_query = NULL;
+
+void add_info_query_t(ABT_info_query_kind query_kind, ABT_bool need_init,
+                      val_type_kind type)
+{
+    info_query_t *p_query = (info_query_t *)calloc(1, sizeof(info_query_t));
+    p_query->query_kind = query_kind;
+    p_query->need_init = need_init;
+    p_query->type = type;
+    p_query->p_next = gp_query;
+    gp_query = p_query;
+}
+
+void info_query_all(ABT_bool init)
+{
+#ifndef ABT_ENABLE_VER_20_API
+    /* Argobots 1.x does not allow calling ABT_info_query_config() when the
+     * runtime is not initialized. */
+    if (!init)
+        return;
+#endif
+    info_query_t *p_query = gp_query;
+    while (p_query) {
+        if (!(p_query->need_init && !init)) {
+            const int idx = p_query->buffer_idx++;
+            int32_t *ptr = (int32_t *)(&p_query->buffers[1 + (idx)*3]);
+            ptr[-1] = 0x77777777;
+            ptr[0] = 0x77777777;
+            ptr[1] = 0x77777777;
+            ptr[2] = 0x77777777;
+            int ret = ABT_info_query_config(p_query->query_kind, (void *)ptr);
+            ATS_ERROR(ret, "ABT_info_query_config");
+            /* Check the size */
+            int nbytes = 0;
+            if (p_query->type == VAL_TYPE_ABT_BOOL) {
+                nbytes = sizeof(ABT_bool);
+                ABT_bool val = *((ABT_bool *)ptr);
+                assert(val == ABT_TRUE || val == ABT_FALSE);
+            } else if (p_query->type == VAL_TYPE_INT) {
+                nbytes = sizeof(int);
+            } else if (p_query->type == VAL_TYPE_UNSIGNED_INT) {
+                nbytes = sizeof(unsigned int);
+            } else if (p_query->type == VAL_TYPE_UINT64_T) {
+                nbytes = sizeof(uint64_t);
+            } else if (p_query->type == VAL_TYPE_SIZE_T) {
+                nbytes = sizeof(size_t);
+            }
+            /* ABT_info_query_config may not overwrite memories around ptr. */
+            if (nbytes <= 4) {
+                assert(ptr[-1] == 0x77777777);
+                assert(ptr[1] == 0x77777777);
+            } else if (nbytes == 8) {
+                assert(ptr[-1] == 0x77777777);
+                assert(ptr[2] == 0x77777777);
+            } else {
+                /* We do not consider such a system. */
+                exit(77);
+            }
+            /* Check consistency. */
+            if (idx > 0) {
+                int32_t *prev_ptr =
+                    (int32_t *)(&p_query->buffers[1 + (idx - 1) * 3]);
+                /* The value must be the same as the previous one. */
+                assert(ptr[-1] == prev_ptr[-1]);
+                assert(ptr[0] == prev_ptr[0]);
+                assert(ptr[1] == prev_ptr[1]);
+                assert(ptr[2] == prev_ptr[2]);
+            }
+        }
+        p_query = p_query->p_next;
+    }
+}
+
+void info_query_free()
+{
+    info_query_t *p_query = gp_query;
+    while (p_query) {
+        info_query_t *p_next = p_query->p_next;
+        free(p_query);
+        p_query = p_next;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int ret;
+
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_DEBUG, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_PRINT_ERRNO, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_LOG, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_VALGRIND, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_PRODUCER, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_CHECK_POOL_CONSUMER, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_PRESERVE_FPU, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_TASK_CANCEL, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_MIGRATION, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_STACKABLE_SCHED, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_SCHED_SLEEP, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_PRINT_CONFIG, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_AFFINITY, ABT_TRUE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_MAX_NUM_XSTREAMS, ABT_FALSE,
+                     VAL_TYPE_UNSIGNED_INT);
+    add_info_query_t(ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE, ABT_FALSE,
+                     VAL_TYPE_SIZE_T);
+    add_info_query_t(ABT_INFO_QUERY_KIND_DEFAULT_SCHED_STACKSIZE, ABT_FALSE,
+                     VAL_TYPE_SIZE_T);
+    add_info_query_t(ABT_INFO_QUERY_KIND_DEFAULT_SCHED_EVENT_FREQ, ABT_FALSE,
+                     VAL_TYPE_UINT64_T);
+    add_info_query_t(ABT_INFO_QUERY_KIND_DEFAULT_SCHED_SLEEP_NSEC, ABT_FALSE,
+                     VAL_TYPE_UINT64_T);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_TOOL, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_FCONTEXT, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_DYNAMIC_PROMOTION, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_STACK_UNWIND, ABT_FALSE,
+                     VAL_TYPE_ABT_BOOL);
+    add_info_query_t(ABT_INFO_QUERY_KIND_ENABLED_STACK_OVERFLOW_CHECK,
+                     ABT_FALSE, VAL_TYPE_INT);
+    add_info_query_t(ABT_INFO_QUERY_KIND_WAIT_POLICY, ABT_FALSE, VAL_TYPE_INT);
+
+    info_query_all(0);
+    ret = ABT_init(argc, argv);
+    ATS_ERROR(ret, "ABT_init");
+
+    info_query_all(1);
+    info_query_all(1);
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+
+    info_query_all(0);
+    info_query_free();
+    return ret;
+}


### PR DESCRIPTION
## Pull Request Description

ULT stack overflow causes numerous issues (see #274, #324, #333, and [this thread](https://lists.argobots.org/pipermail/discuss/2021-April/000113.html)). This PR adds new features to ease stack size configuration.

### 1.  Configure-time stack size setting

The user can configure a default ULT stack size.
```sh
./configure --enable-default-stacksize=102400
```
This setting can be overwritten by `ABT_THREAD_STACKSIZE`
```sh
# The default ULT stack size is that of configure-time (e.g., 102400)
./a.out
# The default ULT stack size is 204800 
ABT_THREAD_STACKSIZE=204800 ./a.out
```

### 2. Run-time stack size check

**If `--enable-ver20-api` is set,** the application can now obtain the default stack size via `ABT_info_query_config()` without initializing Argobots (i.e., before `ABT_init()`).
```c
// Argobots configured with --enable-ver20-api
size_t stacksize;
ABT_info_query_config(ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE, (void *)&stacksize);
assert(stacksize >= 65536);
```
Note that **by default (without `--enable-ver20-api`), `ABT_info_query_config()` needs Argobots initialization** to maintain the backward compatibility of API.
```c
// Default Argobots configuration
ABT_init(0, 0);
size_t stacksize;
// If ABT_info_query_config() is called without initializing Argobots, an error is returned.
ABT_info_query_config(ABT_INFO_QUERY_KIND_DEFAULT_THREAD_STACKSIZE, (void *)&stacksize);
assert(stacksize >= 65536);
ABT_finalize();
```

This PR does not change the default ULT stack size (16KB).
<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
