### PR TITLE
pool: change argument/return types of a few ABT_pool_user_def functions

### DIFF
--- a/examples/scheduling/sched_and_pool_user.c
+++ b/examples/scheduling/sched_and_pool_user.c
@@ -245,6 +245,7 @@ typedef struct pool_t pool_t;
 struct unit_t {
     unit_t *p_prev;
     unit_t *p_next;
+    ABT_thread thread;
 };
 
 struct pool_t {
@@ -259,6 +260,7 @@ static ABT_unit pool_create_unit(ABT_pool pool, ABT_thread thread)
     unit_t *p_unit = (unit_t *)calloc(1, sizeof(unit_t));
     if (!p_unit)
         return ABT_UNIT_NULL;
+    p_unit->thread = thread;
     return (ABT_unit)p_unit;
 }
 
@@ -275,7 +277,7 @@ static ABT_bool pool_is_empty(ABT_pool pool)
     return p_pool->p_head ? ABT_FALSE : ABT_TRUE;
 }
 
-static ABT_unit pool_pop(ABT_pool pool, ABT_pool_context context)
+static ABT_thread pool_pop(ABT_pool pool, ABT_pool_context context)
 {
     pool_t *p_pool;
     ABT_pool_get_data(pool, (void **)&p_pool);
@@ -299,8 +301,8 @@ static ABT_unit pool_pop(ABT_pool pool, ABT_pool_context context)
     }
     pthread_mutex_unlock(&p_pool->lock);
     if (!p_unit)
-        return ABT_UNIT_NULL;
-    return (ABT_unit)p_unit;
+        return ABT_THREAD_NULL;
+    return p_unit->thread;
 }
 
 static void pool_push(ABT_pool pool, ABT_unit unit, ABT_pool_context context)

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1767,7 +1767,7 @@ typedef ABT_bool (*ABT_pool_user_is_empty_fn)(ABT_pool);
  * A caller of \c ABT_pool_user_pop_fn() is undefined, so a program that relies
  * on a caller of this routine is non-conforming.
  */
-typedef ABT_unit (*ABT_pool_user_pop_fn)(ABT_pool, ABT_pool_context);
+typedef ABT_thread (*ABT_pool_user_pop_fn)(ABT_pool, ABT_pool_context);
 /**
  * @ingroup POOL_USER_DEF
  * @fn    void (*ABT_pool_user_push_fn)(ABT_pool pool, ABT_unit unit,
@@ -1858,23 +1858,23 @@ typedef size_t (*ABT_pool_user_get_size_fn)(ABT_pool);
  * A caller of \c ABT_pool_user_pop_wait_fn() is undefined, so a program that
  * relies on a caller of this routine is non-conforming.
  */
-typedef ABT_unit (*ABT_pool_user_pop_wait_fn)(ABT_pool, double,
-                                              ABT_pool_context);
+typedef ABT_thread (*ABT_pool_user_pop_wait_fn)(ABT_pool, double,
+                                                ABT_pool_context);
 /**
  * @ingroup POOL_USER_DEF
- * @fn    void (*ABT_pool_user_pop_many_fn)(ABT_pool pool, ABT_unit *units,
- *                                          size_t max_units,
+ * @fn    void (*ABT_pool_user_pop_many_fn)(ABT_pool pool, ABT_thread *threads,
+ *                                          size_t max_threads,
  *                                          size_t *num_popped,
  *                                          ABT_pool_context context)
  * @brief Function that pops work units from a pool.
  *
  * \c ABT_pool_user_pop_many_fn() pops multiple work units from the pool \c pool
- * and returns them through \c units.  This routine pops at maximum \c max_units
- * work units from the pool and returns the number of popped units to
- * \c num_popped where \c num_popped is not \c NULL.  The popped units are
- * stored in \c units at indices from 0 to \c num_popped - 1.  This routine may
- * not modify elements of \c units at indices from \c num_popped to
- * \c max_units.  The implementation of this routine may change its behavior
+ * and returns them through \c threads.  This routine pops at maximum
+ * \c max_units work units from the pool and returns the number of popped work
+ * units to \c num_popped where \c num_popped is not \c NULL.  The popped work
+ * units are stored in \c threads at indices from 0 to \c num_popped - 1.  This
+ * routine may not modify elements of \c threads at indices from \c num_popped
+ * to \c max_threads.  The implementation of this routine may change its behavior
  * based on the pool context \c context.
  *
  * @note
@@ -1886,7 +1886,7 @@ typedef ABT_unit (*ABT_pool_user_pop_wait_fn)(ABT_pool, double,
  * A caller of \c ABT_pool_user_pop_many_fn() is undefined, so a program that
  * relies on a caller of this routine is non-conforming.
  */
