### PR TITLE
improve ABT_sched_config

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1980,7 +1980,11 @@ ALIASES += DOC_ERROR_INV_ARG_INV_TOOL_QUERY_KIND{2}="\c ABT_ERR_INV_ARG is retur
 
 ALIASES += DOC_ERROR_INV_ARG_NEG{1}="\c ABT_ERR_INV_ARG is returned if \1 is negative.\n"
 
-ALIASES += DOC_ERROR_INV_ARG_SCHED_CONFIG_TYPE="\c ABT_ERR_INV_ARG is returned if a variable of type \c ABT_sched_config_var in the given list has an invalid \c type.\n"
+ALIASES += DOC_ERROR_INV_ARG_SCHED_CONFIG_INDEX{2}="\c ABT_ERR_INV_ARG is returned if \1 does not have a value associated with \2.\n"
+
+ALIASES += DOC_ERROR_INV_ARG_SCHED_CONFIG_TYPE="\c ABT_ERR_INV_ARG is returned if \c type of the given \c ABT_sched_config_var is invalid.\n"
+
+ALIASES += DOC_ERROR_INV_ARG_SCHED_CONFIG_TYPE{1}="\c ABT_ERR_INV_ARG is returned if \1 is invalid.\n"
 
 ALIASES += DOC_ERROR_INV_ARG_ZERO{1}="\c ABT_ERR_INV_ARG is returned if \1 is zero.\n"
 

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1755,6 +1755,10 @@ int ABT_sched_has_to_stop(ABT_sched sched, ABT_bool *stop) ABT_API_PUBLIC;
 int ABT_sched_config_create(ABT_sched_config *config, ...) ABT_API_PUBLIC;
 int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...) ABT_API_PUBLIC;
 int ABT_sched_config_free(ABT_sched_config *config) ABT_API_PUBLIC;
+int ABT_sched_config_set(ABT_sched_config config, int idx,
+                         ABT_sched_config_type type, const void *val) ABT_API_PUBLIC;
+int ABT_sched_config_get(ABT_sched_config config, int idx,
+                         ABT_sched_config_type *p_type, void *val) ABT_API_PUBLIC;
 
 /* Pool */
 int ABT_pool_create(ABT_pool_def *def, ABT_pool_config config,

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -104,6 +104,8 @@ ABT_sched_config_var ABT_sched_basic_freq = { .idx = -4,
  */
 int ABT_sched_config_create(ABT_sched_config *config, ...)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     int abt_errno;
     int i = 0;
     ABTI_sched_config *p_config;
@@ -147,7 +149,7 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
                 break;
             }
             default:
-                abt_errno = ABT_ERR_SCHED_CONFIG;
+                abt_errno = ABT_ERR_INV_ARG;
         }
         if (abt_errno != ABT_SUCCESS) {
             sched_config_free(p_config);
@@ -202,6 +204,8 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
  */
 int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     int idx;
     ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
     ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p_config);
@@ -245,6 +249,8 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
  */
 int ABT_sched_config_free(ABT_sched_config *config)
 {
+    ABTI_UB_ASSERT(ABTI_initialized());
+
     ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(*config);
     ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p_config);
 

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -245,7 +245,7 @@ int ABT_sched_config_free(ABT_sched_config *config)
     ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(*config);
     ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p_config);
 
-    ABTU_free(p_config);
+    sched_config_free(p_config);
 
     *config = ABT_SCHED_CONFIG_NULL;
 

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -255,6 +255,112 @@ int ABT_sched_config_free(ABT_sched_config *config)
     return ABT_SUCCESS;
 }
 
