### PR TITLE
thread: fix asynchronous request handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,9 +179,8 @@ AC_ARG_ENABLE([feature],
 [  --enable-feature@<:@=OPTS@:>@  enable/disable features.
                           "OPTS" is a list of comma separated names including
         all                 - all features always enabled (default)
-        no-thread-cancel    - disable ULT cancellation
-        no-task-cancel      - disable tasklet cancellation
-        no-migration        - disable ULT migrationtask
+        no-cancellation     - disable thread cancellation
+        no-migration        - disable thread migration
         no-ext-thread       - disable supporting external threads
         none|no             - disable all features above
 ],,[enable_feature=all])
@@ -626,16 +625,13 @@ IFS=","
 for option in $enable_feature ; do
     case "$option" in
         all|yes)
-            enable_thread_cancel=yes
-            enable_task_cancel=yes
+            enable_cancellation=yes
             enable_migration=yes
             enable_ext_thread=yes
         ;;
-        no-thread-cancel)
-            enable_thread_cancel=no
-        ;;
-        no-task-cancel)
-            enable_task_cancel=no
+        no-cancellation|no-thread-cancel|no-task-cancel)
+            # no-thread-cancel|no-task-cancel are old (-v1.1) options
+            enable_cancellation=no
         ;;
         no-migration)
             enable_migration=no
@@ -644,8 +640,7 @@ for option in $enable_feature ; do
             enable_ext_thread=no
         ;;
         none|no)
-            enable_thread_cancel=no
-            enable_task_cancel=no
+            enable_cancellation=no
             enable_migration=no
             enable_ext_thread=no
         ;;
@@ -658,17 +653,13 @@ for option in $enable_feature ; do
 done
 IFS="$save_IFS"
 
-AS_IF([test "x$enable_thread_cancel" = "xno"],
-    [AC_DEFINE(ABT_CONFIG_DISABLE_THREAD_CANCEL, 1,
-        [Define to disable ULT cancellation])])
-
-AS_IF([test "x$enable_task_cancel" = "xno"],
-    [AC_DEFINE(ABT_CONFIG_DISABLE_TASK_CANCEL, 1,
-        [Define to disable tasklet cancellation])])
+AS_IF([test "x$enable_cancellation" = "xno"],
+    [AC_DEFINE(ABT_CONFIG_DISABLE_CANCELLATION, 1,
+        [Define to disable thread cancellation])])
 
 AS_IF([test "x$enable_migration" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_MIGRATION, 1,
-        [Define to disable ULT migration])])
+        [Define to disable thread migration])])
 
 AS_IF([test "x$enable_ext_thread" = "xno"],
     [AC_DEFINE(ABT_CONFIG_DISABLE_EXT_THREAD, 1,

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -525,11 +525,6 @@ void ABTI_xstream_schedule(void *p_arg);
 void ABTI_xstream_check_events(ABTI_xstream *p_xstream, ABTI_sched *p_sched);
 void ABTI_xstream_print(ABTI_xstream *p_xstream, FILE *p_os, int indent,
                         ABT_bool print_sub);
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-ABTU_ret_err int ABTI_xstream_migrate_thread(ABTI_global *p_global,
-                                             ABTI_local *p_local,
-                                             ABTI_thread *p_thread);
-#endif
 
 /* Scheduler */
 ABT_sched_def *ABTI_sched_get_basic_def(void);

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -591,6 +591,12 @@ ABTU_ret_err int ABTI_thread_revive(ABTI_global *p_global, ABTI_local *p_local,
 void ABTI_thread_join(ABTI_local **pp_local, ABTI_thread *p_thread);
 void ABTI_thread_free(ABTI_global *p_global, ABTI_local *p_local,
                       ABTI_thread *p_thread);
+void ABTI_thread_handle_request_cancel(ABTI_global *p_global,
+                                       ABTI_xstream *p_local_xstream,
+                                       ABTI_thread *p_thread);
+ABTU_ret_err int ABTI_thread_handle_request_migrate(ABTI_global *p_global,
+                                                    ABTI_local *p_local,
+                                                    ABTI_thread *p_thread);
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent);
 void ABTI_thread_reset_id(void);
 ABT_unit_id ABTI_thread_get_id(ABTI_thread *p_thread);

--- a/src/include/abti_stream.h
+++ b/src/include/abti_stream.h
@@ -45,24 +45,6 @@ static inline ABTI_pool *ABTI_xstream_get_main_pool(ABTI_xstream *p_xstream)
     return ABTI_pool_get_ptr(pool);
 }
 
-static inline void ABTI_xstream_terminate_thread(ABTI_global *p_global,
-                                                 ABTI_local *p_local,
-                                                 ABTI_thread *p_thread)
-{
-    if (!(p_thread->type & ABTI_THREAD_TYPE_NAMED)) {
-        ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABT_THREAD_STATE_TERMINATED);
-        ABTI_thread_free(p_global, p_local, p_thread);
-    } else {
-        /* NOTE: We set the ULT's state as TERMINATED after checking refcount
-         * because the ULT can be freed on a different ES.  In other words, we
-         * must not access any field of p_thead after changing the state to
-         * TERMINATED. */
-        ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABT_THREAD_STATE_TERMINATED);
-    }
-}
-
 static inline ABTI_local *ABTI_xstream_get_local(ABTI_xstream *p_xstream)
 {
     return (ABTI_local *)p_xstream;

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -120,4 +120,22 @@ static inline int ABTI_thread_handle_request(ABTI_thread *p_thread,
 #endif
 }
 
+static inline void ABTI_thread_terminate(ABTI_global *p_global,
+                                         ABTI_local *p_local,
+                                         ABTI_thread *p_thread)
+{
+    if (!(p_thread->type & ABTI_THREAD_TYPE_NAMED)) {
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABT_THREAD_STATE_TERMINATED);
+        ABTI_thread_free(p_global, p_local, p_thread);
+    } else {
+        /* NOTE: We set the ULT's state as TERMINATED after checking refcount
+         * because the ULT can be freed on a different ES.  In other words, we
+         * must not access any field of p_thead after changing the state to
+         * TERMINATED. */
+        ABTD_atomic_release_store_int(&p_thread->state,
+                                      ABT_THREAD_STATE_TERMINATED);
+    }
+}
+
 #endif /* ABTI_THREAD_H_INCLUDED */

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -76,4 +76,48 @@ static inline void ABTI_thread_unset_request(ABTI_thread *p_thread,
     ABTD_atomic_fetch_and_uint32(&p_thread->request, ~req);
 }
 
