### PR TITLE
self: suppress warning message of ABT_self_get_type

### DIFF
--- a/src/self.c
+++ b/src/self.c
@@ -296,8 +296,14 @@ int ABT_self_get_type(ABT_unit_type *type)
     /* By default, type is ABT_UNIT_TYPE_EXT in Argobots 1.x */
     *type = ABT_UNIT_TYPE_EXT;
     ABTI_SETUP_GLOBAL(NULL);
-    ABTI_xstream *p_local_xstream;
-    ABTI_SETUP_LOCAL_XSTREAM(&p_local_xstream);
+    /* Since ABT_ERR_INV_XSTREAM is a valid return, this should not be handled
+     * by ABTI_SETUP_LOCAL_XSTREAM, which warns the user when --enable-debug=err
+     * is set. */
+    ABTI_xstream *p_local_xstream =
+        ABTI_local_get_xstream_or_null(ABTI_local_get_local());
+    if (!p_local_xstream) {
+        return ABT_ERR_INV_XSTREAM;
+    }
     *type = ABTI_thread_type_get_type(p_local_xstream->p_thread->type);
 #else
     ABTI_UB_ASSERT(ABTI_initialized());


### PR DESCRIPTION
## Pull Request Description

This PR fixes #341. Specifically, this PR suppresses a warning message when `ABT_self_get_type()` (Argobots 1.x) is called on an external thread.  This warning message was printed when `--enable-debug=err` (included by `most` or `all`) is set.

(Note that `ABT_initialized()`, `ABT_mutex_trylock()`, and `ABT_cond_timedwait()` also legally return an error like `ABT_self_get_type()`. They do not print a warning message.)

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