-typedef void (*ABT_pool_user_pop_many_fn)(ABT_pool, ABT_unit *, size_t,
+typedef void (*ABT_pool_user_pop_many_fn)(ABT_pool, ABT_thread *, size_t,
                                           size_t *, ABT_pool_context);
 /**
  * @ingroup POOL_USER_DEF
@@ -1916,7 +1916,7 @@ typedef void (*ABT_pool_user_push_many_fn)(ABT_pool, const ABT_unit *, size_t,
 /**
  * @ingroup POOL_USER_DEF
  * @fn    void (*ABT_pool_user_print_all_fn)(ABT_pool pool, void *arg,
- *                                           void (*print_f)(void *, ABT_unit))
+ *                                           void (*print_f)(void *, ABT_thread))
  * @brief Function that applies a user-given function to all work units in a
  *        pool.
  *
@@ -1932,7 +1932,7 @@ typedef void (*ABT_pool_user_push_many_fn)(ABT_pool, const ABT_unit *, size_t,
  * relies on a caller of this routine is non-conforming.
  */
 typedef void (*ABT_pool_user_print_all_fn)(ABT_pool, void *arg,
-                                           void (*)(void *, ABT_unit));
+                                           void (*)(void *, ABT_thread));
 
 /* Pool Functions */
 typedef ABT_unit_type (*ABT_unit_get_type_fn)(ABT_unit);

--- a/src/include/abti_log.h
+++ b/src/include/abti_log.h
@@ -14,17 +14,17 @@ void ABTI_log_debug(const char *format, ...);
 void ABTI_log_debug_thread(const char *msg, ABTI_thread *p_thread);
 void ABTI_log_pool_push(ABTI_pool *p_pool, ABT_unit unit);
 void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit);
-void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit);
-void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_unit *units,
+void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_thread thread);
+void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_thread *threads,
                             size_t num);
 void ABTI_log_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,
                              size_t num);
 
 #define LOG_DEBUG_POOL_PUSH(p_pool, unit) ABTI_log_pool_push(p_pool, unit)
 #define LOG_DEBUG_POOL_REMOVE(p_pool, unit) ABTI_log_pool_remove(p_pool, unit)
-#define LOG_DEBUG_POOL_POP(p_pool, unit) ABTI_log_pool_pop(p_pool, unit)
-#define LOG_DEBUG_POOL_POP_MANY(p_pool, units, num)                            \
-    ABTI_log_pool_pop_many(p_pool, units, num)
+#define LOG_DEBUG_POOL_POP(p_pool, thread) ABTI_log_pool_pop(p_pool, thread)
+#define LOG_DEBUG_POOL_POP_MANY(p_pool, threads, num)                          \
+    ABTI_log_pool_pop_many(p_pool, threads, num)
 #define LOG_DEBUG_POOL_PUSH_MANY(p_pool, units, num)                           \
     ABTI_log_pool_push_many(p_pool, units, num)
 
@@ -36,10 +36,10 @@ void ABTI_log_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,
 #define LOG_DEBUG_POOL_REMOVE(p_pool, unit)                                    \
     do {                                                                       \
     } while (0)
-#define LOG_DEBUG_POOL_POP(p_pool, unit)                                       \
+#define LOG_DEBUG_POOL_POP(p_pool, thread)                                     \
     do {                                                                       \
     } while (0)
