### PR TITLE
info: add start/end tags and pack zeroes in stack dump

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -1373,10 +1373,20 @@ ABTU_ret_err static int print_all_thread_stacks(ABTI_global *p_global, FILE *fp)
     size_t i;
     int abt_errno;
     struct info_pool_set_t pool_set;
+    struct tm *tm = NULL;
+    time_t seconds;
 
     abt_errno = info_initialize_pool_set(&pool_set);
     ABTI_CHECK_ERROR(abt_errno);
     ABTI_xstream *p_xstream = p_global->p_xstream_head;
+
+    seconds = (time_t)ABT_get_wtime();
+    tm = localtime(&seconds);
+    ABTI_ASSERT(tm != NULL);
+    fprintf(fp, "Start of ULT stacks dump %04d/%02d/%02d-%02d:%02d:%02d\n",
+	    tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
+	    tm->tm_min, tm->tm_sec);
+
     while (p_xstream) {
         ABTI_sched *p_main_sched = p_xstream->p_main_sched;
         fprintf(fp, "= xstream[%d] (%p) =\n", p_xstream->rank,
@@ -1404,6 +1414,14 @@ ABTU_ret_err static int print_all_thread_stacks(ABTI_global *p_global, FILE *fp)
         if (abt_errno != ABT_SUCCESS)
             fprintf(fp, "  Failed to print (errno = %d).\n", abt_errno);
     }
+
+    seconds = (time_t)ABT_get_wtime();
+    tm = localtime(&seconds);
+    ABTI_ASSERT(tm != NULL);
+    fprintf(fp, "End of ULT stacks dump %04d/%02d/%02d-%02d:%02d:%02d\n",
+	    tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
+	    tm->tm_min, tm->tm_sec);
+
     info_finalize_pool_set(&pool_set);
     return ABT_SUCCESS;
 }


### PR DESCRIPTION
Presently, there is no tag to indicate when ULTs stacks
dump has completed, when this is difficult to determine
as this process occurs asynchronously. So, start and
end markers with timestamp have been added.

Also, the raw stack dump do not pack the full zeroes
parts, which sometimes causes tons of unnecessary lines
of zeroes to be printed. So, they are packed now to
improve readability.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request, particularly focused on why the work is necessary, not what you did.
-->

## Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
