### PR TITLE
configure: disable simple mutex by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,10 +220,10 @@ AC_ARG_ENABLE([wait-policy],
         passive      - suspend CPU cores on blocking.  It increases latency.
 ],,[enable_wait_policy=auto])
 
-# --disable-simple-mutex
+# --enable-simple-mutex
 AC_ARG_ENABLE([simple-mutex],
-    AS_HELP_STRING([--disable-simple-mutex], [use an experimental mutex implementation]),,
-    [enable_simple_mutex=yes])
+    AS_HELP_STRING([--enable-simple-mutex], [use an old yield-based mutex implementation]),,
+    [enable_simple_mutex=no])
 
 # --enable-static-cacheline-size
 AC_ARG_ENABLE([static-cacheline-size],
@@ -787,10 +787,10 @@ AS_IF([test "x$enable_wait_policy" = "xactive"],
       [AC_DEFINE(ABT_CONFIG_ACTIVE_WAIT_POLICY, 1,
                  [Define to enable the active wait policy])])
 
-# --disable-simple-mutex
+# --enable-simple-mutex
 AS_IF([test "x$enable_simple_mutex" = "xyes"],
       [AC_DEFINE(ABT_CONFIG_USE_SIMPLE_MUTEX, 1,
-                 [Define to use a simple mutex implementation])])
+                 [Define to use an old yield-based mutex implementation])])
 
 
 # --enable-static-cacheline-size


### PR DESCRIPTION
## Pull Request Description

This PR sets `--disable-simple-mutex` at configure time by default.

### History

Because of several bugs in "the non-simple mutex" (#14, #34, #41), the simple mutex became the default implementation for correctness (#102). The simple mutex is yield-based, so most users do not expect this behavior (see #361). The "non-simple mutex" has been reasonably fixed by #268, which can be enabled by setting "--disable-simple-mutex". As requested by several users, this PR now changes the default mutex implementation.

### Performance

The previous default mutex (= `--enable-simple-mutex`) should be slightly faster if the mutex is not contended. The new default mutex (= `--disable-simple-mutex`) should be more efficient if contention happens.  Since some synchronization objects such as `ABT_rwlock` internally uses the logic of `ABT_mutex`, this affects their performance.

If you like the original behavior, please set `--enable-simple-mutex` at configure time, though I believe the new default mutex should perform reasonably well in most cases.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
