### PR TITLE
pool: fix ABTI_pool_pop_timedwait

### DIFF
--- a/src/pool/pool.c
+++ b/src/pool/pool.c
@@ -1444,11 +1444,15 @@ ABT_thread ABTI_pool_pop_timedwait(ABTI_pool *p_pool, double abstime_secs)
     ABT_unit unit =
         p_pool->deprecated_def.p_pop_timedwait(ABTI_pool_get_handle(p_pool),
                                                abstime_secs);
-    ABTI_thread *p_thread =
-        ABTI_unit_get_thread(ABTI_global_get_global(), unit);
-    ABT_thread thread = ABTI_thread_get_handle(p_thread);
-    LOG_DEBUG_POOL_POP(p_pool, thread);
-    return thread;
+    if (unit == ABT_UNIT_NULL) {
+        return ABT_THREAD_NULL;
+    } else {
+        ABTI_thread *p_thread =
+            ABTI_unit_get_thread(ABTI_global_get_global(), unit);
+        ABT_thread thread = ABTI_thread_get_handle(p_thread);
+        LOG_DEBUG_POOL_POP(p_pool, thread);
+        return thread;
+    }
 }
 
 void ABTI_pool_print(ABTI_pool *p_pool, FILE *p_os, int indent)


### PR DESCRIPTION

## Pull Request Description

`ABTI_pool_pop_timedwait()` does not properly handle `ABT_UNIT_NULL`, so it causes SEGV if a user-defined `p_pop_timedwait()` returns `ABT_UNIT_NULL`. This issue was introduced by #357. This patch adds a branch to deal with `ABT_UNIT_NULL`.

This PR should fix #365. Thank you for reporting this issue, @mdorier!

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