-#define LOG_DEBUG_POOL_POP_MANY(p_pool, units, num)                            \
+#define LOG_DEBUG_POOL_POP_MANY(p_pool, threads, num)                          \
     do {                                                                       \
     } while (0)
 #define LOG_DEBUG_POOL_PUSH_MANY(p_pool, units, num)                           \

--- a/src/include/abti_pool.h
+++ b/src/include/abti_pool.h
@@ -76,51 +76,37 @@ ABTU_ret_err static inline int ABTI_pool_remove(ABTI_pool *p_pool,
     return p_pool->deprecated_def.p_remove(ABTI_pool_get_handle(p_pool), unit);
 }
 
-static inline ABT_unit ABTI_pool_pop_wait(ABTI_pool *p_pool, double time_secs,
-                                          ABT_pool_context context)
+static inline ABT_thread ABTI_pool_pop_wait(ABTI_pool *p_pool, double time_secs,
+                                            ABT_pool_context context)
 {
-    ABT_unit unit;
-
     ABTI_UB_ASSERT(p_pool->optional_def.p_pop_wait);
-    unit = p_pool->optional_def.p_pop_wait(ABTI_pool_get_handle(p_pool),
-                                           time_secs, context);
-    LOG_DEBUG_POOL_POP(p_pool, unit);
-
-    return unit;
+    ABT_thread thread =
+        p_pool->optional_def.p_pop_wait(ABTI_pool_get_handle(p_pool), time_secs,
+                                        context);
+    LOG_DEBUG_POOL_POP(p_pool, thread);
+    return thread;
 }
 
-static inline ABT_unit ABTI_pool_pop_timedwait(ABTI_pool *p_pool,
-                                               double abstime_secs)
+/* Defined in pool.c */
+ABT_thread ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs);
+
+static inline ABT_thread ABTI_pool_pop(ABTI_pool *p_pool,
+                                       ABT_pool_context context)
 {
-    ABT_unit unit;
-
-    ABTI_UB_ASSERT(p_pool->deprecated_def.p_pop_timedwait);
-    unit = p_pool->deprecated_def.p_pop_timedwait(ABTI_pool_get_handle(p_pool),
-                                                  abstime_secs);
-    LOG_DEBUG_POOL_POP(p_pool, unit);
-
-    return unit;
+    ABT_thread thread =
+        p_pool->required_def.p_pop(ABTI_pool_get_handle(p_pool), context);
+    LOG_DEBUG_POOL_POP(p_pool, thread);
+    return thread;
 }
 
