### PR TITLE
improve ULT request handling mechanism

### DIFF
--- a/src/arch/fcontext/fcontext_arm64_aapcs_elf_gas.S
+++ b/src/arch/fcontext/fcontext_arm64_aapcs_elf_gas.S
@@ -56,7 +56,7 @@
 .cpu    generic+fp+simd
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .text
 .align  2
@@ -109,9 +109,6 @@ switch_fcontext:
     ldp  x27, x28, [sp, #0x80]
     ldp  x29, x30, [sp, #0x90]
 
-    /* set a return value (x0) to p_old_ctx (x1) */
-    mov  x0, x1
-
     /* load pc */
     ldr  x4, [sp, #0xa0]
 
@@ -122,7 +119,7 @@ switch_fcontext:
 .size   switch_fcontext,.-switch_fcontext
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .text
 .align  2
@@ -149,9 +146,6 @@ jump_fcontext:
     ldp  x27, x28, [sp, #0x80]
     ldp  x29, x30, [sp, #0x90]
 
-    /* set a return value (x0) to p_old_ctx (x1) */
-    mov  x0, x1
-
     /* load pc */
     ldr  x4, [sp, #0xa0]
 
@@ -162,9 +156,9 @@ jump_fcontext:
 .size   jump_fcontext,.-jump_fcontext
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .text
 .align  2
@@ -208,9 +202,8 @@ init_and_switch_fcontext:
 .size   init_and_switch_fcontext,.-init_and_switch_fcontext
 
 /*
-fcontext_t *init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                                   void (*f_thread)(fcontext_t *),
-                                   void *p_stacktop);
+void init_and_jump_fcontext(fcontext_t *p_new_ctx,
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .text
 .align  2
@@ -226,6 +219,209 @@ init_and_jump_fcontext:
     /* sp is 16-byte aligned (the ABI spec requires it) */
     blr  x1
 .size   init_and_jump_fcontext,.-init_and_jump_fcontext
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.text
+.align  2
+.global switch_with_call_fcontext
+.type   switch_with_call_fcontext, %function
+switch_with_call_fcontext:
+    /* prepare stack for GP + FPU */
+    sub  sp, sp, #0xb0
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save d8 - d15 */
+    stp  d8,  d9,  [sp, #0x00]
+    stp  d10, d11, [sp, #0x10]
+    stp  d12, d13, [sp, #0x20]
+    stp  d14, d15, [sp, #0x30]
+#endif
+    /* save x19 - x30 */
+    stp  x19, x20, [sp, #0x40]
+    stp  x21, x22, [sp, #0x50]
+    stp  x23, x24, [sp, #0x60]
+    stp  x25, x26, [sp, #0x70]
+    stp  x27, x28, [sp, #0x80]
+    stp  x29, x30, [sp, #0x90]
+
+    /* save LR as PC */
+    str  x30, [sp, #0xa0]
+
+    /* store SP (pointing to context-data) in p_old_ctx (x3). */
+    /* STR cannot have sp as a target register */
+    mov  x4, sp
+    str  x4, [x3]
+
+    /* restore SP (pointing to context-data) from p_new_ctx (x2) */
+    /* LDR cannot have sp as a target register */
+    ldr  x5, [x2]
+    mov  sp, x5
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* load d8 - d15 */
+    ldp  d8,  d9,  [sp, #0x00]
+    ldp  d10, d11, [sp, #0x10]
+    ldp  d12, d13, [sp, #0x20]
+    ldp  d14, d15, [sp, #0x30]
+#endif
+    /* load x19 - x30 */
+    ldp  x19, x20, [sp, #0x40]
+    ldp  x21, x22, [sp, #0x50]
+    ldp  x23, x24, [sp, #0x60]
+    ldp  x25, x26, [sp, #0x70]
+    ldp  x27, x28, [sp, #0x80]
+    ldp  x29, x30, [sp, #0x90]
+
+    /* load pc */
+    ldr  x4, [sp, #0xa0]
+
+    /* restore stack from GP + FPU */
+    add  sp, sp, #0xb0
+
+    ret  x4
+.size   switch_with_call_fcontext,.-switch_with_call_fcontext
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.text
+.align  2
+.global jump_with_call_fcontext
+.type   jump_with_call_fcontext, %function
+jump_with_call_fcontext:
+    /* restore SP (pointing to context-data) from p_new_ctx (x2) */
+    /* LDR cannot have sp as a target register */
+    ldr  x3, [x2]
+    mov  sp, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* load d8 - d15 */
+    ldp  d8,  d9,  [sp, #0x00]
+    ldp  d10, d11, [sp, #0x10]
+    ldp  d12, d13, [sp, #0x20]
+    ldp  d14, d15, [sp, #0x30]
+#endif
+    /* load x19 - x30 */
+    ldp  x19, x20, [sp, #0x40]
+    ldp  x21, x22, [sp, #0x50]
+    ldp  x23, x24, [sp, #0x60]
+    ldp  x25, x26, [sp, #0x70]
+    ldp  x27, x28, [sp, #0x80]
+    ldp  x29, x30, [sp, #0x90]
+
+    /* load pc */
+    ldr  x4, [sp, #0xa0]
+
+    /* restore stack from GP + FPU */
+    add  sp, sp, #0xb0
+
+    ret  x4
+.size   jump_with_call_fcontext,.-jump_with_call_fcontext
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.text
+.align  2
+.global init_and_switch_with_call_fcontext
+.type   init_and_switch_with_call_fcontext, %function
+init_and_switch_with_call_fcontext:
+    /* prepare stack for GP + FPU */
+    sub  sp, sp, #0xb0
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save d8 - d15 */
+    stp  d8,  d9,  [sp, #0x00]
+    stp  d10, d11, [sp, #0x10]
+    stp  d12, d13, [sp, #0x20]
+    stp  d14, d15, [sp, #0x30]
+#endif
+    /* save x19 - x30 */
+    stp  x19, x20, [sp, #0x40]
+    stp  x21, x22, [sp, #0x50]
+    stp  x23, x24, [sp, #0x60]
+    stp  x25, x26, [sp, #0x70]
+    stp  x27, x28, [sp, #0x80]
+    stp  x29, x30, [sp, #0x90]
+
+    /* save LR as PC */
+    str  x30, [sp, #0xa0]
+
+    /* store SP (pointing to context-data) in p_old_ctx (x5). */
+    /* STR cannot have sp as a target register */
+    mov  x6, sp
+    str  x6, [x5]
+
+    /* shift address in p_stacktop (x4) to lower 16 byte boundary */
+    and  x4, x4, ~0xF
+    /* restore SP (pointing to context-data) from p_stacktop (x4) */
+    sub  sp, x4, #0x10
+
+    /* save p_new_ctx (x2) in x19 (callee-saved) */
+    mov  x19, x2
+    /* save f_thread (x3) in x20 (callee-saved) */
+    mov  x20, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+    /* set the first argument (x0) to p_new_ctx (x19) */
+    mov  x0, x19
+
+    /* call f_thread (x20). p_new_ctx (x0) has been already set */
+    /* sp is 16-byte aligned (the ABI spec requires it) */
+    blr  x20
+.size   init_and_switch_with_call_fcontext,.-init_and_switch_with_call_fcontext
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.text
+.align  2
+.global init_and_jump_with_call_fcontext
+.type   init_and_jump_with_call_fcontext, %function
+init_and_jump_with_call_fcontext:
+    /* shift address in p_stacktop (x4) to lower 16 byte boundary */
+    and  x4, x4, ~0xF
+    /* restore SP (pointing to context-data) from p_stacktop (x4) */
+    sub  sp, x4, #0x10
+
+    /* save p_new_ctx (x2) in x19 (callee-saved) */
+    mov  x19, x2
+    /* save f_thread (x3) in x20 (callee-saved) */
+    mov  x20, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+    /* set the first argument (x0) to p_new_ctx (x19) */
+    mov  x0, x19
+
+    /* call f_thread (x20). p_new_ctx (x0) has been already set */
+    /* sp is 16-byte aligned (the ABI spec requires it) */
+    blr  x20
+.size   init_and_jump_with_call_fcontext,.-init_and_jump_with_call_fcontext
 
 /*
 void peek_fcontext(void *arg, void (*f_peek)(void *), fcontext_t *p_target_ctx);

--- a/src/arch/fcontext/fcontext_arm64_aapcs_macho_gas.S
+++ b/src/arch/fcontext/fcontext_arm64_aapcs_macho_gas.S
@@ -48,7 +48,7 @@
 #include "abt_config.h"
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .text
 .globl  _switch_fcontext
@@ -100,9 +100,6 @@ _switch_fcontext:
     ldp  x27, x28, [sp, #0x80]
     ldp  x29, x30, [sp, #0x90]
 
-    /* set a return value (x0) to p_old_ctx (x1) */
-    mov  x0, x1
-
     /* load pc */
     ldr  x4, [sp, #0xa0]
 
@@ -112,7 +109,7 @@ _switch_fcontext:
     ret x4
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .text
 .globl  _jump_fcontext
@@ -138,9 +135,6 @@ _jump_fcontext:
     ldp  x27, x28, [sp, #0x80]
     ldp  x29, x30, [sp, #0x90]
 
-    /* set a return value (x0) to p_old_ctx (x1) */
-    mov  x0, x1
-
     /* load pc */
     ldr  x4, [sp, #0xa0]
 
@@ -150,9 +144,9 @@ _jump_fcontext:
     ret  x4
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .text
 .globl  _init_and_switch_fcontext
@@ -194,9 +188,8 @@ _init_and_switch_fcontext:
     blr  x1
 
 /*
-fcontext_t *init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                                   void (*f_thread)(fcontext_t *),
-                                   void *p_stacktop);
+void init_and_jump_fcontext(fcontext_t *p_new_ctx,
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .text
 .globl  _init_and_jump_fcontext
@@ -210,6 +203,201 @@ _init_and_jump_fcontext:
     /* call f_thread (x1). p_new_ctx (x0) has been already set */
     /* sp is 16-byte aligned (the ABI spec requires it) */
     blr  x1
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.text
+.globl  _switch_with_call_fcontext
+.balign 16
+_switch_with_call_fcontext:
+    /* prepare stack for GP + FPU */
+    sub  sp, sp, #0xb0
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save d8 - d15 */
+    stp  d8,  d9,  [sp, #0x00]
+    stp  d10, d11, [sp, #0x10]
+    stp  d12, d13, [sp, #0x20]
+    stp  d14, d15, [sp, #0x30]
+#endif
+    /* save x19 - x30 */
+    stp  x19, x20, [sp, #0x40]
+    stp  x21, x22, [sp, #0x50]
+    stp  x23, x24, [sp, #0x60]
+    stp  x25, x26, [sp, #0x70]
+    stp  x27, x28, [sp, #0x80]
+    stp  x29, x30, [sp, #0x90]
+
+    /* save LR as PC */
+    str  x30, [sp, #0xa0]
+
+    /* store SP (pointing to context-data) in p_old_ctx (x3). */
+    /* STR cannot have sp as a target register */
+    mov  x4, sp
+    str  x4, [x3]
+
+    /* restore SP (pointing to context-data) from p_new_ctx (x2) */
+    /* LDR cannot have sp as a target register */
+    ldr  x5, [x2]
+    mov  sp, x5
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* load d8 - d15 */
+    ldp  d8,  d9,  [sp, #0x00]
+    ldp  d10, d11, [sp, #0x10]
+    ldp  d12, d13, [sp, #0x20]
+    ldp  d14, d15, [sp, #0x30]
+#endif
+    /* load x19 - x30 */
+    ldp  x19, x20, [sp, #0x40]
+    ldp  x21, x22, [sp, #0x50]
+    ldp  x23, x24, [sp, #0x60]
+    ldp  x25, x26, [sp, #0x70]
+    ldp  x27, x28, [sp, #0x80]
+    ldp  x29, x30, [sp, #0x90]
+
+    /* load pc */
+    ldr  x4, [sp, #0xa0]
+
+    /* restore stack from GP + FPU */
+    add  sp, sp, #0xb0
+
+    ret  x4
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.text
+.globl  _jump_with_call_fcontext
+.balign 16
+_jump_with_call_fcontext:
+    /* restore SP (pointing to context-data) from p_new_ctx (x2) */
+    /* LDR cannot have sp as a target register */
+    ldr  x3, [x2]
+    mov  sp, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* load d8 - d15 */
+    ldp  d8,  d9,  [sp, #0x00]
+    ldp  d10, d11, [sp, #0x10]
+    ldp  d12, d13, [sp, #0x20]
+    ldp  d14, d15, [sp, #0x30]
+#endif
+    /* load x19 - x30 */
+    ldp  x19, x20, [sp, #0x40]
+    ldp  x21, x22, [sp, #0x50]
+    ldp  x23, x24, [sp, #0x60]
+    ldp  x25, x26, [sp, #0x70]
+    ldp  x27, x28, [sp, #0x80]
+    ldp  x29, x30, [sp, #0x90]
+
+    /* load pc */
+    ldr  x4, [sp, #0xa0]
+
+    /* restore stack from GP + FPU */
+    add  sp, sp, #0xb0
+
+    ret  x4
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.text
+.globl  _init_and_switch_with_call_fcontext
+.balign 16
+_init_and_switch_with_call_fcontext:
+    /* prepare stack for GP + FPU */
+    sub  sp, sp, #0xb0
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save d8 - d15 */
+    stp  d8,  d9,  [sp, #0x00]
+    stp  d10, d11, [sp, #0x10]
+    stp  d12, d13, [sp, #0x20]
+    stp  d14, d15, [sp, #0x30]
+#endif
+    /* save x19 - x30 */
+    stp  x19, x20, [sp, #0x40]
+    stp  x21, x22, [sp, #0x50]
+    stp  x23, x24, [sp, #0x60]
+    stp  x25, x26, [sp, #0x70]
+    stp  x27, x28, [sp, #0x80]
+    stp  x29, x30, [sp, #0x90]
+
+    /* save LR as PC */
+    str  x30, [sp, #0xa0]
+
+    /* store SP (pointing to context-data) in p_old_ctx (x5). */
+    /* STR cannot have sp as a target register */
+    mov  x6, sp
+    str  x6, [x5]
+
+    /* shift address in p_stacktop (x4) to lower 16 byte boundary */
+    and  x4, x4, ~0xF
+    /* restore SP (pointing to context-data) from p_stacktop (x4) */
+    sub  sp, x4, #0x10
+
+    /* save p_new_ctx (x2) in x19 (callee-saved) */
+    mov  x19, x2
+    /* save f_thread (x3) in x20 (callee-saved) */
+    mov  x20, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+    /* set the first argument (x0) to p_new_ctx (x19) */
+    mov  x0, x19
+
+    /* call f_thread (x20). p_new_ctx (x0) has been already set */
+    /* sp is 16-byte aligned (the ABI spec requires it) */
+    blr  x20
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.text
+.globl  _init_and_jump_with_call_fcontext
+.balign 16
+_init_and_jump_with_call_fcontext:
+    /* shift address in p_stacktop (x4) to lower 16 byte boundary */
+    and  x4, x4, ~0xF
+    /* restore SP (pointing to context-data) from p_stacktop (x4) */
+    sub  sp, x4, #0x10
+
+    /* save p_new_ctx (x2) in x19 (callee-saved) */
+    mov  x19, x2
+    /* save f_thread (x3) in x20 (callee-saved) */
+    mov  x20, x3
+
+    /* call f_cb (x1).  cb_arg (x0) has already been set.
+     * all the caller-saved registers will be discarded. */
+    blr  x1
+
+    /* set the first argument (x0) to p_new_ctx (x19) */
+    mov  x0, x19
+
+    /* call f_thread (x20). p_new_ctx (x0) has been already set */
+    /* sp is 16-byte aligned (the ABI spec requires it) */
+    blr  x20
 
 /*
 void peek_fcontext(void *arg, void (*f_peek)(void *), fcontext_t *p_target_ctx);

--- a/src/arch/fcontext/fcontext_i386_sysv_elf_gas.S
+++ b/src/arch/fcontext/fcontext_i386_sysv_elf_gas.S
@@ -20,7 +20,7 @@
 #include "abt_config.h"
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .text
 .globl switch_fcontext
@@ -72,13 +72,12 @@ switch_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* set p_old_ctx (EAX) as the return value. */
     /* indirect jump to context */
     jmp  *%edx
 .size switch_fcontext,.-switch_fcontext
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .text
 .globl jump_fcontext
@@ -87,9 +86,6 @@ void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 jump_fcontext:
     /* load p_new_ctx (the first arg) to EDX */
     movl  0x4(%esp), %edx
-
-    /* load p_old_ctx (the second arg) to EAX */
-    movl  0x8(%esp), %eax
 
     /* restore ESP (pointing to context-data) from p_new_ctx (EDX) */
     movl  (%edx), %esp
@@ -112,15 +108,14 @@ jump_fcontext:
     /* restore return-address */
     popl  %edx
 
-    /* set p_old_ctx (EAX) as the return value. */
     /* indirect jump to context */
     jmp  *%edx
 .size jump_fcontext,.-jump_fcontext
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .text
 .globl init_and_switch_fcontext
@@ -171,9 +166,8 @@ init_and_switch_fcontext:
 .size init_and_switch_fcontext,.-init_and_switch_fcontext
 
 /*
-fcontext_t *init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                                   void (*f_thread)(fcontext_t *),
-                                   void *p_stacktop);
+void init_and_jump_fcontext(fcontext_t *p_new_ctx,
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .text
 .globl init_and_jump_fcontext
@@ -201,6 +195,241 @@ init_and_jump_fcontext:
     /* indirect jump to context */
     jmp  *%edx
 .size init_and_jump_fcontext,.-init_and_jump_fcontext
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.text
+.globl switch_with_call_fcontext
+.align 2
+.type switch_with_call_fcontext,@function
+switch_with_call_fcontext:
+    pushl  %ebp  /* save EBP */
+    pushl  %ebx  /* save EBX */
+    pushl  %esi  /* save ESI */
+    pushl  %edi  /* save EDI */
+
+    /* prepare stack for FPU */
+    leal  -0x8(%esp), %esp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%esp)
+    /* save x87 control-word */
+    fnstcw  0x4(%esp)
+#endif
+
+    /* load p_old_ctx (the fourth arg) to EAX */
+    movl  0x28(%esp), %eax
+
+    /* store ESP in p_old_ctx (EAX) */
+    movl  %esp, (%eax)
+
+    /* load p_new_ctx (the third arg) to EDX */
+    movl  0x24(%esp), %edx
+
+    /* load f_cb (the second arg) to ESI */
+    movl  0x20(%esp), %esi
+
+    /* load cb_arg (the first arg) to EDI */
+    movl  0x1c(%esp), %edi
+
+    /* restore ESP (pointing to context-data) from p_new_ctx (EDX) */
+    movl  (%edx), %esp
+
+    /* set the first arg to cb_arg (EDI).  Be aware of the alignment. */
+    leal   -0xc(%esp), %esp
+    pushl  %edi
+    /* call f_cb (ESI).  All the caller-saved registers will be discarded */
+    call  *%esi
+    /* restore ESP */
+    leal   0x10(%esp), %esp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%esp)
+    /* restore x87 control-word */
+    fldcw  0x4(%esp)
+#endif
+
+    /* prepare stack for FPU */
+    leal  0x8(%esp), %esp
+
+    popl  %edi  /* restore EDI */
+    popl  %esi  /* restore ESI */
+    popl  %ebx  /* restore EBX */
+    popl  %ebp  /* restore EBP */
+
+    /* restore return-address */
+    popl  %edx
+
+    /* indirect jump to context */
+    jmp  *%edx
+.size switch_with_call_fcontext,.-switch_with_call_fcontext
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.text
+.globl jump_with_call_fcontext
+.align 2
+.type jump_with_call_fcontext,@function
+jump_with_call_fcontext:
+    /* load cb_arg (the first arg) to EDI */
+    movl  0x4(%esp), %edi
+
+    /* load f_cb (the second arg) to ESI */
+    movl  0x8(%esp), %esi
+
+    /* load p_new_ctx (the third arg) to EDX */
+    movl  0xc(%esp), %edx
+
+    /* restore ESP (pointing to context-data) from p_new_ctx (EDX) */
+    movl  (%edx), %esp
+
+    /* set the first arg to cb_arg (EDI).  Be aware of the alignment. */
+    leal   -0xc(%esp), %esp
+    pushl  %edi
+    /* call f_cb (ESI).  All the caller-saved registers will be discarded */
+    call  *%esi
+    /* restore ESP */
+    leal   0x10(%esp), %esp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%esp)
+    /* restore x87 control-word */
+    fldcw  0x4(%esp)
+#endif
+
+    /* prepare stack for FPU */
+    leal  0x8(%esp), %esp
+
+    popl  %edi  /* restore EDI */
+    popl  %esi  /* restore ESI */
+    popl  %ebx  /* restore EBX */
+    popl  %ebp  /* restore EBP */
+
+    /* restore return-address */
+    popl  %edx
+
+    /* indirect jump to context */
+    jmp  *%edx
+.size jump_with_call_fcontext,.-jump_with_call_fcontext
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.text
+.globl init_and_switch_with_call_fcontext
+.align 2
+.type init_and_switch_with_call_fcontext,@function
+init_and_switch_with_call_fcontext:
+    pushl  %ebp  /* save EBP */
+    pushl  %ebx  /* save EBX */
+    pushl  %esi  /* save ESI */
+    pushl  %edi  /* save EDI */
+
+    /* prepare stack for FPU */
+    leal  -0x8(%esp), %esp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%esp)
+    /* save x87 control-word */
+    fnstcw  0x4(%esp)
+#endif
+
+    /* load p_old_ctx (the sixth arg) to EDX */
+    movl  0x30(%esp), %edx
+
+    /* store ESP in p_old_ctx (EDX) */
+    movl  %esp, (%edx)
+
+    /* load cb_arg (the first arg) to EDX */
+    movl  0x1c(%esp), %edx
+
+    /* load f_cb (the second arg) to EAX */
+    movl  0x20(%esp), %eax
+
+    /* load p_new_ctx (the third arg) to EDI (callee-saved) */
+    movl  0x24(%esp), %edi
+
+    /* set f_thread (the fourth arg) to ESI (callee-saved) */
+    movl  0x28(%esp), %esi
+
+    /* set p_stacktop (the fifth arg) to ESP */
+    movl  0x2c(%esp), %esp
+
+    /* shift address in ESP to lower 16 byte boundary */
+    andl  $-16, %esp
+
+    /* set the first arg to cb_arg (EDX).  Be aware of the alignment. */
+    leal   -0xc(%esp), %esp
+    pushl  %edx
+    /* call f_cb (EAX).  All the caller-saved registers will be discarded */
+    call  *%eax
+
+    /* for 16-byte function stack alignment, subtract 4 bytes */
+    leal  -0x4(%esp), %esp
+
+    /* set p_new_ctx (EDI) as the first argument. */
+    movl  %edi, 0x4(%esp)
+
+    /* indirect jump to context */
+    jmp  *%esi
+.size init_and_switch_with_call_fcontext,.-init_and_switch_with_call_fcontext
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.text
+.globl init_and_jump_with_call_fcontext
+.align 2
+.type init_and_jump_with_call_fcontext,@function
+init_and_jump_with_call_fcontext:
+    /* load cb_arg (the first arg) to EDX */
+    movl  0x4(%esp), %edx
+
+    /* load f_cb (the second arg) to EAX */
+    movl  0x8(%esp), %eax
+
+    /* load p_new_ctx (the third arg) to EDI (callee-saved) */
+    movl  0xc(%esp), %edi
+
+    /* set f_thread (the fourth arg) to ESI (callee-saved) */
+    movl  0x10(%esp), %esi
+
+    /* set p_stacktop (the fifth arg) to ESP */
+    movl  0x14(%esp), %esp
+
+    /* shift address in ESP to lower 16 byte boundary */
+    andl  $-16, %esp
+
+    /* set the first arg to cb_arg (EDX).  Be aware of the alignment. */
+    leal   -0xc(%esp), %esp
+    pushl  %edx
+    /* call f_cb (EAX).  All the caller-saved registers will be discarded */
+    call  *%eax
+
+    /* for 16-byte function stack alignment, subtract 4 bytes */
+    leal  -0x4(%esp), %esp
+
+    /* set p_new_ctx (EDI) as the first argument. */
+    movl  %edi, 0x4(%esp)
+
+    /* indirect jump to context */
+    jmp  *%esi
+.size init_and_jump_with_call_fcontext,.-init_and_jump_with_call_fcontext
 
 /*
 void peek_fcontext(void *arg, void (*f_peek)(void *), fcontext_t *p_target_ctx);

--- a/src/arch/fcontext/fcontext_ppc64_sysv_elf_gas.S
+++ b/src/arch/fcontext/fcontext_ppc64_sysv_elf_gas.S
@@ -133,7 +133,7 @@
 #include "abt_config.h"
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .globl switch_fcontext
 #if _CALL_ELF == 2
@@ -362,9 +362,6 @@ switch_fcontext:
     /* adjust stack */
     addi  %r1, %r1, 528
 
-    /* use p_old_ctx (R4) as a return value (R3) after jump */
-    mr  %r3, %r4
-
     /* jump to context */
     bctr
 #if _CALL_ELF == 2
@@ -378,7 +375,7 @@ switch_fcontext:
 #endif
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .globl jump_fcontext
 #if _CALL_ELF == 2
@@ -506,9 +503,6 @@ jump_fcontext:
     /* adjust stack */
     addi  %r1, %r1, 528
 
-    /* use p_old_ctx (R4) as a return value (R3) after jump */
-    mr  %r3, %r4
-
     /* jump to context */
     bctr
 #if _CALL_ELF == 2
@@ -523,9 +517,9 @@ jump_fcontext:
 
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .globl init_and_switch_fcontext
 #if _CALL_ELF == 2
@@ -690,8 +684,7 @@ init_and_switch_fcontext:
 
 /*
 void init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                            void (*f_thread)(fcontext_t *),
-                            void *p_stacktop);
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .globl init_and_jump_fcontext
 #if _CALL_ELF == 2
@@ -749,6 +742,685 @@ init_and_jump_fcontext:
     .size .init_and_jump_fcontext, .-.L.init_and_jump_fcontext
 # else
     .size .init_and_jump_fcontext, .-.init_and_jump_fcontext
+# endif
+#endif
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.globl switch_with_call_fcontext
+#if _CALL_ELF == 2
+    .text
+    .align 2
+switch_with_call_fcontext:
+        addis   %r2, %r12, .TOC.-switch_with_call_fcontext@ha
+        addi    %r2, %r2, .TOC.-switch_with_call_fcontext@l
+        .localentry switch_with_call_fcontext, . - switch_with_call_fcontext
+#else
+    .section ".opd","aw"
+    .align 3
+switch_with_call_fcontext:
+# ifdef _CALL_LINUX
+        .quad   .L.switch_with_call_fcontext,.TOC.@tocbase,0
+        .type   switch_with_call_fcontext,@function
+        .text
+        .align 2
+.L.switch_with_call_fcontext:
+# else
+        .hidden .switch_with_call_fcontext
+        .globl  .switch_with_call_fcontext
+        .quad   .switch_with_call_fcontext,.TOC.@tocbase,0
+        .size   switch_with_call_fcontext,24
+        .type   .switch_with_call_fcontext,@function
+        .text
+        .align 2
+.switch_with_call_fcontext:
+# endif
+#endif
+    /* reserve space on stack */
+    subi  %r1, %r1, 528
+    /* save R14 - R31 */
+    std  %r14, 352(%r1)
+    std  %r15, 360(%r1)
+    std  %r16, 368(%r1)
+    std  %r17, 376(%r1)
+    std  %r18, 384(%r1)
+    std  %r19, 392(%r1)
+    std  %r20, 400(%r1)
+    std  %r21, 408(%r1)
+    std  %r22, 416(%r1)
+    std  %r23, 424(%r1)
+    std  %r24, 432(%r1)
+    std  %r25, 440(%r1)
+    std  %r26, 448(%r1)
+    std  %r27, 456(%r1)
+    std  %r28, 464(%r1)
+    std  %r29, 472(%r1)
+    std  %r30, 480(%r1)
+    std  %r31, 488(%r1)
+#if _CALL_ELF != 2
+    /* save TOC */
+    std  %r2,  496(%r1)  # save TOC
+#endif
+
+    /* save CR */
+    mfcr  %r0
+    std  %r0, 504(%r1)
+    /* save LR */
+    mflr  %r0
+    std  %r0, 512(%r1)
+    /* save LR as PC */
+    std  %r0, 520(%r1)
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save F14 - F32 */
+    stfd  %f14, 0(%r1)
+    stfd  %f15, 8(%r1)
+    stfd  %f16, 16(%r1)
+    stfd  %f17, 24(%r1)
+    stfd  %f18, 32(%r1)
+    stfd  %f19, 40(%r1)
+    stfd  %f20, 48(%r1)
+    stfd  %f21, 56(%r1)
+    stfd  %f22, 64(%r1)
+    stfd  %f23, 72(%r1)
+    stfd  %f24, 80(%r1)
+    stfd  %f25, 88(%r1)
+    stfd  %f26, 96(%r1)
+    stfd  %f27, 104(%r1)
+    stfd  %f28, 112(%r1)
+    stfd  %f29, 120(%r1)
+    stfd  %f30, 128(%r1)
+    stfd  %f31, 136(%r1)
+#ifdef __VSX__
+    /* VSCR can be loaded only to Vn.  To store VSCR as it is a vector, */
+    /* it must be written before saving FPSCR. */
+    /* load VSCR. */
+    mfvscr %v19
+    li    %r10, 144
+    /* save VSCR.  Only the last 32 bits are used */
+    stvx  %v19, %r10, %r1
+#endif
+    /* load FPSCR */
+    mffs  %f0
+    /* save FPSCR */
+    stfd  %f0, 144(%r1)
+#ifdef __VSX__
+    /* OpenPOWER saves V20 - V31 (vector units) */
+    /* Note stvx cannot take an immediate value as an offset. */
+    li    %r14, 160
+    stvx  %v20, %r14, %r1
+    li    %r15, 176
+    stvx  %v21, %r15, %r1
+    li    %r16, 192
+    stvx  %v22, %r16, %r1
+    li    %r17, 208
+    stvx  %v23, %r17, %r1
+    li    %r18, 224
+    stvx  %v24, %r18, %r1
+    li    %r19, 240
+    stvx  %v25, %r19, %r1
+    li    %r20, 256
+    stvx  %v26, %r20, %r1
+    li    %r21, 272
+    stvx  %v27, %r21, %r1
+    li    %r22, 288
+    stvx  %v28, %r22, %r1
+    li    %r23, 304
+    stvx  %v29, %r23, %r1
+    li    %r24, 320
+    stvx  %v30, %r24, %r1
+    li    %r25, 336
+    stvx  %v31, %r25, %r1
+#endif
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (R6) */
+    std  %r1, 0(%r6)
+
+    /* restore RSP (pointing to context-data) from p_new_ctx (R5) */
+    ld   %r1, 0(%r5)
+
+    /* set f_cb (R4) to CTR.
+     * f_cb can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r4
+    mtctr %r12
+    /* save necessary things in a stack, including TOC. */
+    subi  %r1, %r1, 48
+    std   %r2, 24(%r1)
+    /* call f_cb.  cb_arg (R3) has already been set.
+     * all the caller-saved registers will be discarded */
+    bctrl
+    /* restore a stack. TOC will be restored below. */
+    addi  %r1, %r1, 48
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore F14 - F31 */
+    lfd  %f14, 0(%r1)
+    lfd  %f15, 8(%r1)
+    lfd  %f16, 16(%r1)
+    lfd  %f17, 24(%r1)
+    lfd  %f18, 32(%r1)
+    lfd  %f19, 40(%r1)
+    lfd  %f20, 48(%r1)
+    lfd  %f21, 56(%r1)
+    lfd  %f22, 64(%r1)
+    lfd  %f23, 72(%r1)
+    lfd  %f24, 80(%r1)
+    lfd  %f25, 88(%r1)
+    lfd  %f26, 96(%r1)
+    lfd  %f27, 104(%r1)
+    lfd  %f28, 112(%r1)
+    lfd  %f29, 120(%r1)
+    lfd  %f30, 128(%r1)
+    lfd  %f31, 136(%r1)
+    /* restore FPSCR */
+    lfd  %f0,  144(%r1)
+    mtfsf  0xff, %f0
+#ifdef __VSX__
+    li    %r10, 144
+    /* Restore VSCR.  Only the last 32 bits are used */
+    lvx   %v19, %r10, %r1
+    mtvscr %v19
+    /* restore V20 - V21 */
+    li    %r14, 160
+    lvx  %v20, %r14, %r1
+    li    %r15, 176
+    lvx  %v21, %r15, %r1
+    li    %r16, 192
+    lvx  %v22, %r16, %r1
+    li    %r17, 208
+    lvx  %v23, %r17, %r1
+    li    %r18, 224
+    lvx  %v24, %r18, %r1
+    li    %r19, 240
+    lvx  %v25, %r19, %r1
+    li    %r20, 256
+    lvx  %v26, %r20, %r1
+    li    %r21, 272
+    lvx  %v27, %r21, %r1
+    li    %r22, 288
+    lvx  %v28, %r22, %r1
+    li    %r23, 304
+    lvx  %v29, %r23, %r1
+    li    %r24, 320
+    lvx  %v30, %r24, %r1
+    li    %r25, 336
+    lvx  %v31, %r25, %r1
+#endif
+#endif
+    /* restore R14 - R31 */
+    ld  %r14, 352(%r1)
+    ld  %r15, 360(%r1)
+    ld  %r16, 368(%r1)
+    ld  %r17, 376(%r1)
+    ld  %r18, 384(%r1)
+    ld  %r19, 392(%r1)
+    ld  %r20, 400(%r1)
+    ld  %r21, 408(%r1)
+    ld  %r22, 416(%r1)
+    ld  %r23, 424(%r1)
+    ld  %r24, 432(%r1)
+    ld  %r25, 440(%r1)
+    ld  %r26, 448(%r1)
+    ld  %r27, 456(%r1)
+    ld  %r28, 464(%r1)
+    ld  %r29, 472(%r1)
+    ld  %r30, 480(%r1)
+    ld  %r31, 488(%r1)
+#if _CALL_ELF != 2
+    /* restore TOC */
+    ld  %r2,  496(%r1)
+#endif
+
+    /* restore CR */
+    ld  %r0, 504(%r1)
+    mtcr  %r0
+    /* restore LR */
+    ld  %r0, 512(%r1)
+    mtlr  %r0
+
+    /* load PC */
+    ld  %r12, 520(%r1)
+    /* restore CTR */
+    mtctr  %r12
+
+    /* adjust stack */
+    addi  %r1, %r1, 528
+
+    /* jump to context */
+    bctr
+#if _CALL_ELF == 2
+    .size switch_with_call_fcontext, .-switch_with_call_fcontext
+#else
+# ifdef _CALL_LINUX
+    .size .switch_with_call_fcontext, .-.L.switch_with_call_fcontext
+# else
+    .size .switch_with_call_fcontext, .-.switch_with_call_fcontext
+# endif
+#endif
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.globl jump_with_call_fcontext
+#if _CALL_ELF == 2
+    .text
+    .align 2
+jump_with_call_fcontext:
+        addis   %r2, %r12, .TOC.-jump_with_call_fcontext@ha
+        addi    %r2, %r2, .TOC.-jump_with_call_fcontext@l
+        .localentry jump_with_call_fcontext, . - jump_with_call_fcontext
+#else
+    .section ".opd","aw"
+    .align 3
+jump_with_call_fcontext:
+# ifdef _CALL_LINUX
+        .quad   .L.jump_with_call_fcontext,.TOC.@tocbase,0
+        .type   jump_with_call_fcontext,@function
+        .text
+        .align 2
+.L.jump_with_call_fcontext:
+# else
+        .hidden .jump_with_call_fcontext
+        .globl  .jump_with_call_fcontext
+        .quad   .jump_with_call_fcontext,.TOC.@tocbase,0
+        .size   jump_with_call_fcontext,24
+        .type   .jump_with_call_fcontext,@function
+        .text
+        .align 2
+.jump_with_call_fcontext:
+# endif
+#endif
+    /* restore RSP (pointing to context-data) from p_new_ctx (R5) */
+    ld  %r1, 0(%r5)
+
+    /* set f_cb (R4) to CTR.
+     * f_cb can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r4
+    mtctr %r12
+    /* save necessary things in a stack, including TOC. */
+    subi  %r1, %r1, 48
+    std   %r2, 24(%r1)
+    /* call f_cb.  cb_arg (R3) has already been set.
+     * all the caller-saved registers will be discarded */
+    bctrl
+    /* restore a stack. TOC will be restored below. */
+    addi  %r1, %r1, 48
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore F14 - F31 */
+    lfd  %f14, 0(%r1)
+    lfd  %f15, 8(%r1)
+    lfd  %f16, 16(%r1)
+    lfd  %f17, 24(%r1)
+    lfd  %f18, 32(%r1)
+    lfd  %f19, 40(%r1)
+    lfd  %f20, 48(%r1)
+    lfd  %f21, 56(%r1)
+    lfd  %f22, 64(%r1)
+    lfd  %f23, 72(%r1)
+    lfd  %f24, 80(%r1)
+    lfd  %f25, 88(%r1)
+    lfd  %f26, 96(%r1)
+    lfd  %f27, 104(%r1)
+    lfd  %f28, 112(%r1)
+    lfd  %f29, 120(%r1)
+    lfd  %f30, 128(%r1)
+    lfd  %f31, 136(%r1)
+    /* restore FPSCR */
+    lfd  %f0,  144(%r1)
+    mtfsf  0xff, %f0
+#ifdef __VSX__
+    li    %r10, 144
+    /* Restore VSCR.  Only the last 32 bits are used */
+    lvx   %v19, %r10, %r1
+    mtvscr %v19
+    /* restore V20 - V21 */
+    li    %r14, 160
+    lvx  %v20, %r14, %r1
+    li    %r15, 176
+    lvx  %v21, %r15, %r1
+    li    %r16, 192
+    lvx  %v22, %r16, %r1
+    li    %r17, 208
+    lvx  %v23, %r17, %r1
+    li    %r18, 224
+    lvx  %v24, %r18, %r1
+    li    %r19, 240
+    lvx  %v25, %r19, %r1
+    li    %r20, 256
+    lvx  %v26, %r20, %r1
+    li    %r21, 272
+    lvx  %v27, %r21, %r1
+    li    %r22, 288
+    lvx  %v28, %r22, %r1
+    li    %r23, 304
+    lvx  %v29, %r23, %r1
+    li    %r24, 320
+    lvx  %v30, %r24, %r1
+    li    %r25, 336
+    lvx  %v31, %r25, %r1
+#endif
+#endif
+    /* restore R14 - R31 */
+    ld  %r14, 352(%r1)
+    ld  %r15, 360(%r1)
+    ld  %r16, 368(%r1)
+    ld  %r17, 376(%r1)
+    ld  %r18, 384(%r1)
+    ld  %r19, 392(%r1)
+    ld  %r20, 400(%r1)
+    ld  %r21, 408(%r1)
+    ld  %r22, 416(%r1)
+    ld  %r23, 424(%r1)
+    ld  %r24, 432(%r1)
+    ld  %r25, 440(%r1)
+    ld  %r26, 448(%r1)
+    ld  %r27, 456(%r1)
+    ld  %r28, 464(%r1)
+    ld  %r29, 472(%r1)
+    ld  %r30, 480(%r1)
+    ld  %r31, 488(%r1)
+#if _CALL_ELF != 2
+    /* restore TOC */
+    ld  %r2,  496(%r1)
+#endif
+
+    /* restore CR */
+    ld  %r0, 504(%r1)
+    mtcr  %r0
+    /* restore LR */
+    ld  %r0, 512(%r1)
+    mtlr  %r0
+
+    /* load PC */
+    ld  %r12, 520(%r1)
+    /* restore CTR */
+    mtctr  %r12
+
+    /* adjust stack */
+    addi  %r1, %r1, 528
+
+    /* jump to context */
+    bctr
+#if _CALL_ELF == 2
+    .size jump_with_call_fcontext, .-jump_with_call_fcontext
+#else
+# ifdef _CALL_LINUX
+    .size .jump_with_call_fcontext, .-.L.jump_with_call_fcontext
+# else
+    .size .jump_with_call_fcontext, .-.jump_with_call_fcontext
+# endif
+#endif
+
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.globl init_and_switch_with_call_fcontext
+#if _CALL_ELF == 2
+    .text
+    .align 2
+init_and_switch_with_call_fcontext:
+        addis   %r2, %r12, .TOC.-init_and_switch_with_call_fcontext@ha
+        addi    %r2, %r2, .TOC.-init_and_switch_with_call_fcontext@l
+        .localentry init_and_switch_with_call_fcontext, . - init_and_switch_with_call_fcontext
+#else
+    .section ".opd","aw"
+    .align 3
+init_and_switch_with_call_fcontext:
+# ifdef _CALL_LINUX
+        .quad   .L.init_and_switch_with_call_fcontext,.TOC.@tocbase,0
+        .type   init_and_switch_with_call_fcontext,@function
+        .text
+        .align 2
+.L.init_and_switch_with_call_fcontext:
+# else
+        .hidden .init_and_switch_with_call_fcontext
+        .globl  .init_and_switch_with_call_fcontext
+        .quad   .init_and_switch_with_call_fcontext,.TOC.@tocbase,0
+        .size   init_and_switch_with_call_fcontext,24
+        .type   .init_and_switch_with_call_fcontext,@function
+        .text
+        .align 2
+.init_and_switch_with_call_fcontext:
+# endif
+#endif
+    /* shift address in p_stacktop (R7) to lower 16 byte boundary */
+    clrrdi  %r7, %r7, 4
+
+    /* save TOC in the target stack (p_stacktop, R7) */
+    /* TOC must be saved when an external function is called. */
+    std  %r2, -24(%r7)
+
+    /* reserve space on stack */
+    subi  %r1, %r1, 528
+    /* save R14 - R31 */
+    std  %r14, 352(%r1)
+    std  %r15, 360(%r1)
+    std  %r16, 368(%r1)
+    std  %r17, 376(%r1)
+    std  %r18, 384(%r1)
+    std  %r19, 392(%r1)
+    std  %r20, 400(%r1)
+    std  %r21, 408(%r1)
+    std  %r22, 416(%r1)
+    std  %r23, 424(%r1)
+    std  %r24, 432(%r1)
+    std  %r25, 440(%r1)
+    std  %r26, 448(%r1)
+    std  %r27, 456(%r1)
+    std  %r28, 464(%r1)
+    std  %r29, 472(%r1)
+    std  %r30, 480(%r1)
+    std  %r31, 488(%r1)
+#if _CALL_ELF != 2
+    /* save TOC */
+    std  %r2,  496(%r1)  # save TOC
+#endif
+
+    /* save CR */
+    mfcr  %r0
+    std  %r0, 504(%r1)
+    /* save LR */
+    mflr  %r0
+    std  %r0, 512(%r1)
+    /* save LR as PC */
+    std  %r0, 520(%r1)
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save F14 - F32 */
+    stfd  %f14, 0(%r1)
+    stfd  %f15, 8(%r1)
+    stfd  %f16, 16(%r1)
+    stfd  %f17, 24(%r1)
+    stfd  %f18, 32(%r1)
+    stfd  %f19, 40(%r1)
+    stfd  %f20, 48(%r1)
+    stfd  %f21, 56(%r1)
+    stfd  %f22, 64(%r1)
+    stfd  %f23, 72(%r1)
+    stfd  %f24, 80(%r1)
+    stfd  %f25, 88(%r1)
+    stfd  %f26, 96(%r1)
+    stfd  %f27, 104(%r1)
+    stfd  %f28, 112(%r1)
+    stfd  %f29, 120(%r1)
+    stfd  %f30, 128(%r1)
+    stfd  %f31, 136(%r1)
+#ifdef __VSX__
+    /* VSCR can be loaded only to Vn.  To store VSCR as it is a vector, */
+    /* it must be written before saving FPSCR. */
+    /* load VSCR. */
+    mfvscr %v19
+    li    %r10, 144
+    /* save VSCR.  Only the last 32 bits are used */
+    stvx  %v19, %r10, %r1
+#endif
+    /* load FPSCR */
+    mffs  %f0
+    /* save FPSCR */
+    stfd  %f0, 144(%r1)
+#ifdef __VSX__
+    /* OpenPOWER saves V20 - V31 (vector units) */
+    /* Note stvx cannot take an immediate value as an offset. */
+    li    %r14, 160
+    stvx  %v20, %r14, %r1
+    li    %r15, 176
+    stvx  %v21, %r15, %r1
+    li    %r16, 192
+    stvx  %v22, %r16, %r1
+    li    %r17, 208
+    stvx  %v23, %r17, %r1
+    li    %r18, 224
+    stvx  %v24, %r18, %r1
+    li    %r19, 240
+    stvx  %v25, %r19, %r1
+    li    %r20, 256
+    stvx  %v26, %r20, %r1
+    li    %r21, 272
+    stvx  %v27, %r21, %r1
+    li    %r22, 288
+    stvx  %v28, %r22, %r1
+    li    %r23, 304
+    stvx  %v29, %r23, %r1
+    li    %r24, 320
+    stvx  %v30, %r24, %r1
+    li    %r25, 336
+    stvx  %v31, %r25, %r1
+#endif
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (R8) */
+    std  %r1, 0(%r8)
+
+    /* set RSP (pointing to context-data) from p_stacktop (R7) */
+    /* R7 must be 16-byte aligned. */
+    subi  %r1, %r7, 48
+
+    /* save p_new_ctx (R5) in R19 (callee-saved) */
+    mr    %r19, %r5
+    /* save f_thread (R6) in R20 (callee-saved) */
+    mr    %r20, %r6
+
+    /* set f_cb (R4) to CTR. */
+    /* f_cb can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r4
+    mtctr %r12
+    /* call CTR (=f_cb) */
+    /* note: cb_arg (R3) has been already set (as the first argument). */
+    /* note: TOC has been saved at the very beginning of the function */
+    /* all the caller-saved registers will be discarded. */
+    bctrl
+
+    /* set the first argument (R3) to p_new_ctx (R19) */
+    mr    %r3, %r19
+
+    /* set f_thread (R20) to CTR. */
+    /* f_thread can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r20
+    mtctr %r12
+
+    /* call CTR (=f_thread) */
+    bctrl
+    /* unreachable. */
+#if _CALL_ELF == 2
+    .size init_and_switch_with_call_fcontext, .-init_and_switch_with_call_fcontext
+#else
+# ifdef _CALL_LINUX
+    .size .init_and_switch_with_call_fcontext, .-.L.init_and_switch_with_call_fcontext
+# else
+    .size .init_and_switch_with_call_fcontext, .-.init_and_switch_with_call_fcontext
+# endif
+#endif
+
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.globl init_and_jump_with_call_fcontext
+#if _CALL_ELF == 2
+    .text
+    .align 2
+init_and_jump_with_call_fcontext:
+        addis   %r2, %r12, .TOC.-init_and_jump_with_call_fcontext@ha
+        addi    %r2, %r2, .TOC.-init_and_jump_with_call_fcontext@l
+        .localentry init_and_jump_with_call_fcontext, . - init_and_jump_with_call_fcontext
+#else
+    .section ".opd","aw"
+    .align 3
+init_and_jump_with_call_fcontext:
+# ifdef _CALL_LINUX
+        .quad   .L.init_and_jump_with_call_fcontext,.TOC.@tocbase,0
+        .type   init_and_jump_with_call_fcontext,@function
+        .text
+        .align 2
+.L.init_and_jump_with_call_fcontext:
+# else
+        .hidden .init_and_jump_with_call_fcontext
+        .globl  .init_and_jump_with_call_fcontext
+        .quad   .init_and_jump_with_call_fcontext,.TOC.@tocbase,0
+        .size   init_and_jump_with_call_fcontext,24
+        .type   .init_and_jump_with_call_fcontext,@function
+        .text
+        .align 2
+.init_and_jump_with_call_fcontext:
+# endif
+#endif
+    /* shift address in p_stacktop (R7) to lower 16 byte boundary */
+    clrrdi  %r7, %r7, 4
+
+    /* save TOC in the target stack (p_stacktop, R7) */
+    /* TOC must be saved when an external function is called. */
+    std  %r2, -24(%r7)
+
+    /* set RSP (pointing to context-data) from p_stacktop (R7) */
+    /* R5 must be 16-byte aligned. */
+    subi  %r1, %r7, 48
+
+    /* save p_new_ctx (R5) in R19 (callee-saved) */
+    mr    %r19, %r5
+    /* save f_thread (R6) in R20 (callee-saved) */
+    mr    %r20, %r6
+
+    /* set f_cb (R4) to CTR. */
+    /* f_cb can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r4
+    mtctr %r12
+    /* call CTR (=f_cb) */
+    /* note: cb_arg (R3) has been already set (as the first argument). */
+    /* note: TOC has been saved at the very beginning of the function */
+    /* all the caller-saved registers will be discarded. */
+    bctrl
+
+    /* set the first argument (R3) to p_new_ctx (R19) */
+    mr    %r3, %r19
+
+    /* set f_thread (R20) to CTR. */
+    /* f_thread can be a global entry point, so R12 must be set as well */
+    mr    %r12, %r20
+    mtctr %r12
+
+    /* call CTR (=f_thread) */
+    bctrl
+    /* unreachable. */
+#if _CALL_ELF == 2
+    .size init_and_jump_with_call_fcontext, .-init_and_jump_with_call_fcontext
+#else
+# ifdef _CALL_LINUX
+    .size .init_and_jump_with_call_fcontext, .-.L.init_and_jump_with_call_fcontext
+# else
+    .size .init_and_jump_with_call_fcontext, .-.init_and_jump_with_call_fcontext
 # endif
 #endif
 

--- a/src/arch/fcontext/fcontext_x86_64_sysv_elf_gas.S
+++ b/src/arch/fcontext/fcontext_x86_64_sysv_elf_gas.S
@@ -34,7 +34,7 @@
 #include "abt_config.h"
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .text
 .globl switch_fcontext
@@ -84,15 +84,12 @@ switch_fcontext:
     /* restore return-address */
     popq  %r8
 
-    /* p_old_ctx (RSI) is set to a return value (RAX) */
-    movq  %rsi, %rax
-
     /* indirect jump to context */
     jmpq  *%r8
 .size switch_fcontext,.-switch_fcontext
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .text
 .globl jump_fcontext
@@ -122,17 +119,14 @@ jump_fcontext:
     /* restore return-address */
     popq  %r8
 
-    /* p_old_ctx (RSI) is set to a return value (RAX) */
-    movq  %rsi, %rax
-
     /* indirect jump to context */
     jmpq  *%r8
 .size jump_fcontext,.-jump_fcontext
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .text
 .globl init_and_switch_fcontext
@@ -172,9 +166,8 @@ init_and_switch_fcontext:
 .size init_and_switch_fcontext,.-init_and_switch_fcontext
 
 /*
-fcontext_t *init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                                   void (*f_thread)(fcontext_t *),
-                                   void *p_stacktop);
+void init_and_jump_fcontext(fcontext_t *p_new_ctx,
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .text
 .globl init_and_jump_fcontext
@@ -192,6 +185,200 @@ init_and_jump_fcontext:
     /* jump to a f_thread (RSI) */
     jmpq *%rsi
 .size init_and_jump_fcontext,.-init_and_jump_fcontext
+
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.text
+.globl switch_with_call_fcontext
+.type switch_with_call_fcontext,@function
+.align 16
+switch_with_call_fcontext:
+    pushq  %rbp  /* save RBP */
+    pushq  %rbx  /* save RBX */
+    pushq  %r15  /* save R15 */
+    pushq  %r14  /* save R14 */
+    pushq  %r13  /* save R13 */
+    pushq  %r12  /* save R12 */
+
+    /* prepare stack for FPU */
+    leaq  -0x8(%rsp), %rsp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%rsp)
+    /* save x87 control-word */
+    fnstcw   0x4(%rsp)
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (RCX) */
+    movq  %rsp, (%rcx)
+
+    /* restore RSP which is stored in p_new_ctx (RDX) */
+    movq  (%rdx), %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%rsp)
+    /* restore x87 control-word */
+    fldcw  0x4(%rsp)
+#endif
+
+    /* prepare stack for FPU */
+    leaq  0x8(%rsp), %rsp
+
+    popq  %r12  /* restrore R12 */
+    popq  %r13  /* restrore R13 */
+    popq  %r14  /* restrore R14 */
+    popq  %r15  /* restrore R15 */
+    popq  %rbx  /* restrore RBX */
+    popq  %rbp  /* restrore RBP */
+
+    /* restore return-address */
+    popq  %r8
+
+    /* indirect jump to context */
+    jmpq  *%r8
+.size switch_with_call_fcontext,.-switch_with_call_fcontext
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.text
+.globl jump_with_call_fcontext
+.type jump_with_call_fcontext,@function
+.align 16
+jump_with_call_fcontext:
+    /* restore RSP which is stored in p_new_ctx (RDX) */
+    movq  (%rdx), %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%rsp)
+    /* restore x87 control-word */
+    fldcw  0x4(%rsp)
+#endif
+
+    /* prepare stack for FPU */
+    leaq  0x8(%rsp), %rsp
+
+    popq  %r12  /* restrore R12 */
+    popq  %r13  /* restrore R13 */
+    popq  %r14  /* restrore R14 */
+    popq  %r15  /* restrore R15 */
+    popq  %rbx  /* restrore RBX */
+    popq  %rbp  /* restrore RBP */
+
+    /* restore return-address */
+    popq  %r8
+
+    /* indirect jump to context */
+    jmpq  *%r8
+.size jump_with_call_fcontext,.-jump_with_call_fcontext
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.text
+.globl init_and_switch_with_call_fcontext
+.type init_and_switch_with_call_fcontext,@function
+.align 16
+init_and_switch_with_call_fcontext:
+    pushq  %rbp  /* save RBP */
+    pushq  %rbx  /* save RBX */
+    pushq  %r15  /* save R15 */
+    pushq  %r14  /* save R14 */
+    pushq  %r13  /* save R13 */
+    pushq  %r12  /* save R12 */
+
+    /* prepare stack for FPU */
+    leaq  -0x8(%rsp), %rsp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%rsp)
+    /* save x87 control-word */
+    fnstcw   0x4(%rsp)
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (R9) */
+    movq  %rsp, (%r9)
+
+    /* shift address in p_stacktop (R8) to lower 16 byte boundary */
+    andq  $-16, %r8
+
+    /* save p_new_ctx (RDX) in R12 (callee-saved) */
+    movq  %rdx, %r12
+    /* save f_thread (RCX) in R13 (callee-saved) */
+    movq  %rcx, %r13
+    /* set p_stacktop (R8) */
+    movq  %r8, %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+    /* For 16-byte function stack alignment, subtract 8 bytes */
+    leaq -0x8(%rsp), %rsp
+
+    /* set the first argument (RDI) to p_new_ctx (R12) */
+    movq  %r12, %rdi
+
+    /* p_new_ctx (RDI) is passed as the first argument of f_thread. */
+    /* jump to a f_thread (R13) */
+    jmpq *%r13
+.size init_and_switch_with_call_fcontext,.-init_and_switch_with_call_fcontext
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.text
+.globl init_and_jump_with_call_fcontext
+.type init_and_jump_with_call_fcontext,@function
+.align 16
+init_and_jump_with_call_fcontext:
+    /* shift address in p_stacktop (R8) to lower 16 byte boundary */
+    andq  $-16, %r8
+
+    /* save p_new_ctx (RDX) in R12 (callee-saved) */
+    movq  %rdx, %r12
+    /* save f_thread (RCX) in R13 (callee-saved) */
+    movq  %rcx, %r13
+    /* set p_stacktop (R8) */
+    movq  %r8, %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+    /* For 16-byte function stack alignment, subtract 8 bytes */
+    leaq -0x8(%rsp), %rsp
+
+    /* set the first argument (RDI) to p_new_ctx (R12) */
+    movq  %r12, %rdi
+
+    /* p_new_ctx (RDI) is passed as the first argument of f_thread. */
+    /* jump to a f_thread (R13) */
+    jmpq *%r13
+.size init_and_jump_with_call_fcontext,.-init_and_jump_with_call_fcontext
 
 /*
 void peek_fcontext(void *arg, void (*f_peek)(void *), fcontext_t *p_target_ctx);

--- a/src/arch/fcontext/fcontext_x86_64_sysv_macho_gas.S
+++ b/src/arch/fcontext/fcontext_x86_64_sysv_macho_gas.S
@@ -34,7 +34,7 @@
 #include "abt_config.h"
 
 /*
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void switch_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
 */
 .text
 .globl _switch_fcontext
@@ -83,14 +83,11 @@ _switch_fcontext:
     /* restore return-address */
     popq  %r8
 
-    /* p_old_ctx (RSI) is set to a return value (RAX) */
-    movq  %rsi, %rax
-
     /* indirect jump to context */
     jmpq  *%r8
 
 /*
-void jump_fcontext(fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+void jump_fcontext(fcontext_t *p_new_ctx);
 */
 .text
 .globl _jump_fcontext
@@ -119,16 +116,13 @@ _jump_fcontext:
     /* restore return-address */
     popq  %r8
 
-    /* p_old_ctx (RSI) is set to a return value (RAX) */
-    movq  %rsi, %rax
-
     /* indirect jump to context */
     jmpq  *%r8
 
 /*
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop, fcontext_t *p_old_ctx);
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *),
+                              void *p_stacktop, fcontext_t *p_old_ctx);
 */
 .text
 .globl _init_and_switch_fcontext
@@ -166,9 +160,8 @@ _init_and_switch_fcontext:
     jmpq *%rsi
 
 /*
-fcontext_t *init_and_jump_fcontext(fcontext_t *p_new_ctx,
-                                   void (*f_thread)(fcontext_t *),
-                                   void *p_stacktop);
+void init_and_jump_fcontext(fcontext_t *p_new_ctx,
+                            void (*f_thread)(fcontext_t *), void *p_stacktop);
 */
 .text
 .globl _init_and_jump_fcontext
@@ -184,6 +177,191 @@ _init_and_jump_fcontext:
     /* p_new_ctx (RDI) is passed as the first argument (RDI) of f_thread. */
     /* jump to a f_thread (RSI) */
     jmpq *%rsi
+
+/*
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx, fcontext_t *p_old_ctx);
+*/
+.text
+.globl _switch_with_call_fcontext
+.align 8
+_switch_with_call_fcontext:
+    pushq  %rbp  /* save RBP */
+    pushq  %rbx  /* save RBX */
+    pushq  %r15  /* save R15 */
+    pushq  %r14  /* save R14 */
+    pushq  %r13  /* save R13 */
+    pushq  %r12  /* save R12 */
+
+    /* prepare stack for FPU */
+    leaq  -0x8(%rsp), %rsp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%rsp)
+    /* save x87 control-word */
+    fnstcw   0x4(%rsp)
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (RCX) */
+    movq  %rsp, (%rcx)
+
+    /* restore RSP which is stored in p_new_ctx (RDX) */
+    movq  (%rdx), %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%rsp)
+    /* restore x87 control-word */
+    fldcw  0x4(%rsp)
+#endif
+
+    /* prepare stack for FPU */
+    leaq  0x8(%rsp), %rsp
+
+    popq  %r12  /* restrore R12 */
+    popq  %r13  /* restrore R13 */
+    popq  %r14  /* restrore R14 */
+    popq  %r15  /* restrore R15 */
+    popq  %rbx  /* restrore RBX */
+    popq  %rbp  /* restrore RBP */
+
+    /* restore return-address */
+    popq  %r8
+
+    /* indirect jump to context */
+    jmpq  *%r8
+
+/*
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx);
+*/
+.text
+.globl _jump_with_call_fcontext
+.align 8
+_jump_with_call_fcontext:
+    /* restore RSP which is stored in p_new_ctx (RDX) */
+    movq  (%rdx), %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* restore MMX control- and status-word */
+    ldmxcsr  (%rsp)
+    /* restore x87 control-word */
+    fldcw  0x4(%rsp)
+#endif
+
+    /* prepare stack for FPU */
+    leaq  0x8(%rsp), %rsp
+
+    popq  %r12  /* restrore R12 */
+    popq  %r13  /* restrore R13 */
+    popq  %r14  /* restrore R14 */
+    popq  %r15  /* restrore R15 */
+    popq  %rbx  /* restrore RBX */
+    popq  %rbp  /* restrore RBP */
+
+    /* restore return-address */
+    popq  %r8
+
+    /* indirect jump to context */
+    jmpq  *%r8
+
+/*
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx);
+*/
+.text
+.globl _init_and_switch_with_call_fcontext
+.align 8
+_init_and_switch_with_call_fcontext:
+    pushq  %rbp  /* save RBP */
+    pushq  %rbx  /* save RBX */
+    pushq  %r15  /* save R15 */
+    pushq  %r14  /* save R14 */
+    pushq  %r13  /* save R13 */
+    pushq  %r12  /* save R12 */
+
+    /* prepare stack for FPU */
+    leaq  -0x8(%rsp), %rsp
+
+#if ABTD_FCONTEXT_PRESERVE_FPU
+    /* save MMX control- and status-word */
+    stmxcsr  (%rsp)
+    /* save x87 control-word */
+    fnstcw   0x4(%rsp)
+#endif
+
+    /* store RSP (pointing to context-data) in p_old_ctx (R9) */
+    movq  %rsp, (%r9)
+
+    /* shift address in p_stacktop (R8) to lower 16 byte boundary */
+    andq  $-16, %r8
+
+    /* save p_new_ctx (RDX) in R12 (callee-saved) */
+    movq  %rdx, %r12
+    /* save f_thread (RCX) in R13 (callee-saved) */
+    movq  %rcx, %r13
+    /* set p_stacktop (R8) */
+    movq  %r8, %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+    /* For 16-byte function stack alignment, subtract 8 bytes */
+    leaq -0x8(%rsp), %rsp
+
+    /* set the first argument (RDI) to p_new_ctx (R12) */
+    movq  %r12, %rdi
+
+    /* p_new_ctx (RDI) is passed as the first argument of f_thread. */
+    /* jump to a f_thread (R13) */
+    jmpq *%r13
+
+/*
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop);
+*/
+.text
+.globl _init_and_jump_with_call_fcontext
+.align 8
+_init_and_jump_with_call_fcontext:
+    /* shift address in p_stacktop (R8) to lower 16 byte boundary */
+    andq  $-16, %r8
+
+    /* save p_new_ctx (RDX) in R12 (callee-saved) */
+    movq  %rdx, %r12
+    /* save f_thread (RCX) in R13 (callee-saved) */
+    movq  %rcx, %r13
+    /* set p_stacktop (R8) */
+    movq  %r8, %rsp
+
+    /* call f_cb (RSI).  cb_arg (RDI) has already been set.
+     * all the caller-saved registers will be discarded */
+    callq *%rsi
+
+    /* For 16-byte function stack alignment, subtract 8 bytes */
+    leaq -0x8(%rsp), %rsp
+
+    /* set the first argument (RDI) to p_new_ctx (R12) */
+    movq  %r12, %rdi
+
+    /* p_new_ctx (RDI) is passed as the first argument of f_thread. */
+    /* jump to a f_thread (R13) */
+    jmpq *%r13
 
 /*
 void peek_fcontext(void *arg, void (*f_peek)(void *), fcontext_t *p_target_ctx);

--- a/src/global.c
+++ b/src/global.c
@@ -320,15 +320,13 @@ ABTU_ret_err static int finailze_library(void)
                                            ABT_TOOL_EVENT_THREAD_NONE, NULL);
 #endif
 
-    /* Set the orphan request for the primary ULT */
-    ABTI_thread_set_request(p_self, ABTI_THREAD_REQ_ORPHAN);
     /* Finish the main scheduler of this local xstream. */
     ABTI_sched_finish(p_local_xstream->p_main_sched);
     /* p_self cannot join the main scheduler since p_self needs to be orphaned.
      * Let's wait till the main scheduler finishes.  This thread will be
      * scheduled when the main root thread finishes. */
-    ABTI_ythread_yield(&p_local_xstream, p_ythread, ABT_SYNC_EVENT_TYPE_OTHER,
-                       NULL);
+    ABTI_ythread_yield_orphan(&p_local_xstream, p_ythread,
+                              ABT_SYNC_EVENT_TYPE_OTHER, NULL);
     ABTI_ASSERT(p_local_xstream == ABTI_local_get_xstream(p_local));
     ABTI_ASSERT(p_local_xstream->p_thread == p_self);
 

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -27,17 +27,29 @@ static inline void ABTDI_fcontext_init(fcontext_t *p_ftx)
 #define ABT_API_PRIVATE
 #endif
 
-fcontext_t *switch_fcontext(fcontext_t *p_new_ctx,
-                            fcontext_t *p_old_ctx) ABT_API_PRIVATE;
-void jump_fcontext(fcontext_t *p_new_ctx,
-                   fcontext_t *p_old_ctx) ABT_API_PRIVATE;
-fcontext_t *init_and_switch_fcontext(fcontext_t *p_new_ctx,
-                                     void (*f_thread)(fcontext_t *),
-                                     void *p_stacktop,
-                                     fcontext_t *p_old_ctx) ABT_API_PRIVATE;
+void switch_fcontext(fcontext_t *p_new_ctx,
+                     fcontext_t *p_old_ctx) ABT_API_PRIVATE;
+void jump_fcontext(fcontext_t *p_new_ctx) ABT_API_PRIVATE;
+void init_and_switch_fcontext(fcontext_t *p_new_ctx,
+                              void (*f_thread)(fcontext_t *), void *p_stacktop,
+                              fcontext_t *p_old_ctx) ABT_API_PRIVATE;
 void init_and_jump_fcontext(fcontext_t *p_new_ctx,
                             void (*f_thread)(fcontext_t *),
                             void *p_stacktop) ABT_API_PRIVATE;
+void switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                               fcontext_t *p_new_ctx,
+                               fcontext_t *p_old_ctx) ABT_API_PRIVATE;
+void jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                             fcontext_t *p_new_ctx) ABT_API_PRIVATE;
+void init_and_switch_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                        fcontext_t *p_new_ctx,
+                                        void (*f_thread)(fcontext_t *),
+                                        void *p_stacktop,
+                                        fcontext_t *p_old_ctx) ABT_API_PRIVATE;
+void init_and_jump_with_call_fcontext(void *cb_arg, void (*f_cb)(void *),
+                                      fcontext_t *p_new_ctx,
+                                      void (*f_thread)(fcontext_t *),
+                                      void *p_stacktop) ABT_API_PRIVATE;
 void peek_fcontext(void *arg, void (*f_peek)(void *),
                    fcontext_t *p_target_ctx) ABT_API_PRIVATE;
 
@@ -93,34 +105,62 @@ ABTD_ythread_context_get_stacksize(ABTD_ythread_context *p_ctx)
     return p_ctx->stacksize;
 }
 
-static inline ABTD_ythread_context *
-ABTD_ythread_context_switch(ABTD_ythread_context *p_old,
-                            ABTD_ythread_context *p_new)
+static inline void ABTD_ythread_context_switch(ABTD_ythread_context *p_old,
+                                               ABTD_ythread_context *p_new)
 {
-    fcontext_t *p_fctx;
     if (ABTDI_fcontext_is_created(&p_new->ctx)) {
         /* The context is already initialized. */
-        p_fctx = switch_fcontext(&p_new->ctx, &p_old->ctx);
+        switch_fcontext(&p_new->ctx, &p_old->ctx);
     } else {
         /* First time. */
-        p_fctx = init_and_switch_fcontext(&p_new->ctx,
-                                          ABTD_ythread_context_func_wrapper,
-                                          p_new->p_stacktop, &p_old->ctx);
+        init_and_switch_fcontext(&p_new->ctx, ABTD_ythread_context_func_wrapper,
+                                 p_new->p_stacktop, &p_old->ctx);
     }
-    return ABTDI_ythread_context_get_context(p_fctx);
 }
 
 ABTU_noreturn static inline void
-ABTD_ythread_context_jump(ABTD_ythread_context *p_old,
-                          ABTD_ythread_context *p_new)
+ABTD_ythread_context_jump(ABTD_ythread_context *p_new)
 {
     if (ABTDI_fcontext_is_created(&p_new->ctx)) {
         /* The context is already initialized. */
-        jump_fcontext(&p_new->ctx, &p_old->ctx);
+        jump_fcontext(&p_new->ctx);
     } else {
         /* First time. */
         init_and_jump_fcontext(&p_new->ctx, ABTD_ythread_context_func_wrapper,
                                p_new->p_stacktop);
+    }
+    ABTU_unreachable();
+}
+
+static inline void
+ABTD_ythread_context_switch_with_call(ABTD_ythread_context *p_old,
+                                      ABTD_ythread_context *p_new,
+                                      void (*f_cb)(void *), void *cb_arg)
+{
+    if (ABTDI_fcontext_is_created(&p_new->ctx)) {
+        /* The context is already initialized. */
+
+        switch_with_call_fcontext(cb_arg, f_cb, &p_new->ctx, &p_old->ctx);
+    } else {
+        /* First time. */
+        init_and_switch_with_call_fcontext(cb_arg, f_cb, &p_new->ctx,
+                                           ABTD_ythread_context_func_wrapper,
+                                           p_new->p_stacktop, &p_old->ctx);
+    }
+}
+
+ABTU_noreturn static inline void
+ABTD_ythread_context_jump_with_call(ABTD_ythread_context *p_new,
+                                    void (*f_cb)(void *), void *cb_arg)
+{
+    if (ABTDI_fcontext_is_created(&p_new->ctx)) {
+        /* The context is already initialized. */
+        jump_with_call_fcontext(cb_arg, f_cb, &p_new->ctx);
+    } else {
+        /* First time. */
+        init_and_jump_with_call_fcontext(cb_arg, f_cb, &p_new->ctx,
+                                         ABTD_ythread_context_func_wrapper,
+                                         p_new->p_stacktop);
     }
     ABTU_unreachable();
 }

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -46,15 +46,8 @@
 #define ABTI_SCHED_REQ_REPLACE (1 << 2)
 
 #define ABTI_THREAD_REQ_JOIN (1 << 0)
-#define ABTI_THREAD_REQ_TERMINATE (1 << 1)
-#define ABTI_THREAD_REQ_CANCEL (1 << 2)
-#define ABTI_THREAD_REQ_MIGRATE (1 << 3)
-#define ABTI_THREAD_REQ_BLOCK (1 << 4)
-#define ABTI_THREAD_REQ_ORPHAN (1 << 5)
-#define ABTI_THREAD_REQ_NON_YIELD                                              \
-    (ABTI_THREAD_REQ_CANCEL | ABTI_THREAD_REQ_MIGRATE |                        \
-     ABTI_THREAD_REQ_TERMINATE | ABTI_THREAD_REQ_BLOCK |                       \
-     ABTI_THREAD_REQ_ORPHAN)
+#define ABTI_THREAD_REQ_CANCEL (1 << 1)
+#define ABTI_THREAD_REQ_MIGRATE (1 << 2)
 
 #define ABTI_THREAD_INIT_ID 0xFFFFFFFFFFFFFFFF
 #define ABTI_TASK_INIT_ID 0xFFFFFFFFFFFFFFFF
@@ -535,6 +528,11 @@ void ABTI_xstream_run_thread(ABTI_global *p_global,
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+ABTU_ret_err int ABTI_xstream_migrate_thread(ABTI_global *p_global,
+                                             ABTI_local *p_local,
+                                             ABTI_thread *p_thread);
+#endif
 
 /* Scheduler */
 ABT_sched_def *ABTI_sched_get_basic_def(void);
@@ -623,10 +621,6 @@ void ABTI_ythread_free_primary(ABTI_global *p_global, ABTI_local *p_local,
                                ABTI_ythread *p_ythread);
 void ABTI_ythread_free_root(ABTI_global *p_global, ABTI_local *p_local,
                             ABTI_ythread *p_ythread);
-void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread);
-void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
-                          ABTI_ythread *p_ythread,
-                          ABT_sync_event_type sync_event_type, void *p_sync);
 void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread);
 void ABTI_ythread_print_stack(ABTI_global *p_global, ABTI_ythread *p_ythread,
                               FILE *p_os);

--- a/src/include/abti_event.h
+++ b/src/include/abti_event.h
@@ -144,20 +144,6 @@ static inline void ABTI_event_ythread_suspend_impl(
 #endif
 }
 
-static inline void ABTI_event_ythread_yield_or_suspend_impl(
-    ABTI_xstream *p_local_xstream, ABTI_ythread *p_ythread,
-    ABTI_thread *p_parent, ABT_sync_event_type sync_event_type, void *p_sync)
-{
-    if (ABTD_atomic_relaxed_load_uint32(&p_ythread->thread.request) &
-        ABTI_THREAD_REQ_BLOCK) {
-        ABTI_event_ythread_suspend_impl(p_local_xstream, p_ythread, p_parent,
-                                        sync_event_type, p_sync);
-    } else {
-        ABTI_event_ythread_yield_impl(p_local_xstream, p_ythread, p_parent,
-                                      sync_event_type, p_sync);
-    }
-}
-
 static inline void ABTI_event_ythread_resume_impl(ABTI_local *p_local,
                                                   ABTI_ythread *p_ythread,
                                                   ABTI_thread *p_caller)
@@ -230,9 +216,8 @@ static inline void ABTI_event_ythread_resume_impl(ABTI_local *p_local,
                                  sync_event_type, p_sync)                      \
     do {                                                                       \
         if (ABTI_ENABLE_EVENT_INTERFACE) {                                     \
-            ABTI_event_ythread_yield_or_suspend_impl(p_local_xstream,          \
-                                                     p_ythread, p_parent,      \
-                                                     sync_event_type, p_sync); \
+            ABTI_event_ythread_yield_impl(p_local_xstream, p_ythread,          \
+                                          p_parent, sync_event_type, p_sync);  \
         }                                                                      \
     } while (0)
 

--- a/src/include/abti_waitlist.h
+++ b/src/include/abti_waitlist.h
@@ -80,10 +80,8 @@ ABTI_waitlist_wait_and_unlock(ABTI_local **pp_local, ABTI_waitlist *p_waitlist,
         p_waitlist->p_tail = &p_ythread->thread;
 
         /* Suspend the current ULT */
-        ABTI_ythread_set_blocked(p_ythread);
-        ABTD_spinlock_release(p_lock);
-        ABTI_ythread_suspend(&p_local_xstream, p_ythread,
-                             ABT_SYNC_EVENT_TYPE_EVENTUAL, p_sync);
+        ABTI_ythread_suspend_unlock(&p_local_xstream, p_ythread, p_lock,
+                                    sync_event_type, p_sync);
         /* Resumed. */
         *pp_local = ABTI_xstream_get_local(p_local_xstream);
     }

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -44,84 +44,47 @@ ABTI_ythread_context_get_ythread(ABTD_ythread_context *p_ctx)
     return (ABTI_ythread *)(((char *)p_ctx) - offsetof(ABTI_ythread, ctx));
 }
 
-ABTU_noreturn static inline void ABTI_ythread_context_jump(ABTI_ythread *p_old,
-                                                           ABTI_ythread *p_new)
+ABTU_noreturn static inline void ABTI_ythread_context_jump(ABTI_ythread *p_new)
 {
-    ABTD_ythread_context_jump(&p_old->ctx, &p_new->ctx);
+    ABTD_ythread_context_jump(&p_new->ctx);
     ABTU_unreachable();
 }
 
-static inline ABTI_ythread *ABTI_ythread_context_switch(ABTI_ythread *p_old,
-                                                        ABTI_ythread *p_new)
+static inline void ABTI_ythread_context_switch(ABTI_ythread *p_old,
+                                               ABTI_ythread *p_new)
 {
-    ABTD_ythread_context *p_ctx =
-        ABTD_ythread_context_switch(&p_old->ctx, &p_new->ctx);
+    ABTD_ythread_context_switch(&p_old->ctx, &p_new->ctx);
     /* Return the previous thread. */
-    return ABTI_ythread_context_get_ythread(p_ctx);
 }
 
 ABTU_noreturn static inline void
-ABTI_ythread_jump_to_primary(ABTI_xstream *p_local_xstream, ABTI_ythread *p_old,
-                             ABTI_ythread *p_new)
+ABTI_ythread_context_jump_with_call(ABTI_ythread *p_new, void (*f_cb)(void *),
+                                    void *cb_arg)
 {
-    p_local_xstream->p_thread = &p_new->thread;
-    ABTI_ythread_context_jump(p_old, p_new);
+    ABTD_ythread_context_jump_with_call(&p_new->ctx, f_cb, cb_arg);
     ABTU_unreachable();
 }
 
-static inline ABTI_ythread *ABTI_ythread_switch_to_sibling_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABTI_ythread *p_new,
-    ABT_bool is_finish, ABT_sync_event_type sync_event_type, void *p_sync)
+static inline void ABTI_ythread_context_switch_with_call(ABTI_ythread *p_old,
+                                                         ABTI_ythread *p_new,
+                                                         void (*f_cb)(void *),
+                                                         void *cb_arg)
 {
-    p_new->thread.p_parent = p_old->thread.p_parent;
-    if (is_finish) {
-        ABTI_xstream *p_local_xstream = *pp_local_xstream;
-        ABTI_event_thread_finish(p_local_xstream, &p_old->thread,
-                                 p_old->thread.p_parent);
-        ABTI_event_thread_run(p_local_xstream, &p_new->thread, &p_old->thread,
-                              p_new->thread.p_parent);
-        p_local_xstream->p_thread = &p_new->thread;
-        ABTI_ythread_context_jump(p_old, p_new);
-        ABTU_unreachable();
-    } else {
-        ABTI_xstream *p_local_xstream = *pp_local_xstream;
-        ABTI_event_thread_run(p_local_xstream, &p_new->thread, &p_old->thread,
-                              p_new->thread.p_parent);
-        p_local_xstream->p_thread = &p_new->thread;
-        /* Context switch starts. */
-        ABTI_ythread *p_prev = ABTI_ythread_context_switch(p_old, p_new);
-        /* Context switch finishes. */
-        *pp_local_xstream = p_prev->thread.p_last_xstream;
-        return p_prev;
-    }
+    ABTD_ythread_context_switch_with_call(&p_old->ctx, &p_new->ctx, f_cb,
+                                          cb_arg);
+    /* Return the previous thread. */
 }
 
-static inline ABTI_ythread *ABTI_ythread_switch_to_parent_internal(
-    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABT_bool is_finish,
-    ABT_sync_event_type sync_event_type, void *p_sync)
+ABTU_noreturn static inline void
+ABTI_ythread_jump_to_primary(ABTI_xstream *p_local_xstream, ABTI_ythread *p_new)
 {
-    ABTI_ythread *p_new = ABTI_thread_get_ythread(p_old->thread.p_parent);
-    if (is_finish) {
-        ABTI_xstream *p_local_xstream = *pp_local_xstream;
-        ABTI_event_thread_finish(p_local_xstream, &p_old->thread,
-                                 p_old->thread.p_parent);
-        p_local_xstream->p_thread = &p_new->thread;
-        ABTI_ythread_context_jump(p_old, p_new);
-        ABTU_unreachable();
-    } else {
-        ABTI_xstream *p_local_xstream = *pp_local_xstream;
-        ABTI_event_ythread_yield(p_local_xstream, p_old, p_old->thread.p_parent,
-                                 sync_event_type, p_sync);
-        p_local_xstream->p_thread = &p_new->thread;
-        /* Context switch starts. */
-        ABTI_ythread *p_prev = ABTI_ythread_context_switch(p_old, p_new);
-        /* Context switch finishes. */
-        *pp_local_xstream = p_prev->thread.p_last_xstream;
-        return p_prev;
-    }
+    p_local_xstream->p_thread = &p_new->thread;
+    p_new->thread.p_last_xstream = p_local_xstream;
+    ABTI_ythread_context_jump(p_new);
+    ABTU_unreachable();
 }
 
-static inline ABTI_ythread *
+static inline void
 ABTI_ythread_switch_to_child_internal(ABTI_xstream **pp_local_xstream,
                                       ABTI_ythread *p_old, ABTI_ythread *p_new)
 {
@@ -130,11 +93,68 @@ ABTI_ythread_switch_to_child_internal(ABTI_xstream **pp_local_xstream,
     ABTI_event_thread_run(p_local_xstream, &p_new->thread, &p_old->thread,
                           p_new->thread.p_parent);
     p_local_xstream->p_thread = &p_new->thread;
+    p_new->thread.p_last_xstream = p_local_xstream;
     /* Context switch starts. */
-    ABTI_ythread *p_prev = ABTI_ythread_context_switch(p_old, p_new);
+    ABTI_ythread_context_switch(p_old, p_new);
     /* Context switch finishes. */
-    *pp_local_xstream = p_prev->thread.p_last_xstream;
-    return p_prev;
+    *pp_local_xstream = p_old->thread.p_last_xstream;
+}
+
+ABTU_noreturn static inline void
+ABTI_ythread_jump_to_sibling_internal(ABTI_xstream *p_local_xstream,
+                                      ABTI_ythread *p_old, ABTI_ythread *p_new,
+                                      void (*f_cb)(void *), void *cb_arg)
+{
+    p_new->thread.p_parent = p_old->thread.p_parent;
+    ABTI_event_thread_run(p_local_xstream, &p_new->thread, &p_old->thread,
+                          p_new->thread.p_parent);
+    p_local_xstream->p_thread = &p_new->thread;
+    p_new->thread.p_last_xstream = p_local_xstream;
+    ABTI_ythread_context_jump_with_call(p_new, f_cb, cb_arg);
+    ABTU_unreachable();
+}
+
+static inline void ABTI_ythread_switch_to_sibling_internal(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABTI_ythread *p_new,
+    void (*f_cb)(void *), void *cb_arg)
+{
+    p_new->thread.p_parent = p_old->thread.p_parent;
+    ABTI_xstream *p_local_xstream = *pp_local_xstream;
+    ABTI_event_thread_run(p_local_xstream, &p_new->thread, &p_old->thread,
+                          p_new->thread.p_parent);
+    p_local_xstream->p_thread = &p_new->thread;
+    p_new->thread.p_last_xstream = p_local_xstream;
+    /* Context switch starts. */
+    ABTI_ythread_context_switch_with_call(p_old, p_new, f_cb, cb_arg);
+    /* Context switch finishes. */
+    *pp_local_xstream = p_old->thread.p_last_xstream;
+}
+
+ABTU_noreturn static inline void
+ABTI_ythread_jump_to_parent_internal(ABTI_xstream *p_local_xstream,
+                                     ABTI_ythread *p_old, void (*f_cb)(void *),
+                                     void *cb_arg)
+{
+    ABTI_ythread *p_new = ABTI_thread_get_ythread(p_old->thread.p_parent);
+    p_local_xstream->p_thread = &p_new->thread;
+    ABTI_ASSERT(p_new->thread.p_last_xstream == p_local_xstream);
+    ABTI_ythread_context_jump_with_call(p_new, f_cb, cb_arg);
+    ABTU_unreachable();
+}
+
+static inline void
+ABTI_ythread_switch_to_parent_internal(ABTI_xstream **pp_local_xstream,
+                                       ABTI_ythread *p_old,
+                                       void (*f_cb)(void *), void *cb_arg)
+{
+    ABTI_ythread *p_new = ABTI_thread_get_ythread(p_old->thread.p_parent);
+    ABTI_xstream *p_local_xstream = *pp_local_xstream;
+    p_local_xstream->p_thread = &p_new->thread;
+    ABTI_ASSERT(p_new->thread.p_last_xstream == p_local_xstream);
+    /* Context switch starts. */
+    ABTI_ythread_context_switch_with_call(p_old, p_new, f_cb, cb_arg);
+    /* Context switch finishes. */
+    *pp_local_xstream = p_old->thread.p_last_xstream;
 }
 
 static inline ABT_bool ABTI_ythread_context_peek(ABTI_ythread *p_ythread,
@@ -144,64 +164,165 @@ static inline ABT_bool ABTI_ythread_context_peek(ABTI_ythread *p_ythread,
     return ABTD_ythread_context_peek(&p_ythread->ctx, f_peek, arg);
 }
 
-/* Return the previous thread. */
-static inline ABTI_ythread *ABTI_ythread_switch_to_sibling(
-    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_old, ABTI_ythread *p_new,
-    ABT_sync_event_type sync_event_type, void *p_sync)
+static inline void ABTI_ythread_run_child(ABTI_xstream **pp_local_xstream,
+                                          ABTI_ythread *p_parent,
+                                          ABTI_ythread *p_child)
 {
-    return ABTI_ythread_switch_to_sibling_internal(pp_local_xstream, p_old,
-                                                   p_new, ABT_FALSE,
-                                                   sync_event_type, p_sync);
+    ABTD_atomic_release_store_int(&p_child->thread.state,
+                                  ABT_THREAD_STATE_RUNNING);
+    ABTI_ythread_switch_to_child_internal(pp_local_xstream, p_parent, p_child);
 }
 
-static inline ABTI_ythread *
-ABTI_ythread_switch_to_parent(ABTI_xstream **pp_local_xstream,
-                              ABTI_ythread *p_old,
-                              ABT_sync_event_type sync_event_type, void *p_sync)
-{
-    return ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_old,
-                                                  ABT_FALSE, sync_event_type,
-                                                  p_sync);
-}
-
-static inline ABTI_ythread *
-ABTI_ythread_switch_to_child(ABTI_xstream **pp_local_xstream,
-                             ABTI_ythread *p_old, ABTI_ythread *p_new)
-{
-    return ABTI_ythread_switch_to_child_internal(pp_local_xstream, p_old,
-                                                 p_new);
-}
-
-ABTU_noreturn static inline void
-ABTI_ythread_jump_to_sibling(ABTI_xstream *p_local_xstream, ABTI_ythread *p_old,
-                             ABTI_ythread *p_new)
-{
-    ABTI_ythread_switch_to_sibling_internal(&p_local_xstream, p_old, p_new,
-                                            ABT_TRUE,
-                                            ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
-    ABTU_unreachable();
-}
-
-ABTU_noreturn static inline void
-ABTI_ythread_jump_to_parent(ABTI_xstream *p_local_xstream, ABTI_ythread *p_old)
-{
-    ABTI_ythread_switch_to_parent_internal(&p_local_xstream, p_old, ABT_TRUE,
-                                           ABT_SYNC_EVENT_TYPE_UNKNOWN, NULL);
-    ABTU_unreachable();
-}
+void ABTI_ythread_callback_yield(void *arg);
 
 static inline void ABTI_ythread_yield(ABTI_xstream **pp_local_xstream,
                                       ABTI_ythread *p_ythread,
                                       ABT_sync_event_type sync_event_type,
                                       void *p_sync)
 {
-    /* Change the state of current running thread */
+    ABTI_event_ythread_yield(*pp_local_xstream, p_ythread,
+                             p_ythread->thread.p_parent, sync_event_type,
+                             p_sync);
+    ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_ythread,
+                                           ABTI_ythread_callback_yield,
+                                           (void *)p_ythread);
+}
+
+void ABTI_ythread_callback_yield_to(void *arg);
+
+static inline void ABTI_ythread_yield_to(ABTI_xstream **pp_local_xstream,
+                                         ABTI_ythread *p_self,
+                                         ABTI_ythread *p_ythread,
+                                         ABT_sync_event_type sync_event_type,
+                                         void *p_sync)
+{
+    ABTI_event_ythread_yield(*pp_local_xstream, p_self, p_self->thread.p_parent,
+                             sync_event_type, p_sync);
     ABTD_atomic_release_store_int(&p_ythread->thread.state,
-                                  ABT_THREAD_STATE_READY);
-    /* Switch to the top scheduler */
-    ABTI_ythread_switch_to_parent(pp_local_xstream, p_ythread, sync_event_type,
-                                  p_sync);
-    /* Back to the original thread */
+                                  ABT_THREAD_STATE_RUNNING);
+    ABTI_ythread_switch_to_sibling_internal(pp_local_xstream, p_self, p_ythread,
+                                            ABTI_ythread_callback_yield_to,
+                                            (void *)p_self);
+}
+
+void ABTI_ythread_callback_suspend(void *arg);
+
+static inline void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
+                                        ABTI_ythread *p_ythread,
+                                        ABT_sync_event_type sync_event_type,
+                                        void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_ythread,
+                               p_ythread->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_ythread,
+                                           ABTI_ythread_callback_suspend,
+                                           (void *)p_ythread);
+}
+
+void ABTI_ythread_callback_terminate(void *arg);
+
+ABTU_noreturn static inline void
+ABTI_ythread_terminate(ABTI_xstream *p_local_xstream, ABTI_ythread *p_ythread)
+{
+    ABTI_event_thread_finish(p_local_xstream, &p_ythread->thread,
+                             p_ythread->thread.p_parent);
+    ABTI_ythread_jump_to_parent_internal(p_local_xstream, p_ythread,
+                                         ABTI_ythread_callback_terminate,
+                                         (void *)p_ythread);
+    ABTU_unreachable();
+}
+
+ABTU_noreturn static inline void
+ABTI_ythread_terminate_to(ABTI_xstream *p_local_xstream,
+                          ABTI_ythread *p_ythread, ABTI_ythread *p_target)
+{
+    ABTI_event_thread_finish(p_local_xstream, &p_ythread->thread,
+                             p_ythread->thread.p_parent);
+    ABTD_atomic_release_store_int(&p_ythread->thread.state,
+                                  ABT_THREAD_STATE_RUNNING);
+    ABTI_ythread_jump_to_sibling_internal(p_local_xstream, p_ythread, p_target,
+                                          ABTI_ythread_callback_terminate,
+                                          (void *)p_ythread);
+    ABTU_unreachable();
+}
+
+typedef struct {
+    ABTI_ythread *p_prev;
+    ABTD_spinlock *p_lock;
+} ABTI_ythread_callback_suspend_unlock_arg;
+
+void ABTI_ythread_callback_suspend_unlock(void *arg);
+
+static inline void
+ABTI_ythread_suspend_unlock(ABTI_xstream **pp_local_xstream,
+                            ABTI_ythread *p_ythread, ABTD_spinlock *p_lock,
+                            ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_ythread,
+                               p_ythread->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_callback_suspend_unlock_arg arg = { p_ythread, p_lock };
+    ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_ythread,
+                                           ABTI_ythread_callback_suspend_unlock,
+                                           (void *)&arg);
+}
+
+typedef struct {
+    ABTI_ythread *p_prev;
+    ABTI_ythread *p_target;
+} ABTI_ythread_callback_suspend_join_arg;
+
+void ABTI_ythread_callback_suspend_join(void *arg);
+
+static inline void
+ABTI_ythread_suspend_join(ABTI_xstream **pp_local_xstream, ABTI_ythread *p_self,
+                          ABTI_ythread *p_target,
+                          ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_self,
+                               p_self->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_callback_suspend_join_arg arg = { p_self, p_target };
+    ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_self,
+                                           ABTI_ythread_callback_suspend_join,
+                                           (void *)&arg);
+}
+
+typedef struct {
+    ABTI_ythread *p_prev;
+    ABTI_sched *p_main_sched;
+} ABTI_ythread_callback_suspend_replace_sched_arg;
+
+void ABTI_ythread_callback_suspend_replace_sched(void *arg);
+
+static inline void ABTI_ythread_suspend_replace_sched(
+    ABTI_xstream **pp_local_xstream, ABTI_ythread *p_ythread,
+    ABTI_sched *p_main_sched, ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_ythread,
+                               p_ythread->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_callback_suspend_replace_sched_arg arg = { p_ythread,
+                                                            p_main_sched };
+    ABTI_ythread_switch_to_parent_internal(
+        pp_local_xstream, p_ythread,
+        ABTI_ythread_callback_suspend_replace_sched, (void *)&arg);
+}
+
+void ABTI_ythread_callback_orphan(void *arg);
+
+static inline void
+ABTI_ythread_yield_orphan(ABTI_xstream **pp_local_xstream,
+                          ABTI_ythread *p_ythread,
+                          ABT_sync_event_type sync_event_type, void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_ythread,
+                               p_ythread->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_switch_to_parent_internal(pp_local_xstream, p_ythread,
+                                           ABTI_ythread_callback_orphan,
+                                           (void *)p_ythread);
 }
 
 #endif /* ABTI_YTHREAD_H_INCLUDED */

--- a/src/self.c
+++ b/src/self.c
@@ -667,7 +667,6 @@ int ABT_self_suspend(void)
     ABTI_ythread *p_self;
     ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_self);
 
-    ABTI_ythread_set_blocked(p_self);
     ABTI_ythread_suspend(&p_local_xstream, p_self, ABT_SYNC_EVENT_TYPE_USER,
                          NULL);
     return ABT_SUCCESS;

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -5,47 +5,142 @@
 
 #include "abti.h"
 
-#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
+static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev);
 
+#ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 struct unwind_stack_t {
     FILE *fp;
 };
 static void ythread_unwind_stack(void *arg);
-
 #endif
 
-void ABTI_ythread_set_blocked(ABTI_ythread *p_ythread)
+/*****************************************************************************/
+/* Private APIs                                                              */
+/*****************************************************************************/
+
+void ABTI_ythread_callback_yield(void *arg)
 {
-    /* The root thread cannot be blocked */
-    ABTI_ASSERT(!(p_ythread->thread.type & ABTI_THREAD_TYPE_ROOT));
-
-    /* To prevent the scheduler from adding the ULT to the pool */
-    ABTI_thread_set_request(&p_ythread->thread, ABTI_THREAD_REQ_BLOCK);
-
-    /* Change the ULT's state to BLOCKED */
-    ABTD_atomic_release_store_int(&p_ythread->thread.state,
-                                  ABT_THREAD_STATE_BLOCKED);
-
-    /* Increase the number of blocked ULTs */
-    ABTI_pool *p_pool = p_ythread->thread.p_pool;
-    ABTI_pool_inc_num_blocked(p_pool);
+    // ABTI_event_ythread_yield(p_local_xstream, p_cur_ythread,
+    //                      p_cur_ythread->thread.p_parent,
+    //                      ABT_SYNC_EVENT_TYPE_USER, NULL);
+    ABTI_ythread *p_prev = (ABTI_ythread *)arg;
+    if (ythread_callback_handle_request(p_prev))
+        return;
+    /* Push this thread back to the pool. */
+    ABTI_pool_add_thread(&p_prev->thread);
 }
 
-/* NOTE: This routine should be called after ABTI_ythread_set_blocked. */
-void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
-                          ABTI_ythread *p_ythread,
-                          ABT_sync_event_type sync_event_type, void *p_sync)
+/* Before yield_to, p_prev->thread.p_pool's num_blocked must be incremented to
+ * avoid making a pool empty. */
+void ABTI_ythread_callback_yield_to(void *arg)
 {
-    ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    ABTI_ASSERT(&p_ythread->thread == p_local_xstream->p_thread);
-    ABTI_ASSERT(p_ythread->thread.p_last_xstream == p_local_xstream);
+    // ABTI_event_ythread_yield(p_local_xstream, p_cur_ythread,
+    //                      p_cur_ythread->thread.p_parent,
+    //                      ABT_SYNC_EVENT_TYPE_USER, NULL);
+    ABTI_ythread *p_prev = (ABTI_ythread *)arg;
+    /* p_prev->thread.p_pool is loaded before ABTI_pool_add_thread() to keep
+     * num_blocked consistent. Otherwise, other threads might pop p_prev
+     * that has been pushed by ABTI_pool_add_thread() and change
+     * p_prev->thread.p_pool by ABT_unit_set_associated_pool(). */
+    ABTI_pool *p_pool = p_prev->thread.p_pool;
+    if (!ythread_callback_handle_request(p_prev)) {
+        /* Push this thread back to the pool. */
+        ABTI_pool_add_thread(&p_prev->thread);
+    }
+    /* Decrease the number of blocked threads, which has been increased
+     * by p_prev to avoid making a pool size 0. */
+    ABTI_pool_dec_num_blocked(p_pool);
+}
 
-    /* Switch to the scheduler, i.e., suspend p_ythread  */
-    ABTI_ythread_switch_to_parent(pp_local_xstream, p_ythread, sync_event_type,
-                                  p_sync);
-    /* The suspended ULT resumes its execution from here. */
+void ABTI_ythread_callback_suspend(void *arg)
+{
+    ABTI_ythread *p_prev = (ABTI_ythread *)arg;
+    if (ythread_callback_handle_request(p_prev))
+        return;
+    /* Increase the number of blocked threads */
+    ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Set this thread's state to BLOCKED. */
+    ABTD_atomic_release_store_int(&p_prev->thread.state,
+                                  ABT_THREAD_STATE_BLOCKED);
+}
+
+void ABTI_ythread_callback_terminate(void *arg)
+{
+    /* Terminate this thread. */
+    ABTI_ythread *p_prev = (ABTI_ythread *)arg;
+    ABTI_xstream_terminate_thread(ABTI_global_get_global(),
+                                  ABTI_xstream_get_local(
+                                      p_prev->thread.p_last_xstream),
+                                  &p_prev->thread);
+}
+
+void ABTI_ythread_callback_suspend_unlock(void *arg)
+{
+    ABTI_ythread_callback_suspend_unlock_arg *p_arg =
+        (ABTI_ythread_callback_suspend_unlock_arg *)arg;
+    /* p_arg might point to the stack of the original ULT, so do not
+     * access it after that ULT becomes resumable. */
+    ABTI_ythread *p_prev = p_arg->p_prev;
+    ABTD_spinlock *p_lock = p_arg->p_lock;
+    if (ythread_callback_handle_request(p_prev))
+        return;
+    /* Increase the number of blocked threads */
+    ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Set this thread's state to BLOCKED. */
+    ABTD_atomic_release_store_int(&p_prev->thread.state,
+                                  ABT_THREAD_STATE_BLOCKED);
+    /* Release the lock. */
+    ABTD_spinlock_release(p_lock);
+}
+
+void ABTI_ythread_callback_suspend_join(void *arg)
+{
+    ABTI_ythread_callback_suspend_join_arg *p_arg =
+        (ABTI_ythread_callback_suspend_join_arg *)arg;
+    /* p_arg might point to the stack of the original ULT, so do not
+     * access it after that ULT becomes resumable. */
+    ABTI_ythread *p_prev = p_arg->p_prev;
+    ABTI_ythread *p_target = p_arg->p_target;
+    if (ythread_callback_handle_request(p_prev))
+        return;
+    /* Increase the number of blocked threads */
+    ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Set this thread's state to BLOCKED. */
+    ABTD_atomic_release_store_int(&p_prev->thread.state,
+                                  ABT_THREAD_STATE_BLOCKED);
+    /* Set the link in the context of the target ULT. This p_link might be
+     * read by p_target running on another ES in parallel, so release-store
+     * is needed here. */
+    ABTD_atomic_release_store_ythread_context_ptr(&p_target->ctx.p_link,
+                                                  &p_prev->ctx);
+}
+
+void ABTI_ythread_callback_suspend_replace_sched(void *arg)
+{
+    ABTI_ythread_callback_suspend_replace_sched_arg *p_arg =
+        (ABTI_ythread_callback_suspend_replace_sched_arg *)arg;
+    /* p_arg might point to the stack of the original ULT, so do not
+     * access it after that ULT becomes resumable. */
+    ABTI_ythread *p_prev = p_arg->p_prev;
+    ABTI_sched *p_main_sched = p_arg->p_main_sched;
+    if (ythread_callback_handle_request(p_prev))
+        return;
+    /* Increase the number of blocked threads */
+    ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Set this thread's state to BLOCKED. */
+    ABTD_atomic_release_store_int(&p_prev->thread.state,
+                                  ABT_THREAD_STATE_BLOCKED);
+    /* Ask the current main scheduler to replace its scheduler */
+    ABTI_sched_set_request(p_main_sched, ABTI_SCHED_REQ_REPLACE);
+}
+
+void ABTI_ythread_callback_orphan(void *arg)
+{
+    ABTI_ythread *p_prev = (ABTI_ythread *)arg;
+    ABTI_thread_unset_associated_pool(ABTI_global_get_global(),
+                                      &p_prev->thread);
 }
 
 void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
@@ -53,13 +148,6 @@ void ABTI_ythread_set_ready(ABTI_local *p_local, ABTI_ythread *p_ythread)
     /* The ULT must be in BLOCKED state. */
     ABTI_ASSERT(ABTD_atomic_acquire_load_int(&p_ythread->thread.state) ==
                 ABT_THREAD_STATE_BLOCKED);
-
-    /* We should wait until the scheduler of the blocked ULT resets the BLOCK
-     * request. Otherwise, the ULT can be pushed to a pool here and be
-     * scheduled by another scheduler if it is pushed to a shared pool. */
-    while (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
-           ABTI_THREAD_REQ_BLOCK)
-        ABTD_atomic_pause();
 
     ABTI_event_ythread_resume(p_local, p_ythread,
                               ABTI_local_get_xstream_or_null(p_local)
@@ -164,6 +252,56 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
         }
     }
     fflush(p_os);
+}
+
+/*****************************************************************************/
+/* Internal static functions                                                 */
+/*****************************************************************************/
+
+/* Return ABT_TRUE if p_prev should terminate. */
+static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
+{
+#if defined(ABT_CONFIG_DISABLE_THREAD_CANCEL) &&                               \
+    defined(ABT_CONFIG_DISABLE_MIGRATION)
+    return ABT_FALSE;
+#else
+    /* At least either cancellation or migration is enabled. */
+    const uint32_t request =
+        ABTD_atomic_acquire_load_uint32(&p_prev->thread.request);
+
+    /* Check cancellation request. */
+#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+    if (ABTU_unlikely(request & ABTI_THREAD_REQ_CANCEL)) {
+        ABTD_ythread_cancel(p_prev->thread.p_last_xstream, p_prev);
+        ABTI_xstream_terminate_thread(ABTI_global_get_global(),
+                                      ABTI_xstream_get_local(
+                                          p_prev->thread.p_last_xstream),
+                                      &p_prev->thread);
+        return ABT_TRUE;
+    }
+#endif /* !ABT_CONFIG_DISABLE_THREAD_CANCEL */
+
+    /* Check migration request. */
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+    if (ABTU_unlikely(request & ABTI_THREAD_REQ_MIGRATE)) {
+        /* This is the case when the ULT requests migration of itself. */
+        ABTD_atomic_release_store_int(&p_prev->thread.state,
+                                      ABT_THREAD_STATE_READY);
+        int abt_errno =
+            ABTI_xstream_migrate_thread(ABTI_global_get_global(),
+                                        ABTI_xstream_get_local(
+                                            p_prev->thread.p_last_xstream),
+                                        &p_prev->thread);
+        if (abt_errno != ABT_SUCCESS) {
+            /* Migration failed.  Let's push it back to its associated pool. */
+            ABTI_pool_add_thread(&p_prev->thread);
+        }
+        return ABT_FALSE;
+    }
+#endif /* !ABT_CONFIG_DISABLE_MIGRATION */
+#endif
+    /* This thread does not terminate. */
+    return ABT_FALSE;
 }
 
 #ifdef ABT_CONFIG_ENABLE_STACK_UNWIND


### PR DESCRIPTION
## Pull Request Description


## Problem

Some threading functions need to perform an operation to complete *after context switching*.  For example, a ULT that yields needs to be pushed back to its associated pool after it switches to its parent ULT (otherwise, another scheduler accesses that pool and executes that ULT which is still running, crashing the program).  Such an operation across context switch is achieved by request handling: before a ULT yields, this ULT sets a "POOL_PUSH" request, and the resuming ULT (= the parent scheduler) executes a pool operation based on its request.

This request handling mechanism is very complicated since the developer does not know which request handling would be performed by which ULT.  For example, a join-termination request attached to a joinee (i.e., a ULT that finishes) is handled only by a joiner (i.e., a ULT that calls `ABTI_thread_join()`), but this flow is difficult to follow since those are implemented in different files.  The algorithm is often complicated since some request handling operations include atomic operations (e.g., setting a ULT that suspends to resumable after context switch).  This is similar to a critical section that starts and finishes in different functions (that are running on different ULTs). making the logic extremely hard to understand.  It increases the maintenance cost and prevents flexibility.

## Solution

This PR introduces a callback mechanism to perform request handling.  The next ULT just runs a callback function without knowing its detail (i.e., without knowledge of requests that are possibly set to the previous ULT).

Passing a callback function to the next ULT is heavy, so we introduce a new fcontext implementation that embeds calling this callback operation.

This PR is not divisible since this PR changes the core algorithm in Argobots including the raw fcontext implementation.
In any case, those technical details do not matter any threading features supported by Argobots.  

### Performance

First of all, this patch is for code maintenance, so performance improvement is not the primary goal.  Potentially this PR can degrade the performance because of function calling overheads (the request handling code was inlined) while it improves since it removes branches (the request handling code has several branches to support various requests).

The following shows the performance.
 - `Main`: the current Argobots
 - `-O2`: the default configuration
 - `opt`: `--enable-perf-opt`

Higher is better.  The results show that the performance is almost the same (in most cases, within 5%), which should be acceptable.

![image](https://user-images.githubusercontent.com/15073003/124635287-df4a4780-de4c-11eb-9948-223ab4e2705d.png)


<details><summary> Benchmark code (collapsed)</summary>
<p>

```c
#include <abt.h>
#include <stdio.h>
#include <stdlib.h>
#include <assert.h>

typedef struct {
    ABT_thread thread;
    int num_yields;
} thread_arg_t;

void thread_func(void *arg)
{
    thread_arg_t *p_arg = (thread_arg_t *)arg;
    const int num_yields = p_arg->num_yields;
    for (int i = 0; i < num_yields; i++) {
        ABT_thread_yield();
    }
}

int main(int argc, const char **argv)
{
    if (argc != 3) {
        printf("Usage: ./a.out NUM_THREADS NUM_YIELDS\n");
        return -1;
    }
    const double min_repeat_sec = 1.0; // [s]
    const int num_min_repeats = 10;
    const int num_warmups = 3;
    const int num_threads = atoi(argv[1]);
    const int num_yields = atoi(argv[2]);

    ABT_init(0, NULL);
    thread_arg_t *thread_args =
        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_threads);
    for (int i = 0; i < num_threads; i++) {
        thread_args[i].num_yields = num_yields;
    }

    // Use a private pool since it is the fastest.
    ABT_pool pool;
    ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE, &pool);
    ABT_sched sched;
    ABT_sched_create_basic(ABT_SCHED_BASIC, 1, &pool, ABT_SCHED_CONFIG_NULL,
                           &sched);
    ABT_xstream xstream;
    ABT_self_get_xstream(&xstream);
    ABT_xstream_set_main_sched(xstream, sched);
    // Measurement
    double start_time, end_time;
    int repeat = 0, target_repeat = num_warmups + num_min_repeats;
    while (1) {
        repeat++;
        if (repeat == num_warmups)
            start_time = ABT_get_wtime();
        // Kernel starts
        for (int i = 0; i < num_threads; i++) {
            ABT_thread_create(pool, thread_func, &thread_args[i],
                              ABT_THREAD_ATTR_NULL, &thread_args[i].thread);
        }
        for (int i = num_threads - 1; i >= 0; i--) {
            ABT_thread_free(&thread_args[i].thread);
        }
        // Kernel ends
        if (repeat == target_repeat) {
            end_time = ABT_get_wtime();
            if (end_time - start_time > min_repeat_sec) {
                break;
            } else {
                target_repeat *= 2;
            }
        }
    }
    printf("[%d, %d] %f [ns per ULT]\n", num_threads, num_yields,
           (end_time - start_time) / num_threads / (repeat - num_warmups) *
               1.0e9);
    free(thread_args);
    ABT_finalize();
    return 0;
}
```

</p></details>

<details><summary> Experimental setting (collapsed)</summary>
<p>

All experiments used 1 core.
x86/64: Intel Skylake 8180 (openSUSE 15.2, gcc 7.5.0)
ARM: ThunderX2 (RedHat 7.6, gcc 9.3.0)
POWER: Summit-like POWER 9 machine (RedHat, gcc 9.3.0)
Average of 10 executions.
Fork-join benchmark: # of yields = 0
Yield benchmark: # of ULTs = 8
</p></details>

This PR is necessary to implement work-first scheduling (#155).

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