+#define ABTI_THREAD_HANDLE_REQUEST_NONE ((int)0x0)
+#define ABTI_THREAD_HANDLE_REQUEST_CANCELLED ((int)0x1)
+#define ABTI_THREAD_HANDLE_REQUEST_MIGRATED ((int)0x2)
+
+static inline int ABTI_thread_handle_request(ABTI_thread *p_thread,
+                                             ABT_bool allow_termination)
+{
+#if defined(ABT_CONFIG_DISABLE_CANCELLATION) &&                                \
+    defined(ABT_CONFIG_DISABLE_MIGRATION)
+    return ABTI_THREAD_HANDLE_REQUEST_NONE;
+#else
+    /* At least either cancellation or migration is enabled. */
+    const uint32_t request =
+        ABTD_atomic_acquire_load_uint32(&p_thread->request);
+
+    /* Check cancellation request. */
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
+    if (allow_termination && ABTU_unlikely(request & ABTI_THREAD_REQ_CANCEL)) {
+        ABTI_thread_handle_request_cancel(ABTI_global_get_global(),
+                                          p_thread->p_last_xstream, p_thread);
+        return ABTI_THREAD_HANDLE_REQUEST_CANCELLED;
+    }
+#endif /* !ABT_CONFIG_DISABLE_CANCELLATION */
+
+    /* Check migration request. */
+#ifndef ABT_CONFIG_DISABLE_MIGRATION
+    if (ABTU_unlikely(request & ABTI_THREAD_REQ_MIGRATE)) {
+        /* This is the case when the ULT requests migration of itself. */
+        int abt_errno =
+            ABTI_thread_handle_request_migrate(ABTI_global_get_global(),
+                                               ABTI_xstream_get_local(
+                                                   p_thread->p_last_xstream),
+                                               p_thread);
+        if (abt_errno == ABT_SUCCESS) {
+            return ABTI_THREAD_HANDLE_REQUEST_MIGRATED;
+        }
+        /* Migration failed. */
+    }
+#endif /* !ABT_CONFIG_DISABLE_MIGRATION */
+
+    return ABTI_THREAD_HANDLE_REQUEST_NONE;
+#endif
+}
+
 #endif /* ABTI_THREAD_H_INCLUDED */

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -573,81 +573,53 @@ static inline void ABTI_ythread_schedule(ABTI_global *p_global,
                                          ABTI_thread *p_thread)
 {
     ABTI_xstream *p_local_xstream = *pp_local_xstream;
-    if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
-        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
-        /* Execute a ULT */
-#ifndef ABT_CONFIG_DISABLE_CANCELLATION
-        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
-            ABTI_THREAD_REQ_CANCEL) {
-            ABTI_ythread_cancel(p_local_xstream, p_ythread);
-            ABTI_xstream_terminate_thread(p_global,
-                                          ABTI_xstream_get_local(
-                                              p_local_xstream),
-                                          &p_ythread->thread);
-            return;
-        }
-#endif
+    const int request_op = ABTI_thread_handle_request(p_thread, ABT_TRUE);
+    if (ABTU_likely(request_op == ABTI_THREAD_HANDLE_REQUEST_NONE)) {
+        /* Execute p_thread. */
+        ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
+        if (p_ythread) {
+            /* p_thread is yieldable.  Let's switch the context.  Since the
+             * argument is pp_local_xstream, p_local_xstream->p_thread must be
+             * yieldable. */
+            ABTI_ythread *p_self =
+                ABTI_thread_get_ythread(p_local_xstream->p_thread);
+            ABTI_ythread_run_child(pp_local_xstream, p_self, p_ythread);
+            /* The previous ULT (p_ythread) may not be the same as one to which
+             * the context has been switched. */
+        } else {
+            /* p_thread is not yieldable. */
+            /* Change the task state */
+            ABTD_atomic_release_store_int(&p_thread->state,
+                                          ABT_THREAD_STATE_RUNNING);
 
-#ifndef ABT_CONFIG_DISABLE_MIGRATION
-        if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
-            ABTI_THREAD_REQ_MIGRATE) {
-            int abt_errno = ABTI_xstream_migrate_thread(p_global,
-                                                        ABTI_xstream_get_local(
-                                                            p_local_xstream),
-                                                        &p_ythread->thread);
-            if (!ABTI_IS_ERROR_CHECK_ENABLED || abt_errno == ABT_SUCCESS) {
-                /* Migration succeeded, so we do not need to schedule p_ythread.
-                 */
-                return;
-            }
-        }
-#endif
-        /* Switch the context.  Since the argument is pp_local_xstream,
-         * p_local_xstream->p_thread must be yieldable. */
-        ABTI_ythread *p_self =
-            ABTI_thread_get_ythread(p_local_xstream->p_thread);
-        ABTI_ythread_run_child(pp_local_xstream, p_self, p_ythread);
-        /* The previous ULT (p_ythread) may not be the same as one to which the
-         * context has been switched. */
-    } else {
-        /* Execute a tasklet */
-#ifndef ABT_CONFIG_DISABLE_CANCELLATION
-        if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
-            ABTI_THREAD_REQ_CANCEL) {
-            ABTI_event_thread_cancel(p_local_xstream, p_thread);
+            /* Set the associated ES */
+            p_thread->p_last_xstream = p_local_xstream;
+
+            /* Execute the task function */
+            ABTI_thread *p_sched_thread = p_local_xstream->p_thread;
+            p_local_xstream->p_thread = p_thread;
+            p_thread->p_parent = p_sched_thread;
+
+            /* Execute the task function */
+            ABTI_event_thread_run(p_local_xstream, p_thread, p_sched_thread,
+                                  p_sched_thread);
+            p_thread->f_thread(p_thread->p_arg);
+            ABTI_event_thread_finish(p_local_xstream, p_thread, p_sched_thread);
+
+            /* Set the current running scheduler's thread */
+            p_local_xstream->p_thread = p_sched_thread;
+
+            /* Terminate the tasklet */
             ABTI_xstream_terminate_thread(p_global,
                                           ABTI_xstream_get_local(
                                               p_local_xstream),
                                           p_thread);
-            return;
         }