-static inline ABT_unit ABTI_pool_pop(ABTI_pool *p_pool,
-                                     ABT_pool_context context)
-{
-    ABT_unit unit;
-
-    unit = p_pool->required_def.p_pop(ABTI_pool_get_handle(p_pool), context);
-    LOG_DEBUG_POOL_POP(p_pool, unit);
-
-    return unit;
-}
-
-static inline void ABTI_pool_pop_many(ABTI_pool *p_pool, ABT_unit *units,
+static inline void ABTI_pool_pop_many(ABTI_pool *p_pool, ABT_thread *threads,
                                       size_t len, size_t *num,
                                       ABT_pool_context context)
 {
     ABTI_UB_ASSERT(p_pool->optional_def.p_pop_many);
-    p_pool->optional_def.p_pop_many(ABTI_pool_get_handle(p_pool), units, len,
+    p_pool->optional_def.p_pop_many(ABTI_pool_get_handle(p_pool), threads, len,
                                     num, context);
-    LOG_DEBUG_POOL_POP_MANY(p_pool, units, *num);
+    LOG_DEBUG_POOL_POP_MANY(p_pool, threads, *num);
 }
 
 static inline void ABTI_pool_push_many(ABTI_pool *p_pool, const ABT_unit *units,

--- a/src/info.c
+++ b/src/info.c
@@ -1259,20 +1259,19 @@ struct info_pool_set_t {
     size_t len;
 };
 
-static void info_print_unit(void *arg, ABT_unit unit)
+static void info_print_unit(void *arg, ABT_thread thread)
 {
     /* This function may not have any side effect on unit because it is passed
      * to p_print_all. */
     struct info_print_unit_arg_t *p_arg;
     p_arg = (struct info_print_unit_arg_t *)arg;
     FILE *fp = p_arg->fp;
-    ABTI_thread *p_thread =
-        ABTI_unit_get_thread(ABTI_global_get_global(), unit);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
 
     if (!p_thread) {
-        fprintf(fp, "=== unknown (%p) ===\n", (void *)unit);
+        fprintf(fp, "=== unknown (%p) ===\n", (void *)thread);
     } else if (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) {
-        fprintf(fp, "=== ULT (%p) ===\n", (void *)unit);
+        fprintf(fp, "=== ULT (%p) ===\n", (void *)thread);
         ABTI_ythread *p_ythread = ABTI_thread_get_ythread(p_thread);
         ABT_unit_id thread_id = ABTI_thread_get_id(&p_ythread->thread);
         fprintf(fp,
@@ -1281,7 +1280,7 @@ static void info_print_unit(void *arg, ABT_unit unit)
                 (uint64_t)thread_id, (void *)&p_ythread->ctx);
         ABTI_ythread_print_stack(p_arg->p_global, p_ythread, fp);
     } else {
-        fprintf(fp, "=== tasklet (%p) ===\n", (void *)unit);
+        fprintf(fp, "=== tasklet (%p) ===\n", (void *)thread);
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -149,15 +149,15 @@ void ABTI_log_pool_remove(ABTI_pool *p_pool, ABT_unit unit)
     }
 }
 
-void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
+void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_thread thread)
 {
     ABTI_global *p_global = ABTI_global_get_global_or_null();
     if (!p_global || p_global->use_logging == ABT_FALSE)
         return;
-    if (unit == ABT_UNIT_NULL)
+    if (thread == ABT_THREAD_NULL)
         return;
 
-    ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+    ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
     char unit_type = (p_thread->type & ABTI_THREAD_TYPE_YIELDABLE) ? 'U' : 'T';
     if (p_thread->p_last_xstream) {
         ABTI_log_debug("[%c%" PRIu64 ":E%d] popped from P%" PRIu64 "\n",
@@ -169,12 +169,12 @@ void ABTI_log_pool_pop(ABTI_pool *p_pool, ABT_unit unit)
     }
 }
 
-void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_unit *units,
+void ABTI_log_pool_pop_many(ABTI_pool *p_pool, const ABT_thread *threads,
                             size_t num)
 {
     size_t i;
     for (i = 0; i < num; i++) {
-        ABTI_log_pool_pop(p_pool, units[i]);
+        ABTI_log_pool_pop(p_pool, threads[i]);
     }
 }
 

--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -95,7 +95,7 @@ static void sched_run(ABT_sched sched)
     ABTI_global *p_global = ABTI_global_get_global();
     ABTI_xstream *p_local_xstream =
         ABTI_local_get_xstream(ABTI_local_get_local());
-    ABT_unit unit = ABT_UNIT_NULL;
+    ABT_thread thread = ABT_THREAD_NULL;
     uint32_t pop_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
@@ -115,10 +115,9 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[i]);
             ++pop_count;
-            if ((unit =
-                     ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER)) !=
-                ABT_UNIT_NULL) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            thread = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER);
+            if (thread != ABT_THREAD_NULL) {
+                ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
                 ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 break;
             }
@@ -128,7 +127,7 @@ static void sched_run(ABT_sched sched)
             ABTI_xstream_check_events(p_local_xstream, p_sched);
             if (ABTI_sched_has_to_stop(p_sched) == ABT_TRUE)
                 break;
-            SCHED_SLEEP(unit != ABT_UNIT_NULL, p_data->sleep_time);
+            SCHED_SLEEP(thread != ABT_THREAD_NULL, p_data->sleep_time);
             pop_count = 0;
         }
     }

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -111,10 +111,10 @@ static void sched_run(ABT_sched sched)
             ABT_pool pool = pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
             /* Pop one work unit */
