### PR TITLE
self: add ABT_self_schedule

### DIFF
--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1900,6 +1900,7 @@ int ABT_self_resume_suspend_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_exit(void) ABT_API_PUBLIC;
 int ABT_self_exit_to(ABT_thread thread) ABT_API_PUBLIC;
 int ABT_self_resume_exit_to(ABT_thread thread) ABT_API_PUBLIC;
+int ABT_self_schedule(ABT_thread thread, ABT_pool pool) ABT_API_PUBLIC;
 int ABT_self_set_arg(void *arg) ABT_API_PUBLIC;
 int ABT_self_get_arg(void **arg) ABT_API_PUBLIC;
 int ABT_self_get_thread_func(void (**thread_func)(void *)) ABT_API_PUBLIC;

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -522,9 +522,6 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
 void ABTI_xstream_free(ABTI_global *p_global, ABTI_local *p_local,
                        ABTI_xstream *p_xstream, ABT_bool force_free);
 void ABTI_xstream_schedule(void *p_arg);
-void ABTI_xstream_run_thread(ABTI_global *p_global,
-                             ABTI_xstream **pp_local_xstream,
-                             ABTI_thread *p_thread);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -568,5 +568,87 @@ ABTI_ythread_yield_orphan(ABTI_xstream **pp_local_xstream, ABTI_ythread *p_self,
                                            ABTI_ythread_callback_orphan,
                                            (void *)p_self);
 }
+static inline void ABTI_ythread_schedule(ABTI_global *p_global,
+                                         ABTI_xstream **pp_local_xstream,
+                                         ABTI_thread *p_thread)
+{
+    ABTI_xstream *p_local_xstream = *pp_local_xstream;
+    if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
+        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
+        /* Execute a ULT */
+#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
+            ABTI_THREAD_REQ_CANCEL) {
+            ABTI_ythread_cancel(p_local_xstream, p_ythread);
+            ABTI_xstream_terminate_thread(p_global,
+                                          ABTI_xstream_get_local(
+                                              p_local_xstream),
+                                          &p_ythread->thread);
+            return;
+        }
+#endif
+
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
+            ABTI_THREAD_REQ_MIGRATE) {
+            int abt_errno = ABTI_xstream_migrate_thread(p_global,
+                                                        ABTI_xstream_get_local(
+                                                            p_local_xstream),
+                                                        &p_ythread->thread);
+            if (!ABTI_IS_ERROR_CHECK_ENABLED || abt_errno == ABT_SUCCESS) {
+                /* Migration succeeded, so we do not need to schedule p_ythread.
+                 */
+                return;
+            }
+        }
+#endif
+        /* Switch the context.  Since the argument is pp_local_xstream,
+         * p_local_xstream->p_thread must be yieldable. */
+        ABTI_ythread *p_self =
+            ABTI_thread_get_ythread(p_local_xstream->p_thread);
+        ABTI_ythread_run_child(pp_local_xstream, p_self, p_ythread);
+        /* The previous ULT (p_ythread) may not be the same as one to which the
+         * context has been switched. */
+    } else {
+        /* Execute a tasklet */
+#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
+        if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
+            ABTI_THREAD_REQ_CANCEL) {
+            ABTI_event_thread_cancel(p_local_xstream, p_thread);
+            ABTI_xstream_terminate_thread(p_global,
+                                          ABTI_xstream_get_local(
+                                              p_local_xstream),
+                                          p_thread);
+            return;
+        }
+#endif
+
+        /* Change the task state */
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABT_THREAD_STATE_RUNNING);
+
+        /* Set the associated ES */
+        p_thread->p_last_xstream = p_local_xstream;
+
+        /* Execute the task function */
+        ABTI_thread *p_sched_thread = p_local_xstream->p_thread;
+        p_local_xstream->p_thread = p_thread;
+        p_thread->p_parent = p_sched_thread;
+
+        /* Execute the task function */
+        ABTI_event_thread_run(p_local_xstream, p_thread, p_sched_thread,
+                              p_sched_thread);
+        p_thread->f_thread(p_thread->p_arg);
+        ABTI_event_thread_finish(p_local_xstream, p_thread, p_sched_thread);
+
+        /* Set the current running scheduler's thread */
+        p_local_xstream->p_thread = p_sched_thread;
+
+        /* Terminate the tasklet */
+        ABTI_xstream_terminate_thread(p_global,
+                                      ABTI_xstream_get_local(p_local_xstream),
+                                      p_thread);
+    }
+}
 
 #endif /* ABTI_YTHREAD_H_INCLUDED */

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -117,7 +117,7 @@ static void sched_run(ABT_sched sched)
             ++pop_count;
             if ((unit = ABTI_pool_pop(p_pool)) != ABT_UNIT_NULL) {
                 ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+                ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 break;
             }
         }

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -114,7 +114,7 @@ static void sched_run(ABT_sched sched)
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+                ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 run_cnt_nowait++;
                 break;
             }
