### PR TITLE
thread: add ABT_thread_revive_to

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1796,6 +1796,8 @@ int ABT_thread_create_many(int num_threads, ABT_pool *pool_list,
                       ABT_API_PUBLIC;
 int ABT_thread_revive(ABT_pool pool, void(*thread_func)(void *), void *arg,
                       ABT_thread *thread) ABT_API_PUBLIC;
+int ABT_thread_revive_to(ABT_pool pool, void (*thread_func)(void *), void *arg,
+                         ABT_thread *thread) ABT_API_PUBLIC;
 int ABT_thread_free(ABT_thread *thread) ABT_API_PUBLIC;
 int ABT_thread_free_many(int num_threads, ABT_thread *thread_list) ABT_API_PUBLIC;
 int ABT_thread_join(ABT_thread thread) ABT_API_PUBLIC;

--- a/test/basic/thread_create4.c
+++ b/test/basic/thread_create4.c
@@ -45,15 +45,27 @@ int main(int argc, char *argv[])
         ATS_ERROR(ret, "ABT_pool_get_size");
         assert(size == 1);
 
-        ret = ABT_thread_free(&thread);
-        ATS_ERROR(ret, "ABT_thread_free");
+        ret = ABT_thread_join(thread);
+        ATS_ERROR(ret, "ABT_thread_join");
         assert(g_counter == 1);
 
-        /* Child-first (ABT_thread_create_to) */
-        ret = ABT_thread_create_to(main_pool, thread_func, NULL,
-                                   ABT_THREAD_ATTR_NULL, &thread);
-        ATS_ERROR(ret, "ABT_thread_create_to");
+        /* Parent-first (ABT_thread_revive) */
+        ret = ABT_thread_revive(main_pool, thread_func, NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_revive");
+        assert(g_counter == 1);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 1);
+
+        ret = ABT_thread_join(thread);
+        ATS_ERROR(ret, "ABT_thread_join");
         assert(g_counter == 2);
+
+        /* Child-first (ABT_thread_revive_to) */
+        ret = ABT_thread_revive_to(main_pool, thread_func, NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_revive_to");
+        assert(g_counter == 3);
 
         ret = ABT_pool_get_size(main_pool, &size);
         ATS_ERROR(ret, "ABT_pool_get_size");
@@ -61,7 +73,47 @@ int main(int argc, char *argv[])
 
         ret = ABT_thread_free(&thread);
         ATS_ERROR(ret, "ABT_thread_free");
-        assert(g_counter == 2);
+        assert(g_counter == 3);
+
+        /* Child-first (ABT_thread_create_to) */
+        ret = ABT_thread_create_to(main_pool, thread_func, NULL,
+                                   ABT_THREAD_ATTR_NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_create_to");
+        assert(g_counter == 4);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 0);
+
+        ret = ABT_thread_join(thread);
+        ATS_ERROR(ret, "ABT_thread_join");
+        assert(g_counter == 4);
+
+        /* Parent-first (ABT_thread_revive) */
+        ret = ABT_thread_revive(main_pool, thread_func, NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_revive");
+        assert(g_counter == 4);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 1);
+
+        ret = ABT_thread_join(thread);
+        ATS_ERROR(ret, "ABT_thread_join");
+        assert(g_counter == 5);
+
+        /* Child-first (ABT_thread_revive_to) */
+        ret = ABT_thread_revive_to(main_pool, thread_func, NULL, &thread);
+        ATS_ERROR(ret, "ABT_thread_revive_to");
+        assert(g_counter == 6);
+
+        ret = ABT_pool_get_size(main_pool, &size);
+        ATS_ERROR(ret, "ABT_pool_get_size");
+        assert(size == 0);
+
+        ret = ABT_thread_free(&thread);
+        ATS_ERROR(ret, "ABT_thread_free");
+        assert(g_counter == 6);
     }
 
     /* Finalize */

--- a/test/basic/thread_revive.c
+++ b/test/basic/thread_revive.c
@@ -92,6 +92,21 @@ void thread_create(void *arg)
     }
     ATS_printf(1, "[U%lu:E%u]: revived %d ULTs\n", id, rank, num_threads);
 
+    /* Join ULTs */
+    for (i = 0; i < num_threads; i++) {
+        ret = ABT_thread_join(threads[i]);
+        ATS_ERROR(ret, "ABT_thread_join");
+    }
+    ATS_printf(1, "[U%lu:E%u]: joined %d ULTs\n", id, rank, num_threads);
+
+    /* Revive-to ULTs with thread_func() */
+    for (i = 0; i < num_threads; i++) {
+        ret =
+            ABT_thread_revive_to(my_pool, thread_func, (void *)1, &threads[i]);
+        ATS_ERROR(ret, "ABT_thread_revive_to");
+    }
+    ATS_printf(1, "[U%lu:E%u]: revived %d ULTs\n", id, rank, num_threads);
+
     /* Join and free ULTs */
     for (i = 0; i < num_threads; i++) {
         ret = ABT_thread_free(&threads[i]);


### PR DESCRIPTION
## Pull Request Description

Related to #345. This PR implements a child-first ULT revival operation.
```c
int ABT_thread_revive_to(ABT_pool pool, void (*thread_func)(void *), void *arg, ABT_thread *thread);
```

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
