### PR TITLE
new pool API for ABT_pool_user_def

### DIFF
--- a/examples/profiling/async_engine.c
+++ b/examples/profiling/async_engine.c
@@ -120,16 +120,18 @@ void sched_run(ABT_sched sched)
     ABT_sched_get_pools(sched, 1, 0, &op_pool);
 
     while (1) {
-        ABT_unit unit;
+        ABT_thread thread;
         if (g_wait_mode == 0) {
-            ABT_pool_pop(op_pool, &unit);
+            ABT_pool_pop_thread(op_pool, &thread);
         } else {
-            ABT_pool_pop_wait(op_pool, &unit, POOL_POP_WAIT_SEC);
+            ABT_pool_pop_wait_thread(op_pool, &thread, POOL_POP_WAIT_SEC);
         }
-        if (unit != ABT_UNIT_NULL) {
-            ABT_xstream_run_unit(unit, op_pool);
+        if (thread != ABT_THREAD_NULL) {
+            /* If pool is set to ABT_POOL_NULL, the thread will go back to its
+             * original pool if it yields. */
+            ABT_self_schedule(thread, ABT_POOL_NULL);
         }
-        if (++work_count >= 128 || (g_wait_mode && unit == ABT_UNIT_NULL)) {
+        if (++work_count >= 128 || (g_wait_mode && thread == ABT_THREAD_NULL)) {
             ABT_bool stop;
             ABT_sched_has_to_stop(sched, &stop);
             if (stop == ABT_TRUE)

--- a/examples/scheduling/sched_user.c
+++ b/examples/scheduling/sched_user.c
@@ -95,7 +95,6 @@ static void sched_run(ABT_sched sched)
     sched_data_t *p_data;
     int num_pools;
     ABT_pool *pools;
-    ABT_unit unit;
     int target;
     ABT_bool stop;
     unsigned seed = time(NULL);
@@ -107,16 +106,20 @@ static void sched_run(ABT_sched sched)
 
     while (1) {
         /* Execute one work unit from the scheduler's pool */
-        ABT_pool_pop(pools[0], &unit);
-        if (unit != ABT_UNIT_NULL) {
-            ABT_xstream_run_unit(unit, pools[0]);
+        ABT_thread thread;
+        ABT_pool_pop_thread(pools[0], &thread);
+        if (thread != ABT_THREAD_NULL) {
+            /* "thread" is associated with its original pool (pools[0]). */
+            ABT_self_schedule(thread, ABT_POOL_NULL);
         } else if (num_pools > 1) {
             /* Steal a work unit from other pools */
             target =
                 (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
-            ABT_pool_pop(pools[target], &unit);
-            if (unit != ABT_UNIT_NULL) {
-                ABT_xstream_run_unit(unit, pools[target]);
+            ABT_pool_pop_thread(pools[target], &thread);
+            if (thread != ABT_THREAD_NULL) {
+                /* "thread" is associated with its original pool
+                 * (pools[target]). */
+                ABT_self_schedule(thread, pools[target]);
             }
         }
 

--- a/examples/stencil/stencil_forkjoin_divconq_hrws.c
+++ b/examples/stencil/stencil_forkjoin_divconq_hrws.c
@@ -66,33 +66,33 @@ void sched_run(ABT_sched sched)
     ABT_sched_get_pools(sched, num_pools, 0, pools);
 
     while (1) {
-        ABT_unit unit;
+        ABT_thread thread;
         /* Try to pop a ULT from a local pool*/
-        ABT_pool_pop(pools[0], &unit);
-        if (unit != ABT_UNIT_NULL) {
-            ABT_xstream_run_unit(unit, pools[0]);
+        ABT_pool_pop_thread(pools[0], &thread);
+        if (thread != ABT_THREAD_NULL) {
+            ABT_self_schedule(thread, pools[0]);
             goto EVENT_CHECK;
         }
         if (num_pools > 1) {
             /* If failed, try to pop a ULT from level-1 pools several times */
             int repeat = 0;
-            while (repeat++ < 2 && unit == ABT_UNIT_NULL) {
+            while (repeat++ < 2 && thread == ABT_THREAD_NULL) {
                 unsigned rand_val = rand_r(&seed);
                 int victim = rand_val % (num_pools / 2);
-                ABT_pool_pop(pools[victim], &unit);
+                ABT_pool_pop_thread(pools[victim], &thread);
             }
-            if (unit != ABT_UNIT_NULL) {
-                ABT_xstream_run_unit(unit, pools[0]);
+            if (thread != ABT_THREAD_NULL) {
+                ABT_self_schedule(thread, pools[0]);
                 goto EVENT_CHECK;
             }
             /* If failed, try to pop a ULT from all the pools */
             {
                 unsigned rand_val = rand_r(&seed);
                 int victim = rand_val % num_pools;
-                ABT_pool_pop(pools[victim], &unit);
+                ABT_pool_pop_thread(pools[victim], &thread);
             }
-            if (unit != ABT_UNIT_NULL) {
-                ABT_xstream_run_unit(unit, pools[0]);
+            if (thread != ABT_THREAD_NULL) {
+                ABT_self_schedule(thread, pools[0]);
             }
         }
     EVENT_CHECK:

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -2305,6 +2305,33 @@ int ABT_pool_get_access(ABT_pool pool, ABT_pool_access *access) ABT_API_PUBLIC;
 int ABT_pool_is_empty(ABT_pool pool, ABT_bool *is_empty) ABT_API_PUBLIC;
 int ABT_pool_get_size(ABT_pool pool, size_t *size) ABT_API_PUBLIC;
 int ABT_pool_get_total_size(ABT_pool pool, size_t *size) ABT_API_PUBLIC;
+int ABT_pool_pop_thread(ABT_pool pool, ABT_thread *thread) ABT_API_PUBLIC;
+int ABT_pool_pop_thread_ex(ABT_pool pool, ABT_thread *thread,
+                           ABT_pool_context pool_ctx) ABT_API_PUBLIC;
+int ABT_pool_pop_threads(ABT_pool pool, ABT_thread *threads, size_t len,
+                         size_t *num) ABT_API_PUBLIC;
+int ABT_pool_pop_threads_ex(ABT_pool pool, ABT_thread *threads, size_t len,
+                            size_t *num, ABT_pool_context pool_ctx) ABT_API_PUBLIC;
+int ABT_pool_push_thread(ABT_pool pool, ABT_thread thread) ABT_API_PUBLIC;
+int ABT_pool_push_thread_ex(ABT_pool pool, ABT_thread thread,
+                            ABT_pool_context pool_ctx) ABT_API_PUBLIC;
+int ABT_pool_push_threads(ABT_pool pool, const ABT_thread *threads,
+                          size_t num) ABT_API_PUBLIC;
+int ABT_pool_push_threads_ex(ABT_pool pool, const ABT_thread *threads,
+                             size_t num, ABT_pool_context pool_ctx) ABT_API_PUBLIC;
+int ABT_pool_pop_wait_thread(ABT_pool pool, ABT_thread *thread,
+                             double time_secs) ABT_API_PUBLIC;
+int ABT_pool_pop_wait_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                double time_secs,
+                                ABT_pool_context pool_ctx) ABT_API_PUBLIC;
+int ABT_pool_print_all_threads(ABT_pool pool, void *arg,
+                               void (*print_fn)(void *arg, ABT_thread)) ABT_API_PUBLIC;
+int ABT_pool_set_data(ABT_pool pool, void *data) ABT_API_PUBLIC;
+int ABT_pool_get_data(ABT_pool pool, void **data) ABT_API_PUBLIC;
+int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched) ABT_API_PUBLIC;
+int ABT_pool_get_id(ABT_pool pool, int *id) ABT_API_PUBLIC;
+
+/* Old Pool API.  Use ABT_pool_xxx_thread() instead. */
 int ABT_pool_pop(ABT_pool pool, ABT_unit *unit) ABT_API_PUBLIC;
 int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *unit, double time_secs) ABT_API_PUBLIC;
 int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *unit, double abstime_secs)
@@ -2313,10 +2340,6 @@ int ABT_pool_remove(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
 int ABT_pool_push(ABT_pool pool, ABT_unit unit) ABT_API_PUBLIC;
 int ABT_pool_print_all(ABT_pool pool, void *arg,
                        void (*print_fn)(void *arg, ABT_unit)) ABT_API_PUBLIC;
-int ABT_pool_set_data(ABT_pool pool, void *data) ABT_API_PUBLIC;
-int ABT_pool_get_data(ABT_pool pool, void **data) ABT_API_PUBLIC;
-int ABT_pool_add_sched(ABT_pool pool, ABT_sched sched) ABT_API_PUBLIC;
-int ABT_pool_get_id(ABT_pool pool, int *id) ABT_API_PUBLIC;
 
 /* Pool config */
 int ABT_pool_config_create(ABT_pool_config *config) ABT_API_PUBLIC;

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -15,16 +15,36 @@ void ABTI_log_debug_thread(const char *msg, ABTI_thread *p_thread);
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit);
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit);
 void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
+void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_unit *units,
+                            size_t num);
+void ABTI_log_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,
+                             size_t num);
 
 #define LOG_DEBUG_POOL_PUSH(p_pool, unit) ABTI_log_pool_push(p_pool, unit)
 #define LOG_DEBUG_POOL_REMOVE(p_pool, unit) ABTI_log_pool_remove(p_pool, unit)
 #define LOG_DEBUG_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
+#define LOG_DEBUG_POOL_POP_MANY(p_pool, units, num)                            \
+    ABTI_log_pool_pop_many(p_pool, units, num)
+#define LOG_DEBUG_POOL_PUSH_MANY(p_pool, units, num)                           \
+    ABTI_log_pool_push_many(p_pool, units, num)
 
 #else
 
-#define LOG_DEBUG_POOL_PUSH(p_pool, unit)
-#define LOG_DEBUG_POOL_REMOVE(p_pool, unit)
-#define LOG_DEBUG_POOL_POP(p_pool, unit)
+#define LOG_DEBUG_POOL_PUSH(p_pool, unit)                                      \
+    do {                                                                       \
+    } while (0)
+#define LOG_DEBUG_POOL_REMOVE(p_pool, unit)                                    \
+    do {                                                                       \
+    } while (0)
+#define LOG_DEBUG_POOL_POP(p_pool, unit)                                       \
+    do {                                                                       \
+    } while (0)
+#define LOG_DEBUG_POOL_POP_MANY(p_pool, units, num)                            \
+    do {                                                                       \
+    } while (0)
+#define LOG_DEBUG_POOL_PUSH_MANY(p_pool, units, num)                           \
+    do {                                                                       \
+    } while (0)
 
 #endif /* ABT_CONFIG_USE_DEBUG_LOG */
 

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -113,6 +113,25 @@ static inline ABT_unit ABTI_pool_pop(ABTI_pool *p_pool,
     return unit;
 }
 
+static inline void ABTI_pool_pop_many(ABTI_pool *p_pool, ABT_unit *units,
+                                      size_t len, size_t *num,
+                                      ABT_pool_context context)
+{
+    ABTI_UB_ASSERT(p_pool->optional_def.p_pop_many);
+    p_pool->optional_def.p_pop_many(ABTI_pool_get_handle(p_pool), units, len,
+                                    num, context);
+    LOG_DEBUG_POOL_POP_MANY(p_pool, units, *num);
+}
+
+static inline void ABTI_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,
+                                       size_t num, ABT_pool_context context)
+{
+    ABTI_UB_ASSERT(p_pool->optional_def.p_push_many);
+    p_pool->optional_def.p_push_many(ABTI_pool_get_handle(p_pool), units, num,
+                                     context);
+    LOG_DEBUG_POOL_PUSH_MANY(p_pool, units, num);
+}
+
 /* Increase num_scheds to mark the pool as having another scheduler. If the
  * pool is not available, it returns ABT_ERR_INV_POOL_ACCESS.  */
 static inline void ABTI_pool_retain(ABTI_pool *p_pool)

--- a/src/log.c
+++ b/src/log.c
@@ -169,4 +169,22 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
     }
 }
 
+void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_unit *units,
+                            size_t num)
+{
+    size_t i;
+    for (i = 0; i < num; i++) {
+        ABTI_log_pool_pop(p_pool, units[i]);
+    }
+}
+
+void ABTI_log_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,
+                             size_t num)
+{
+    size_t i;
+    for (i = 0; i < num; i++) {
+        ABTI_log_pool_push(p_pool, units[i]);
+    }
+}
+
 #endif /* ABT_CONFIG_USE_DEBUG_LOG */

--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -17,6 +17,18 @@ pool_create_def_from_old_def(const ABT_pool_def *p_def,
                              ABTI_pool_required_def *p_required_def,
                              ABTI_pool_optional_def *p_optional_def,
                              ABTI_pool_deprecated_def *p_deprecated_def);
+static inline int pool_pop_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                     ABT_pool_context pool_ctx);
+static inline int pool_pop_threads_ex(ABT_pool pool, ABT_thread *threads,
+                                      size_t len, size_t *num,
+                                      ABT_pool_context pool_ctx);
+static inline int pool_push_thread_ex(ABT_pool pool, ABT_thread thread,
+                                      ABT_pool_context pool_ctx);
+static inline int pool_push_threads_ex(ABT_pool pool, const ABT_thread *threads,
+                                       size_t num, ABT_pool_context pool_ctx);
+static inline int pool_pop_wait_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                          double time_secs,
+                                          ABT_pool_context pool_ctx);
 
 /** @defgroup POOL Pool
  * This group is for Pool.
@@ -425,6 +437,394 @@ int ABT_pool_get_size(ABT_pool pool, size_t *size)
     ABTI_CHECK_TRUE(p_pool->optional_def.p_get_size, ABT_ERR_POOL);
 
     *size = ABTI_pool_get_size(p_pool);
+    return ABT_SUCCESS;
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop a work unit from a pool.
+ *
+ * The functionality of this routine is the same as \c ABT_pool_pop_thread_ex()
+ * while \c ABT_POOL_CONTEXT_OP_POOL_OTHER is passed as \c pool_ctx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c thread}
+ *
+ * @param[in]  pool    pool handle
+ * @param[out] thread  work unit handle
+ * @return Error code
+ */
+int ABT_pool_pop_thread(ABT_pool pool, ABT_thread *thread)
+{
+    return pool_pop_thread_ex(pool, thread, ABT_POOL_CONTEXT_OP_POOL_OTHER);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop a work unit from a pool.
+ *
+ * \c ABT_pool_pop_thread_ex() pops a work unit from the pool \c pool and sets
+ * it to \c thread.  The pool context \c pool_ctx is passed to \c pool.  If the
+ * underlying pool implementation successfully pops a work unit, this routine
+ * sets \c thread to a work unit handle associated with the returned
+ * \c ABT_unit.  Otherwise, this routine sets \c thread to \c ABT_THREAD_NULL.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c thread}
+ *
+ * @param[in]  pool      pool handle
+ * @param[out] p_unit    work unit handle
+ * @param[in]  pool_ctx  pool context
+ * @return Error code
+ */
+int ABT_pool_pop_thread_ex(ABT_pool pool, ABT_thread *thread,
+                           ABT_pool_context pool_ctx)
+{
+    return pool_pop_thread_ex(pool, thread, pool_ctx);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop work units from a pool.
+ *
+ * The functionality of this routine is the same as \c ABT_pool_pop_threads_ex()
+ * while \c ABT_POOL_CONTEXT_OP_POOL_OTHER is passed as \c pool_ctx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_pop_many_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c threads, \c len is positive}
+ * \DOC_UNDEFINED_NULL_PTR{\c num}
+ *
+ * @param[in]  pool    pool handle
+ * @param[out] thread  work unit handle
+ * @return Error code
+ */
+int ABT_pool_pop_threads(ABT_pool pool, ABT_thread *threads, size_t len,
+                         size_t *num)
+{
+    return pool_pop_threads_ex(pool, threads, len, num,
+                               ABT_POOL_CONTEXT_OP_POOL_OTHER);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop work units from a pool.
+ *
+ * \c ABT_pool_pop_thread_ex() pops at most \c len work units from the pool
+ * \c pool and sets them to \c threads.  The number of popped work units is set
+ * to \c num.  The pool context \c pool_ctx is passed to \c pool.
+ *
+ * If the underlying pool implementation successfully pops work units, this
+ * routine sets the first \c num elements of \c threads to work unit handles
+ * associated with the returned \c ABT_unit.
+ *
+ * @note
+ * \DOC_NOTE_NO_PADDING{\c threads, \c len}
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_pop_many_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c threads}
+ * \DOC_UNDEFINED_NULL_PTR{\c num}
+ *
+ * @param[in]  pool      pool handle
+ * @param[out] threads   work unit handles
+ * @param[in]  len       the number of \c threads entries
+ * @param[out] num       the number of popped work units
+ * @param[in]  pool_ctx  pool context
+ * @return Error code
+ */
+int ABT_pool_pop_threads_ex(ABT_pool pool, ABT_thread *threads, size_t len,
+                            size_t *num, ABT_pool_context pool_ctx)
+{
+    return pool_pop_threads_ex(pool, threads, len, num, pool_ctx);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Push a work unit to a pool.
+ *
+ * The functionality of this routine is the same as \c ABT_pool_push_thread_ex()
+ * while \c ABT_POOL_CONTEXT_OP_POOL_OTHER is passed as \c pool_ctx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[in] pool    pool handle
+ * @param[in] thread  work unit handle
+ * @return Error code
+ */
+int ABT_pool_push_thread(ABT_pool pool, ABT_thread thread)
+{
+    return pool_push_thread_ex(pool, thread, ABT_POOL_CONTEXT_OP_POOL_OTHER);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Push a work unit to a pool.
+ *
+ * \c ABT_pool_push_thread_ex() pushes the work unit \c thread to the pool
+ * \c pool.  The pool context \c pool_ctx is passed to \c pool.  If \c thread
+ * is \c ABT_THREAD_NULL, this routine does not push a work unit and returns
+ * \c ABT_SUCCESS.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ *
+ * @param[in] pool      pool handle
+ * @param[in] thread    work unit handle
+ * @param[in] pool_ctx  pool context
+ * @return Error code
+ */
+int ABT_pool_push_thread_ex(ABT_pool pool, ABT_thread thread,
+                            ABT_pool_context pool_ctx)
+{
+    return pool_push_thread_ex(pool, thread, pool_ctx);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Push work units to a pool.
+ *
+ * The functionality of this routine is the same as
+ * \c ABT_pool_push_threads_ex() while \c ABT_POOL_CONTEXT_OP_POOL_OTHER is
+ * passed as \c pool_ctx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_push_many_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR_CONDITIONAL{\c threads, \c num is positive}
+ *
+ * @param[in] pool     pool handle
+ * @param[in] threads  work unit handles
+ * @param[in] num      the number of work unit handles
+ * @return Error code
+ */
+int ABT_pool_push_threads(ABT_pool pool, const ABT_thread *threads, size_t num)
+{
+    return pool_push_threads_ex(pool, threads, num,
+                                ABT_POOL_CONTEXT_OP_POOL_OTHER);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Push work units to a pool.
+ *
+ * \c ABT_pool_push_threads_ex() pushes \c num work units stored in \c threads
+ * to the pool \c pool.  The pool context \c pool_ctx is passed to \c pool.
+ * This routine ignores \c ABT_THREAD_NULL.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_RESOURCE
+ * \DOC_ERROR_RESOURCE_UNIT_CREATE
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_push_many_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR_CONDITIONAL{\c threads, \c num is positive}
+ *
+ * @param[in] pool      pool handle
+ * @param[in] threads   work unit handles
+ * @param[in] num       the number of work unit handles
+ * @param[in] pool_ctx  pool context
+ * @return Error code
+ */
+int ABT_pool_push_threads_ex(ABT_pool pool, const ABT_thread *threads,
+                             size_t num, ABT_pool_context pool_ctx)
+{
+    return pool_push_threads_ex(pool, threads, num, pool_ctx);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop a work unit from a pool.
+ *
+ * The functionality of this routine is the same as
+ * \c ABT_pool_pop_wait_thread_ex() while \c ABT_POOL_CONTEXT_OP_POOL_OTHER is
+ * passed as \c pool_ctx.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_pop_wait_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c thread}
+ *
+ * @param[in]  pool       pool handle
+ * @param[out] thread     work unit handle
+ * @param[in]  time_secs  duration of waiting time (seconds)
+ * @return Error code
+ */
+int ABT_pool_pop_wait_thread(ABT_pool pool, ABT_thread *thread,
+                             double time_secs)
+{
+    return pool_pop_wait_thread_ex(pool, thread, time_secs,
+                                   ABT_POOL_CONTEXT_OP_POOL_OTHER);
+}
+
+/**
+ * @ingroup POOL
+ * @brief   Pop a work unit from a pool.
+ *
+ * \c ABT_pool_pop_wait_thread_ex() pops a work unit from the pool \c pool and
+ * sets it to \c thread.  The pool context \c pool_ctx is passed to \c pool.
+ * This routine might block on \c pool to wait for up to \c time_sec seconds
+ * when \c pool does not have a work unit to return.
+ *
+ * If the underlying pool implementation successfully pops a work unit, this
+ * routine sets \c thread to a work unit handle associated with the returned
+ * \c ABT_unit.  Otherwise, this routine sets \c thread to \c ABT_THREAD_NULL.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_pop_wait_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c thread}
+ *
+ * @param[in]  pool       pool handle
+ * @param[out] thread     work unit handle
+ * @param[in]  time_secs  duration of waiting time (seconds)
+ * @param[in]  pool_ctx   pool context
+ * @return Error code
+ */
+int ABT_pool_pop_wait_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                double time_secs, ABT_pool_context pool_ctx)
+{
+    return pool_pop_wait_thread_ex(pool, thread, time_secs, pool_ctx);
+}
+
+typedef struct {
+    void *arg;
+    void (*print_fn)(void *arg, ABT_thread);
+} pool_print_all_threads_wrapper_arg_t;
+
+static void pool_print_all_threads_wrapper(void *arg, ABT_unit unit)
+{
+    pool_print_all_threads_wrapper_arg_t *p_arg =
+        (pool_print_all_threads_wrapper_arg_t *)arg;
+    ABTI_global *p_global = ABTI_global_get_global();
+    ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+    ABT_thread thread = ABTI_thread_get_handle(p_thread);
+    p_arg->print_fn(p_arg->arg, thread);
+}
+/**
+ * @ingroup POOL
+ * @brief   Apply a print function to every work unit in a pool.
+ *
+ * \c ABT_pool_print_all_threads() calls \c print_fn() for every work unit in
+ * the pool \c pool.  \c print_fn() is called with \c arg as its first argument
+ * and the handle of the work unit as the second argument.
+ *
+ * @note
+ * As the name of the argument implies, \c print_fn() may not have any side
+ * effect; \c ABT_pool_print_all_threads() is for debugging and profiling.  For
+ * example, changing the state of \c ABT_thread in \c print_fn() is forbidden.
+ *
+ * @contexts
+ * \DOC_CONTEXT_INIT \DOC_CONTEXT_NOCTXSWITCH
+ *
+ * @errors
+ * \DOC_ERROR_SUCCESS
+ * \DOC_ERROR_INV_POOL_HANDLE{\c pool}
+ * \DOC_ERROR_POOL_UNSUPPORTED_FEATURE{\c pool, \c ABT_pool_user_print_all_fn}
+ *
+ * @undefined
+ * \DOC_UNDEFINED_UNINIT
+ * \DOC_UNDEFINED_NULL_PTR{\c print_fn}
+ * \DOC_UNDEFINED_CHANGE_STATE{\c print_fn()}
+ *
+ * @param[in] pool      pool handle
+ * @param[in] arg       argument passed to \c print_fn
+ * @param[in] print_fn  user-defined print function
+ * @return Error code
+ */
+int ABT_pool_print_all_threads(ABT_pool pool, void *arg,
+                               void (*print_fn)(void *arg, ABT_thread))
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(print_fn);
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_CHECK_TRUE(p_pool->optional_def.p_print_all, ABT_ERR_POOL);
+
+    pool_print_all_threads_wrapper_arg_t wrapper_arg = { arg, print_fn };
+    p_pool->optional_def.p_print_all(pool, (void *)&wrapper_arg,
+                                     pool_print_all_threads_wrapper);
     return ABT_SUCCESS;
 }
 
@@ -1295,4 +1695,142 @@ pool_create(ABT_pool_access access,
 static inline uint64_t pool_get_new_id(void)
 {
     return (uint64_t)ABTD_atomic_fetch_add_uint64(&g_pool_id, 1);
+}
+
+static inline int pool_pop_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                     ABT_pool_context pool_ctx)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread);
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABT_unit unit = ABTI_pool_pop(p_pool, pool_ctx);
+    if (unit != ABT_UNIT_NULL) {
+        ABTI_global *p_global = ABTI_global_get_global();
+        ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+        *thread = ABTI_thread_get_handle(p_thread);
+    } else {
+        *thread = ABT_THREAD_NULL;
+    }
+    return ABT_SUCCESS;
+}
+
+static inline int pool_pop_threads_ex(ABT_pool pool, ABT_thread *threads,
+                                      size_t len, size_t *num,
+                                      ABT_pool_context pool_ctx)
+{
+    ABTI_STATIC_ASSERT(sizeof(ABT_unit) == sizeof(ABT_thread));
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(threads || len == 0);
+    ABTI_UB_ASSERT(num);
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_CHECK_TRUE(p_pool->optional_def.p_pop_many, ABT_ERR_POOL);
+
+    if (len > 0) {
+        ABTI_pool_pop_many(p_pool, (ABT_unit *)threads, len, num, pool_ctx);
+        /* Translate units to threads. */
+        size_t num_popped = *num;
+        if (num_popped > 0) {
+            size_t i;
+            ABTI_global *p_global = ABTI_global_get_global();
+            for (i = 0; i < num_popped; i++) {
+                ABTI_thread *p_thread =
+                    ABTI_unit_get_thread(p_global, (ABT_unit)threads[i]);
+                threads[i] = ABTI_thread_get_handle(p_thread);
+            }
+        }
+    }
+    return ABT_SUCCESS;
+}
+
+static inline int pool_push_thread_ex(ABT_pool pool, ABT_thread thread,
+                                      ABT_pool_context pool_ctx)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
+
+    if (p_thread) {
+        ABTI_global *p_global = ABTI_global_get_global();
+        int abt_errno =
+            ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+        ABTI_CHECK_ERROR(abt_errno);
+        ABTI_pool_push(p_pool, p_thread->unit, pool_ctx);
+    }
+    return ABT_SUCCESS;
+}
+
+static inline int pool_push_threads_ex(ABT_pool pool, const ABT_thread *threads,
+                                       size_t num, ABT_pool_context pool_ctx)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(threads || num == 0);
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_CHECK_TRUE(p_pool->optional_def.p_push_many, ABT_ERR_POOL);
+
+    if (num > 0) {
+        ABTI_global *p_global = ABTI_global_get_global();
+        int abt_errno;
+        ABT_unit *push_units, push_units_buffer[64];
+        if (num > sizeof(push_units_buffer) / sizeof(push_units_buffer[0])) {
+            abt_errno =
+                ABTU_malloc(sizeof(ABT_unit) * num, (void **)&push_units);
+            ABTI_CHECK_ERROR(abt_errno);
+        } else {
+            push_units = push_units_buffer;
+        }
+
+        size_t i, num_units = 0;
+        for (i = 0; i < num; i++) {
+            /* FIXME: the following can break the intermediate mapping if an
+             * error happens. */
+            ABTI_thread *p_thread = ABTI_thread_get_ptr(threads[i]);
+            ABTI_CHECK_NULL_THREAD_PTR(p_thread);
+            if (p_thread) {
+                abt_errno =
+                    ABTI_thread_set_associated_pool(p_global, p_thread, p_pool);
+                if (abt_errno != ABT_SUCCESS) {
+                    if (push_units != push_units_buffer)
+                        ABTU_free(push_units);
+                    ABTI_HANDLE_ERROR(abt_errno);
+                }
+                push_units[num_units++] = p_thread->unit;
+            }
+        }
+        if (num_units > 0) {
+            ABTI_pool_push_many(p_pool, push_units, num_units, pool_ctx);
+        }
+        if (push_units != push_units_buffer)
+            ABTU_free(push_units);
+    }
+    return ABT_SUCCESS;
+}
+
+static inline int pool_pop_wait_thread_ex(ABT_pool pool, ABT_thread *thread,
+                                          double time_secs,
+                                          ABT_pool_context pool_ctx)
+{
+    ABTI_UB_ASSERT(ABTI_initialized());
+    ABTI_UB_ASSERT(thread);
+
+    ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
+    ABTI_CHECK_NULL_POOL_PTR(p_pool);
+    ABTI_CHECK_TRUE(p_pool->optional_def.p_pop_wait, ABT_ERR_POOL);
+
+    ABT_unit unit = ABTI_pool_pop_wait(p_pool, time_secs, pool_ctx);
+    if (unit != ABT_UNIT_NULL) {
+        ABTI_global *p_global = ABTI_global_get_global();
+        ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+        *thread = ABTI_thread_get_handle(p_thread);
+    } else {
+        *thread = ABT_THREAD_NULL;
+    }
+    return ABT_SUCCESS;
 }

