### PR TITLE
self: add ABT_self_yield_to and its friends

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1888,6 +1888,7 @@ int ABT_self_get_last_pool_id(int *pool_id) ABT_API_PUBLIC;
 int ABT_self_set_associated_pool(ABT_pool pool) ABT_API_PUBLIC;
 int ABT_self_get_unit(ABT_unit *unit) ABT_API_PUBLIC;
 int ABT_self_yield(void) ABT_API_PUBLIC;
+int ABT_self_yield_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
 int ABT_self_exit(void) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1890,6 +1890,7 @@ int ABT_self_get_unit(ABT_unit *unit) ABT_API_PUBLIC;
 int ABT_self_yield(void) ABT_API_PUBLIC;
 int ABT_self_yield_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
+int ABT_self_suspend_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_exit(void) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;
 int ABT_self_get_arg(void **arg) ABT_API_PUBLIC;

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1892,6 +1892,7 @@ int ABT_self_yield_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_suspend(void) ABT_API_PUBLIC;
 int ABT_self_suspend_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_exit(void) ABT_API_PUBLIC;
+int ABT_self_exit_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;
 int ABT_self_get_arg(void **arg) ABT_API_PUBLIC;
 int ABT_self_get_thread_func(void (**thread_func)(void *)) ABT_API_PUBLIC;

--- a/src/include/abtd.h
+++ b/src/include/abtd.h
@@ -100,6 +100,9 @@ void ABTD_affinity_list_free(ABTD_affinity_list *p_list);
 
 /* ULT Context */
 void ABTD_ythread_exit(ABTI_xstream *p_local_xstream, ABTI_ythread *p_ythread);
+void ABTD_ythread_exit_to(ABTI_xstream *p_local_xstream,
+                          ABTI_ythread *p_cur_ythread,
+                          ABTI_ythread *p_tar_ythread);
 void ABTD_ythread_cancel(ABTI_xstream *p_local_xstream,
                          ABTI_ythread *p_ythread);
 

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -617,6 +617,9 @@ ABTU_ret_err int ABTI_ythread_create_sched(ABTI_global *p_global,
                                            ABTI_sched *p_sched);
 ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
                                      ABTI_ythread *p_ythread);
+ABTU_noreturn void ABTI_ythread_exit_to(ABTI_xstream *p_local_xstream,
+                                        ABTI_ythread *p_cur_ythread,
+                                        ABTI_ythread *p_tar_ythread);
 void ABTI_ythread_free_primary(ABTI_global *p_global, ABTI_local *p_local,
                                ABTI_ythread *p_ythread);
 void ABTI_ythread_free_root(ABTI_global *p_global, ABTI_local *p_local,

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -188,6 +188,21 @@ static inline void ABTI_ythread_yield(ABTI_xstream **pp_local_xstream,
                                            (void *)p_ythread);
 }
 
+static inline void ABTI_ythread_yield_to(ABTI_xstream **pp_local_xstream,
+                                         ABTI_ythread *p_self,
+                                         ABTI_ythread *p_ythread,
+                                         ABT_sync_event_type sync_event_type,
+                                         void *p_sync)
+{
+    ABTI_event_ythread_yield(*pp_local_xstream, p_self, p_self->thread.p_parent,
+                             sync_event_type, p_sync);
+    ABTD_atomic_release_store_int(&p_ythread->thread.state,
+                                  ABT_THREAD_STATE_RUNNING);
+    ABTI_ythread_switch_to_sibling_internal(pp_local_xstream, p_self, p_ythread,
+                                            ABTI_ythread_callback_yield,
+                                            (void *)p_self);
+}
+
 /* Old interface used for ABT_thread_yield_to() */
 void ABTI_ythread_callback_thread_yield_to(void *arg);
 

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -188,21 +188,21 @@ static inline void ABTI_ythread_yield(ABTI_xstream **pp_local_xstream,
                                            (void *)p_ythread);
 }
 
-void ABTI_ythread_callback_yield_to(void *arg);
+/* Old interface used for ABT_thread_yield_to() */
+void ABTI_ythread_callback_thread_yield_to(void *arg);
 
