### PR TITLE
implement a child-first scheduling option

### DIFF
--- a/examples/stencil/.gitignore
+++ b/examples/stencil/.gitignore
@@ -6,6 +6,7 @@ stencil_forkjoin
 stencil_forkjoin_divconq
 stencil_forkjoin_divconq_hrws
 stencil_forkjoin_divconq_rws
+stencil_forkjoin_divconq_rws_cf
 stencil_forkjoin_revive
 stencil_forkjoin_task
 stencil_forkjoin_task_revive

--- a/examples/stencil/Makefile.am
+++ b/examples/stencil/Makefile.am
@@ -12,6 +12,7 @@ TESTS = \
 	stencil_forkjoin_divconq \
 	stencil_forkjoin_divconq_hrws \
 	stencil_forkjoin_divconq_rws \
+	stencil_forkjoin_divconq_rws_cf \
 	stencil_forkjoin_revive \
 	stencil_forkjoin_task \
 	stencil_forkjoin_task_revive \
@@ -32,6 +33,7 @@ stencil_forkjoin_SOURCES = stencil_forkjoin.c
 stencil_forkjoin_divconq_SOURCES = stencil_forkjoin_divconq.c
 stencil_forkjoin_divconq_hrws_SOURCES = stencil_forkjoin_divconq_hrws.c
 stencil_forkjoin_divconq_rws_SOURCES = stencil_forkjoin_divconq_rws.c
+stencil_forkjoin_divconq_rws_cf_SOURCES = stencil_forkjoin_divconq_rws_cf.c
 stencil_forkjoin_revive_SOURCES = stencil_forkjoin_revive.c
 stencil_forkjoin_task_SOURCES = stencil_forkjoin_task.c
 stencil_forkjoin_task_revive_SOURCES = stencil_forkjoin_task_revive.c