--- a/test/basic/xstream_set_main_sched.c
+++ b/test/basic/xstream_set_main_sched.c
@@ -46,24 +46,40 @@ void sched_run(ABT_sched sched)
     while (1) {
         int i;
         for (i = 0; i < p_data->num_pools; i++) {
-            ABT_unit unit;
-            ret = ABT_pool_pop(p_data->pools[i], &unit);
-            ATS_ERROR(ret, "ABT_pool_pop");
-            if (unit != ABT_UNIT_NULL) {
-                if (work_count % 3 == 0) {
-                    ABT_xstream_run_unit(unit, p_data->pools[i]);
-                } else if (work_count % 3 == 1) {
-                    ABT_thread thread;
-                    ret = ABT_unit_get_thread(unit, &thread);
-                    ATS_ERROR(ret, "ABT_unit_get_thread");
-                    ret = ABT_self_schedule(thread, ABT_POOL_NULL);
-                    ATS_ERROR(ret, "ABT_self_schedule");
-                } else {
-                    ABT_thread thread;
-                    ret = ABT_unit_get_thread(unit, &thread);
-                    ATS_ERROR(ret, "ABT_unit_get_thread");
-                    ret = ABT_self_schedule(thread, p_data->pools[i]);
-                    ATS_ERROR(ret, "ABT_self_schedule");
+            if (work_count % 5 < 3) {
+                ABT_unit unit;
+                ret = ABT_pool_pop(p_data->pools[i], &unit);
+                ATS_ERROR(ret, "ABT_pool_pop");
+                if (unit != ABT_UNIT_NULL) {
+                    if (work_count % 5 == 0) {
+                        ABT_xstream_run_unit(unit, p_data->pools[i]);
+                    } else if (work_count % 5 == 1) {
+                        ABT_thread thread;
+                        ret = ABT_unit_get_thread(unit, &thread);
+                        ATS_ERROR(ret, "ABT_unit_get_thread");
+                        ret = ABT_self_schedule(thread, ABT_POOL_NULL);
+                        ATS_ERROR(ret, "ABT_self_schedule");
+                    } else {
+                        ABT_thread thread;
+                        ret = ABT_unit_get_thread(unit, &thread);
+                        ATS_ERROR(ret, "ABT_unit_get_thread");
+                        ret = ABT_self_schedule(thread, p_data->pools[i]);
+                        ATS_ERROR(ret, "ABT_self_schedule");
+                    }
+                }
+            } else {
+                /* work_count == 3 or 4 */
+                ABT_thread thread;
+                ret = ABT_pool_pop_thread(p_data->pools[i], &thread);
+                ATS_ERROR(ret, "ABT_pool_pop_thread");
+                if (thread != ABT_THREAD_NULL) {
+                    if (work_count % 5 == 3) {
+                        ret = ABT_self_schedule(thread, ABT_POOL_NULL);
+                        ATS_ERROR(ret, "ABT_self_schedule");
+                    } else {
+                        ret = ABT_self_schedule(thread, p_data->pools[i]);
+                        ATS_ERROR(ret, "ABT_self_schedule");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Pull Request Description


This PR adds new pool functions to use a custom pool defined by `ABT_pool_user_def`. New features include `p_push_many`, `p_pop_many`, and `ABT_pool_context`.

```c
int ABT_pool_pop_thread(ABT_pool pool, ABT_thread *thread);
int ABT_pool_pop_thread_ex(ABT_pool pool, ABT_thread *thread, ABT_pool_context pool_ctx);
int ABT_pool_pop_threads(ABT_pool pool, ABT_thread *threads, size_t len, size_t *num);
int ABT_pool_pop_threads_ex(ABT_pool pool, ABT_thread *threads, size_t len, size_t *num,
                            ABT_pool_context pool_ctx);
int ABT_pool_push_thread(ABT_pool pool, ABT_thread thread);
int ABT_pool_push_thread_ex(ABT_pool pool, ABT_thread thread, ABT_pool_context pool_ctx);
int ABT_pool_push_threads(ABT_pool pool, const ABT_thread *threads, size_t num);
int ABT_pool_push_threads_ex(ABT_pool pool, const ABT_thread *threads, size_t num,
                             ABT_pool_context pool_ctx);
int ABT_pool_pop_wait_thread(ABT_pool pool, ABT_thread *thread, double time_secs);
int ABT_pool_pop_wait_thread_ex(ABT_pool pool, ABT_thread *thread, double time_secs,
                                ABT_pool_context pool_ctx);
int ABT_pool_print_all_threads(ABT_pool pool, void *arg, void (*print_fn)(void *arg, ABT_thread));
```

In terms of design, the main difference is that all the new functions take `ABT_thread` instead of `ABT_unit`.  This mapping is more intuitive for users. Previously `ABT_unit` is a "scheduling work unit" that encapsulates `ABT_thread`, which is also a "schedulable work unit", but this is hard for users to understand.

In any case, the custom scheduler can be written as follows:

```c
void sched_run(ABT_sched sched) {
    ...
    while (1) {
        ABT_thread thread;
        ABT_pool_pop_thread(my_pool, &thread);
        if (thread != ABT_THREAD_NULL) {
            ABT_self_schedule(thread, my_pool);
        }
#if 0
        /* The current way of scheduling is still supported. */
        ABT_unit unit;
        ABT_pool_pop(my_pool, &unit);
        if (unit != ABT_UNIT_NULL) {
            ABT_xstream_run_unit(unit, my_pool);
        }
#endif
    }
}
```

The user can access `thread` easily, so the user can customize the scheduler more flexibly.
```c
while (1) {
    ABT_thread thread;
    ABT_pool_pop_thread(my_pool, &thread);
    if (thread != ABT_THREAD_NULL) {
        double priority_value;
        ABT_thread_get_specific(thread, priority_key, (void **)&priority_value);
        if (priority_value < 0.0) {
            ABT_self_schedule(thread, low_priority_pool);
        } else {
            ABT_self_schedule(thread, my_pool);
        }
    }
}
```

This PR does not affect the existing APIs.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