@@ -135,7 +135,7 @@ static void sched_run(ABT_sched sched)
             }
             if (unit != ABT_UNIT_NULL) {
                 ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+                ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 break;
             }
         }

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -114,7 +114,7 @@ static void sched_run(ABT_sched sched)
             ABT_unit unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+                ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
                 break;
             }

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -109,7 +109,7 @@ static void sched_run(ABT_sched sched)
         unit = ABTI_pool_pop(p_pool);
         if (unit != ABT_UNIT_NULL) {
             ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-            ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+            ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
@@ -120,7 +120,7 @@ static void sched_run(ABT_sched sched)
             unit = ABTI_pool_pop(p_pool);
             if (unit != ABT_UNIT_NULL) {
                 ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
-                ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+                ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
             }
         }

--- a/src/stream.c
+++ b/src/stream.c
@@ -1288,7 +1288,7 @@ int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool)
     int abt_errno =
         ABTI_unit_set_associated_pool(p_global, unit, p_pool, &p_thread);
     ABTI_CHECK_ERROR(abt_errno);
-    ABTI_xstream_run_thread(p_global, &p_local_xstream, p_thread);
+    ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
     return ABT_SUCCESS;
 }
 
@@ -1610,89 +1610,6 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
     /* Come back to the primary thread.  Now this thread is executed on top of
      * the main scheduler, which is running on the root thread. */
     (*pp_local_xstream)->p_thread = &p_ythread->thread;
-}
-
-void ABTI_xstream_run_thread(ABTI_global *p_global,
-                             ABTI_xstream **pp_local_xstream,
-                             ABTI_thread *p_thread)
-{
-    ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
-        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
-        /* Execute a ULT */
-#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
-            ABTI_THREAD_REQ_CANCEL) {
-            ABTI_ythread_cancel(p_local_xstream, p_ythread);
-            ABTI_xstream_terminate_thread(p_global,
-                                          ABTI_xstream_get_local(
-                                              p_local_xstream),
-                                          &p_ythread->thread);
-            return;
-        }
-#endif
-
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
-            ABTI_THREAD_REQ_MIGRATE) {
-            int abt_errno = ABTI_xstream_migrate_thread(p_global,
-                                                        ABTI_xstream_get_local(
-                                                            p_local_xstream),
-                                                        &p_ythread->thread);
-            if (!ABTI_IS_ERROR_CHECK_ENABLED || abt_errno == ABT_SUCCESS) {
-                /* Migration succeeded, so we do not need to schedule p_ythread.
-                 */
-                return;
-            }
-        }
-#endif
-        /* Switch the context.  Since the argument is pp_local_xstream,
-         * p_local_xstream->p_thread must be yieldable. */
-        ABTI_ythread *p_self =
-            ABTI_thread_get_ythread(p_local_xstream->p_thread);
-        ABTI_ythread_run_child(pp_local_xstream, p_self, p_ythread);
-        /* The previous ULT (p_ythread) may not be the same as one to which the
-         * context has been switched. */
-    } else {
-        /* Execute a tasklet */
-#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
-        if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
-            ABTI_THREAD_REQ_CANCEL) {
-            ABTI_event_thread_cancel(p_local_xstream, p_thread);
-            ABTI_xstream_terminate_thread(p_global,
-                                          ABTI_xstream_get_local(
-                                              p_local_xstream),
-                                          p_thread);
-            return;
-        }
-#endif
-
-        /* Change the task state */
-        ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABT_THREAD_STATE_RUNNING);
-
-        /* Set the associated ES */
-        p_thread->p_last_xstream = p_local_xstream;
-
-        /* Execute the task function */
-        ABTI_thread *p_sched_thread = p_local_xstream->p_thread;
-        p_local_xstream->p_thread = p_thread;
-        p_thread->p_parent = p_sched_thread;
-
-        /* Execute the task function */
-        ABTI_event_thread_run(p_local_xstream, p_thread, p_sched_thread,
-                              p_sched_thread);
-        p_thread->f_thread(p_thread->p_arg);
-        ABTI_event_thread_finish(p_local_xstream, p_thread, p_sched_thread);
-
-        /* Set the current running scheduler's thread */
-        p_local_xstream->p_thread = p_sched_thread;
-
-        /* Terminate the tasklet */
-        ABTI_xstream_terminate_thread(p_global,
-                                      ABTI_xstream_get_local(p_local_xstream),
-                                      p_thread);
-    }
 }
 
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched)