-            ABT_unit unit =
+            ABT_thread thread =
                 ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER);
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            if (thread != ABT_THREAD_NULL) {
+                ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
                 ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 run_cnt_nowait++;
                 break;
@@ -125,18 +125,19 @@ static void sched_run(ABT_sched sched)
          * above. */
         if (!run_cnt_nowait) {
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[0]);
-            ABT_unit unit;
+            ABT_thread thread;
             if (p_pool->optional_def.p_pop_wait) {
-                unit = ABTI_pool_pop_wait(p_pool, 0.1,
-                                          ABT_POOL_CONTEXT_OP_POOL_OTHER);
+                thread = ABTI_pool_pop_wait(p_pool, 0.1,
+                                            ABT_POOL_CONTEXT_OP_POOL_OTHER);
             } else if (p_pool->deprecated_def.p_pop_timedwait) {
-                unit = ABTI_pool_pop_timedwait(p_pool, ABTI_get_wtime() + 0.1);
+                thread =
+                    ABTI_pool_pop_timedwait(p_pool, ABTI_get_wtime() + 0.1);
             } else {
                 /* No "wait" pop, so let's use a normal one. */
-                unit = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER);
+                thread = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER);
             }
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            if (thread != ABT_THREAD_NULL) {
+                ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
                 ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 break;
             }

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -111,10 +111,10 @@ static void sched_run(ABT_sched sched)
         for (i = 0; i < num_pools; i++) {
             ABT_pool pool = pools[i];
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            ABT_unit unit =
+            ABT_thread thread =
                 ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OP_POOL_OTHER);
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            if (thread != ABT_THREAD_NULL) {
+                ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
                 ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
                 break;

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -88,7 +88,6 @@ static void sched_run(ABT_sched sched)
     sched_data *p_data;
     int num_pools;
     ABT_pool *pools;
-    ABT_unit unit;
     int target;
     unsigned seed = time(NULL);
     CNT_DECL(run_cnt);
@@ -106,9 +105,10 @@ static void sched_run(ABT_sched sched)
         /* Execute one work unit from the scheduler's pool */
         ABT_pool pool = pools[0];
         ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-        unit = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OWNER_PRIMARY);