--- a/examples/stencil/stencil_forkjoin_divconq_rws_cf.c
+++ b/examples/stencil/stencil_forkjoin_divconq_rws_cf.c
@@ -1,0 +1,234 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+/*
+ * Base implementation: stencil_forkjoin_divconq_rws.c
+ *
+ * Parallel 2D stencil code based on a fork-join strategy.  In every iteration,
+ * it creates as many ULTs as the number of blocks (num_blocksX * num_blocksY)
+ * and frees them.  Fork-join in each iteration is needed for halo
+ * synchronization.
+ *
+ * This divide-and-conquer version creates ULTs in a divide-and-conquer manner.
+ * Each ULT is in charge of [blockX_from, blockX_to) x [blockY_from, blockY_to)
+ * blocks.  If either X or Y side is longer than 1, it divides that side by
+ * two and creates corresponding child ULTs; since it is applied to both X and Y
+ * axes, each ULT has at most four children.  If the lengths of both sides
+ * are 1, the ULT becomes a leaf node and runs the five-point stencil kernel.
+ *
+ * In this version, ULTs are scheduled in a typical random-work-stealing manner.
+ * Created ULTs are pushed to the local pool.  A scheduler first tries to get a
+ * ULT from its local pool unless it is empty; otherwise a scheduler tries to
+ * steal a ULT from another pool that is randomly chosen.
+ *
+ * Furthermore, this version uses child-first scheduling so that created ULTs
+ * (children) are executed first.  This scheduling pattern is known to be
+ * effective when parallelism is recursive; since each execution stream schedule
+ * tasks in a depth-first manner if no work stealing happens, it improves data
+ * locality compared with parent-first scheduling, which execute ULTs in a
+ * breadth-first manner.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <abt.h>
+#include "stencil_helper.h"
+
+/* Global variables. */
+int num_blocksX, num_blocksY;
+int blocksize;
+int num_iters;
+int num_xstreams;
+int validate;
+
+typedef struct {
+    double *values_old;
+    double *values_new;
+    int blockX_from;
+    int blockY_from;
+    int blockX_to;
+    int blockY_to;
+    ABT_pool *pools;
+    ABT_thread thread;
+} thread_arg_t;
+
+void thread(void *arg)
+{
+    double *values_old = ((thread_arg_t *)arg)->values_old;
+    double *values_new = ((thread_arg_t *)arg)->values_new;
+    int blockX_from = ((thread_arg_t *)arg)->blockX_from;
+    int blockY_from = ((thread_arg_t *)arg)->blockY_from;
+    int blockX_to = ((thread_arg_t *)arg)->blockX_to;
+    int blockY_to = ((thread_arg_t *)arg)->blockY_to;
+    ABT_pool *pools = ((thread_arg_t *)arg)->pools;
+
+    if (blockX_to - blockX_from == 1 && blockY_to - blockY_from == 1) {
+        /* Run stencil kernel. */
+        int x, y;
+        for (y = blockY_from * blocksize; y < blockY_to * blocksize; y++) {
+            for (x = blockX_from * blocksize; x < blockX_to * blocksize; x++) {
+                values_new[INDEX(x, y)] =
+                    values_old[INDEX(x, y)] * (1.0 / 2.0) +
+                    (values_old[INDEX(x + 1, y)] + values_old[INDEX(x - 1, y)] +
+                     values_old[INDEX(x, y + 1)] +
+                     values_old[INDEX(x, y - 1)]) *
+                        (1.0 / 8.0);
+            }
+        }
+    } else {
+        /* Divide the region and create child threads (maximum four). */
+        thread_arg_t thread_args[4];
+        int i, xdiv, ydiv;
+        for (ydiv = 0; ydiv < 2; ydiv++) {
+            for (xdiv = 0; xdiv < 2; xdiv++) {
+                int index = xdiv + ydiv * 2;
+                thread_args[index].values_old = values_old;
+                thread_args[index].values_new = values_new;
+                if (xdiv == 0) {
+                    thread_args[index].blockX_from = blockX_from;
+                    thread_args[index].blockX_to =
+                        blockX_from + (blockX_to - blockX_from) / 2;
+                } else {
+                    thread_args[index].blockX_from =
+                        blockX_from + (blockX_to - blockX_from) / 2;
+                    thread_args[index].blockX_to = blockX_to;
+                }
+                if (ydiv == 0) {
+                    thread_args[index].blockY_from = blockY_from;
+                    thread_args[index].blockY_to =
+                        blockY_from + (blockY_to - blockY_from) / 2;
+                } else {
+                    thread_args[index].blockY_from =
+                        blockY_from + (blockY_to - blockY_from) / 2;
+                    thread_args[index].blockY_to = blockY_to;
+                }
+                thread_args[index].pools = pools;
+                if (thread_args[index].blockX_to -
+                            thread_args[index].blockX_from !=
+                        0 &&
+                    thread_args[index].blockY_to -
+                            thread_args[index].blockY_from !=
+                        0) {
+                    /* Push a ULT to the local pool (pools[rank]). */
+                    int rank;
+                    ABT_xstream_self_rank(&rank);
+                    ABT_thread_create_to(pools[rank], thread,
+                                         &thread_args[index],
+                                         ABT_THREAD_ATTR_NULL,
+                                         &thread_args[index].thread);
+                } else {
+                    thread_args[index].thread = ABT_THREAD_NULL;
+                }
+            }
+        }
+        /* Join child threads. */
+        for (i = 0; i < 4; i++) {
+            if (thread_args[i].thread != ABT_THREAD_NULL) {
+                ABT_thread_free(&thread_args[i].thread);
+            }
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int i, j, t;
+    /* Read arguments. */
+    int read_arg_ret =
+        read_args(argc, argv, &num_blocksX, &num_blocksY, &blocksize,
+                  &num_iters, &num_xstreams, &validate);
+    if (read_arg_ret != 0) {
+        return -1;
+    }
+
+    /* Allocate memory. */
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_pool *pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * num_xstreams);
+    double *values_old = (double *)malloc(sizeof(double) * WIDTH * HEIGHT);
+    double *values_new = (double *)malloc(sizeof(double) * WIDTH * HEIGHT);
+
+    /* Initialize grid values. */
+    init_values(values_old, values_new, num_blocksX, num_blocksY, blocksize);
+
+    /* Initialize Argobots. */
+    ABT_init(argc, argv);
+
+    /* Create pools. */
+    for (i = 0; i < num_xstreams; i++) {
+        ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC, ABT_TRUE,
+                              &pools[i]);
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < num_xstreams; i++) {
+        ABT_pool *tmp = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+        for (j = 0; j < num_xstreams; j++) {
+            tmp[j] = pools[(i + j) % num_xstreams];
+        }
+        ABT_sched_create_basic(ABT_SCHED_RANDWS, num_xstreams, tmp,
+                               ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        free(tmp);
+    }
+
+    /* Set up a primary execution stream. */
+    ABT_xstream_self(&xstreams[0]);
+    ABT_xstream_set_main_sched(xstreams[0], scheds[0]);
+
+    /* Create secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        ABT_xstream_create(scheds[i], &xstreams[i]);
+    }
+
+    /* Iterates stencil computation. */
+    for (t = 0; t < num_iters; t++) {
+        thread_arg_t thread_arg;
+        thread_arg.values_old = values_old;
+        thread_arg.values_new = values_new;
+        thread_arg.blockX_from = 0;
+        thread_arg.blockY_from = 0;
+        thread_arg.blockX_to = num_blocksX;
+        thread_arg.blockY_to = num_blocksY;
+        thread_arg.pools = pools;
+        thread(&thread_arg);
+        /* Swap values_old and values_new. */
+        double *values_tmp = values_new;
+        values_new = values_old;
+        values_old = values_tmp;
+    }
+
+    /* Join secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        ABT_xstream_join(xstreams[i]);
+        ABT_xstream_free(&xstreams[i]);
+    }
+
+    /* Finalize Argobots */
+    ABT_finalize();
+
+    /* Validate results.  values_old has the latest values. */
+    int validate_ret = 0;
+    if (validate) {
+        validate_ret = validate_values(values_old, num_blocksX, num_blocksY,
+                                       blocksize, num_iters);
+    }
+
+    /* Free allocated memory. */
+    free(xstreams);
+    free(pools);
+    free(scheds);
+    free(values_old);
+    free(values_new);
+
+    if (validate_ret != 0) {
+        printf("Validation failed.\n");
+        return -1;
+    } else if (validate) {
+        printf("Validation succeeded.\n");
+    }
+    return 0;
+}

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1785,6 +1785,8 @@ int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool) ABT_API_PUBLIC;
 /* User-level Thread (ULT) */
 int ABT_thread_create(ABT_pool pool, void (*thread_func)(void *), void *arg,
                       ABT_thread_attr attr, ABT_thread *newthread) ABT_API_PUBLIC;