-#endif
-
-        /* Change the task state */
-        ABTD_atomic_release_store_int(&p_thread->state,
-                                      ABT_THREAD_STATE_RUNNING);
-
-        /* Set the associated ES */
-        p_thread->p_last_xstream = p_local_xstream;
-
-        /* Execute the task function */
-        ABTI_thread *p_sched_thread = p_local_xstream->p_thread;
-        p_local_xstream->p_thread = p_thread;
-        p_thread->p_parent = p_sched_thread;
-
-        /* Execute the task function */
-        ABTI_event_thread_run(p_local_xstream, p_thread, p_sched_thread,
-                              p_sched_thread);
-        p_thread->f_thread(p_thread->p_arg);
-        ABTI_event_thread_finish(p_local_xstream, p_thread, p_sched_thread);
-
-        /* Set the current running scheduler's thread */
-        p_local_xstream->p_thread = p_sched_thread;
-
-        /* Terminate the tasklet */
-        ABTI_xstream_terminate_thread(p_global,
-                                      ABTI_xstream_get_local(p_local_xstream),
-                                      p_thread);
+    } else if (request_op == ABTI_THREAD_HANDLE_REQUEST_CANCELLED) {
+        /* If p_thread is cancelled, there's nothing to do. */
+    } else if (request_op == ABTI_THREAD_HANDLE_REQUEST_MIGRATED) {
+        /* If p_thread is migrated, let's push p_thread back to its pool. */
+        ABTI_pool_add_thread(p_thread);
     }
 }
 

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -598,10 +598,9 @@ static inline void ABTI_ythread_schedule(ABTI_global *p_global,
             p_local_xstream->p_thread = p_sched_thread;
 
             /* Terminate the tasklet */
-            ABTI_xstream_terminate_thread(p_global,
-                                          ABTI_xstream_get_local(
-                                              p_local_xstream),
-                                          p_thread);
+            ABTI_thread_terminate(p_global,
+                                  ABTI_xstream_get_local(p_local_xstream),
+                                  p_thread);
         }
     } else if (request_op == ABTI_THREAD_HANDLE_REQUEST_CANCELLED) {
         /* If p_thread is cancelled, there's nothing to do. */

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -576,7 +576,7 @@ static inline void ABTI_ythread_schedule(ABTI_global *p_global,
     if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
         ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
         /* Execute a ULT */
-#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
         if (ABTD_atomic_acquire_load_uint32(&p_ythread->thread.request) &
             ABTI_THREAD_REQ_CANCEL) {
             ABTI_ythread_cancel(p_local_xstream, p_ythread);
@@ -611,7 +611,7 @@ static inline void ABTI_ythread_schedule(ABTI_global *p_global,
          * context has been switched. */
     } else {
         /* Execute a tasklet */
-#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
         if (ABTD_atomic_acquire_load_uint32(&p_thread->request) &
             ABTI_THREAD_REQ_CANCEL) {
             ABTI_event_thread_cancel(p_local_xstream, p_thread);

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -450,18 +450,6 @@ ABTI_ythread_exit_to(ABTI_xstream *p_local_xstream, ABTI_ythread *p_self,
     ABTU_unreachable();
 }
 
-static inline void ABTI_ythread_cancel(ABTI_xstream *p_local_xstream,
-                                       ABTI_ythread *p_ythread)
-{
-    /* When we cancel a ULT, if other ULT is blocked to join the canceled ULT,
-     * we have to wake up the joiner ULT.  However, unlike the case when the
-     * ULT has finished its execution and calls ythread_terminate/exit,
-     * this function is called by the scheduler.  Therefore, we should not
-     * context switch to the joiner ULT and need to always wake it up. */
-    ABTI_ythread_resume_joiner(p_local_xstream, p_ythread);
-    ABTI_event_thread_cancel(p_local_xstream, &p_ythread->thread);
-}
-
 typedef struct {
     ABTI_ythread *p_prev;
     ABTI_ythread *p_next;

--- a/src/info.c
+++ b/src/info.c
@@ -268,14 +268,14 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_THREAD_CANCEL:
-#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
             *((ABT_bool *)val) = ABT_TRUE;
 #else
             *((ABT_bool *)val) = ABT_FALSE;
 #endif
             break;
         case ABT_INFO_QUERY_KIND_ENABLED_TASK_CANCEL:
-#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
             *((ABT_bool *)val) = ABT_TRUE;
 #else
             *((ABT_bool *)val) = ABT_FALSE;
@@ -1121,14 +1121,7 @@ void ABTI_info_print_config(ABTI_global *p_global, FILE *fp)
 #endif
                 "\n");
     fprintf(fp, " - thread cancellation: "
-#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
-                "enabled"
-#else
-                "disabled"
-#endif
-                "\n");
-    fprintf(fp, " - task cancellation: "
-#ifndef ABT_CONFIG_DISABLE_TASK_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
                 "enabled"
 #else
                 "disabled"

--- a/src/thread.c
+++ b/src/thread.c
@@ -872,7 +872,7 @@ int ABT_thread_cancel(ABT_thread thread)
 {
     ABTI_UB_ASSERT(ABTI_initialized());
 
-#ifdef ABT_CONFIG_DISABLE_THREAD_CANCEL
+#ifdef ABT_CONFIG_DISABLE_CANCELLATION
     ABTI_HANDLE_ERROR(ABT_ERR_FEATURE_NA);
 #else
     ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);

--- a/src/thread.c
+++ b/src/thread.c
@@ -2662,9 +2662,8 @@ void ABTI_thread_handle_request_cancel(ABTI_global *p_global,
         ABTI_ythread_resume_joiner(p_local_xstream, p_ythread);
     }
     ABTI_event_thread_cancel(p_local_xstream, p_thread);
-    ABTI_xstream_terminate_thread(p_global,
-                                  ABTI_xstream_get_local(p_local_xstream),
-                                  p_thread);
+    ABTI_thread_terminate(p_global, ABTI_xstream_get_local(p_local_xstream),
+                          p_thread);
 }
 
 ABTU_ret_err int ABTI_thread_handle_request_migrate(ABTI_global *p_global,

--- a/src/thread.c
+++ b/src/thread.c
@@ -2651,6 +2651,50 @@ ABTU_ret_err int ABTI_thread_get_mig_data(ABTI_global *p_global,
     return ABT_SUCCESS;
 }
 
+void ABTI_thread_handle_request_cancel(ABTI_global *p_global,
+                                       ABTI_xstream *p_local_xstream,
+                                       ABTI_thread *p_thread)
+{
+    ABTI_ythread *p_ythread = ABTI_thread_get_ythread_or_null(p_thread);
+    if (p_ythread) {
+        /* When we cancel a ULT, if other ULT is blocked to join the canceled
+         * ULT, we have to wake up the joiner ULT. */
+        ABTI_ythread_resume_joiner(p_local_xstream, p_ythread);
+    }
+    ABTI_event_thread_cancel(p_local_xstream, p_thread);
+    ABTI_xstream_terminate_thread(p_global,
+                                  ABTI_xstream_get_local(p_local_xstream),
+                                  p_thread);
+}
+
+ABTU_ret_err int ABTI_thread_handle_request_migrate(ABTI_global *p_global,
+                                                    ABTI_local *p_local,
+                                                    ABTI_thread *p_thread)
+{
+    int abt_errno;
+
+    ABTI_thread_mig_data *p_mig_data;
+    abt_errno =
+        ABTI_thread_get_mig_data(p_global, p_local, p_thread, &p_mig_data);
+    ABTI_CHECK_ERROR(abt_errno);
+
+    /* Extracting an argument embedded in a migration request. */
+    ABTI_pool *p_pool =
+        ABTD_atomic_relaxed_load_ptr(&p_mig_data->p_migration_pool);
+
+    /* Change the associated pool */
+    abt_errno = ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+    ABTI_CHECK_ERROR(abt_errno);
+    /* Call a callback function */
+    if (p_mig_data->f_migration_cb) {
+        ABT_thread thread = ABTI_thread_get_handle(p_thread);
+        p_mig_data->f_migration_cb(thread, p_mig_data->p_migration_cb_arg);
+    }
+    /* Unset the migration request. */
+    ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
+    return ABT_SUCCESS;
+}
+
 void ABTI_thread_print(ABTI_thread *p_thread, FILE *p_os, int indent)
 {
     if (p_thread == NULL) {

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -330,7 +330,6 @@ static inline int ythread_callback_handle_request(ABTI_ythread *p_prev,
     if (ABTU_unlikely(request & ABTI_THREAD_REQ_MIGRATE)) {
         /* This is the case when the ULT requests migration of itself. */
         ABTI_thread *p_thread = &p_prev->thread;
-        ABTD_atomic_release_store_int(&p_thread->state, ABT_THREAD_STATE_READY);
         int abt_errno;
         ABTI_global *p_global = ABTI_global_get_global();
         ABTI_local *p_local = ABTI_xstream_get_local(p_thread->p_last_xstream);
@@ -355,18 +354,10 @@ static inline int ythread_callback_handle_request(ABTI_ythread *p_prev,
                 }
                 /* Unset the migration request. */
                 ABTI_thread_unset_request(p_thread, ABTI_THREAD_REQ_MIGRATE);
-
-                /* Add the unit to the scheduler's pool */
-                ABTI_pool_push(p_pool, p_thread->unit);
-            } else {
-                /* Migration failed.  Push it back to its associated pool. */
-                ABTI_pool_add_thread(&p_prev->thread);
+                return YTHREAD_CALLBACK_HANDLE_REQUEST_MIGRATED;
             }
-        } else {
-            /* Migration failed.  Let's push it back to its associated pool. */
-            ABTI_pool_add_thread(&p_prev->thread);
         }
-        return YTHREAD_CALLBACK_HANDLE_REQUEST_MIGRATED;
+        /* Migration failed. */
     }
 #endif /* !ABT_CONFIG_DISABLE_MIGRATION */
 

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -5,7 +5,12 @@
 
 #include "abti.h"
 
-static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev);
+#define YTHREAD_CALLBACK_HANDLE_REQUEST_NONE ((int)0x0)
+#define YTHREAD_CALLBACK_HANDLE_REQUEST_CANCELLED ((int)0x1)
+#define YTHREAD_CALLBACK_HANDLE_REQUEST_MIGRATED ((int)0x2)
+
+static inline int ythread_callback_handle_request(ABTI_ythread *p_prev,
+                                                  ABT_bool allow_termination);
 
 #ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
 #define UNW_LOCAL_ONLY
@@ -23,10 +28,13 @@ static void ythread_unwind_stack(void *arg);
 void ABTI_ythread_callback_yield(void *arg)
 {
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
-    if (ythread_callback_handle_request(p_prev))
-        return;
-    /* Push this thread back to the pool. */
-    ABTI_pool_add_thread(&p_prev->thread);
+    if (ythread_callback_handle_request(p_prev, ABT_TRUE) &
+        YTHREAD_CALLBACK_HANDLE_REQUEST_CANCELLED) {
+        /* p_prev is terminated. */
+    } else {
+        /* Push p_prev back to the pool. */
+        ABTI_pool_add_thread(&p_prev->thread);
+    }
 }
 
 /* Before yield_to, p_prev->thread.p_pool's num_blocked must be incremented to
@@ -39,12 +47,16 @@ void ABTI_ythread_callback_thread_yield_to(void *arg)
      * that has been pushed by ABTI_pool_add_thread() and change
      * p_prev->thread.p_pool by ABT_unit_set_associated_pool(). */
     ABTI_pool *p_pool = p_prev->thread.p_pool;
-    if (!ythread_callback_handle_request(p_prev)) {
-        /* Push this thread back to the pool. */
+    if (ythread_callback_handle_request(p_prev, ABT_TRUE) &
+        YTHREAD_CALLBACK_HANDLE_REQUEST_CANCELLED) {
+        /* p_prev is terminated. */
+    } else {
+        /* Push p_prev back to the pool. */
         ABTI_pool_add_thread(&p_prev->thread);
     }
-    /* Decrease the number of blocked threads, which has been increased
-     * by p_prev to avoid making a pool size 0. */
+    /* Decrease the number of blocked threads of the original pool (i.e., before
+     * migration), which has been increased by p_prev to avoid making a pool
+     * size 0. */
     ABTI_pool_dec_num_blocked(p_pool);
 }
 
@@ -56,21 +68,25 @@ void ABTI_ythread_callback_resume_yield_to(void *arg)
      * access it after that ULT becomes resumable. */
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTI_ythread *p_next = p_arg->p_next;
-    if (!ythread_callback_handle_request(p_prev)) {
+    if (ythread_callback_handle_request(p_prev, ABT_TRUE) &
+        YTHREAD_CALLBACK_HANDLE_REQUEST_CANCELLED) {
+        /* p_prev is terminated. */
+    } else {
         /* Push this thread back to the pool. */
         ABTI_pool_add_thread(&p_prev->thread);
     }
-    /* Decrease the number of blocked threads. */
+    /* Decrease the number of blocked threads of p_next's pool. */
     ABTI_pool_dec_num_blocked(p_next->thread.p_pool);
 }
 
 void ABTI_ythread_callback_suspend(void *arg)
 {
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
-    if (ythread_callback_handle_request(p_prev))
-        return;
-    /* Increase the number of blocked threads */
+    /* Increase the number of blocked threads of the original pool (i.e., before
+     * migration) */
     ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Request handling.  p_prev->thread.p_pool might be changed. */
+    ythread_callback_handle_request(p_prev, ABT_FALSE);
     /* Set this thread's state to BLOCKED. */
     ABTD_atomic_release_store_int(&p_prev->thread.state,
                                   ABT_THREAD_STATE_BLOCKED);
@@ -84,8 +100,6 @@ void ABTI_ythread_callback_resume_suspend_to(void *arg)
      * access it after that ULT becomes resumable. */
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTI_ythread *p_next = p_arg->p_next;
-    if (ythread_callback_handle_request(p_prev))
-        return;
     ABTI_pool *p_prev_pool = p_prev->thread.p_pool;
     ABTI_pool *p_next_pool = p_next->thread.p_pool;
     if (p_prev_pool != p_next_pool) {
@@ -94,6 +108,8 @@ void ABTI_ythread_callback_resume_suspend_to(void *arg)
         /* Decrease the number of blocked threads of p_next's pool */
         ABTI_pool_dec_num_blocked(p_next_pool);
     }
+    /* Request handling.  p_prev->thread.p_pool might be changed. */
+    ythread_callback_handle_request(p_prev, ABT_FALSE);
     /* Set this thread's state to BLOCKED. */
     ABTD_atomic_release_store_int(&p_prev->thread.state,
                                   ABT_THREAD_STATE_BLOCKED);
@@ -134,10 +150,10 @@ void ABTI_ythread_callback_suspend_unlock(void *arg)
      * access it after that ULT becomes resumable. */
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTD_spinlock *p_lock = p_arg->p_lock;
-    if (ythread_callback_handle_request(p_prev))
-        return;
     /* Increase the number of blocked threads */
     ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Request handling.  p_prev->thread.p_pool might be changed. */
+    ythread_callback_handle_request(p_prev, ABT_FALSE);
     /* Set this thread's state to BLOCKED. */
     ABTD_atomic_release_store_int(&p_prev->thread.state,
                                   ABT_THREAD_STATE_BLOCKED);
@@ -153,10 +169,10 @@ void ABTI_ythread_callback_suspend_join(void *arg)
      * access it after that ULT becomes resumable. */
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTI_ythread *p_target = p_arg->p_target;
-    if (ythread_callback_handle_request(p_prev))
-        return;
     /* Increase the number of blocked threads */
     ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Request handling.  p_prev->thread.p_pool might be changed. */
+    ythread_callback_handle_request(p_prev, ABT_FALSE);
     /* Set this thread's state to BLOCKED. */
     ABTD_atomic_release_store_int(&p_prev->thread.state,
                                   ABT_THREAD_STATE_BLOCKED);
@@ -175,10 +191,10 @@ void ABTI_ythread_callback_suspend_replace_sched(void *arg)
      * access it after that ULT becomes resumable. */
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTI_sched *p_main_sched = p_arg->p_main_sched;
-    if (ythread_callback_handle_request(p_prev))
-        return;
     /* Increase the number of blocked threads */
     ABTI_pool_inc_num_blocked(p_prev->thread.p_pool);
+    /* Request handling.  p_prev->thread.p_pool might be changed. */
+    ythread_callback_handle_request(p_prev, ABT_FALSE);
     /* Set this thread's state to BLOCKED. */
     ABTD_atomic_release_store_int(&p_prev->thread.state,
                                   ABT_THREAD_STATE_BLOCKED);
@@ -188,6 +204,7 @@ void ABTI_ythread_callback_suspend_replace_sched(void *arg)
 
 void ABTI_ythread_callback_orphan(void *arg)
 {
+    /* It's a special operation, so request handling is unnecessary. */
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
     ABTI_thread_unset_associated_pool(ABTI_global_get_global(),
                                       &p_prev->thread);
@@ -285,12 +302,12 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-/* Return ABT_TRUE if p_prev should terminate. */
-static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
+static inline int ythread_callback_handle_request(ABTI_ythread *p_prev,
+                                                  ABT_bool allow_termination)
 {
 #if defined(ABT_CONFIG_DISABLE_CANCELLATION) &&                                \
     defined(ABT_CONFIG_DISABLE_MIGRATION)
-    return ABT_FALSE;
+    return YTHREAD_CALLBACK_HANDLE_REQUEST_NONE;
 #else
     /* At least either cancellation or migration is enabled. */
     const uint32_t request =
@@ -298,13 +315,13 @@ static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
 
     /* Check cancellation request. */
 #ifndef ABT_CONFIG_DISABLE_CANCELLATION
-    if (ABTU_unlikely(request & ABTI_THREAD_REQ_CANCEL)) {
+    if (allow_termination && ABTU_unlikely(request & ABTI_THREAD_REQ_CANCEL)) {
         ABTI_ythread_cancel(p_prev->thread.p_last_xstream, p_prev);
         ABTI_xstream_terminate_thread(ABTI_global_get_global(),
                                       ABTI_xstream_get_local(
                                           p_prev->thread.p_last_xstream),
                                       &p_prev->thread);
-        return ABT_TRUE;
+        return YTHREAD_CALLBACK_HANDLE_REQUEST_CANCELLED;
     }
 #endif /* !ABT_CONFIG_DISABLE_CANCELLATION */
 
@@ -323,12 +340,12 @@ static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
             /* Migration failed.  Let's push it back to its associated pool. */
             ABTI_pool_add_thread(&p_prev->thread);
         }
-        return ABT_FALSE;
+        return YTHREAD_CALLBACK_HANDLE_REQUEST_MIGRATED;
     }
 #endif /* !ABT_CONFIG_DISABLE_MIGRATION */
+
+    return YTHREAD_CALLBACK_HANDLE_REQUEST_NONE;
 #endif
-    /* This thread does not terminate. */
-    return ABT_FALSE;
 }
 
 #ifdef ABT_CONFIG_ENABLE_STACK_UNWIND

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -112,10 +112,9 @@ void ABTI_ythread_callback_exit(void *arg)
 {
     /* Terminate this thread. */
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
-    ABTI_xstream_terminate_thread(ABTI_global_get_global(),
-                                  ABTI_xstream_get_local(
-                                      p_prev->thread.p_last_xstream),
-                                  &p_prev->thread);
+    ABTI_thread_terminate(ABTI_global_get_global(),
+                          ABTI_xstream_get_local(p_prev->thread.p_last_xstream),
+                          &p_prev->thread);
 }
 
 void ABTI_ythread_callback_resume_exit_to(void *arg)
@@ -127,10 +126,9 @@ void ABTI_ythread_callback_resume_exit_to(void *arg)
     ABTI_ythread *p_prev = p_arg->p_prev;
     ABTI_ythread *p_next = p_arg->p_next;
     /* Terminate this thread. */
-    ABTI_xstream_terminate_thread(ABTI_global_get_global(),
-                                  ABTI_xstream_get_local(
-                                      p_prev->thread.p_last_xstream),
-                                  &p_prev->thread);
+    ABTI_thread_terminate(ABTI_global_get_global(),
+                          ABTI_xstream_get_local(p_prev->thread.p_last_xstream),
+                          &p_prev->thread);
     /* Decrease the number of blocked threads. */
     ABTI_pool_dec_num_blocked(p_next->thread.p_pool);
 }

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -288,7 +288,7 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
 /* Return ABT_TRUE if p_prev should terminate. */
 static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
 {
-#if defined(ABT_CONFIG_DISABLE_THREAD_CANCEL) &&                               \
+#if defined(ABT_CONFIG_DISABLE_CANCELLATION) &&                                \
     defined(ABT_CONFIG_DISABLE_MIGRATION)
     return ABT_FALSE;
 #else
@@ -297,7 +297,7 @@ static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
         ABTD_atomic_acquire_load_uint32(&p_prev->thread.request);
 
     /* Check cancellation request. */
-#ifndef ABT_CONFIG_DISABLE_THREAD_CANCEL
+#ifndef ABT_CONFIG_DISABLE_CANCELLATION
     if (ABTU_unlikely(request & ABTI_THREAD_REQ_CANCEL)) {
         ABTI_ythread_cancel(p_prev->thread.p_last_xstream, p_prev);
         ABTI_xstream_terminate_thread(ABTI_global_get_global(),
@@ -306,7 +306,7 @@ static inline ABT_bool ythread_callback_handle_request(ABTI_ythread *p_prev)
                                       &p_prev->thread);
         return ABT_TRUE;
     }
-#endif /* !ABT_CONFIG_DISABLE_THREAD_CANCEL */
+#endif /* !ABT_CONFIG_DISABLE_CANCELLATION */
 
     /* Check migration request. */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION


### PR DESCRIPTION
## Pull Request Description

Currently, Argobots supports two types of asynchronous requests for threads: cancellation and migration.  Now both are checked on context switching, but those requests can break the algorithm (e.g., cancelling a ULT that is waiting for a synchronization object). This can be the user's responsibility, but the runtime should ignore those requests if it can potentially break the algorithm since migration and cancellation timings are not defined.

This patch fixes this request handling algorithm and cleans it up to make its logic simpler.

As a result, this PR reduces the number of request handling sites, so this PR should not degrade the performance of the Argobots runtime.  This PR should not affect most user programs because most users do not use these features.

If you find any issues, please let us know!

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