--- a/src/thread.c
+++ b/src/thread.c
@@ -3157,7 +3157,7 @@ static void thread_root_func(void *arg)
             ABTI_xstream *p_xstream = p_local_xstream;
             ABTI_thread *p_thread =
                 ABTI_unit_get_thread_from_builtin_unit(unit);
-            ABTI_xstream_run_thread(p_global, &p_xstream, p_thread);
+            ABTI_ythread_schedule(p_global, &p_xstream, p_thread);
             /* The root thread must be executed on the same execution stream. */
             ABTI_ASSERT(p_xstream == p_local_xstream);
         }

--- a/test/basic/xstream_set_main_sched.c
+++ b/test/basic/xstream_set_main_sched.c
@@ -50,7 +50,21 @@ void sched_run(ABT_sched sched)
             ret = ABT_pool_pop(p_data->pools[i], &unit);
             ATS_ERROR(ret, "ABT_pool_pop");
             if (unit != ABT_UNIT_NULL) {
-                ABT_xstream_run_unit(unit, p_data->pools[i]);
+                if (work_count % 3 == 0) {
+                    ABT_xstream_run_unit(unit, p_data->pools[i]);
+                } else if (work_count % 3 == 1) {
+                    ABT_thread thread;
+                    ret = ABT_unit_get_thread(unit, &thread);
+                    ATS_ERROR(ret, "ABT_unit_get_thread");
+                    ret = ABT_self_schedule(thread, ABT_POOL_NULL);
+                    ATS_ERROR(ret, "ABT_self_schedule");
+                } else {
+                    ABT_thread thread;
+                    ret = ABT_unit_get_thread(unit, &thread);
+                    ATS_ERROR(ret, "ABT_unit_get_thread");
+                    ret = ABT_self_schedule(thread, p_data->pools[i]);
+                    ATS_ERROR(ret, "ABT_self_schedule");
+                }
             }
         }
         if (++work_count >= 16) {


### PR DESCRIPTION
## Pull Request Description

This PR implements a new API `ABT_self_schedule()`, which is similar to `ABT_xstream_run_unit()`.
```c
int ABT_self_schedule(ABT_thread thread, ABT_pool pool);
```
The difference is the following two points.
1. `ABT_self_schedule()` takes `ABT_thread`, not `ABT_unit`.
2. `ABT_self_schedule()` accepts `ABT_POOL_NULL`, and if so, pool association of `thread` is not changed.

This PR completes all the basic context switching functions that bypass a scheduler. The new set of API should give users full flexibility of ULT scheduling; it should be especially useful to implement special ULT synchronization mechanisms on top of Argobots.
![image](https://user-images.githubusercontent.com/15073003/125694678-4724ac8f-1291-4eaf-ae54-886488b86523.png)

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

This patch does not affect the existing API.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