-static inline void ABTI_ythread_yield_to(ABTI_xstream **pp_local_xstream,
-                                         ABTI_ythread *p_self,
-                                         ABTI_ythread *p_ythread,
-                                         ABT_sync_event_type sync_event_type,
-                                         void *p_sync)
+static inline void
+ABTI_ythread_thread_yield_to(ABTI_xstream **pp_local_xstream,
+                             ABTI_ythread *p_self, ABTI_ythread *p_ythread,
+                             ABT_sync_event_type sync_event_type, void *p_sync)
 {
     ABTI_event_ythread_yield(*pp_local_xstream, p_self, p_self->thread.p_parent,
                              sync_event_type, p_sync);
     ABTD_atomic_release_store_int(&p_ythread->thread.state,
                                   ABT_THREAD_STATE_RUNNING);
-    ABTI_ythread_switch_to_sibling_internal(pp_local_xstream, p_self, p_ythread,
-                                            ABTI_ythread_callback_yield_to,
-                                            (void *)p_self);
+    ABTI_ythread_switch_to_sibling_internal(
+        pp_local_xstream, p_self, p_ythread,
+        ABTI_ythread_callback_thread_yield_to, (void *)p_self);
 }
 
 void ABTI_ythread_callback_suspend(void *arg);

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -235,6 +235,20 @@ static inline void ABTI_ythread_suspend(ABTI_xstream **pp_local_xstream,
                                            (void *)p_ythread);
 }
 
+static inline void ABTI_ythread_suspend_to(ABTI_xstream **pp_local_xstream,
+                                           ABTI_ythread *p_self,
+                                           ABTI_ythread *p_ythread,
+                                           ABT_sync_event_type sync_event_type,
+                                           void *p_sync)
+{
+    ABTI_event_ythread_suspend(*pp_local_xstream, p_self,
+                               p_self->thread.p_parent, sync_event_type,
+                               p_sync);
+    ABTI_ythread_switch_to_sibling_internal(pp_local_xstream, p_self, p_ythread,
+                                            ABTI_ythread_callback_suspend,
+                                            (void *)p_self);
+}
+
 void ABTI_ythread_callback_terminate(void *arg);
 
 ABTU_noreturn static inline void