+int ABT_thread_create_to(ABT_pool pool, void (*thread_func)(void *), void *arg,
+                         ABT_thread_attr attr, ABT_thread *newthread) ABT_API_PUBLIC;
 int ABT_thread_create_on_xstream(ABT_xstream xstream,
                       void (*thread_func)(void *), void *arg,
                       ABT_thread_attr attr, ABT_thread *newthread) ABT_API_PUBLIC;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -8,6 +8,8 @@ basic/xstream_rank
 basic/xstream_set_main_sched
 basic/thread_create
 basic/thread_create2
+basic/thread_create3
+basic/thread_create4
 basic/thread_create_on_xstream
 basic/thread_revive
 basic/thread_attr

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -13,6 +13,8 @@ TESTS = \
 	xstream_set_main_sched \
 	thread_create \
 	thread_create2 \
+	thread_create3 \
+	thread_create4 \
 	thread_create_on_xstream \
 	thread_revive \
 	thread_attr \
@@ -114,6 +116,8 @@ xstream_rank_SOURCES = xstream_rank.c
 xstream_set_main_sched_SOURCES = xstream_set_main_sched.c
 thread_create_SOURCES = thread_create.c
 thread_create2_SOURCES = thread_create2.c
+thread_create3_SOURCES = thread_create3.c
+thread_create4_SOURCES = thread_create4.c
 thread_create_on_xstream_SOURCES = thread_create_on_xstream.c
 thread_revive_SOURCES = thread_revive.c
 thread_attr_SOURCES = thread_attr.c
