### PR TITLE
added case num_pools == 0 in schedulers

### DIFF
--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -111,6 +111,9 @@ static void sched_run(ABT_sched sched)
     num_pools = p_data->num_pools;
     pools = p_data->pools;
 
+    if (num_pools == 0)
+        return;
+
     while (1) {
         for (i = 0; i < num_pools; i++) {
             ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[i]);

--- a/src/sched/basic_wait.c
+++ b/src/sched/basic_wait.c
@@ -103,6 +103,9 @@ static void sched_run(ABT_sched sched)
     num_pools = p_data->num_pools;
     pools = p_data->pools;
 
+    if (num_pools == 0)
+        return;
+
     while (1) {
         run_cnt_nowait = 0;
 

--- a/src/sched/prio.c
+++ b/src/sched/prio.c
@@ -103,6 +103,9 @@ static void sched_run(ABT_sched sched)
     num_pools = p_sched->num_pools;
     pools = p_data->pools;
 
+    if (num_pools == 0)
+        return;
+
     while (1) {
         CNT_INIT(run_cnt, 0);
 

--- a/src/sched/randws.c
+++ b/src/sched/randws.c
@@ -99,6 +99,9 @@ static void sched_run(ABT_sched sched)
     num_pools = p_sched->num_pools;
     pools = p_data->pools;
 
+    if (num_pools == 0)
+        return;
+
     while (1) {
         CNT_INIT(run_cnt, 0);
 


### PR DESCRIPTION
## Pull Request Description

Fixes the case where `num_pools` is 0 in the schedulers implementation. See issue https://github.com/pmodels/argobots/issues/381.

## Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
