### PR TITLE
thread: lazy stack allocation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,12 @@ AC_ARG_ENABLE([aligned-alloc],
         [do not use aligned memory allocation]),,
         [enable_aligned_alloc=yes])
 
+# --enable-lazy-stack-alloc
+AC_ARG_ENABLE([lazy-stack-alloc],
+    AS_HELP_STRING([--enable-lazy-stack-alloc],
+        [lazily allocate and eagerly release ULT stacks]),,
+        [enable_lazy_stack_alloc=no])
+
 # --enable-feature
 AC_ARG_ENABLE([feature],
 [  --enable-feature@<:@=OPTS@:>@  enable/disable features.
@@ -618,6 +624,10 @@ AS_IF([test "x$enable_aligned_alloc" != "xno"],
     [AC_DEFINE(ABT_CONFIG_USE_ALIGNED_ALLOC, 1,
         [Define to allocate objects aligned to the cache line size])])
 
+# --enable-lazy-stack-alloc
+AS_IF([test "x$enable_lazy_stack_alloc" != "xyes"],
+    [AC_DEFINE(ABT_CONFIG_DISABLE_LAZY_STACK_ALLOC, 1,
+        [Define to disable lazy stack allocation])])
 
 # --enable-feature
 save_IFS="$IFS"

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -631,6 +631,8 @@ enum ABT_info_query_kind {
     ABT_INFO_QUERY_KIND_ENABLED_STACK_OVERFLOW_CHECK,
     /** Wait policy */
     ABT_INFO_QUERY_KIND_WAIT_POLICY,
+    /** Whether a ULT stack is lazily allocated by default or not */
+    ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC,
 };
 
 /**

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -78,10 +78,9 @@ static void ABTD_ythread_context_func_wrapper(fcontext_t *p_fctx)
 }
 
 static inline void ABTD_ythread_context_init(ABTD_ythread_context *p_ctx,
-                                             void *p_stack, size_t stacksize)
+                                             void *p_stacktop, size_t stacksize)
 {
     ABTDI_fcontext_init(&p_ctx->ctx);
-    void *p_stacktop = (void *)(((char *)p_stack) + stacksize);
     p_ctx->p_stacktop = p_stacktop;
     p_ctx->stacksize = stacksize;
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
@@ -93,10 +92,10 @@ static inline void ABTD_ythread_context_reinit(ABTD_ythread_context *p_ctx)
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
 }
 
-static inline void *ABTD_ythread_context_get_stack(ABTD_ythread_context *p_ctx)
+static inline void *
+ABTD_ythread_context_get_stacktop(ABTD_ythread_context *p_ctx)
 {
-    void *p_stack = (void *)(((char *)p_ctx->p_stacktop) - p_ctx->stacksize);
-    return p_stack;
+    return p_ctx->p_stacktop;
 }
 
 static inline size_t

--- a/src/include/abtd_fcontext.h
+++ b/src/include/abtd_fcontext.h
@@ -86,6 +86,28 @@ static inline void ABTD_ythread_context_init(ABTD_ythread_context *p_ctx,
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
 }
 
+static inline void ABTD_ythread_context_init_lazy(ABTD_ythread_context *p_ctx,
+                                                  size_t stacksize)
+{
+    ABTDI_fcontext_init(&p_ctx->ctx);
+    p_ctx->p_stacktop = NULL;
+    p_ctx->stacksize = stacksize;
+    ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
+}
+
+static inline void
+ABTD_ythread_context_lazy_set_stack(ABTD_ythread_context *p_ctx,
+                                    void *p_stacktop)
+{
+    p_ctx->p_stacktop = p_stacktop;
+}
+
+static inline void
+ABTD_ythread_context_lazy_unset_stack(ABTD_ythread_context *p_ctx)
+{
+    p_ctx->p_stacktop = NULL;
+}
+
 static inline void ABTD_ythread_context_reinit(ABTD_ythread_context *p_ctx)
 {
     ABTDI_fcontext_init(&p_ctx->ctx);
@@ -96,6 +118,12 @@ static inline void *
 ABTD_ythread_context_get_stacktop(ABTD_ythread_context *p_ctx)
 {
     return p_ctx->p_stacktop;
+}
+
+static inline ABT_bool
+ABTD_ythread_context_has_stack(const ABTD_ythread_context *p_ctx)
+{
+    return p_ctx->p_stacktop ? ABT_TRUE : ABT_FALSE;
 }
 
 static inline size_t

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -117,7 +117,7 @@ static inline void ABTDI_ythread_context_make(ABTD_ythread_context *p_ctx)
 static inline ABT_bool
 ABTD_ythread_context_is_started(const ABTD_ythread_context *p_ctx)
 {
-    return p_new->p_ctx ? ABT_TRUE : ABT_FALSE;
+    return p_ctx->p_ctx ? ABT_TRUE : ABT_FALSE;
 }
 
 static inline void ABTD_ythread_context_switch(ABTD_ythread_context *p_old,

--- a/src/include/abtd_ucontext.h
+++ b/src/include/abtd_ucontext.h
@@ -71,6 +71,25 @@ static inline void ABTD_ythread_context_init(ABTD_ythread_context *p_ctx,
     ABTD_atomic_relaxed_store_ythread_context_ptr(&p_ctx->p_link, NULL);
 }
 
+static inline void ABTD_ythread_context_init_lazy(ABTD_ythread_context *p_ctx,
+                                                  size_t stacksize)
+{
+    ABTD_ythread_context_init(p_ctx, NULL, stacksize);
+}
+
+static inline void
+ABTD_ythread_context_lazy_set_stack(ABTD_ythread_context *p_ctx,
+                                    void *p_stacktop)
+{
+    p_ctx->p_stacktop = p_stacktop;
+}
+
+static inline void
+ABTD_ythread_context_lazy_unset_stack(ABTD_ythread_context *p_ctx)
+{
+    p_ctx->p_stacktop = NULL;
+}
+
 static inline void ABTD_ythread_context_reinit(ABTD_ythread_context *p_ctx)
 {
     p_ctx->p_ctx = NULL;
@@ -83,6 +102,12 @@ static inline void *
 ABTD_ythread_context_get_stacktop(ABTD_ythread_context *p_ctx)
 {
     return p_ctx->p_stacktop;
+}
+
+static inline ABT_bool
+ABTD_ythread_context_has_stack(const ABTD_ythread_context *p_ctx)
+{
+    return p_ctx->p_stacktop ? ABT_TRUE : ABT_FALSE;
 }
 
 static inline size_t

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -88,15 +88,36 @@ enum ABTI_stack_guard {
 #define ABTI_THREAD_TYPE_NAMED ((ABTI_thread_type)(0x1 << 5))
 #define ABTI_THREAD_TYPE_MIGRATABLE ((ABTI_thread_type)(0x1 << 6))
 
+/* Memory management.  Only one flag must be set. */
+/* Only a thread descriptor is allocated.  It is from a memory pool.
+ * This thread does not have a ULT stack allocated by the Argobots runtime. */
 #define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC ((ABTI_thread_type)(0x1 << 7))
+/* Only a thread descriptor is allocated.  It is allocated by malloc().
+ * This thread does not have a ULT stack allocated by the Argobots runtime. */
 #define ABTI_THREAD_TYPE_MEM_MALLOC_DESC ((ABTI_thread_type)(0x1 << 8))
+/* Both a thread descriptor and a ULT stack are allocated together from a memory
+ * pool. */
 #define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK ((ABTI_thread_type)(0x1 << 9))
+/* Both a thread descriptor and a ULT stack are allocated together by malloc().
+ */
 #define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK ((ABTI_thread_type)(0x1 << 10))
+/* Both a thread descriptor and a ULT stack are allocated separately.  A memory
+ * pool is used for a descriptor.   A ULT stack is lazily allocated from a
+ * memory pool (so p_stack can be NULL). */
+#define ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_MEMPOOL_LAZY_STACK                   \
+    ((ABTI_thread_type)(0x1 << 11))
+/* Both a thread descriptor and a ULT stack are allocated separately.  A memory
+ * pool is used for a descriptor.   A ULT stack is lazily allocated from a
+ * memory pool (so p_stack can be NULL). */
+#define ABTI_THREAD_TYPE_MEM_MALLOC_DESC_MEMPOOL_LAZY_STACK                    \
+    ((ABTI_thread_type)(0x1 << 12))
 
 #define ABTI_THREAD_TYPES_MEM                                                  \
     (ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC | ABTI_THREAD_TYPE_MEM_MALLOC_DESC |    \
      ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK |                                 \
-     ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK)
+     ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK |                                  \
+     ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_MEMPOOL_LAZY_STACK |                    \
+     ABTI_THREAD_TYPE_MEM_MALLOC_DESC_MEMPOOL_LAZY_STACK)
 
 /* ABTI_MUTEX_ATTR_NONE must be 0. See ABT_MUTEX_INITIALIZER. */
 #define ABTI_MUTEX_ATTR_NONE 0

--- a/src/include/abti.h
+++ b/src/include/abti.h
@@ -416,9 +416,8 @@ struct ABTI_thread {
 };
 
 struct ABTI_thread_attr {
-    void *p_stack;                /* Stack address */
-    size_t stacksize;             /* Stack size (in bytes) */
-    ABTI_thread_type thread_type; /* Thread type */
+    void *p_stack;    /* Stack address */
+    size_t stacksize; /* Stack size (in bytes) */
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     ABT_bool migratable;              /* Migratability */
     void (*f_cb)(ABT_thread, void *); /* Callback function */

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -265,10 +265,10 @@ ABTI_mem_alloc_ythread_default(ABTI_global *p_global, ABTI_local *p_local,
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
 ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
-    ABTI_global *p_global, ABTI_local *p_local, ABTI_thread_attr *p_attr,
-    ABTI_ythread **pp_ythread)
+    ABTI_global *p_global, ABTI_local *p_local, size_t stacksize,
+    ABTI_thread_attr *p_attr, ABTI_ythread **pp_ythread)
 {
-    size_t stacksize = p_global->thread_stacksize;
+    ABTI_UB_ASSERT(stacksize == p_global->thread_stacksize);
     ABTI_ythread *p_ythread;
     void *p_stack;
     /* If an external thread allocates a stack, we use ABTU_malloc. */

--- a/src/include/abti_mem.h
+++ b/src/include/abti_mem.h
@@ -53,6 +53,7 @@ static inline void ABTI_mem_check_stack_canary(void *p_stack)
 }
 #endif
 
+/* p_stack can be NULL. */
 static inline void ABTI_mem_register_stack(const ABTI_global *p_global,
                                            void *p_stack, size_t stacksize,
                                            ABT_bool mprotect_if_needed)
@@ -257,16 +258,17 @@ ABTI_mem_alloc_ythread_default(ABTI_global *p_global, ABTI_local *p_local,
         ABTI_mem_register_stack(p_global, p_stack, stacksize, ABT_TRUE);
 #endif
     }
-    /* Initialize members of ABTI_thread_attr. */
+    /* Initialize the context. */
     ABTD_ythread_context_init(&p_ythread->ctx, p_stack, stacksize);
     *pp_ythread = p_ythread;
     return ABT_SUCCESS;
 }
 
 #ifdef ABT_CONFIG_USE_MEM_POOL
-ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
-    ABTI_global *p_global, ABTI_local *p_local, size_t stacksize,
-    ABTI_thread_attr *p_attr, ABTI_ythread **pp_ythread)
+ABTU_ret_err static inline int
+ABTI_mem_alloc_ythread_mempool_desc_stack(ABTI_global *p_global,
+                                          ABTI_local *p_local, size_t stacksize,
+                                          ABTI_ythread **pp_ythread)
 {
     ABTI_UB_ASSERT(stacksize == p_global->thread_stacksize);
     ABTI_ythread *p_ythread;
@@ -287,7 +289,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_STACK;
         ABTI_mem_register_stack(p_global, p_stack, stacksize, ABT_FALSE);
     }
-    /* Copy members of p_attr. */
+    /* Initialize the context. */
     ABTD_ythread_context_init(&p_ythread->ctx, p_stack, stacksize);
     *pp_ythread = p_ythread;
     return ABT_SUCCESS;
@@ -295,9 +297,8 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_mempool_desc_stack(
 #endif
 
 ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack(
-    ABTI_global *p_global, ABTI_thread_attr *p_attr, ABTI_ythread **pp_ythread)
+    ABTI_global *p_global, size_t stacksize, ABTI_ythread **pp_ythread)
 {
-    size_t stacksize = p_attr->stacksize;
     ABTI_ythread *p_ythread;
     void *p_stack;
     int abt_errno =
@@ -305,7 +306,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack(
                                                       &p_stack);
     ABTI_CHECK_ERROR(abt_errno);
 
-    /* Copy members of p_attr. */
+    /* Initialize the context. */
     p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC_STACK;
     ABTD_ythread_context_init(&p_ythread->ctx, p_stack, stacksize);
     ABTI_mem_register_stack(p_global, p_stack, stacksize, ABT_TRUE);
@@ -315,7 +316,7 @@ ABTU_ret_err static inline int ABTI_mem_alloc_ythread_malloc_desc_stack(
 
 ABTU_ret_err static inline int
 ABTI_mem_alloc_ythread_mempool_desc(ABTI_global *p_global, ABTI_local *p_local,
-                                    ABTI_thread_attr *p_attr,
+                                    size_t stacksize, void *p_stack,
                                     ABTI_ythread **pp_ythread)
 {
     ABTI_ythread *p_ythread;
@@ -331,11 +332,9 @@ ABTI_mem_alloc_ythread_mempool_desc(ABTI_global *p_global, ABTI_local *p_local,
         ABTI_CHECK_ERROR(abt_errno);
         p_ythread->thread.type = ABTI_THREAD_TYPE_MEM_MALLOC_DESC;
     }
-    /* Copy members of p_attr. */
-    ABTD_ythread_context_init(&p_ythread->ctx, p_attr->p_stack,
-                              p_attr->stacksize);
-    ABTI_mem_register_stack(p_global, p_attr->p_stack, p_attr->stacksize,
-                            ABT_TRUE);
+    /* Initialize the context. */
+    ABTD_ythread_context_init(&p_ythread->ctx, p_stack, stacksize);
+    ABTI_mem_register_stack(p_global, p_stack, stacksize, ABT_TRUE);
     *pp_ythread = p_ythread;
     return ABT_SUCCESS;
 }

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -121,13 +121,14 @@ static inline int ABTI_thread_handle_request(ABTI_thread *p_thread,
 }
 
 static inline void ABTI_thread_terminate(ABTI_global *p_global,
-                                         ABTI_local *p_local,
+                                         ABTI_xstream *p_local_xstream,
                                          ABTI_thread *p_thread)
 {
     if (!(p_thread->type & ABTI_THREAD_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_thread->state,
                                       ABT_THREAD_STATE_TERMINATED);
-        ABTI_thread_free(p_global, p_local, p_thread);
+        ABTI_thread_free(p_global, ABTI_xstream_get_local(p_local_xstream),
+                         p_thread);
     } else {
         /* NOTE: We set the ULT's state as TERMINATED after checking refcount
          * because the ULT can be freed on a different ES.  In other words, we

--- a/src/include/abti_thread.h
+++ b/src/include/abti_thread.h
@@ -120,11 +120,26 @@ static inline int ABTI_thread_handle_request(ABTI_thread *p_thread,
 #endif
 }
 
+ABTU_ret_err static inline int
+ABTI_mem_alloc_ythread_mempool_stack(ABTI_xstream *p_local_xstream,
+                                     ABTI_ythread *p_ythread);
+static inline void
+ABTI_mem_free_ythread_mempool_stack(ABTI_xstream *p_local_xstream,
+                                    ABTI_ythread *p_ythread);
+
 static inline void ABTI_thread_terminate(ABTI_global *p_global,
                                          ABTI_xstream *p_local_xstream,
                                          ABTI_thread *p_thread)
 {
-    if (!(p_thread->type & ABTI_THREAD_TYPE_NAMED)) {
+    const ABTI_thread_type thread_type = p_thread->type;
+    if (thread_type & (ABTI_THREAD_TYPE_MEM_MEMPOOL_DESC_MEMPOOL_LAZY_STACK |
+                       ABTI_THREAD_TYPE_MEM_MALLOC_DESC_MEMPOOL_LAZY_STACK)) {
+        ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
+        if (ABTD_ythread_context_has_stack(&p_ythread->ctx)) {
+            ABTI_mem_free_ythread_mempool_stack(p_local_xstream, p_ythread);
+        }
+    }
+    if (!(thread_type & ABTI_THREAD_TYPE_NAMED)) {
         ABTD_atomic_release_store_int(&p_thread->state,
                                       ABT_THREAD_STATE_TERMINATED);
         ABTI_thread_free(p_global, ABTI_xstream_get_local(p_local_xstream),

--- a/src/include/abti_thread_attr.h
+++ b/src/include/abti_thread_attr.h
@@ -41,12 +41,10 @@ ABTI_thread_attr_get_handle(ABTI_thread_attr *p_attr)
 
 static inline void ABTI_thread_attr_init(ABTI_thread_attr *p_attr,
                                          void *p_stack, size_t stacksize,
-                                         ABTI_thread_type thread_type,
                                          ABT_bool migratable)
 {
     p_attr->p_stack = p_stack;
     p_attr->stacksize = stacksize;
-    p_attr->thread_type = thread_type;
 #ifndef ABT_CONFIG_DISABLE_MIGRATION
     p_attr->migratable = migratable;
     p_attr->f_cb = NULL;

--- a/src/include/abti_tool.h
+++ b/src/include/abti_tool.h
@@ -99,6 +99,8 @@ ABTI_tool_event_thread(ABTI_local *p_local, uint64_t event_code,
                        ABTI_pool *p_pool, ABTI_thread *p_parent,
                        ABT_sync_event_type sync_event_type, void *p_sync_object)
 {
+    if (p_thread->type & ABTI_THREAD_TYPE_ROOT)
+        return; /* A root thread should not be exposed to the user. */
     ABTI_global *p_global = gp_ABTI_global;
     while (1) {
         uint64_t current_mask = ABTD_atomic_acquire_load_uint64(

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -655,9 +655,7 @@ static inline void ABTI_ythread_schedule(ABTI_global *p_global,
             p_local_xstream->p_thread = p_sched_thread;
 
             /* Terminate the tasklet */
-            ABTI_thread_terminate(p_global,
-                                  ABTI_xstream_get_local(p_local_xstream),
-                                  p_thread);
+            ABTI_thread_terminate(p_global, p_local_xstream, p_thread);
         }
     } else if (request_op == ABTI_THREAD_HANDLE_REQUEST_CANCELLED) {
         /* If p_thread is cancelled, there's nothing to do. */

--- a/src/include/abti_ythread.h
+++ b/src/include/abti_ythread.h
@@ -70,22 +70,34 @@ ABTI_ythread_context_get_ythread(ABTD_ythread_context *p_ctx)
 
 ABTU_noreturn static inline void ABTI_ythread_context_jump(ABTI_ythread *p_new)
 {
-    ABTD_ythread_context_jump(&p_new->ctx);
+    if (ABTD_ythread_context_is_started(&p_new->ctx)) {
+        ABTD_ythread_context_jump(&p_new->ctx);
+    } else {
+        ABTD_ythread_context_start_and_jump(&p_new->ctx);
+    }
     ABTU_unreachable();
 }
 
 static inline void ABTI_ythread_context_switch(ABTI_ythread *p_old,
                                                ABTI_ythread *p_new)
 {
-    ABTD_ythread_context_switch(&p_old->ctx, &p_new->ctx);
-    /* Return the previous thread. */
+    if (ABTD_ythread_context_is_started(&p_new->ctx)) {
+        ABTD_ythread_context_switch(&p_old->ctx, &p_new->ctx);
+    } else {
+        ABTD_ythread_context_start_and_switch(&p_old->ctx, &p_new->ctx);
+    }
 }
 
 ABTU_noreturn static inline void
 ABTI_ythread_context_jump_with_call(ABTI_ythread *p_new, void (*f_cb)(void *),
                                     void *cb_arg)
 {
-    ABTD_ythread_context_jump_with_call(&p_new->ctx, f_cb, cb_arg);
+    if (ABTD_ythread_context_is_started(&p_new->ctx)) {
+        ABTD_ythread_context_jump_with_call(&p_new->ctx, f_cb, cb_arg);
+    } else {
+        ABTD_ythread_context_start_and_jump_with_call(&p_new->ctx, f_cb,
+                                                      cb_arg);
+    }
     ABTU_unreachable();
 }
 
@@ -94,9 +106,14 @@ static inline void ABTI_ythread_context_switch_with_call(ABTI_ythread *p_old,
                                                          void (*f_cb)(void *),
                                                          void *cb_arg)
 {
-    ABTD_ythread_context_switch_with_call(&p_old->ctx, &p_new->ctx, f_cb,
-                                          cb_arg);
-    /* Return the previous thread. */
+    if (ABTD_ythread_context_is_started(&p_new->ctx)) {
+        ABTD_ythread_context_switch_with_call(&p_old->ctx, &p_new->ctx, f_cb,
+                                              cb_arg);
+    } else {
+        ABTD_ythread_context_start_and_switch_with_call(&p_old->ctx,
+                                                        &p_new->ctx, f_cb,
+                                                        cb_arg);
+    }
 }
 
 ABTU_noreturn static inline void

--- a/src/info.c
+++ b/src/info.c
@@ -186,6 +186,12 @@ static void info_trigger_print_all_thread_stacks(
  *   if the wait policy of Argobots is passive.  \c val is set to 1 if the wait
  *   policy of Argobots is active.
  *
+ * - \c ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC
+ *
+ *   \c val must be a pointer to a variable of type \c ABT_bool.  \c val is set
+ *   to \c ABT_TRUE if Argobots is configured to enable lazy allocation for ULT
+ *   stacks by default.  Otherwise, \c val is set to \c ABT_FALSE.
+ *
  * @changev20
  * \DOC_DESC_V1X_RETURN_INFO_IF_POSSIBLE
  * @endchangev20
@@ -420,6 +426,13 @@ int ABT_info_query_config(ABT_info_query_kind query_kind, void *val)
             *((int *)val) = 1;
 #else
             *((int *)val) = 0;
+#endif
+            break;
+        case ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC:
+#ifdef ABT_CONFIG_DISABLE_LAZY_STACK_ALLOC
+            *((ABT_bool *)val) = ABT_FALSE;
+#else
+            *((ABT_bool *)val) = ABT_TRUE;
 #endif
             break;
         default:

--- a/src/stream.c
+++ b/src/stream.c
@@ -1609,7 +1609,8 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
 
     /* Context switch to the root thread. */
     p_xstream->p_root_ythread->thread.p_last_xstream = p_xstream;
-    ABTI_ythread_context_switch(p_ythread, p_xstream->p_root_ythread);
+    ABTI_ythread_context_switch(*pp_local_xstream, p_ythread,
+                                p_xstream->p_root_ythread);
     /* Come back to the primary thread.  Now this thread is executed on top of
      * the main scheduler, which is running on the root thread. */
     (*pp_local_xstream)->p_thread = &p_ythread->thread;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1609,8 +1609,7 @@ void ABTI_xstream_start_primary(ABTI_global *p_global,
 
     /* Context switch to the root thread. */
     p_xstream->p_root_ythread->thread.p_last_xstream = p_xstream;
-    ABTD_ythread_context_switch(&p_ythread->ctx,
-                                &p_xstream->p_root_ythread->ctx);
+    ABTI_ythread_context_switch(p_ythread, p_xstream->p_root_ythread);
     /* Come back to the primary thread.  Now this thread is executed on top of
      * the main scheduler, which is running on the root thread. */
     (*pp_local_xstream)->p_thread = &p_ythread->thread;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1730,7 +1730,11 @@ static void *xstream_launch_root_ythread(void *p_xstream)
     ABTI_ythread *p_root_ythread = p_local_xstream->p_root_ythread;
     p_local_xstream->p_thread = &p_local_xstream->p_root_ythread->thread;
     p_root_ythread->thread.p_last_xstream = p_local_xstream;
+
+    /* Run the root thread. */
     p_root_ythread->thread.f_thread(p_root_ythread->thread.p_arg);
+    ABTI_thread_terminate(ABTI_global_get_global(), p_local_xstream,
+                          &p_root_ythread->thread);
 
     /* Reset the current ES and its local info. */
     ABTI_local_set_xstream(NULL);

--- a/src/task.c
+++ b/src/task.c
@@ -582,7 +582,7 @@ ABTU_ret_err static int task_create(ABTI_global *p_global, ABTI_local *p_local,
     ABTI_CHECK_ERROR(abt_errno);
     abt_errno = ABTI_thread_init_pool(p_global, p_newtask, p_pool);
     if (ABTI_IS_ERROR_CHECK_ENABLED && abt_errno != ABT_SUCCESS) {
-        ABTI_mem_free_nythread(p_global, p_local, p_newtask);
+        ABTI_mem_free_thread(p_global, p_local, p_newtask);
         ABTI_HANDLE_ERROR(abt_errno);
     }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -2551,11 +2551,13 @@ ABTU_ret_err int ABTI_ythread_create_root(ABTI_global *p_global,
         /* For secondary ESs, the stack of an OS thread is used. */
         ABTI_thread_attr_init(&attr, NULL, 0, ABT_FALSE);
     }
+    const ABTI_thread_type thread_type = ABTI_THREAD_TYPE_YIELDABLE |
+                                         ABTI_THREAD_TYPE_ROOT |
+                                         ABTI_THREAD_TYPE_NAMED;
     ABTI_ythread *p_root_ythread;
     int abt_errno =
         ythread_create(p_global, p_local, NULL, thread_root_func, NULL, &attr,
-                       ABTI_THREAD_TYPE_YIELDABLE | ABTI_THREAD_TYPE_ROOT, NULL,
-                       THREAD_POOL_OP_NONE, &p_root_ythread);
+                       thread_type, NULL, THREAD_POOL_OP_NONE, &p_root_ythread);
     ABTI_CHECK_ERROR(abt_errno);
     *pp_root_ythread = p_root_ythread;
     return ABT_SUCCESS;
@@ -3230,8 +3232,7 @@ static void thread_root_func(void *arg)
 
     if (p_local_xstream->type == ABTI_XSTREAM_TYPE_PRIMARY) {
         /* Let us jump back to the primary thread (then finalize Argobots) */
-        ABTI_ythread_jump_to_primary(p_local_xstream,
-                                     p_global->p_primary_ythread);
+        ABTI_ythread_exit_to_primary(p_global, p_local_xstream, p_root_ythread);
     }
 }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -2659,8 +2659,7 @@ void ABTI_thread_handle_request_cancel(ABTI_global *p_global,
         ABTI_ythread_resume_joiner(p_local_xstream, p_ythread);
     }
     ABTI_event_thread_cancel(p_local_xstream, p_thread);
-    ABTI_thread_terminate(p_global, ABTI_xstream_get_local(p_local_xstream),
-                          p_thread);
+    ABTI_thread_terminate(p_global, p_local_xstream, p_thread);
 }
 
 ABTU_ret_err int ABTI_thread_handle_request_migrate(ABTI_global *p_global,

--- a/src/thread.c
+++ b/src/thread.c
@@ -2843,17 +2843,10 @@ ythread_create(ABTI_global *p_global, ABTI_local *p_local, ABTI_pool *p_pool,
             const size_t stacksize = p_attr->stacksize;
             if (ABTU_likely(stacksize == default_stacksize)) {
                 /* 1. A thread that uses a stack of a default size. */
-#ifdef ABT_CONFIG_USE_MEM_POOL
                 abt_errno =
                     ABTI_mem_alloc_ythread_mempool_desc_stack(p_global, p_local,
                                                               stacksize,
                                                               &p_newthread);
-#else
-                abt_errno =
-                    ABTI_mem_alloc_ythread_malloc_desc_stack(p_global,
-                                                             stacksize,
-                                                             &p_newthread);
-#endif
             } else if (stacksize != 0) {
                 /* 2. A thread that uses a stack of a non-default size. */
                 abt_errno =

--- a/src/thread.c
+++ b/src/thread.c
@@ -2846,30 +2846,33 @@ ythread_create(ABTI_global *p_global, ABTI_local *p_local, ABTI_pool *p_pool,
 #ifdef ABT_CONFIG_USE_MEM_POOL
                 abt_errno =
                     ABTI_mem_alloc_ythread_mempool_desc_stack(p_global, p_local,
-                                                              stacksize, p_attr,
+                                                              stacksize,
                                                               &p_newthread);
 #else
                 abt_errno =
-                    ABTI_mem_alloc_ythread_malloc_desc_stack(p_global, p_attr,
+                    ABTI_mem_alloc_ythread_malloc_desc_stack(p_global,
+                                                             stacksize,
                                                              &p_newthread);
 #endif
             } else if (stacksize != 0) {
                 /* 2. A thread that uses a stack of a non-default size. */
                 abt_errno =
-                    ABTI_mem_alloc_ythread_malloc_desc_stack(p_global, p_attr,
+                    ABTI_mem_alloc_ythread_malloc_desc_stack(p_global,
+                                                             stacksize,
                                                              &p_newthread);
             } else {
                 /* 3. A thread that uses OS-level thread's stack */
                 abt_errno =
-                    ABTI_mem_alloc_ythread_mempool_desc(p_global, p_local,
-                                                        p_attr, &p_newthread);
+                    ABTI_mem_alloc_ythread_mempool_desc(p_global, p_local, 0,
+                                                        NULL, &p_newthread);
             }
             ABTI_CHECK_ERROR(abt_errno);
         } else {
             /* 4. A thread that uses a user-allocated stack. */
-            abt_errno =
-                ABTI_mem_alloc_ythread_mempool_desc(p_global, p_local, p_attr,
-                                                    &p_newthread);
+            abt_errno = ABTI_mem_alloc_ythread_mempool_desc(p_global, p_local,
+                                                            p_attr->stacksize,
+                                                            p_attr->p_stack,
+                                                            &p_newthread);
             ABTI_CHECK_ERROR(abt_errno);
         }
 #ifndef ABT_CONFIG_DISABLE_MIGRATION

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -141,8 +141,7 @@ void ABTI_ythread_callback_exit(void *arg)
     /* Terminate this thread. */
     ABTI_ythread *p_prev = (ABTI_ythread *)arg;
     ABTI_thread_terminate(ABTI_global_get_global(),
-                          ABTI_xstream_get_local(p_prev->thread.p_last_xstream),
-                          &p_prev->thread);
+                          p_prev->thread.p_last_xstream, &p_prev->thread);
 }
 
 void ABTI_ythread_callback_resume_exit_to(void *arg)
@@ -155,8 +154,7 @@ void ABTI_ythread_callback_resume_exit_to(void *arg)
     ABTI_ythread *p_next = p_arg->p_next;
     /* Terminate this thread. */
     ABTI_thread_terminate(ABTI_global_get_global(),
-                          ABTI_xstream_get_local(p_prev->thread.p_last_xstream),
-                          &p_prev->thread);
+                          p_prev->thread.p_last_xstream, &p_prev->thread);
     /* Decrease the number of blocked threads. */
     ABTI_pool_dec_num_blocked(p_next->thread.p_pool);
 }

--- a/src/ythread.c
+++ b/src/ythread.c
@@ -233,9 +233,9 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
 {
     ABTD_ythread_print_context(p_ythread, p_os, 0);
     fprintf(p_os,
-            "stack     : %p\n"
+            "stacktop  : %p\n"
             "stacksize : %" PRIu64 "\n",
-            ABTD_ythread_context_get_stack(&p_ythread->ctx),
+            ABTD_ythread_context_get_stacktop(&p_ythread->ctx),
             (uint64_t)ABTD_ythread_context_get_stacksize(&p_ythread->ctx));
 
 #ifdef ABT_CONFIG_ENABLE_STACK_UNWIND
@@ -260,17 +260,17 @@ ABTU_no_sanitize_address void ABTI_ythread_print_stack(ABTI_global *p_global,
     }
 #endif
 
-    void *p_stack = ABTD_ythread_context_get_stack(&p_ythread->ctx);
+    void *p_stacktop = ABTD_ythread_context_get_stacktop(&p_ythread->ctx);
     size_t i, j,
         stacksize = ABTD_ythread_context_get_stacksize(&p_ythread->ctx);
-    if (stacksize == 0 || p_stack == NULL) {
+    if (stacksize == 0 || p_stacktop == NULL) {
         /* Some threads do not have p_stack (e.g., the main thread) */
         fprintf(p_os, "no stack\n");
         fflush(0);
         return;
     }
-
     if (p_global->print_raw_stack) {
+        void *p_stack = (void *)(((char *)p_stacktop) - stacksize);
         char buffer[32];
         const size_t value_width = 8;
         const int num_bytes = sizeof(buffer);

--- a/test/leakcheck/affinity.c
+++ b/test/leakcheck/affinity.c
@@ -38,10 +38,12 @@ int main()
          i++) {
         int ret = setenv("ABT_SET_AFFINITY", legal_affinity_strs[i], 1);
         assert(ret == 0);
-        do {
-            rtrace_start();
-            program(0);
-        } while (!rtrace_stop());
+        if (use_rtrace()) {
+            do {
+                rtrace_start();
+                program(0);
+            } while (!rtrace_stop());
+        }
         /* If no failure, it should succeed again. */
         program(1);
     }
@@ -51,10 +53,12 @@ int main()
          i++) {
         int ret = setenv("ABT_SET_AFFINITY", illegal_affinity_strs[i], 1);
         assert(ret == 0);
-        do {
-            rtrace_start();
-            program(0);
-        } while (!rtrace_stop());
+        if (use_rtrace()) {
+            do {
+                rtrace_start();
+                program(0);
+            } while (!rtrace_stop());
+        }
         /* If no failure, it should succeed again. */
         program(1);
     }

--- a/test/leakcheck/barrier.c
+++ b/test/leakcheck/barrier.c
@@ -112,10 +112,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/cond.c
+++ b/test/leakcheck/cond.c
@@ -176,10 +176,12 @@ int main()
 
     int type;
     for (type = 0; type < 2; type++) {
-        do {
-            rtrace_start();
-            program(type, 0);
-        } while (!rtrace_stop());
+        if (use_rtrace()) {
+            do {
+                rtrace_start();
+                program(type, 0);
+            } while (!rtrace_stop());
+        }
 
         /* If no failure, it should succeed again. */
         program(type, 1);

--- a/test/leakcheck/eventual.c
+++ b/test/leakcheck/eventual.c
@@ -100,10 +100,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/future.c
+++ b/test/leakcheck/future.c
@@ -136,13 +136,17 @@ int main()
 {
     setup_env();
     rtrace_init();
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
-    rtrace_finalize();
+
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);
+
+    rtrace_finalize();
     return 0;
 }

--- a/test/leakcheck/init_finalize.c
+++ b/test/leakcheck/init_finalize.c
@@ -27,10 +27,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/key.c
+++ b/test/leakcheck/key.c
@@ -144,10 +144,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/mutex.c
+++ b/test/leakcheck/mutex.c
@@ -197,10 +197,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/pool.c
+++ b/test/leakcheck/pool.c
@@ -378,10 +378,12 @@ int main()
     for (i = 0; i < (int)(sizeof(kinds) / sizeof(kinds[0])); i++) {
         for (automatic = 0; automatic <= 1; automatic++) {
             for (type = 0; type < 4; type++) {
-                do {
-                    rtrace_start();
-                    program(kinds[i], automatic, type, 0);
-                } while (!rtrace_stop());
+                if (use_rtrace()) {
+                    do {
+                        rtrace_start();
+                        program(kinds[i], automatic, type, 0);
+                    } while (!rtrace_stop());
+                }
 
                 /* If no failure, it should succeed again. */
                 program(kinds[i], automatic, type, 1);
@@ -393,10 +395,12 @@ int main()
     for (i = 0; i < (int)(sizeof(extra_kinds) / sizeof(extra_kinds[0])); i++) {
         for (automatic = 0; automatic <= 1; automatic++) {
             for (type = 0; type < 1; type++) {
-                do {
-                    rtrace_start();
-                    program(extra_kinds[i], automatic, type, 0);
-                } while (!rtrace_stop());
+                if (use_rtrace()) {
+                    do {
+                        rtrace_start();
+                        program(extra_kinds[i], automatic, type, 0);
+                    } while (!rtrace_stop());
+                }
 
                 /* If no failure, it should succeed again. */
                 program(extra_kinds[i], automatic, type, 1);

--- a/test/leakcheck/rwlock.c
+++ b/test/leakcheck/rwlock.c
@@ -105,10 +105,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/sched.c
+++ b/test/leakcheck/sched.c
@@ -386,10 +386,13 @@ int main()
     for (i = 0; i < (int)(sizeof(predefs) / sizeof(predefs[0])); i++) {
         for (automatic = 0; automatic <= 1; automatic++) {
             for (type = 0; type < 7; type++) {
-                do {
-                    rtrace_start();
-                    program(predefs[i], automatic, type, 0);
-                } while (!rtrace_stop());
+
+                if (use_rtrace()) {
+                    do {
+                        rtrace_start();
+                        program(predefs[i], automatic, type, 0);
+                    } while (!rtrace_stop());
+                }
 
                 /* If no failure, it should succeed again. */
                 program(predefs[i], automatic, type, 1);
@@ -404,10 +407,13 @@ int main()
          i++) {
         for (automatic = 0; automatic <= 1; automatic++) {
             for (type = 0; type < 2; type++) { /* Only check 0 and 1. */
-                do {
-                    rtrace_start();
-                    program(extra_predefs[i], automatic, type, 0);
-                } while (!rtrace_stop());
+
+                if (use_rtrace()) {
+                    do {
+                        rtrace_start();
+                        program(extra_predefs[i], automatic, type, 0);
+                    } while (!rtrace_stop());
+                }
 
                 /* If no failure, it should succeed again. */
                 program(extra_predefs[i], automatic, type, 1);

--- a/test/leakcheck/thread.c
+++ b/test/leakcheck/thread.c
@@ -215,10 +215,13 @@ int main()
     for (pool_op = 0; pool_op <= 2; pool_op++) {
         for (named = 0; named <= 1; named++) {
             for (type = 0; type < 3; type++) {
-                do {
-                    rtrace_start();
-                    program(pool_op, named, type, 0);
-                } while (!rtrace_stop());
+
+                if (use_rtrace()) {
+                    do {
+                        rtrace_start();
+                        program(pool_op, named, type, 0);
+                    } while (!rtrace_stop());
+                }
 
                 /* If no failure, it should succeed again. */
                 program(pool_op, named, type, 1);

--- a/test/leakcheck/timer.c
+++ b/test/leakcheck/timer.c
@@ -77,10 +77,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);

--- a/test/leakcheck/unit.c
+++ b/test/leakcheck/unit.c
@@ -293,10 +293,13 @@ int main()
 
     int use_predef;
     for (use_predef = 0; use_predef <= 5; use_predef++) {
-        do {
-            rtrace_start();
-            program(use_predef, 0);
-        } while (!rtrace_stop());
+
+        if (use_rtrace()) {
+            do {
+                rtrace_start();
+                program(use_predef, 0);
+            } while (!rtrace_stop());
+        }
         /* If no failure, it should succeed again. */
         program(use_predef, 1);
     }

--- a/test/leakcheck/util.h
+++ b/test/leakcheck/util.h
@@ -20,4 +20,24 @@ static void setup_env(void)
     ret = setenv("ABT_MEM_MAX_NUM_STACKS", "4", 1);
     assert(ret == 0);
 }
+
+static int use_rtrace(void)
+{
+    int ret;
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    assert(ret == ABT_SUCCESS);
+#endif
+    ABT_bool lazy_stack_alloc;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_LAZY_STACK_ALLOC,
+                                (void *)&lazy_stack_alloc);
+    assert(ret == ABT_SUCCESS);
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    assert(ret == ABT_SUCCESS);
+#endif
+    /* Currently the lazy stack allocation mechanism does not handle all the
+     * memory leak cases properly. */
+    return lazy_stack_alloc ? 0 : 1;
+}
 #endif /* UTIL_H_INCLUDED */

--- a/test/leakcheck/xstream.c
+++ b/test/leakcheck/xstream.c
@@ -161,10 +161,12 @@ int main()
 
     int type;
     for (type = 0; type < 3; type++) {
-        do {
-            rtrace_start();
-            program(type, 0);
-        } while (!rtrace_stop());
+        if (use_rtrace()) {
+            do {
+                rtrace_start();
+                program(type, 0);
+            } while (!rtrace_stop());
+        }
 
         /* If no failure, it should succeed again. */
         program(type, 1);

--- a/test/leakcheck/xstream_barrier.c
+++ b/test/leakcheck/xstream_barrier.c
@@ -78,10 +78,12 @@ int main()
     setup_env();
     rtrace_init();
 
-    do {
-        rtrace_start();
-        program(0);
-    } while (!rtrace_stop());
+    if (use_rtrace()) {
+        do {
+            rtrace_start();
+            program(0);
+        } while (!rtrace_stop());
+    }
 
     /* If no failure, it should succeed again. */
     program(1);


### PR DESCRIPTION
## Pull Request Description

This PR implements lazy-stack-allocation (LSA) and eager-stack-release (ESR) optimization in the following paper: https://ieeexplore.ieee.org/document/9018074.

This optimization is disabled by default.  Please turn it on if you want.
```sh
./configure --enable-lazy-stack-alloc
```

The idea of this optimization is assigning ULT stacks to **only active ULTs**.  This method has two merits.
1. Because ULT stacks are associated with ULTs only when needed, it can reduce the ULT stack consumption (or the user can make each stack larger).
2. Because the same ULT stack can be used for consecutively executed ULTs, it can improve the cache locality.

### Idea

Consider the following code:
```c
for (int i = 0; i < 4; i++) {
    ABT_thread_create(..., &threads[i]);
}
for (int i = 0; i < 4; i++) {
    ABT_thread_free(&threads[i]);
}
```

The current Argobots allocates stacks in `ABT_thread_create()`, so 4 ULT stacks are consumed to `threads[0:4]` in the first loop.  Those stacks are freed by `ABT_thread_free()`.

Ultimately, a ULT stack is to keep the intermediate state of a ULT function.  We need to save a state (function call stacks) in a ULT stack if a ULT context switches to another.  However, if those `threads` do not "yield" --just running ULT functions without yield--, we do not need to save such a state.  In this case, as a result, allocating 4 ULT stacks for `threads` are wasteful.

![image](https://user-images.githubusercontent.com/15073003/128048923-cbc6bb99-c734-4bf1-879a-339b4b90b049.png)

If we assign a stack on "scheduling" (`ABT_self_schedue()`) and frees it when a ULT finishes, the code above consumes only 1 ULT stack if a ULT function does not yield.  This does not prevent a ULT from yielding.  The maximum stack consumption does not exceed the stack consumption of the current Argobots (i.e., at most 1 stack per ULT).

### Evaluation

Performance improvement is sometimes significant.

 - `Main`: the current Argobots
 - `-O2`: the default configuration
 - `opt`: `--enable-perf-opt`
 - `w/ Lazy`: this PR + `--enable-lazy-stack-alloc`
 - `wo Lazy`: this PR without `--enable-lazy-stack-alloc`

![image](https://user-images.githubusercontent.com/15073003/128048358-96630818-f944-4a39-ad4a-eb4cddb41704.png)

#### Performance
Typically this optimization is beneficial when fewer ULTs yield.  The left figures show a non-yield case; in this case, the ULT overhead gets constant thanks to a better cache locality. The right figures show a yield case; in this case, there is not performance benefit. This PR adds a few branches, so it degrades the performance when a ULT yields.  Note that the performance degradation of yield is negligible in most real applications since the cause of "yield" is often the real performance bottleneck (e.g., mutex, waiting for request completion, frequent ULT synchronization, and so on).


#### Memory footprint
The memory footprint is significantly low; with `--enable-lazy-stack-alloc`, this benchmark uses only 1 ULT stack (16KB if ULT stack is 16KB) for ULTs while it allocates 2 million ULT stacks (32GB in total) without this setting.

Please check the paper above if you are interested in it.

<details><summary> Benchmark code (collapsed)</summary>
<p>

```c
#include <abt.h>
#include <stdio.h>
#include <stdlib.h>
#include <assert.h>

typedef struct {
    ABT_thread thread;
    int num_yields;
} thread_arg_t;

void thread_func(void *arg)
{
    thread_arg_t *p_arg = (thread_arg_t *)arg;
    const int num_yields = p_arg->num_yields;
    for (int i = 0; i < num_yields; i++) {
        ABT_thread_yield();
    }
}

int main(int argc, const char **argv)
{
    if (argc != 3) {
        printf("Usage: ./a.out NUM_THREADS NUM_YIELDS\n");
        return -1;
    }
    const double min_repeat_sec = 1.0; // [s]
    const int num_min_repeats = 10;
    const int num_warmups = 3;
    const int num_threads = atoi(argv[1]);
    const int num_yields = atoi(argv[2]);

    ABT_init(0, NULL);
    thread_arg_t *thread_args =
        (thread_arg_t *)malloc(sizeof(thread_arg_t) * num_threads);
    for (int i = 0; i < num_threads; i++) {
        thread_args[i].num_yields = num_yields;
    }

    // Use a private pool since it is the fastest.
    ABT_pool pool;
    ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_PRIV, ABT_TRUE, &pool);
    ABT_sched sched;
    ABT_sched_create_basic(ABT_SCHED_BASIC, 1, &pool, ABT_SCHED_CONFIG_NULL,
                           &sched);
    ABT_xstream xstream;
    ABT_self_get_xstream(&xstream);
    ABT_xstream_set_main_sched(xstream, sched);
    // Measurement
    double start_time, end_time;
    int repeat = 0, target_repeat = num_warmups + num_min_repeats;
    while (1) {
        repeat++;
        if (repeat == num_warmups)
            start_time = ABT_get_wtime();
        // Kernel starts
        for (int i = 0; i < num_threads; i++) {
            ABT_thread_create(pool, thread_func, &thread_args[i],
                              ABT_THREAD_ATTR_NULL, &thread_args[i].thread);
        }
        for (int i = num_threads - 1; i >= 0; i--) {
            ABT_thread_free(&thread_args[i].thread);
        }
        // Kernel ends
        if (repeat == target_repeat) {
            end_time = ABT_get_wtime();
            if (end_time - start_time > min_repeat_sec) {
                break;
            } else {
                target_repeat *= 2;
            }
        }
    }
    printf("[%d, %d] %f [ns per ULT]\n", num_threads, num_yields,
           (end_time - start_time) / num_threads / (repeat - num_warmups) *
               1.0e9);
    free(thread_args);
    ABT_finalize();
    return 0;
}
```

</p></details>

<details><summary> Experimental setting (collapsed)</summary>
<p>

All experiments used 1 core.
x86/64: Intel Skylake 8180 (openSUSE 15.2, gcc 7.5.0)
ARM: ThunderX2 (RedHat 7.6, gcc 9.2.0)
POWER: Summit-like POWER 9 machine (RedHat, gcc 9.3.0)
Average of 10 executions.
Fork-join benchmark: # of yields = 0
Yield benchmark: # of ULTs = 8
</p></details>

### Limitation

Scheduling a new ULT can need memory allocation, which can fail if the system does not have enough memory.  Currently Argobots does not handle this error.  This will be fixed in the future and at this point, this method should be enabled by default.


<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