@@ -201,6 +205,8 @@ testing:
 	./xstream_set_main_sched
 	./thread_create
 	./thread_create2
+	./thread_create3
+	./thread_create4
 	./thread_create_on_xstream
 	./thread_revive
 	./thread_attr

--- a/test/basic/thread_create3.c
+++ b/test/basic/thread_create3.c
@@ -1,0 +1,133 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks if named/unnamed create/create_to can be mixed. */
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define BINARY_DEPTH 8 /* 2 ** BINARY_DEPTH ULTs will be created */
+
+static inline uint32_t get_rand(uint32_t seed)
+{
+    /* thread-safe pseudo random generator.  Randomness is not important. */
+    return ((seed * 1103515245) + 12345) & 0x7fffffff;
+}
+
+void binary(void *arg)
+{
+    int i, ret;
+    const intptr_t depth = (intptr_t)arg;
+    if (depth <= 0) {
+        /* Leaf node. */
+        return;
+    }
+    const intptr_t child_depth = depth - 1;
+    ABT_thread threads[2] = { ABT_THREAD_NULL, ABT_THREAD_NULL };
+    for (i = 0; i < 2; i++) {
+        ABT_pool pool;
+        ret = ABT_self_get_last_pool(&pool);
+        ATS_ERROR(ret, "ABT_self_get_last_pool");
+
+        uint32_t rand_val = get_rand(((intptr_t)&i) + i) >> 3;
+        ABT_thread *p_thread = (rand_val / 4 <= 1) ? &threads[i] : NULL;
+        if (rand_val % 2 == 0) {
+            ret = ABT_thread_create(pool, binary, (void *)child_depth,
+                                    ABT_THREAD_ATTR_NULL, p_thread);
+            ATS_ERROR(ret, "ABT_thread_create");
+        } else {
+            ret = ABT_thread_create_to(pool, binary, (void *)child_depth,
+                                       ABT_THREAD_ATTR_NULL, p_thread);
+            ATS_ERROR(ret, "ABT_thread_create_to");
+        }
+    }
+    for (i = 0; i < 2; i++) {
+        if (threads[i] != ABT_THREAD_NULL) {
+            ret = ABT_thread_free(&threads[i]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int i, ret, num_xstreams = DEFAULT_NUM_XSTREAMS;
+    if (argc > 1)
+        num_xstreams = atoi(argv[1]);
+    assert(num_xstreams >= 0);
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_pool *pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    ABT_sched *scheds = (ABT_sched *)malloc(sizeof(ABT_sched) * num_xstreams);
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, num_xstreams + 1);
+
+    /* Create pools. */
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPMC,
+                                    ABT_TRUE, &pools[i]);
+        ATS_ERROR(ret, "ABT_pool_create_basic");
+    }
+
+    /* Create schedulers. */
+    for (i = 0; i < num_xstreams; i++) {
+        int j;
+        ABT_pool *tmp = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+        for (j = 0; j < num_xstreams; j++) {
+            tmp[j] = pools[(i + j) % num_xstreams];
+        }
+        ret = ABT_sched_create_basic(ABT_SCHED_DEFAULT, num_xstreams, tmp,
+                                     ABT_SCHED_CONFIG_NULL, &scheds[i]);
+        ATS_ERROR(ret, "ABT_sched_create_basic");
+        free(tmp);
+    }
+
+    /* Set up the primary execution stream. */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    ret = ABT_xstream_set_main_sched(xstreams[0], scheds[0]);
+    ATS_ERROR(ret, "ABT_xstream_set_main_sched");
+
+    /* Create secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(scheds[i], &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    binary((void *)((intptr_t)BINARY_DEPTH));
+
+    /* Join secondary execution streams. */
+    for (i = 1; i < num_xstreams; i++) {
+        while (1) {
+            ABT_bool on_primary;
+            ret = ABT_self_on_primary_xstream(&on_primary);
+            ATS_ERROR(ret, "ABT_self_on_primary_xstream");
+            if (on_primary) {
+                break;
+            }
+            ret = ABT_self_yield();
+            ATS_ERROR(ret, "ABT_self_yield");
+        }
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Free allocated memory. */
+    free(xstreams);
+    free(pools);
+    free(scheds);
+
+    return ret;
+}

--- a/test/basic/thread_create4.c
+++ b/test/basic/thread_create4.c
@@ -1,0 +1,70 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "abt.h"
+#include "abttest.h"
+
+/* This test checks the order of execution. */
+
+int g_counter = 0;
+void thread_func(void *arg)
+{
+    g_counter++;
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+    int ret;
+
+    /* Initialize */
+    ATS_read_args(argc, argv);
+    ATS_init(argc, argv, 1);
+
+    ABT_pool main_pool;
+    ret = ABT_self_get_last_pool(&main_pool);
+    ATS_ERROR(ret, "ABT_self_get_last_pool");
+
+    for (i = 0; i < 5; i++) {
+        ABT_thread thread;
+        size_t size;
+        g_counter = 0;
+
+        /* Parent-first (ABT_thread_create) */
+        ret = ABT_thread_create(main_pool, thread_func, NULL,
+                                ABT_THREAD_ATTR_NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_create");
+        assert(g_counter == 0);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 1);
+
+        ret = ABT_thread_free(&thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        assert(g_counter == 1);
+
+        /* Child-first (ABT_thread_create_to) */
+        ret = ABT_thread_create_to(main_pool, thread_func, NULL,
+                                   ABT_THREAD_ATTR_NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_create_to");
+        assert(g_counter == 2);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 0);
+
+        ret = ABT_thread_free(&thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        assert(g_counter == 2);
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+    return ret;
+}


### PR DESCRIPTION

## Pull Request Description

This PR closes #155.

Everyone loves child-first scheduling.  This PR implements `ABT_thread_create_to()` which enables child-first thread creation.  `ABT_thread_create_to()` creates a ULT and jumps to that ULT after pushing the calling ULT to its associated pool.

Note that currently, the pool (=task queue) management is different from that of Cilk, so the behavior is not the same as the typical Cilk-like child-first random-work stealing.  This needs #154, which hasn't been implemented yet.

### Performance

Typically, divide-and-conquer recursive parallel algorithms prefer child-first scheduling.  The following shows the performance of divide-and-conquer 2D stencil computation.

Note that this benchmark does not optimize the stencil kernel (e.g., by vectorization), so the performance should be suboptimal.  This evaluation is to show the difference between parent-first (**PF**) and child-first (**CF**).  In this setting, child-first (**CF**) performs better when more execution streams are used.

![image](https://user-images.githubusercontent.com/15073003/125139518-47f82500-e0d6-11eb-96cd-9c2ec904f30a.png)

<details><summary> Experimental setting (collapsed)</summary>
<p>

All experiments used 1 core.
x86/64: Intel Skylake 8180 (openSUSE 15.2, gcc 7.5.0)
ARM: ThunderX2 (RedHat 7.6, gcc 9.3.0)
POWER: Summit-like POWER 9 machine (RedHat, gcc 9.3.0)
Average of 20 executions. Iterative kernels are measured (no warm-up).
```sh
numactl --interleave=all examples/stencil/stencil_forkjoin_divconq_rws -e $NUM_ESS -x 100 -y 100 -b 50 -i 100 -v 0
numactl --interleave=all examples/stencil/stencil_forkjoin_divconq_rws_cf -e $NUM_ESS -x 100 -y 100 -b 50 -i 100 -v 0
```

(`numactl --interleave=all` stabilizes the performance.)

</p></details>

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->