--- a/src/self.c
+++ b/src/self.c
@@ -638,6 +638,66 @@ int ABT_self_yield(void)
 
 /**
  * @ingroup SELF
+ * @brief   Yield the calling ULT to another ULT.
+ *
+ * \c ABT_self_yield_to() yields the calling ULT and schedules the ULT
+ * \c thread as a child thread of the calling ULT's parent.  The calling ULT is
+ * pushed to its associated pool.  It is the user's responsibility to pop
+ * \c thread from its associated pool before calling this routine.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_THREAD_HANDLE{\c thread}
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_THREAD_NY
+ * \DOC_ERROR_INV_THREAD_NY{\c thread}
+ * \DOC_ERROR_INV_THREAD_MAIN_SCHED_THREAD{the caller}
+ * \DOC_ERROR_INV_THREAD_MAIN_SCHED_THREAD{\c thread}
+ * \DOC_ERROR_INV_THREAD_CALLER{\c thread}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{the caller}
+ * \DOC_UNDEFINED_THREAD_UNSAFE{\c thread}
+ * \DOC_UNDEFINED_WORK_UNIT_IN_POOL{\c thread,
+ *                                  the pool associated with \c thread}
+ * \DOC_UNDEFINED_WORK_UNIT_NOT_READY{\c thread}
+ *
+ * @param[in] thread  handle to the target thread
+ * @return Error code
+ */
+int ABT_self_yield_to(ABT_thread thread)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+
+    ABTI_xstream *p_local_xstream;
+    ABTI_ythread *p_cur_ythread;
+    ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_cur_ythread);
+
+    ABTI_thread *p_tar_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_tar_thread);
+    ABTI_ythread *p_tar_ythread = ABTI_thread_get_ythread_or_null(p_tar_thread);
+    ABTI_CHECK_NULL_YTHREAD_PTR(p_tar_ythread);
+    ABTI_CHECK_TRUE(p_cur_ythread != p_tar_ythread, ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE(!(p_cur_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
+                    ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE(!(p_tar_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
+                    ABT_ERR_INV_THREAD);
+    ABTI_UB_ASSERT(!(p_tar_ythread->thread.p_pool->u_is_in_pool &&
+                     p_tar_ythread->thread.p_pool->u_is_in_pool(
+                         p_tar_ythread->thread.unit) == ABT_TRUE));
+
+    /* Switch the context */
+    ABTI_ythread_yield_to(&p_local_xstream, p_cur_ythread, p_tar_ythread,
+                          ABT_SYNC_EVENT_TYPE_USER, NULL);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
  * @brief   Suspend the calling ULT.
  *
  * \c ABT_self_suspend() suspends the execution of the calling ULT and switches

--- a/src/self.c
+++ b/src/self.c
@@ -836,6 +836,64 @@ int ABT_self_exit(void)
 
 /**
  * @ingroup SELF
+ * @brief   Terminate the calling ULT and jump to another ULT.
+ *
+ * \c ABT_self_suspend_to() terminates the calling ULT and schedules the ULT
+ * \c thread as a child thread of the calling ULT's parent.   This routine does
+ * not return if it succeeds.  It is the user's responsibility to pop \c thread
+ * from its associated pool before calling this routine.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_INV_THREAD_HANDLE{\c thread}
+ * \DOC_ERROR_INV_XSTREAM_EXT
+ * \DOC_ERROR_INV_THREAD_NY
+ * \DOC_ERROR_INV_THREAD_NY{\c thread}
+ * \DOC_ERROR_INV_THREAD_MAIN_SCHED_THREAD{the caller}
+ * \DOC_ERROR_INV_THREAD_MAIN_SCHED_THREAD{\c thread}
+ * \DOC_ERROR_INV_THREAD_PRIMARY_ULT{the caller}
+ * \DOC_ERROR_INV_THREAD_CALLER{\c thread}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{\c thread}
+ * \DOC_UNDEFINED_WORK_UNIT_IN_POOL{\c thread,
+ *                                  the pool associated with \c thread}
+ * \DOC_UNDEFINED_WORK_UNIT_NOT_READY{\c thread}
+ *
+ * @param[in] thread  handle to the target thread
+ * @return Error code
+ */
+int ABT_self_exit_to(ABT_thread thread)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+
+    ABTI_xstream *p_local_xstream;
+    ABTI_ythread *p_cur_ythread;
+    ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_cur_ythread);
+
+    ABTI_thread *p_tar_thread = ABTI_thread_get_ptr(thread);
+    ABTI_CHECK_NULL_THREAD_PTR(p_tar_thread);
+    ABTI_ythread *p_tar_ythread = ABTI_thread_get_ythread_or_null(p_tar_thread);
+    ABTI_CHECK_NULL_YTHREAD_PTR(p_tar_ythread);
+    ABTI_CHECK_TRUE(p_cur_ythread != p_tar_ythread, ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE(!(p_cur_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
+                    ABT_ERR_INV_THREAD);
+    ABTI_CHECK_TRUE(!(p_tar_ythread->thread.type & ABTI_THREAD_TYPE_MAIN_SCHED),
+                    ABT_ERR_INV_THREAD);
+    ABTI_UB_ASSERT(!(p_tar_ythread->thread.p_pool->u_is_in_pool &&
+                     p_tar_ythread->thread.p_pool->u_is_in_pool(
+                         p_tar_ythread->thread.unit) == ABT_TRUE));
+
+    /* Switch the context */
+    ABTI_ythread_exit_to(p_local_xstream, p_cur_ythread, p_tar_ythread);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SELF
  * @brief   Set an argument for a work-unit function of the calling work unit
  *
  * \c ABT_self_set_arg() sets the argument \c arg for the caller's work-unit

--- a/src/thread.c
+++ b/src/thread.c
@@ -1161,8 +1161,8 @@ int ABT_thread_yield_to(ABT_thread thread)
     p_tar_ythread->thread.p_last_xstream = p_local_xstream;
 
     /* Switch the context */
-    ABTI_ythread_yield_to(&p_local_xstream, p_cur_ythread, p_tar_ythread,
-                          ABT_SYNC_EVENT_TYPE_USER, NULL);
+    ABTI_ythread_thread_yield_to(&p_local_xstream, p_cur_ythread, p_tar_ythread,
+                                 ABT_SYNC_EVENT_TYPE_USER, NULL);
     return ABT_SUCCESS;
 }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -1068,18 +1068,10 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
  * its associated pool.
  *
  * @note
- * This routine is experimental.  The details of this function may be updated in
- * the future.
- *
- * @changev20
- * \DOC_DESC_V1X_YIELD_TASK
- *
- * \DOC_DESC_V1X_YIELD_EXT
- * @endchangev20
+ * \DOC_NOTE_REPLACEMENT{\c ABT_self_yield_to()}
  *
  * @contexts
- * \DOC_V1X \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH\n
- * \DOC_V20 \DOC_CONTEXT_INIT_YIELDABLE \DOC_CONTEXT_CTXSWITCH
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_CTXSWITCH
  *
  * @errors
  * \DOC_ERROR_SUCCESS
@@ -1090,8 +1082,6 @@ int ABT_thread_set_associated_pool(ABT_thread thread, ABT_pool pool)
  * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{a pool associated with \c thread,
  *                                     functions that are necessary for this
  *                                     routine}
- * \DOC_V20 \DOC_ERROR_INV_THREAD_NY
- * \DOC_V20 \DOC_ERROR_INV_XSTREAM_EXT
  *
  * @undefined
  * \DOC_UNDEFINED_UNINIT
@@ -1110,7 +1100,6 @@ int ABT_thread_yield_to(ABT_thread thread)
 
     ABTI_xstream *p_local_xstream;
     ABTI_ythread *p_cur_ythread;
-#ifndef ABT_CONFIG_ENABLE_VER_20_API
     p_local_xstream = ABTI_local_get_xstream_or_null(ABTI_local_get_local());
     if (ABTI_IS_EXT_THREAD_ENABLED && p_local_xstream == NULL) {
         return ABT_SUCCESS;
@@ -1120,9 +1109,6 @@ int ABT_thread_yield_to(ABT_thread thread)
         if (!p_cur_ythread)
             return ABT_SUCCESS;
     }
-#else
-    ABTI_SETUP_LOCAL_YTHREAD(&p_local_xstream, &p_cur_ythread);
-#endif
 
     ABTI_thread *p_tar_thread = ABTI_thread_get_ptr(thread);
     ABTI_CHECK_NULL_THREAD_PTR(p_tar_thread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -2477,6 +2477,15 @@ ABTU_noreturn void ABTI_ythread_exit(ABTI_xstream *p_local_xstream,
     ABTU_unreachable();
 }
 
+ABTU_noreturn void ABTI_ythread_exit_to(ABTI_xstream *p_local_xstream,
+                                        ABTI_ythread *p_cur_ythread,
+                                        ABTI_ythread *p_tar_ythread)
+{
+    /* Terminate this ULT */
+    ABTD_ythread_exit_to(p_local_xstream, p_cur_ythread, p_tar_ythread);
+    ABTU_unreachable();
+}
+
 ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_global *p_global,
                                           ABTI_local *p_local,
                                           ABTI_thread *p_thread,

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -34,7 +34,7 @@ void ABTI_ythread_callback_yield(void *arg)
 
 /* Before yield_to, p_prev->thread.p_pool's num_blocked must be incremented to
  * avoid making a pool empty. */
-void ABTI_ythread_callback_yield_to(void *arg)
+void ABTI_ythread_callback_thread_yield_to(void *arg)
 {
     // ABTI_event_ythread_yield(p_local_xstream, p_cur_ythread,
     //                      p_cur_ythread->thread.p_parent,

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -61,6 +61,7 @@ basic/rwlock_writer_excl
 basic/eventual_create
 basic/eventual_test
 basic/barrier
+basic/self_exit_to
 basic/self_rank_id
 basic/self_suspend_to
 basic/self_type

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -62,6 +62,7 @@ basic/eventual_create
 basic/eventual_test
 basic/barrier
 basic/self_rank_id
+basic/self_suspend_to
 basic/self_type
 basic/self_yield_to
 basic/ext_thread

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -63,6 +63,7 @@ basic/eventual_test
 basic/barrier
 basic/self_rank_id
 basic/self_type
+basic/self_yield_to
 basic/ext_thread
 basic/ext_thread2
 basic/ext_thread_barrier

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
 	eventual_test \
 	barrier \
 	self_rank_id \
+	self_suspend_to \
 	self_type \
 	self_yield_to \
 	ext_thread \
@@ -166,6 +167,7 @@ eventual_create_SOURCES = eventual_create.c
 eventual_test_SOURCES = eventual_test.c
 barrier_SOURCES = barrier.c
 self_rank_id_SOURCES = self_rank_id.c
+self_suspend_to_SOURCES = self_suspend_to.c
 self_type_SOURCES = self_type.c
 self_yield_to_SOURCES = self_yield_to.c
 ext_thread_SOURCES = ext_thread.c
@@ -251,6 +253,7 @@ testing:
 	./eventual_test
 	./barrier
 	./self_rank_id
+	./self_suspend_to
 	./self_type
 	./self_yield_to
 	./ext_thread

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	eventual_create \
 	eventual_test \
 	barrier \
+	self_exit_to \
 	self_rank_id \
 	self_suspend_to \
 	self_type \
@@ -166,6 +167,7 @@ future_create_SOURCES = future_create.c
 eventual_create_SOURCES = eventual_create.c
 eventual_test_SOURCES = eventual_test.c
 barrier_SOURCES = barrier.c
+self_exit_to_SOURCES = self_exit_to.c
 self_rank_id_SOURCES = self_rank_id.c
 self_suspend_to_SOURCES = self_suspend_to.c
 self_type_SOURCES = self_type.c
@@ -252,6 +254,7 @@ testing:
 	./eventual_create
 	./eventual_test
 	./barrier
+	./self_exit_to
 	./self_rank_id
 	./self_suspend_to
 	./self_type

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -68,6 +68,7 @@ TESTS = \
 	barrier \
 	self_rank_id \
 	self_type \
+	self_yield_to \
 	ext_thread \
 	ext_thread2 \
 	ext_thread_barrier \
@@ -166,6 +167,7 @@ eventual_test_SOURCES = eventual_test.c
 barrier_SOURCES = barrier.c
 self_rank_id_SOURCES = self_rank_id.c
 self_type_SOURCES = self_type.c
+self_yield_to_SOURCES = self_yield_to.c
 ext_thread_SOURCES = ext_thread.c
 ext_thread2_SOURCES = ext_thread2.c
 ext_thread_barrier_SOURCES = ext_thread_barrier.c
@@ -250,6 +252,7 @@ testing:
 	./barrier
 	./self_rank_id
 	./self_type
+	./self_yield_to
 	./ext_thread
 	./ext_thread2
 	./ext_thread_barrier

--- a/test/basic/self_exit_to.c
+++ b/test/basic/self_exit_to.c
@@ -1,0 +1,154 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 500
+
+typedef struct {
+    ABT_xstream xstream;
+    ABT_thread next_thread;
+} xstream_info_t;
+
+int g_num_xstreams = DEFAULT_NUM_XSTREAMS;
+xstream_info_t *g_xstreams;
+ABT_pool *g_pools;
+
+void thread_func(void *arg)
+{
+    ABT_thread self;
+    int ret, rank, i;
+    ret = ABT_self_get_thread(&self);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+
+    for (i = 0; i < 10; i++) {
+        ret = ABT_self_get_xstream_rank(&rank);
+        ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+        assert(g_xstreams[rank - 1].next_thread == ABT_THREAD_NULL ||
+               g_xstreams[rank - 1].next_thread == self);
+        /* Randomly get the next ULT. */
+        int victim_id = i % g_num_xstreams;
+        ABT_unit unit;
+        ret = ABT_pool_pop(g_pools[victim_id], &unit);
+        ATS_ERROR(ret, "ABT_pool_pop");
+        if (unit != ABT_UNIT_NULL) {
+            /* Terminate this ULT and jump to that ULT. */
+            ABT_thread target;
+            ret = ABT_unit_get_thread(unit, &target);
+            ATS_ERROR(ret, "ABT_unit_get_thread");
+            g_xstreams[rank - 1].next_thread = target;
+            ret = ABT_self_exit_to(target);
+            ATS_ERROR(ret, "ABT_self_exit_to");
+            /* Unreachable. */
+            assert(0);
+        } else {
+            /* Failed to get the next ULT.  Let's just yield. */
+            g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+            ret = ABT_self_yield();
+            ATS_ERROR(ret, "ABT_self_yield");
+        }
+    }
+    /* Finish this ULT. */
+    ret = ABT_self_get_xstream_rank(&rank);
+    ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+    g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+    ret = ABT_self_exit();
+    ATS_ERROR(ret, "ABT_self_exit");
+    /* Unreachable. */
+    assert(0);
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    int ret;
+    int num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1)
+        g_num_xstreams = atoi(argv[1]);
+    assert(g_num_xstreams >= 0);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    g_xstreams =
+        (xstream_info_t *)malloc(sizeof(xstream_info_t) * g_num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
+    g_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * g_num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, g_num_xstreams + 1);
+
+    /* Create pools. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &g_pools[i]);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        int j;
+        ABT_pool *tmp = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+        for (j = 0; j < g_num_xstreams; j++) {
+            tmp[j] = g_pools[(i + j) % g_num_xstreams];
+        }
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, g_num_xstreams, tmp,
+                                     ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create_basic");
+        free(tmp);
+    }
+
+    /* Create secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        g_xstreams[i].next_thread = ABT_THREAD_NULL;
+        ret = ABT_xstream_create(scheds[i], &g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Create unnamed threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, NULL);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Join named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    /* Join secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_free(&g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Free allocated memory. */
+    free(g_xstreams);
+    free(threads);
+    free(g_pools);
+    free(scheds);
+
+    return ret;
+}

--- a/test/basic/self_suspend_to.c
+++ b/test/basic/self_suspend_to.c
@@ -1,0 +1,171 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 100
+
+typedef struct {
+    ABT_xstream xstream;
+    ABT_thread prev_thread;
+    ABT_thread next_thread;
+} xstream_info_t;
+
+int g_num_xstreams = DEFAULT_NUM_XSTREAMS;
+xstream_info_t *g_xstreams;
+ABT_pool *g_pools;
+
+void thread_func(void *arg)
+{
+    ABT_thread self;
+    int ret, rank, i;
+    ret = ABT_self_get_thread(&self);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+    {
+        ret = ABT_self_get_xstream_rank(&rank);
+        ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+        assert(g_xstreams[rank - 1].next_thread == ABT_THREAD_NULL ||
+               g_xstreams[rank - 1].next_thread == self);
+        /* If there's a previous thread, let's wake it up. */
+        if (g_xstreams[rank - 1].prev_thread != ABT_THREAD_NULL) {
+            /* Wake up the previous thread. */
+            ret = ABT_thread_resume(g_xstreams[rank - 1].prev_thread);
+            ATS_ERROR(ret, "ABT_thread_resume");
+        }
+        g_xstreams[rank - 1].prev_thread = ABT_THREAD_NULL;
+        g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+    }
+
+    for (i = 0; i < 10; i++) {
+        /* Randomly get the next ULT. */
+        int victim_id = i % g_num_xstreams;
+        ABT_unit unit;
+        ret = ABT_pool_pop(g_pools[victim_id], &unit);
+        ATS_ERROR(ret, "ABT_pool_pop");
+        if (unit != ABT_UNIT_NULL) {
+            /* Suspend this ULT and jump to that ULT. */
+            ABT_thread target;
+            ret = ABT_unit_get_thread(unit, &target);
+            ATS_ERROR(ret, "ABT_unit_get_thread");
+            g_xstreams[rank - 1].prev_thread = self;
+            g_xstreams[rank - 1].next_thread = target;
+            ret = ABT_self_suspend_to(target);
+            ATS_ERROR(ret, "ABT_self_suspend_to");
+        } else {
+            /* Failed to get the next ULT.  Let's just yield. */
+            g_xstreams[rank - 1].prev_thread = ABT_THREAD_NULL;
+            g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+            ret = ABT_self_yield();
+            ATS_ERROR(ret, "ABT_self_yield");
+        }
+        ret = ABT_self_get_xstream_rank(&rank);
+        ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+        assert(g_xstreams[rank - 1].next_thread == ABT_THREAD_NULL ||
+               g_xstreams[rank - 1].next_thread == self);
+        /* If there's a previous thread, let's wake it up. */
+        if (g_xstreams[rank - 1].prev_thread != ABT_THREAD_NULL) {
+            /* Wake up the previous thread. */
+            ret = ABT_thread_resume(g_xstreams[rank - 1].prev_thread);
+            ATS_ERROR(ret, "ABT_thread_resume");
+            g_xstreams[rank - 1].prev_thread = ABT_THREAD_NULL;
+        }
+        g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+    }
+    /* Finish this thread. */
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    int ret;
+    int num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1)
+        g_num_xstreams = atoi(argv[1]);
+    assert(g_num_xstreams >= 0);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    g_xstreams =
+        (xstream_info_t *)malloc(sizeof(xstream_info_t) * g_num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
+    g_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * g_num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, g_num_xstreams + 1);
+
+    /* Create pools. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &g_pools[i]);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        int j;
+        ABT_pool *tmp = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+        for (j = 0; j < g_num_xstreams; j++) {
+            tmp[j] = g_pools[(i + j) % g_num_xstreams];
+        }
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, g_num_xstreams, tmp,
+                                     ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create_basic");
+        free(tmp);
+    }
+
+    /* Create secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        g_xstreams[i].prev_thread = ABT_THREAD_NULL;
+        g_xstreams[i].next_thread = ABT_THREAD_NULL;
+        ret = ABT_xstream_create(scheds[i], &g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Create unnamed threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, NULL);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Join named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    /* Join secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_free(&g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Free allocated memory. */
+    free(g_xstreams);
+    free(threads);
+    free(g_pools);
+    free(scheds);
+
+    return ret;
+}

--- a/test/basic/self_yield_to.c
+++ b/test/basic/self_yield_to.c
@@ -1,0 +1,148 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_THREADS 100
+
+typedef struct {
+    ABT_xstream xstream;
+    ABT_thread next_thread;
+} xstream_info_t;
+
+int g_num_xstreams = DEFAULT_NUM_XSTREAMS;
+xstream_info_t *g_xstreams;
+ABT_pool *g_pools;
+
+void thread_func(void *arg)
+{
+    ABT_thread self;
+    int ret, rank, i;
+    ret = ABT_self_get_thread(&self);
+    ATS_ERROR(ret, "ABT_self_get_thread");
+
+    for (i = 0; i < 10; i++) {
+        ret = ABT_self_get_xstream_rank(&rank);
+        ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+        assert(g_xstreams[rank - 1].next_thread == ABT_THREAD_NULL ||
+               g_xstreams[rank - 1].next_thread == self);
+        /* Randomly get the next ULT. */
+        int victim_id = i % g_num_xstreams;
+        ABT_unit unit;
+        ret = ABT_pool_pop(g_pools[victim_id], &unit);
+        ATS_ERROR(ret, "ABT_pool_pop");
+        if (unit != ABT_UNIT_NULL) {
+            /* Yield to that ULT. */
+            ABT_thread target;
+            ret = ABT_unit_get_thread(unit, &target);
+            ATS_ERROR(ret, "ABT_unit_get_thread");
+            g_xstreams[rank - 1].next_thread = target;
+            ret = ABT_self_yield_to(target);
+            ATS_ERROR(ret, "ABT_self_yield_to");
+        } else {
+            /* Failed to get the next ULT.  Let's just yield. */
+            g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+            ret = ABT_self_yield();
+            ATS_ERROR(ret, "ABT_self_yield");
+        }
+    }
+    /* Finish this ULT. */
+    ret = ABT_self_get_xstream_rank(&rank);
+    ATS_ERROR(ret, "ABT_self_get_xstream_rank");
+    g_xstreams[rank - 1].next_thread = ABT_THREAD_NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    int ret;
+    int num_threads = DEFAULT_NUM_THREADS;
+    if (argc > 1)
+        g_num_xstreams = atoi(argv[1]);
+    assert(g_num_xstreams >= 0);
+    if (argc > 2)
+        num_threads = atoi(argv[2]);
+    assert(num_threads >= 0);
+
+    g_xstreams =
+        (xstream_info_t *)malloc(sizeof(xstream_info_t) * g_num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_threads);
+    g_pools = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * g_num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, g_num_xstreams + 1);
+
+    /* Create pools. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &g_pools[i]);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        int j;
+        ABT_pool *tmp = (ABT_pool *)malloc(sizeof(ABT_pool) * g_num_xstreams);
+        for (j = 0; j < g_num_xstreams; j++) {
+            tmp[j] = g_pools[(i + j) % g_num_xstreams];
+        }
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, g_num_xstreams, tmp,
+                                     ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create_basic");
+        free(tmp);
+    }
+
+    /* Create secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        g_xstreams[i].next_thread = ABT_THREAD_NULL;
+        ret = ABT_xstream_create(scheds[i], &g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Create unnamed threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_create(g_pools[i % g_num_xstreams], thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, NULL);
+        ATS_ERROR(ret, "ABT_thread_create");
+    }
+
+    /* Join named threads */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_free(&threads[i]);
+        ATS_ERROR(ret, "ABT_thread_free");
+    }
+
+    /* Join secondary execution streams. */
+    for (i = 0; i < g_num_xstreams; i++) {
+        ret = ABT_xstream_free(&g_xstreams[i].xstream);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Free allocated memory. */
+    free(g_xstreams);
+    free(threads);
+    free(g_pools);
+    free(scheds);
+
+    return ret;
+}


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

This PR implements the following new APIs, which become feasible thanks to #342.

```c
int ABT_self_yield_to(ABT_thread thread);
int ABT_self_suspend_to(ABT_thread thread);
int ABT_self_exit_to(ABT_thread thread);
```

Specifically, `ABT_self_yield_to()` is an important API since it can replace the current `ABT_thread_yield_to()`; `ABT_thread_yield_to()` internally uses `pool_remove()`, which is **not thread-safe**, so the target ULT of `ABT_thread_yield_to()` must be in a pool that is accessed by no other ULTs/execution streams in parallel.  This restriction makes `ABT_thread_yield_to()` useless.

To do something similar to `ABT_thread_yield_to()`, the user can do the following:
```c
// mimic ABT_thread_yield_to()
void thread_yield_to(ABT_thread thread) {
  ABT_pool pool;
  ABT_unit unit;
  ABT_thread_get_last_pool(thread, &pool);
  ABT_thread_get_unit(thread, &unit)
  ABT_pool_remove(pool, unit); // not thread-safe (i.e., if unit is not in the pool, the program crashes)
  ABT_self_yield_to(thread);
}
```

Instead, the user might want to do something like this with `ABT_self_yield_to()`.  The following is an example of priority-based scheduling.
```c
// Directly jump to a ULT in a priority pool (for some reasons)
ABT_unit unit;
ABT_pool_pop(high_prio_pool, &unit); // Thread-safe.
if (unit != ABT_UNIT_NULL) {
  ABT_thread thread;
  ABT_unit_get_thread(unit, &thread);
  // Directly yield to a high-priority ULT.
  ABT_self_yield_to(thread);
}
```

This patch does not affect the existing functions.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->

