### PR TITLE
configure: Restore libuwnind support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,14 @@ AC_ARG_WITH([libunwind],
     AS_HELP_STRING([--with-libunwind=PATH],
         [specify path where libunwind include directory and lib directory can be found]))
 
+# --enable-stack-unwind
+AC_ARG_ENABLE([stack-unwind],
+[  --enable-stack-unwind@<:@=OPTS@:>@ enable stack unwinding, which is disabled by default.
+        yes|verbose  - enable stack unwinding.  Dump the raw stack information too
+        unwind-only  - enable stack unwinding.  Do not dump the raw stack information
+        no|none      - disable stack unwinding
+],,[enable_stack_unwind=no])
+
 # --with-papi
 AC_ARG_WITH([papi],
     AS_HELP_STRING([--with-papi=PATH],


### PR DESCRIPTION
## Pull Request Description

The commit 3196bbf3d05702b7f124ac7cd6a13ad9cf585caf removed the support of libunwind.
From the message https://github.com/pmodels/argobots/commit/3196bbf3d05702b7f124ac7cd6a13ad9cf585caf#r143955103, it seems to not be intentional.

DAOS-15596 ticket, Update Argobots to 1.2


## Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers

<!--
Tips: you may want to run the following command to format each of your commit.
  argobots_root_dir$ bash ./maint/code-cleanup.sh CHANGED_FILE_PATH
-->