+/**
+ * @ingroup SCHED_CONFIG
+ * @brief   Register a value to a scheduler configuration.
+ *
+ * \c ABT_sched_config_set() associated a value pointed to by the value \c val
+ * with the index \c idx in the scheduler configuration \c config.  This routine
+ * overwrites a value and its type if a value has already been associated with
+ * \c idx.
+ *
+ * @note
+ * For example, this routine can be called as follows to set a value that is
+ * corresponding to \c idx = \a 1.
+ * @code{.c}
+ * const ABT_sched_config_var var = { 1, ABT_SCHED_CONFIG_INT };
+ * int val = 10;
+ * ABT_sched_config_set(&config, var.idx, var.type, &val);
+ * @endcode
+ *
+ * If \c value is \c NULL, this routine deletes a value associated with \c idx
+ * if such exists.
+ *
+ * @note
+ * This routine returns \c ABT_SUCCESS even if \c value is \c NULL but no value
+ * is associated with \c idx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_ARG_SCHED_CONFIG_TYPE{\c type}
+ * \DOC_ERROR_INV_SCHED_CONFIG_HANDLE{\c config}
+ * \DOC_ERROR_RESOURCE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{\c config}
+ *
+ * @param[in]  config  scheduler configuration handle
+ * @param[in]  idx     index of a target value
+ * @param[in]  type    type of a target value
+ * @param[in]  val     target value
+ * @return Error code
+ */
+int ABT_sched_config_set(ABT_sched_config config, int idx,
+                         ABT_sched_config_type type, const void *val)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
+    ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p_config);
+    int abt_errno = sched_config_set(p_config, idx, type, val);
+    ABTI_CHECK_ERROR(abt_errno);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup SCHED_CONFIG
+ * @brief   Retrieve a value from a scheduler configuration.
+ *
+ * \c ABT_sched_config_get() reads a value associated with the index \c idx of
+ * \c ABT_sched_config_var from the scheduler configuration \c config.  If
+ * \c val is not \c NULL, \c val is set to the value.  If \c type is not
+ * \c NULL, \c type is set to the type of the value.
+ *
+ * @note
+ * For example, this routine can be called as follows to get a value that is
+ * corresponding to \c idx = \a 1.
+ * @code{.c}
+ * const ABT_sched_config_var var = { 1, ABT_SCHED_CONFIG_INT };
+ * int val;
+ * ABT_sched_config_type type;
+ * ABT_sched_config_get(&config, var.idx, &type, &val);
+ * assert(type == var.type);
+ * @endcode
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_ARG_SCHED_CONFIG_INDEX{\c config, \c idx}
+ * \DOC_ERROR_INV_SCHED_CONFIG_HANDLE{\c config}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_THREAD_UNSAFE{\c config}
+ *
+ * @param[in]  config  scheduler configuration handle
+ * @param[in]  idx     index of a target value
+ * @param[out] type    type of a target value
+ * @param[out] val     target value
+ * @return Error code
+ */
+int ABT_sched_config_get(ABT_sched_config config, int idx,
+                         ABT_sched_config_type *type, void *val)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+
+    ABTI_sched_config *p_config = ABTI_sched_config_get_ptr(config);
+    ABTI_CHECK_NULL_SCHED_CONFIG_PTR(p_config);
+    int abt_errno = sched_config_get(p_config, idx, type, val);
+    ABTI_CHECK_ERROR(abt_errno);
+    return ABT_SUCCESS;
+}
+
 /*****************************************************************************/
 /* Private APIs                                                              */
 /*****************************************************************************/

--- a/src/sched/config.c
+++ b/src/sched/config.c
@@ -10,7 +10,10 @@
 #include <string.h>
 
 static inline size_t sched_config_type_size(ABT_sched_config_type type);