-        if (unit != ABT_UNIT_NULL) {
-            ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+        ABT_thread thread =
+            ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OWNER_PRIMARY);
+        if (thread != ABT_THREAD_NULL) {
+            ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
             ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
             CNT_INC(run_cnt);
         } else if (num_pools > 1) {
@@ -117,9 +117,9 @@ static void sched_run(ABT_sched sched)
                 (num_pools == 2) ? 1 : (rand_r(&seed) % (num_pools - 1) + 1);
             pool = pools[target];
             p_pool = ABTI_pool_get_ptr(pool);
-            unit = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OWNER_SECONDARY);
-            if (unit != ABT_UNIT_NULL) {
-                ABTI_thread *p_thread = ABTI_unit_get_thread(p_global, unit);
+            thread = ABTI_pool_pop(p_pool, ABT_POOL_CONTEXT_OWNER_SECONDARY);
+            if (thread != ABT_THREAD_NULL) {
+                ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
                 ABTI_ythread_schedule(p_global, &p_local_xstream, p_thread);
                 CNT_INC(run_cnt);
             }

--- a/src/thread.c
+++ b/src/thread.c
@@ -3218,12 +3218,11 @@ static void thread_root_func(void *arg)
     ABTI_pool *p_root_pool = p_local_xstream->p_root_pool;
 
     do {
-        ABT_unit unit =
+        ABT_thread thread =
             ABTI_pool_pop(p_root_pool, ABT_POOL_CONTEXT_OWNER_PRIMARY);
-        if (unit != ABT_UNIT_NULL) {
+        if (thread != ABT_THREAD_NULL) {
             ABTI_xstream *p_xstream = p_local_xstream;
-            ABTI_thread *p_thread =
-                ABTI_unit_get_thread_from_builtin_unit(unit);
+            ABTI_thread *p_thread = ABTI_thread_get_ptr(thread);
             ABTI_ythread_schedule(p_global, &p_xstream, p_thread);
             /* The root thread must be executed on the same execution stream. */
             ABTI_ASSERT(p_xstream == p_local_xstream);

--- a/test/basic/pool_custom.c
+++ b/test/basic/pool_custom.c
@@ -526,11 +526,11 @@ void pool3_push(ABT_pool pool, ABT_unit unit, ABT_pool_context context)
     queue_push(&pool3_queue, p_unit);
 }
 
-ABT_unit pool3_pop(ABT_pool pool, ABT_pool_context context)
+ABT_thread pool3_pop(ABT_pool pool, ABT_pool_context context)
 {
     assert(g_pool3 == pool);
     unit_t *p_unit = queue_pop(&pool3_queue);
-    return p_unit ? ((ABT_unit)p_unit) : ABT_UNIT_NULL;
+    return p_unit ? p_unit->thread : ABT_THREAD_NULL;
 }
 
 void pool3_free(ABT_pool pool)
@@ -606,11 +606,11 @@ void pool4_push(ABT_pool pool, ABT_unit unit, ABT_pool_context context)
     queue_push(&pool4_queue, p_unit);
 }
 
-ABT_unit pool4_pop(ABT_pool pool, ABT_pool_context context)
+ABT_thread pool4_pop(ABT_pool pool, ABT_pool_context context)
 {
     assert(g_pool4 == pool);
     unit_t *p_unit = queue_pop(&pool4_queue);
-    return p_unit ? ((ABT_unit)p_unit) : ABT_UNIT_NULL;
+    return p_unit ? p_unit->thread : ABT_THREAD_NULL;
 }
 
 void pool4_free(ABT_pool pool)

--- a/test/leakcheck/pool.c
+++ b/test/leakcheck/pool.c
@@ -94,9 +94,14 @@ ABT_unit pool_pop_old(ABT_pool pool)
     return pool_data->units[--pool_data->num_units];
 }
 
-ABT_unit pool_pop(ABT_pool pool, ABT_pool_context context)
+ABT_thread pool_pop(ABT_pool pool, ABT_pool_context context)
 {
-    return pool_pop_old(pool);
+    ABT_unit unit = pool_pop_old(pool);
+    if (unit != ABT_UNIT_NULL) {
+        return (ABT_thread)unit;
+    } else {
+        return ABT_THREAD_NULL;
+    }
 }
 
 int pool_free_old(ABT_pool pool)

--- a/test/leakcheck/unit.c
+++ b/test/leakcheck/unit.c
@@ -100,9 +100,14 @@ ABT_unit pool_pop_old(ABT_pool pool)
     return pool_data->units[--pool_data->num_units];
 }
 
-ABT_unit pool_pop(ABT_pool pool, ABT_pool_context context)
+ABT_thread pool_pop(ABT_pool pool, ABT_pool_context context)
 {
-    return pool_pop_old(pool);
+    ABT_unit unit = pool_pop_old(pool);
+    if (unit != ABT_UNIT_NULL) {
+        return ((unit_t *)unit)->thread;
+    } else {
+        return ABT_THREAD_NULL;
+    }
 }
 
 int pool_free_old(ABT_pool pool)


### PR DESCRIPTION
## Pull Request Description

**This does not affect the API defined in the Argobots 1.1 specification.**

This PR fixes the API defined by #354.

## Problem

