### PR TITLE
ythread: remove unnecessary comments

### DIFF
--- a/src/ythread.c
+++ b/src/ythread.c
@@ -22,9 +22,6 @@ static void ythread_unwind_stack(void *arg);
 
 void ABTI_ythread_callback_yield(void *arg)
 {
-    // ABTI_event_ythread_yield(p_local_xstream, p_cur_ythread,
-    //                      p_cur_ythread->thread.p_parent,
-    //                      ABT_SYNC_EVENT_TYPE_USER, NULL);
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
     if (ythread_callback_handle_request(p_prev))
         return;
@@ -36,9 +33,6 @@ void ABTI_ythread_callback_yield(void *arg)
  * avoid making a pool empty. */
 void ABTI_ythread_callback_thread_yield_to(void *arg)
 {
-    // ABTI_event_ythread_yield(p_local_xstream, p_cur_ythread,
-    //                      p_cur_ythread->thread.p_parent,
-    //                      ABT_SYNC_EVENT_TYPE_USER, NULL);
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
     /* p_prev->thread.p_pool is loaded before ABTI_pool_add_thread() to keep
      * num_blocked consistent. Otherwise, other threads might pop p_prev


### PR DESCRIPTION

## Pull Request Description

This PR removes comments wrongly left by #342. Those comments do not use `/**/`.  This patch removes them since they are unnecessary.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