-ABTU_ret_err static int sched_config_add(ABTI_sched_config *p_config, int idx,
+ABTU_ret_err static int sched_config_get(const ABTI_sched_config *p_config,
+                                         int idx, ABT_sched_config_type *p_type,
+                                         void *p_val);
+ABTU_ret_err static int sched_config_set(ABTI_sched_config *p_config, int idx,
                                          ABT_sched_config_type type,
                                          const void *p_val);
 static void sched_config_free(ABTI_sched_config *p_config);
@@ -126,20 +129,20 @@ int ABT_sched_config_create(ABT_sched_config *config, ...)
         switch (var.type) {
             case ABT_SCHED_CONFIG_INT: {
                 int int_val = va_arg(varg_list, int);
-                abt_errno = sched_config_add(p_config, idx,
+                abt_errno = sched_config_set(p_config, idx,
                                              ABT_SCHED_CONFIG_INT, &int_val);
                 break;
             }
             case ABT_SCHED_CONFIG_DOUBLE: {
                 double double_val = va_arg(varg_list, double);
                 abt_errno =
-                    sched_config_add(p_config, idx, ABT_SCHED_CONFIG_DOUBLE,
+                    sched_config_set(p_config, idx, ABT_SCHED_CONFIG_DOUBLE,
                                      &double_val);
                 break;
             }
             case ABT_SCHED_CONFIG_PTR: {
                 void *ptr_val = va_arg(varg_list, void *);
-                abt_errno = sched_config_add(p_config, idx,
+                abt_errno = sched_config_set(p_config, idx,
                                              ABT_SCHED_CONFIG_PTR, &ptr_val);
                 break;
             }
@@ -208,7 +211,7 @@ int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...)
     for (idx = 0; idx < num_vars; idx++) {
         void *ptr = va_arg(varg_list, void *);
         if (ptr) {
-            int abt_errno = ABTI_sched_config_read(p_config, idx, ptr);
+            int abt_errno = sched_config_get(p_config, idx, NULL, ptr);
             /* It's okay even if there's no associated value. */
             (void)abt_errno;
         }
@@ -259,32 +262,44 @@ int ABT_sched_config_free(ABT_sched_config *config)
 ABTU_ret_err int ABTI_sched_config_read(const ABTI_sched_config *p_config,
                                         int idx, void *p_val)
 {
-    int table_index = ((idx % ABTI_SCHED_CONFIG_HTABLE_SIZE) +
-                       ABTI_SCHED_CONFIG_HTABLE_SIZE) %
-                      ABTI_SCHED_CONFIG_HTABLE_SIZE;
-    if (p_config->elements[table_index].idx == ABTI_SCHED_CONFIG_UNUSED_INDEX) {
-        return ABT_ERR_OTHER;
-    } else {
-        const ABTI_sched_config_element *p_element =
-            &p_config->elements[table_index];
-        while (p_element) {
-            if (p_element->idx == idx) {
-                memcpy(p_val, p_element->val,
-                       sched_config_type_size(p_element->type));
-                return ABT_SUCCESS;
-            } else {
-                p_element = p_element->p_next;
-            }
-        }
-        return ABT_ERR_OTHER;
-    }
+    return sched_config_get(p_config, idx, NULL, p_val);
 }
 
 /*****************************************************************************/
 /* Internal static functions                                                 */
 /*****************************************************************************/
 
-ABTU_ret_err static int sched_config_add(ABTI_sched_config *p_config, int idx,
+ABTU_ret_err static int sched_config_get(const ABTI_sched_config *p_config,
+                                         int idx, ABT_sched_config_type *p_type,
+                                         void *p_val)
+{
+    int table_index = ((idx % ABTI_SCHED_CONFIG_HTABLE_SIZE) +
+                       ABTI_SCHED_CONFIG_HTABLE_SIZE) %
+                      ABTI_SCHED_CONFIG_HTABLE_SIZE;
+    if (p_config->elements[table_index].idx == ABTI_SCHED_CONFIG_UNUSED_INDEX) {
+        return ABT_ERR_INV_ARG;
+    } else {
+        const ABTI_sched_config_element *p_element =
+            &p_config->elements[table_index];
+        while (p_element) {
+            if (p_element->idx == idx) {
+                if (p_val) {
+                    memcpy(p_val, p_element->val,
+                           sched_config_type_size(p_element->type));
+                }
+                if (p_type) {
+                    *p_type = p_element->type;
+                }
+                return ABT_SUCCESS;
+            } else {
+                p_element = p_element->p_next;
+            }
+        }
+        return ABT_ERR_INV_ARG;
+    }
+}
+
+ABTU_ret_err static int sched_config_set(ABTI_sched_config *p_config, int idx,
                                          ABT_sched_config_type type,
                                          const void *p_val)
 {
@@ -292,31 +307,57 @@ ABTU_ret_err static int sched_config_add(ABTI_sched_config *p_config, int idx,
                        ABTI_SCHED_CONFIG_HTABLE_SIZE) %
                       ABTI_SCHED_CONFIG_HTABLE_SIZE;
     if (p_config->elements[table_index].idx == ABTI_SCHED_CONFIG_UNUSED_INDEX) {
-        p_config->elements[table_index].idx = idx;
-        p_config->elements[table_index].type = type;
-        memcpy(p_config->elements[table_index].val, p_val,
-               sched_config_type_size(type));
+        if (p_val) {
+            /* Newly add. */
+            p_config->elements[table_index].idx = idx;
+            p_config->elements[table_index].type = type;
+            memcpy(p_config->elements[table_index].val, p_val,
+                   sched_config_type_size(type));
+        }
     } else {
         ABTI_sched_config_element *p_element = &p_config->elements[table_index];
+        ABTI_sched_config_element **pp_element = NULL;
         while (p_element) {
             if (p_element->idx == idx) {
-                /* Update. */
-                p_element->type = type;
-                memcpy(p_element->val, p_val, sched_config_type_size(type));
+                if (p_val) {
+                    /* Update. */
+                    p_element->type = type;
+                    memcpy(p_element->val, p_val, sched_config_type_size(type));
+                } else {
+                    /* Remove the element. */
+                    if (pp_element) {
+                        *pp_element = p_element->p_next;
+                        ABTU_free(p_element);
+                    } else {
+                        ABTI_sched_config_element *p_next = p_element->p_next;
+                        if (p_next) {
+                            memcpy(p_element, p_next,
+                                   sizeof(ABTI_sched_config_element));
+                            ABTU_free(p_next);
+                        } else {
+                            p_element->idx = ABTI_SCHED_CONFIG_UNUSED_INDEX;
+                        }
+                    }
+                }
                 break;
             } else if (!p_element->p_next) {
-                ABTI_sched_config_element *p_new_element;
-                int abt_errno =
-                    ABTU_calloc(1, sizeof(ABTI_sched_config_element),
-                                (void **)&p_new_element);
-                ABTI_CHECK_ERROR(abt_errno);
-                p_new_element->idx = idx;
-                p_new_element->type = type;
-                memcpy(p_new_element->val, p_val, sched_config_type_size(type));
-                p_element->p_next = p_new_element;
+                if (p_val) {
+                    /* Newly add. */
+                    ABTI_sched_config_element *p_new_element;
+                    int abt_errno =
+                        ABTU_calloc(1, sizeof(ABTI_sched_config_element),
+                                    (void **)&p_new_element);
+                    ABTI_CHECK_ERROR(abt_errno);
+                    p_new_element->idx = idx;
+                    p_new_element->type = type;
+                    memcpy(p_new_element->val, p_val,
+                           sched_config_type_size(type));
+                    p_element->p_next = p_new_element;
+                }
                 break;
             } else {
-                p_element = p_element->p_next;
+                pp_element = &p_element->p_next;
+                p_element = *pp_element;
             }
         }
     }

--- a/test/basic/sched_config.c
+++ b/test/basic/sched_config.c
@@ -12,52 +12,187 @@
 #include "abttest.h"
 
 ABT_sched_config_var param_a = { .idx = 0, .type = ABT_SCHED_CONFIG_INT };
-
 ABT_sched_config_var param_b = { .idx = 1, .type = ABT_SCHED_CONFIG_DOUBLE };
+ABT_bool g_check_error;
+
+void check_val(ABT_sched_config config, const int *ans_a, const double *ans_b)
+{
+    int ret;
+    int val_a = 1;
+    double val_b = 2.0;
+    /* Check ABT_sched_config_read. */
+    if (param_b.idx <= 4) {
+        if (param_b.idx == 1) {
+            ret = ABT_sched_config_read(config, 2, &val_a, &val_b);
+        } else if (param_b.idx == 2) {
+            ret = ABT_sched_config_read(config, 3, &val_a, NULL, &val_b);
+        } else if (param_b.idx == 3) {
+            ret = ABT_sched_config_read(config, 4, &val_a, NULL, NULL, &val_b);
+        } else if (param_b.idx == 4) {
+            ret = ABT_sched_config_read(config, 5, &val_a, NULL, NULL, NULL,
+                                        &val_b);
+        } else {
+            ret = ABT_ERR_OTHER;
+        }
+        ATS_ERROR(ret, "ABT_sched_config_read");
+        if (ans_a) {
+            assert(val_a == *ans_a);
+        } else {
+            assert(val_a == 1);
+        }
+        if (ans_b) {
+            assert(val_b == *ans_b);
+        } else {
+            assert(val_b == 2.0);
+        }
+    }
+    if (g_check_error || ans_a) {
+        /* Check ABT_sched_config_get for param_a. */
+        val_a = 1;
+        ABT_sched_config_type type = (ABT_sched_config_type)77;
+        ret = ABT_sched_config_get(config, param_a.idx, &type, &val_a);
+        if (ans_a) {
+            ATS_ERROR(ret, "ABT_sched_config_get");
+            assert(val_a == *ans_a && type == param_a.type);
+            ret = ABT_sched_config_get(config, param_a.idx, NULL, NULL);
+            ATS_ERROR(ret, "ABT_sched_config_get");
+        } else {
+            assert(ret != ABT_SUCCESS && val_a == 1 &&
+                   type == (ABT_sched_config_type)77);
+        }
+    }
+    if (g_check_error || ans_b) {
+        /* Check ABT_sched_config_get for param_b. */
+        val_b = 1;
+        ABT_sched_config_type type = (ABT_sched_config_type)77;
+        ret = ABT_sched_config_get(config, param_b.idx, &type, &val_b);
+        if (ans_b) {
+            ATS_ERROR(ret, "ABT_sched_config_get");
+            assert(val_b == *ans_b && type == param_b.type);
+            ret = ABT_sched_config_get(config, param_b.idx, NULL, NULL);
+            ATS_ERROR(ret, "ABT_sched_config_get");
+        } else {
+            assert(ret != ABT_SUCCESS && val_b == 1 &&
+                   type == (ABT_sched_config_type)77);
+        }
+    }
+}
 
 int main(int argc, char *argv[])
 {
-    int a = 5;
-    double b = 3.0;
-    ABT_sched_config config1, config2, config3, config4;
-
-    int a2;
-    double b2;
+    const int a = 5, a2 = 8;
+    int ret, i, param_b_idx;
+    const double b = 3.0, b2 = 7.0;
+    ABT_sched_config config;
 
     /* Initialize */
     ATS_read_args(argc, argv);
     ATS_init(argc, argv, 1);
 
-    ABT_sched_config_create(&config1, param_a, a, ABT_sched_config_var_end);
-    a2 = 0;
-    b2 = 0.0;
-    ABT_sched_config_read(config1, 2, &a2, &b2);
-    ABT_sched_config_free(&config1);
-    assert(a2 == a && b2 == 0.0);
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_CHECK_ERROR,
+                                (void *)&g_check_error);
+    ATS_ERROR(ret, "ABT_info_query_config");
 
-    ABT_sched_config_create(&config2, param_b, b, ABT_sched_config_var_end);
-    a2 = 0;
-    b2 = 0.0;
-    ABT_sched_config_read(config2, 2, &a2, &b2);
-    ABT_sched_config_free(&config2);
-    assert(a2 == 0 && b2 == b);
+    for (param_b_idx = 1; param_b_idx <= 9; param_b_idx++) {
+        /* Change param_b.idx to check the internal hash table implementation.
+         */
+        param_b.idx = param_b_idx;
 
-    ABT_sched_config_create(&config3, param_a, a, param_b, b,
-                            ABT_sched_config_var_end);
-    a2 = 0;
-    b2 = 0.0;
-    ABT_sched_config_read(config3, 2, &a2, &b2);
-    ABT_sched_config_free(&config3);
-    assert(a2 == a && b2 == b);
+        /* {a, x} */
+        ret = ABT_sched_config_create(&config, param_a, a,
+                                      ABT_sched_config_var_end);
+        ATS_ERROR(ret, "ABT_sched_config_create");
+        check_val(config, &a, NULL);
 
-    ABT_sched_config_create(&config4, param_b, b, param_a, a,
-                            ABT_sched_config_var_end);
-    a2 = 0;
-    b2 = 0.0;
-    ABT_sched_config_read(config4, 2, &a2, &b2);
-    ABT_sched_config_free(&config4);
-    assert(a2 == a && b2 == b);
+        /* {a, x} -> {a2, x} */
+        ret = ABT_sched_config_set(config, param_a.idx, param_a.type, &a2);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a2, NULL);
 
+        /* {a2, x} -> {a2, b} */
+        ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a2, &b);
+
+        /* {a2, x} -> {a2, b2} */
+        ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b2);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a2, &b2);
+
+        /* {a2, b2} -> {x, b2} */
+        ret = ABT_sched_config_set(config, param_a.idx, param_a.type, NULL);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, NULL, &b2);
+
+        /* {x, b2} -> {x, b2} */
+        ret = ABT_sched_config_set(config, param_a.idx, param_a.type, NULL);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, NULL, &b2);
+
+        /* {x, b2} -> {a, b2} */
+        ret = ABT_sched_config_set(config, param_a.idx, param_a.type, &a);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a, &b2);
+
+        /* {a, b2} -> {a, b} */
+        ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a, &b);
+
+        /* {a, b} -> {a, x} */
+        ret = ABT_sched_config_set(config, param_b.idx, param_b.type, NULL);
+        ATS_ERROR(ret, "ABT_sched_config_set");
+        check_val(config, &a, NULL);
+
+        ret = ABT_sched_config_free(&config);
+        ATS_ERROR(ret, "ABT_sched_config_free");
+
+        /* {x, b} */
+        ret = ABT_sched_config_create(&config, param_b, b,
+                                      ABT_sched_config_var_end);
+        ATS_ERROR(ret, "ABT_sched_config_create");
+        check_val(config, NULL, &b);
+
+        for (i = 0; i < 10; i++) {
+            /* {x, b} -> {x, b} */
+            ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b);
+            ATS_ERROR(ret, "ABT_sched_config_set");
+            check_val(config, NULL, &b);
+
+            /* {x, b} -> {x, b2} */
+            ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b2);
+            ATS_ERROR(ret, "ABT_sched_config_set");
+            check_val(config, NULL, &b2);
+
+            /* {x, b2} -> {x, b} */
+            ret = ABT_sched_config_set(config, param_b.idx, param_b.type, &b);
+            ATS_ERROR(ret, "ABT_sched_config_set");
+            check_val(config, NULL, &b);
+
+            /* {x, b} -> {x, x} */
+            ret = ABT_sched_config_set(config, param_b.idx, param_b.type, NULL);
+            ATS_ERROR(ret, "ABT_sched_config_set");
+            check_val(config, NULL, NULL);
+        }
+        ret = ABT_sched_config_free(&config);
+        ATS_ERROR(ret, "ABT_sched_config_free");
+
+        /* {a, b} */
+        ret = ABT_sched_config_create(&config, param_a, a, param_b, b,
+                                      ABT_sched_config_var_end);
+        ATS_ERROR(ret, "ABT_sched_config_create");
+        check_val(config, &a, &b);
+        ret = ABT_sched_config_free(&config);
+        ATS_ERROR(ret, "ABT_sched_config_free");
+
+        /* {a, b} */
+        ret = ABT_sched_config_create(&config, param_b, b, param_a, a,
+                                      ABT_sched_config_var_end);
+        ATS_ERROR(ret, "ABT_sched_config_create");
+        check_val(config, &a, &b);
+        ret = ABT_sched_config_free(&config);
+        ATS_ERROR(ret, "ABT_sched_config_free");
+    }
     /* Finalize */
     return ATS_finalize(0);
 }


### PR DESCRIPTION
## Pull Request Description

This PR adds two new functions to provide simpler interface to access `ABT_sched_config`.
```c
int ABT_sched_config_set(ABT_sched_config config, int idx, ABT_sched_config_type type, const void *val);
int ABT_sched_config_get(ABT_sched_config config, int idx, ABT_sched_config_type *p_type, void *val);
```

Those functions are simpler than existing variadic functions:
```c
int ABT_sched_config_create(ABT_sched_config *config, ...);
int ABT_sched_config_read(ABT_sched_config config, int num_vars, ...);
```
To be honest, I do not remember arguments for `...`.

This PR also fixes several issues including memory leak.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