Currently, Argobots internally employs a ABT_unit to ABT_thread hash table for some legacy APIs that take `ABT_unit` but not taking its associated pool (`ABT_pool`) (see #317).  Note that getting `ABT_unit` from `ABT_thread` is easy since `ABT_thread` saves this information.

We would like to remove this hash table since it is heavy (at most `malloc()` + spinlock).

The following legacy functions have this issue:
```c
int ABT_xstream_run_unit(ABT_unit unit, ABT_pool pool);
// Replacement:
// int ABT_self_schedule(ABT_thread thread, ABT_pool pool);

int ABT_pool_push(ABT_pool pool, ABT_unit unit);
// Replacement:
// int ABT_pool_push_thread(ABT_pool pool, ABT_thread thread);

int ABT_unit_set_associated_pool(ABT_unit unit, ABT_pool pool);
// Replacement:
// int ABT_unit_set_associated_pool(ABT_thread thread, ABT_pool pool);

int ABT_unit_get_thread(ABT_unit unit, ABT_thread *thread);
// (This routine is added to use this existing mapping)
```

Currently, this hash table is necessary to maintain those functions.  If these functions are removed in the future, the following functions become unusable.
```c
int ABT_pool_pop(ABT_pool pool, ABT_unit *unit);
// Replacement:
// int ABT_pool_pop_thread(ABT_pool pool, ABT_thread *thread);

int ABT_pool_pop_wait(ABT_pool pool, ABT_unit *unit, double time_secs);
// Replacement:
// int ABT_pool_pop_wait_thread(ABT_pool pool, ABT_thread *thread, double time_secs);

int ABT_pool_pop_timedwait(ABT_pool pool, ABT_unit *unit, double abstime_secs);
// (This routine is deprecated)

int ABT_pool_remove(ABT_pool pool, ABT_unit unit);
// (This routine is deprecated)

int ABT_pool_print_all(ABT_pool pool, void *arg, void (*print_fn)(void *arg, ABT_unit));
// Replacement:
// int ABT_pool_print_all_threads(ABT_pool pool, void *arg, void (*print_fn)(void *arg, ABT_thread));
```

In addition, the current API needs to change the following to return `ABT_thread` so that the runtime does not need to look up the hash table.
```c
typedef ABT_unit (*ABT_pool_user_pop_fn)(ABT_pool, ABT_pool_context);
typedef ABT_unit (*ABT_pool_user_pop_wait_fn)(ABT_pool, double, ABT_pool_context);
typedef void (*ABT_pool_user_pop_many_fn)(ABT_pool, ABT_unit *, size_t, size_t *, ABT_pool_context);
typedef void (*ABT_pool_user_print_all_fn)(ABT_pool, void *arg, void (*)(void *, ABT_unit));
// Many ABT_pool_def functions, but ABT_pool_def itself should be replaced by ABT_pool_user_def.
```
Note that getting `ABT_thread` from `ABT_unit` should be easy for the pool implementation since `ABT_unit` is prepared by a user-defined pool.

## What this PR does

This PR changes function signatures of the following functions.
```c
typedef ABT_thread (*ABT_pool_user_pop_fn)(ABT_pool, ABT_pool_context);
typedef ABT_thread (*ABT_pool_user_pop_wait_fn)(ABT_pool, double, ABT_pool_context);
typedef void (*ABT_pool_user_pop_many_fn)(ABT_pool, ABT_thread *, size_t, size_t *, ABT_pool_context);
typedef void (*ABT_pool_user_print_all_fn)(ABT_pool, void *arg, void (*)(void *, ABT_thread));
```

The idea behind this design is that we use `ABT_unit` only as an input for a user-defined pool.
```
// Example: pop
[User] <--ABT_thread--- [Argobots runtime] <--ABT_thread--- [User-defined pool]
// Example: push
[User] ---ABT_thread--> [Argobots runtime] --- ABT_unit --> [User-defined pool]
// Note:
// - The Argobots runtime has ABT_thread -> ABT_unit mapping
// - A user-defined pool has ABT_unit -> ABT_thread mapping
```

This design has the following merits.
- Except for a user-defined pool, the user does not need to consider `ABT_unit`.
- The Argobots runtime does not need to maintain `ABT_unit`-to-`ABT_thread` mapping (`ABT_thread` to `ABT_unit` is easy for the Argobots runtime).
- A user-defined pool does not need to maintain `ABT_thread`-to-`ABT_unit` mapping; the user can just create a special `ABT_unit` data structure that encapsulates `ABT_thread` (or maybe `ABT_unit` = `ABT_thread`).

### Performance implication

This PR just changes the function signatures.  This PR does not remove the hash table since we need to maintain the existing functions (such as `ABT_xstream_run_unit()`).  I also note that this hash table is specialized for built-in pools so if the user uses only built-in pools, there is no performance concern.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
