### PR TITLE
eventual: provide a static initializer for eventual

### DIFF
--- a/src/eventual.c
+++ b/src/eventual.c
@@ -44,6 +44,9 @@ int ABT_eventual_create(int nbytes, ABT_eventual *neweventual)
     ABTI_UB_ASSERT(ABTI_initialized());
     ABTI_UB_ASSERT(neweventual);
 
+    /* Check if the size of ABT_eventual_memory is okay. */
+    ABTI_STATIC_ASSERT(sizeof(ABTI_eventual) <= sizeof(ABT_eventual_memory));
+
     int abt_errno;
     ABTI_eventual *p_eventual;
     ABTI_CHECK_TRUE(nbytes >= 0, ABT_ERR_INV_ARG);

--- a/src/include/abt.h.in
+++ b/src/include/abt.h.in
@@ -1265,6 +1265,71 @@ typedef struct {
     ((ABT_cond)p_cond_memory)
 
 /**
+ * @ingroup EVENTUAL
+ * @brief   A struct that can be converted to \c ABT_eventual.
+ * @hideinitializer
+ *
+ * \c ABT_eventual_memory is a struct to statically allocate and initialize
+ * \c ABT_eventual.  \c ABT_eventual_memory can be statically initialized by
+ * \c ABT_EVENTUAL_INITIALIZER and converted to \c ABT_eventual by
+ * \c ABT_EVENTUAL_MEMORY_GET_HANDLE().
+ *
+ * The initialized \c ABT_eventual does not hold a memory buffer, so the user
+ * may not set a value of the statically initialized \c ABT_eventual by
+ * \c ABT_eventual_set()
+ *
+ * \c dummy may not be accessed by a user.
+ */
+typedef struct {
+    int dummy[16];
+} ABT_eventual_memory;
+
+/**
+ * @ingroup EVENTUAL
+ * @brief   Initialize \c ABT_eventual_memory.
+ *
+ * \c ABT_EVENTUAL_INITIALIZER statically initializes \c ABT_eventual_memory.
+
+ * The following example shows how to use \c ABT_EVENTUAL_INITIALIZER.
+ * @code{.c}
+ * ABT_eventual_memory eventual_mem = ABT_EVENTUAL_INITIALIZER;
+ *
+ * void thread(void *)
+ * {
+ *     ABT_eventual eventual = ABT_EVENTUAL_MEMORY_GET_HANDLE(&eventual_mem);
+ *     if (...) {
+ *         ABT_eventual_wait(eventual);
+ *     } else {
+ *         [...];
+ *         ABT_eventual_set(eventual, NULL, 0);
+ *     }
+ * }
+ * @endcode
+ *
+ * \c ABT_eventual_memory that is in use may not be initialized again.
+ */
+#define ABT_EVENTUAL_INITIALIZER                                               \
+    { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }
+
+/**
+ * @ingroup EVENTUAL
+ * @brief   Obtain \c ABT_eventual from \c ABT_eventual_memory.
+ *
+ * \c ABT_EVENTUAL_MEMORY_GET_HANDLE() takes the pointer \c p_eventual_memory,
+ * which points to \c ABT_eventual_memory, and returns \c ABT_eventual that
+ * internally uses \c p_eventual_memory to store the data.  If the memory
+ * pointed to by \c p_eventual_memory is not properly initialized, it returns a
+ * corrupted eventual.
+ *
+ * \c ABT_eventual obtained by \c ABT_EVENTUAL_MEMORY_GET_HANDLE() may not be
+ * freed by \c ABT_eventual_free().  The lifetime of \c ABT_eventual obtained by
+ * \c ABT_EVENTUAL_MEMORY_GET_HANDLE() is the same as that of
+ * \c ABT_eventual_memory.
+ */
+#define ABT_EVENTUAL_MEMORY_GET_HANDLE(p_eventual_memory)                      \
+    ((ABT_eventual)p_eventual_memory)
+
+/**
  * @ingroup SCHED_CONFIG
  * @brief   A struct that sets and gets a scheduler configuration.
  */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -63,6 +63,7 @@ basic/rwlock_reader_incl
 basic/rwlock_reader_writer_excl
 basic/rwlock_writer_excl
 basic/eventual_create
+basic/eventual_static
 basic/eventual_test
 basic/barrier
 basic/self_exit_to

--- a/test/basic/Makefile.am
+++ b/test/basic/Makefile.am
@@ -68,6 +68,7 @@ TESTS = \
 	rwlock_reader_incl \
 	future_create \
 	eventual_create \
+	eventual_static \
 	eventual_test \
 	barrier \
 	self_exit_to \
@@ -174,6 +175,7 @@ rwlock_reader_writer_excl_SOURCES = rwlock_reader_writer_excl.c
 rwlock_reader_incl_SOURCES = rwlock_reader_incl.c
 future_create_SOURCES = future_create.c
 eventual_create_SOURCES = eventual_create.c
+eventual_static_SOURCES = eventual_static.c
 eventual_test_SOURCES = eventual_test.c
 barrier_SOURCES = barrier.c
 self_exit_to_SOURCES = self_exit_to.c
@@ -266,6 +268,7 @@ testing:
 	./rwlock_reader_incl
 	./future_create
 	./eventual_create
+	./eventual_static
 	./eventual_test
 	./barrier
 	./self_exit_to

--- a/test/basic/eventual_static.c
+++ b/test/basic/eventual_static.c
@@ -1,0 +1,269 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include "abt.h"
+#include "abttest.h"
+
+#define DEFAULT_NUM_XSTREAMS 4
+#define DEFAULT_NUM_PTHREADS 4
+#define DEFAULT_NUM_THREADS 4
+#define DEFAULT_NUM_ITER 40
+
+ABT_eventual_memory g_eventual_mem = ABT_EVENTUAL_INITIALIZER;
+
+typedef struct {
+    ABT_eventual eventual;
+    int counter;
+} eventual_set;
+eventual_set g_eventual_sets[2];
+int g_iter = DEFAULT_NUM_ITER;
+
+#define NUM_EVENTUAL_SETS                                                      \
+    ((int)(sizeof(g_eventual_sets) / sizeof(g_eventual_sets[0])))
+
+void barrier(int num_waiters)
+{
+    static ABT_mutex_memory mutex_mem = ABT_MUTEX_INITIALIZER;
+    static ABT_cond_memory cond_mem = ABT_COND_INITIALIZER;
+    static int wait_counter = 0;
+    ABT_mutex mutex = ABT_MUTEX_MEMORY_GET_HANDLE(&mutex_mem);
+    ABT_cond cond = ABT_COND_MEMORY_GET_HANDLE(&cond_mem);
+
+    int ret;
+    /* Increment a counter. */
+    ret = ABT_mutex_lock(mutex);
+    ATS_ERROR(ret, "ABT_mutex_lock");
+    wait_counter++;
+    if (wait_counter < num_waiters) {
+        ret = ABT_cond_wait(cond, mutex);
+        ATS_ERROR(ret, "ABT_cond_wait");
+    } else {
+        wait_counter = 0;
+        ret = ABT_cond_broadcast(cond);
+        ATS_ERROR(ret, "ABT_cond_broadcast");
+    }
+    ret = ABT_mutex_unlock(mutex);
+    ATS_ERROR(ret, "ABT_mutex_unlock");
+}
+
+typedef struct {
+    int tid;
+    int num_total_threads;
+} thread_arg_t;
+
+void thread_func(void *arg)
+{
+    int i, ret;
+    thread_arg_t *p_arg = (thread_arg_t *)arg;
+    for (i = 0; i < g_iter; i++) {
+        int j;
+        for (j = 0; j < NUM_EVENTUAL_SETS; j++) {
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                if (i == 0) {
+                    g_eventual_sets[j].counter = 0;
+                } else {
+                    assert(g_eventual_sets[j].counter == i);
+                }
+                g_eventual_sets[j].counter += 1;
+                ret = ABT_eventual_set(g_eventual_sets[j].eventual, NULL, 0);
+                ATS_ERROR(ret, "ABT_eventual_set");
+            } else {
+                ret = ABT_eventual_wait(g_eventual_sets[j].eventual, NULL);
+                ATS_ERROR(ret, "ABT_eventual_wait");
+            }
+            assert(g_eventual_sets[j].counter == i + 1);
+            barrier(p_arg->num_total_threads);
+            if (p_arg->tid == g_iter % p_arg->num_total_threads) {
+                ret = ABT_eventual_reset(g_eventual_sets[j].eventual);
+                ATS_ERROR(ret, "ABT_eventual_reset");
+            }
+            barrier(p_arg->num_total_threads);
+        }
+    }
+}
+
+void *pthread_func(void *arg)
+{
+    thread_func(arg);
+    return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, j, ret;
+    int num_xstreams = DEFAULT_NUM_XSTREAMS;
+    int num_pthreads = DEFAULT_NUM_PTHREADS;
+    int num_threads = DEFAULT_NUM_THREADS;
+    ABT_eventual_memory eventual_mem = ABT_EVENTUAL_INITIALIZER;
+
+    /* Read arguments. */
+    ATS_read_args(argc, argv);
+    if (argc >= 2) {
+        num_xstreams = ATS_get_arg_val(ATS_ARG_N_ES);
+        num_threads = ATS_get_arg_val(ATS_ARG_N_ULT);
+        g_iter = ATS_get_arg_val(ATS_ARG_N_ITER);
+    }
+
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_init(0, NULL);
+    ATS_ERROR(ret, "ABT_init");
+#endif
+    ABT_bool support_external_thread;
+    ret = ABT_info_query_config(ABT_INFO_QUERY_KIND_ENABLED_EXTERNAL_THREAD,
+                                (void *)&support_external_thread);
+    ATS_ERROR(ret, "ABT_info_query_config");
+#ifndef ABT_ENABLE_VER_20_API
+    ret = ABT_finalize();
+    ATS_ERROR(ret, "ABT_finalize");
+#endif
+
+    /* Set up eventuals. */
+    g_eventual_sets[0].eventual =
+        ABT_EVENTUAL_MEMORY_GET_HANDLE(&g_eventual_mem);
+    g_eventual_sets[1].eventual = ABT_EVENTUAL_MEMORY_GET_HANDLE(&eventual_mem);
+
+    /* Allocate thread_args. */
+    thread_arg_t *thread_args = (thread_arg_t *)malloc(
+        sizeof(thread_arg_t) * (num_pthreads + num_xstreams * num_threads));
+
+    /* Currently, eventual functions need Argobots initialization. */
+#if 0
+    /* Use eventuals before ABT_Init(). */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            thread_args[i].tid = i;
+            thread_args[i].num_total_threads = num_pthreads;
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, &thread_args[i]);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+    }
+#endif
+
+    /* Initialize */
+    ATS_init(argc, argv, num_xstreams);
+
+    ATS_printf(2, "# of ESs : %d\n", num_xstreams);
+    ATS_printf(1, "# of ULTs: %d\n", num_threads);
+    ATS_printf(1, "# of iter: %d\n", g_iter);
+
+    ABT_xstream *xstreams =
+        (ABT_xstream *)malloc(sizeof(ABT_xstream) * num_xstreams);
+    ABT_thread *threads =
+        (ABT_thread *)malloc(sizeof(ABT_thread) * num_xstreams * num_threads);
+
+    /* Create execution streams */
+    ret = ABT_xstream_self(&xstreams[0]);
+    ATS_ERROR(ret, "ABT_xstream_self");
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_create(ABT_SCHED_NULL, &xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_create");
+    }
+
+    /* Get the pools attached to an execution stream */
+    ABT_pool *pools;
+    pools = (ABT_pool *)malloc(sizeof(ABT_pool) * num_xstreams);
+    for (i = 0; i < num_xstreams; i++) {
+        ret = ABT_xstream_get_main_pools(xstreams[i], 1, pools + i);
+        ATS_ERROR(ret, "ABT_xstream_get_main_pools");
+    }
+
+    /* Create ULTs */
+    const int num_total_threads = (support_external_thread ? num_pthreads : 0) +
+                                  num_xstreams * num_threads;
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            int tid = i * num_threads + j;
+            thread_args[tid].tid = tid;
+            thread_args[tid].num_total_threads = num_total_threads;
+            ret = ABT_thread_create(pools[i], thread_func, &thread_args[tid],
+                                    ABT_THREAD_ATTR_NULL,
+                                    &threads[i * num_threads + j]);
+            ATS_ERROR(ret, "ABT_thread_create");
+        }
+    }
+
+    /* Create Pthreads. */
+    pthread_t *pthreads;
+    if (support_external_thread) {
+        pthreads = (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            int tid = num_xstreams * num_threads + i;
+            thread_args[tid].tid = tid;
+            thread_args[tid].num_total_threads = num_total_threads;
+            ret = pthread_create(&pthreads[i], NULL, pthread_func,
+                                 &thread_args[tid]);
+            assert(ret == 0);
+        }
+    }
+
+    /* Join and free ULTs */
+    for (i = 0; i < num_xstreams; i++) {
+        for (j = 0; j < num_threads; j++) {
+            ret = ABT_thread_free(&threads[i * num_threads + j]);
+            ATS_ERROR(ret, "ABT_thread_free");
+        }
+    }
+
+    /* Join Pthreads. */
+    if (support_external_thread) {
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+    }
+
+    /* Join execution streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_join(xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_join");
+    }
+
+    /* Free execution streams */
+    for (i = 1; i < num_xstreams; i++) {
+        ret = ABT_xstream_free(&xstreams[i]);
+        ATS_ERROR(ret, "ABT_xstream_free");
+    }
+
+    /* Finalize */
+    ret = ATS_finalize(0);
+
+    /* Currently, eventual functions need Argobots initialization. */
+#if 0
+    /* Use eventuals after finalization. */
+    if (support_external_thread) {
+        pthread_t *pthreads =
+            (pthread_t *)malloc(sizeof(pthread_t) * num_pthreads);
+        for (i = 0; i < num_pthreads; i++) {
+            thread_args[i].tid = i;
+            thread_args[i].num_total_threads = num_pthreads;
+            ret = pthread_create(&pthreads[i], NULL, pthread_func, &thread_args[i]);
+            assert(ret == 0);
+        }
+        for (i = 0; i < num_pthreads; i++) {
+            ret = pthread_join(pthreads[i], NULL);
+            assert(ret == 0);
+        }
+        free(pthreads);
+    }
+#endif
+
+    free(threads);
+    free(xstreams);
+    free(pools);
+    free(thread_args);
+
+    return ret;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes #362. Specifically, this PR implements a static initializer for `ABT_eventual`. The static initializer is cheaper than `ABT_eventual_create()`. There's no need to explicitly free a statically initialized eventual, so it might be easy to handle in some cases.

Note that a statically initialized `ABT_eventual` does not accept `nbytes`. Setting a value is prohibited.

@mdorier: For possible future optimizations, `ABT_eventual` functions require Argobots initialization unlike `ABT_mutex` and `ABT_cond`; some (not all) `ABT_mutex/cond` functions can be called before `ABT_init()` and after `ABT_finialize()` (see #299). If you need this for `ABT_eventual`, please leave a comment.

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
